### PR TITLE
fix: move HelpChatWidget inside Providers so it renders

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,11 +45,11 @@ export default async function RootLayout({
           <AppLayout logoUrl={settings?.logoUrl ?? undefined}>
             {children}
           </AppLayout>
+          <HelpChatWidget
+            userId={session?.user?.id}
+            userRole={session?.user?.role}
+          />
         </Providers>
-        <HelpChatWidget
-          userId={session?.user?.id}
-          userRole={session?.user?.role}
-        />
         <Toaster position="bottom-right" richColors />
       </body>
     </html>


### PR DESCRIPTION
## Summary
- The `HelpChatWidget` was rendered **outside** `<Providers>` in `layout.tsx`, so `usePermissions()` had no `PermissionsProvider` context
- `loaded` stayed `false` → widget returned `null` → invisible on every page
- Moved it inside `<Providers>` — chat bubble now renders correctly

## Test plan
- [x] Verified locally: green chat bubble visible on `/projects`
- [x] No console errors
- [ ] CI Playwright tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)