### PR TITLE
feat: Playwright auth setup for real-data testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+e2e/.auth/
 
 # next.js
 /.next/

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,22 @@
+import { test as setup, expect } from "@playwright/test";
+
+setup("authenticate", async ({ page }) => {
+  await page.goto("/api/auth/signin");
+
+  // Click the "Sign in with Test" button to get to the credentials form
+  await page.getByText("Sign in with Test").click();
+
+  // Fill the credentials form
+  await page.locator('input[name="email"]').fill("jadkins@goldentouchremodeling.com");
+  await page.locator('input[name="secret"]').fill(process.env.PLAYWRIGHT_TEST_SECRET || "");
+
+  // Submit the form
+  await page.locator('button[type="submit"]').click();
+
+  // Wait for redirect after successful login
+  await page.waitForURL("**/projects**", { timeout: 15_000 });
+  await expect(page).not.toHaveURL(/.*signin.*/);
+
+  // Save signed-in state
+  await page.context().storageState({ path: "e2e/.auth/user.json" });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,8 +16,16 @@ export default defineConfig({
   },
   projects: [
     {
+      name: "setup",
+      testMatch: /auth\.setup\.ts/,
+    },
+    {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: "e2e/.auth/user.json",
+      },
+      dependencies: ["setup"],
     },
   ],
   webServer: process.env.CI

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,14 +1,39 @@
 import { NextAuthOptions, getServerSession } from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
+import CredentialsProvider from "next-auth/providers/credentials";
 import { prisma } from "@/lib/prisma";
 
+const providers: NextAuthOptions["providers"] = [
+    GoogleProvider({
+        clientId: process.env.GOOGLE_CLIENT_ID || "",
+        clientSecret: process.env.GOOGLE_CLIENT_SECRET || "",
+    }),
+];
+
+// Test-only credentials provider — only active when PLAYWRIGHT_TEST_SECRET is set
+if (process.env.PLAYWRIGHT_TEST_SECRET) {
+    providers.push(
+        CredentialsProvider({
+            name: "Test",
+            credentials: {
+                email: { type: "text" },
+                secret: { type: "text" },
+            },
+            async authorize(credentials) {
+                if (credentials?.secret !== process.env.PLAYWRIGHT_TEST_SECRET) return null;
+                if (!credentials.email) return null;
+                const user = await prisma.user.findUnique({
+                    where: { email: credentials.email.toLowerCase() },
+                });
+                if (!user) return null;
+                return { id: user.id, name: user.name, email: user.email };
+            },
+        })
+    );
+}
+
 export const authOptions: NextAuthOptions = {
-    providers: [
-        GoogleProvider({
-            clientId: process.env.GOOGLE_CLIENT_ID || "",
-            clientSecret: process.env.GOOGLE_CLIENT_SECRET || "",
-        }),
-    ],
+    providers,
     pages: {
         signIn: "/login",
         error: "/login?error=AccessDenied",


### PR DESCRIPTION
Adds credentials provider for test auth. Ready for QA.