### PR TITLE
fix: site audit — Decimal arithmetic + dead nav + E2E coverage

### DIFF
--- a/e2e/coverage-expansion.spec.ts
+++ b/e2e/coverage-expansion.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const PROJECT_ID = "cmml6vt3y000lpwrh0p9p3k12";
+
+const CRASH_REGEX =
+  /Something went wrong|Internal Server Error|Application error/i;
+const DECIMAL_REGEX = /\[object Object\]|Decimal\{|BigNumber/;
+const FORBIDDEN_PATTERNS = [
+  { pattern: /\$0[0-9]{4,}/, label: "$079261-style currency bug" },
+  { pattern: /NaN/, label: "NaN value" },
+];
+
+async function assertCleanPage(page: Page, path: string) {
+  const res = await page.goto(path, {
+    waitUntil: "networkidle",
+    timeout: 30_000,
+  });
+  expect(
+    res?.status(),
+    `${path} returned HTTP ${res?.status()}`
+  ).toBeLessThan(400);
+
+  const body = await page.locator("body").innerText();
+  expect(body, `${path} shows crash UI`).not.toMatch(CRASH_REGEX);
+  expect(body, `${path} leaks Decimal objects`).not.toMatch(DECIMAL_REGEX);
+  for (const { pattern, label } of FORBIDDEN_PATTERNS) {
+    expect(body, `${path} contains: ${label}`).not.toMatch(pattern);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Project sub-pages missing from full-workflow.spec.ts
+// ---------------------------------------------------------------------------
+test.describe("Coverage — Project Sub-pages", () => {
+  test("overview loads", async ({ page }) => {
+    const res = await page.goto(`/projects/${PROJECT_ID}/overview`, {
+      waitUntil: "networkidle",
+    });
+    expect(res?.status()).toBeLessThan(500);
+  });
+
+  test("messages page loads", async ({ page }) => {
+    await assertCleanPage(page, `/projects/${PROJECT_ID}/messages`);
+  });
+
+  test("settings page loads", async ({ page }) => {
+    await assertCleanPage(page, `/projects/${PROJECT_ID}/settings`);
+  });
+
+  test("timeclock page loads", async ({ page }) => {
+    await assertCleanPage(page, `/projects/${PROJECT_ID}/timeclock`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Portal pages
+// ---------------------------------------------------------------------------
+test.describe("Coverage — Portal", () => {
+  test("/portal loads or redirects", async ({ page }) => {
+    const res = await page.goto("/portal", { waitUntil: "networkidle" });
+    expect(res?.status()).toBeLessThan(500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sub-portal pages
+// ---------------------------------------------------------------------------
+test.describe("Coverage — Sub Portal", () => {
+  test("/sub-portal redirects cleanly", async ({ page }) => {
+    const res = await page.goto("/sub-portal", { waitUntil: "networkidle" });
+    expect(res?.status()).toBeLessThan(500);
+  });
+
+  test("/sub-portal/login loads cleanly", async ({ page }) => {
+    await assertCleanPage(page, "/sub-portal/login");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lead sub-pages (discover ID from list)
+// ---------------------------------------------------------------------------
+test.describe("Coverage — Lead Sub-pages", () => {
+  test("lead detail and sub-pages load", async ({ page }) => {
+    await page.goto("/leads", { waitUntil: "networkidle" });
+    const firstLink = page.locator('a[href*="/leads/"]').first();
+    if ((await firstLink.count()) === 0) {
+      test.skip();
+      return;
+    }
+    const href = await firstLink.getAttribute("href");
+    if (!href) {
+      test.skip();
+      return;
+    }
+    const leadId = href.split("/leads/")[1]?.split("/")[0]?.split("?")[0];
+    if (!leadId) {
+      test.skip();
+      return;
+    }
+
+    await assertCleanPage(page, `/leads/${leadId}`);
+
+    const subPages = [
+      "contracts",
+      "estimates",
+      "files",
+      "meetings",
+      "notes",
+      "schedule",
+      "takeoffs",
+      "tasks",
+    ];
+    for (const sub of subPages) {
+      await assertCleanPage(page, `/leads/${leadId}/${sub}`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Company detail pages (discover IDs from list)
+// ---------------------------------------------------------------------------
+test.describe("Coverage — Company Detail Pages", () => {
+  test("team-member detail page loads", async ({ page }) => {
+    await page.goto("/company/team-members", { waitUntil: "networkidle" });
+    const link = page.locator('a[href*="/company/team-members/"]').first();
+    if ((await link.count()) === 0) {
+      test.skip();
+      return;
+    }
+    const href = await link.getAttribute("href");
+    if (href) await assertCleanPage(page, href);
+  });
+
+  test("subcontractor detail page loads", async ({ page }) => {
+    await page.goto("/company/subcontractors", { waitUntil: "networkidle" });
+    const link = page.locator('a[href*="/company/subcontractors/"]').first();
+    if ((await link.count()) === 0) {
+      test.skip();
+      return;
+    }
+    const href = await link.getAttribute("href");
+    if (href) await assertCleanPage(page, href);
+  });
+});

--- a/e2e/quality-gate.spec.ts
+++ b/e2e/quality-gate.spec.ts
@@ -83,6 +83,8 @@ test.describe("Quality Gate — Page Load", () => {
     "/settings/sales-taxes",
     "/settings/payment-methods",
     "/settings/integrations",
+    "/settings/integrations/gusto",
+    "/settings/integrations/quickbooks",
     "/settings/contacts",
     "/settings/cost-codes",
     "/settings/calendar",
@@ -135,6 +137,8 @@ test.describe("Quality Gate — Page Load", () => {
     "/reports/payments",
     "/reports/tax-liability",
     "/reports/global-tracker",
+    "/reports/payouts",
+    "/reports/transactions",
   ];
 
   for (const route of reportRoutes) {

--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -61,7 +61,7 @@ export default async function PortalDashboard() {
             ) : (
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                     {projects.map(p => {
-                        const activeInvoices = p.invoices.reduce((sum, inv) => sum + inv.balanceDue, 0);
+                        const activeInvoices = p.invoices.reduce((sum, inv) => sum + Number(inv.balanceDue), 0);
 
                         return (
                             <Link href={`/portal/projects/${p.id}`} key={p.id} className="hui-card group overflow-hidden hover:shadow-md transition flex flex-col">

--- a/src/app/projects/[id]/timeclock/page.tsx
+++ b/src/app/projects/[id]/timeclock/page.tsx
@@ -54,11 +54,15 @@ export default async function TimeClockPage({
         orderBy: { code: 'asc' }
     });
     
-    const teamMembers = await prisma.user.findMany({
+    const teamMembersRaw = await prisma.user.findMany({
         where: { status: { not: "DISABLED" } },
         select: { id: true, name: true, email: true, hourlyRate: true },
         orderBy: { name: 'asc' }
     });
+    const teamMembers = teamMembersRaw.map(u => ({
+        ...u,
+        hourlyRate: Number(u.hourlyRate),
+    }));
 
     return (
         <TimeClockClient

--- a/src/app/reports/global-tracker/page.tsx
+++ b/src/app/reports/global-tracker/page.tsx
@@ -36,9 +36,9 @@ export default async function GlobalTrackerPage() {
     };
 
     const rows: Row[] = projects.map(p => {
-        const budget = p.estimates.reduce((s, e) => s + e.totalAmount, 0);
-        const invoiced = p.invoices.reduce((s, i) => s + i.totalAmount, 0);
-        const balance = p.invoices.reduce((s, i) => s + i.balanceDue, 0);
+        const budget = p.estimates.reduce((s, e) => s + Number(e.totalAmount), 0);
+        const invoiced = p.invoices.reduce((s, i) => s + Number(i.totalAmount), 0);
+        const balance = p.invoices.reduce((s, i) => s + Number(i.balanceDue), 0);
         const paid = invoiced - balance;
 
         const tasks = p.scheduleTasks;

--- a/src/app/reports/open-invoices/page.tsx
+++ b/src/app/reports/open-invoices/page.tsx
@@ -28,7 +28,7 @@ export default async function OpenInvoicesPage() {
         orderBy: { issueDate: "asc" },
     });
 
-    const totalOutstanding = invoices.reduce((sum, inv) => sum + inv.balanceDue, 0);
+    const totalOutstanding = invoices.reduce((sum, inv) => sum + Number(inv.balanceDue), 0);
     const overdueCount = invoices.filter(i => i.status === "Overdue").length;
 
     const byBucket: Record<string, typeof invoices> = { "0–30": [], "31–60": [], "61–90": [], "90+": [] };
@@ -40,7 +40,7 @@ export default async function OpenInvoicesPage() {
     const bucketTotals = BUCKET_ORDER.map(b => ({
         label: b,
         count: byBucket[b].length,
-        total: byBucket[b].reduce((s, i) => s + i.balanceDue, 0),
+        total: byBucket[b].reduce((s, i) => s + Number(i.balanceDue), 0),
     }));
 
     const fmt = (n: number) => n.toLocaleString("en-US", { style: "currency", currency: "USD", minimumFractionDigits: 0 });
@@ -87,7 +87,7 @@ export default async function OpenInvoicesPage() {
                     <div key={bucket} className="hui-card overflow-hidden">
                         <div className="px-4 py-3 border-b border-hui-border bg-hui-surface">
                             <span className="text-sm font-semibold text-hui-textMain">{bucket} days</span>
-                            <span className="ml-2 text-sm text-hui-textMuted">({byBucket[bucket].length} invoices · {fmt(byBucket[bucket].reduce((s, i) => s + i.balanceDue, 0))})</span>
+                            <span className="ml-2 text-sm text-hui-textMuted">({byBucket[bucket].length} invoices · {fmt(byBucket[bucket].reduce((s, i) => s + Number(i.balanceDue), 0))})</span>
                         </div>
                         <table className="w-full text-sm">
                             <thead>
@@ -116,8 +116,8 @@ export default async function OpenInvoicesPage() {
                                         <td className="px-4 py-3 text-hui-textMuted">
                                             {inv.issueDate ? new Date(inv.issueDate).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" }) : "—"}
                                         </td>
-                                        <td className="px-4 py-3 text-right text-hui-textMain">{fmt(inv.totalAmount)}</td>
-                                        <td className="px-4 py-3 text-right font-semibold text-hui-textMain">{fmt(inv.balanceDue)}</td>
+                                        <td className="px-4 py-3 text-right text-hui-textMain">{fmt(Number(inv.totalAmount))}</td>
+                                        <td className="px-4 py-3 text-right font-semibold text-hui-textMain">{fmt(Number(inv.balanceDue))}</td>
                                         <td className="px-4 py-3">
                                             <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${inv.status === "Overdue" ? "bg-red-100 text-red-700" : "bg-yellow-100 text-yellow-700"}`}>
                                                 {inv.status}

--- a/src/app/reports/payments/page.tsx
+++ b/src/app/reports/payments/page.tsx
@@ -23,7 +23,7 @@ export default async function PaymentsReportPage() {
         orderBy: { paidAt: "desc" },
     });
 
-    const totalCollected = payments.reduce((sum, p) => sum + p.amount, 0);
+    const totalCollected = payments.reduce((sum, p) => sum + Number(p.amount), 0);
 
     // Group by month
     const byMonth: Record<string, typeof payments> = {};
@@ -68,7 +68,7 @@ export default async function PaymentsReportPage() {
                     <div key={month} className="hui-card overflow-hidden">
                         <div className="px-4 py-3 border-b border-hui-border bg-hui-surface flex items-center justify-between">
                             <span className="text-sm font-semibold text-hui-textMain">{month}</span>
-                            <span className="text-sm text-hui-textMuted">{fmt(byMonth[month].reduce((s, p) => s + p.amount, 0))}</span>
+                            <span className="text-sm text-hui-textMuted">{fmt(byMonth[month].reduce((s, p) => s + Number(p.amount), 0))}</span>
                         </div>
                         <table className="w-full text-sm">
                             <thead>
@@ -101,7 +101,7 @@ export default async function PaymentsReportPage() {
                                                 {paidDate ? new Date(paidDate).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" }) : "—"}
                                             </td>
                                             <td className="px-4 py-3 text-hui-textMuted capitalize">{p.paymentMethod ?? "—"}</td>
-                                            <td className="px-4 py-3 text-right font-semibold text-hui-textMain">{fmt(p.amount)}</td>
+                                            <td className="px-4 py-3 text-right font-semibold text-hui-textMain">{fmt(Number(p.amount))}</td>
                                         </tr>
                                     );
                                 })}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -27,7 +27,7 @@ export default function Sidebar({ logoUrl }: { logoUrl?: string }) {
                                 <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">Planning</h3>
                                 <ul className="space-y-2 text-sm">
                                     {can("contracts") && <li><Link href="/projects" className="hover:text-hui-primary block transition">All Contracts</Link></li>}
-                                    {can("estimates") && <li><Link href="/projects/all/estimates" className="hover:text-hui-primary block transition">All Estimates</Link></li>}
+                                    {can("estimates") && <li><Link href="/estimates" className="hover:text-hui-primary block transition">All Estimates</Link></li>}
                                     {can("takeoffs") && <li><Link href="/projects" className="hover:text-hui-primary block transition">All Takeoffs</Link></li>}
                                     {can("floorPlans") && <li><Link href="/projects" className="hover:text-hui-primary block transition">All 3D Floor Plans</Link></li>}
                                 </ul>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1641,7 +1641,7 @@ export async function deleteEstimate(estimateId: string) {
     } else if (estimate.leadId) {
         revalidatePath(`/leads/${estimate.leadId}`);
     } else {
-        revalidatePath("/projects/all/estimates");
+        revalidatePath("/estimates");
     }
     return { success: true };
 }
@@ -1985,7 +1985,7 @@ export async function sendEstimateToClient(estimateId: string, templateId?: stri
     // Revalidate paths
     if (estimate.projectId) revalidatePath(`/projects/${estimate.projectId}/estimates`);
     if (estimate.leadId) revalidatePath(`/leads/${estimate.leadId}`);
-    revalidatePath("/projects/all/estimates");
+    revalidatePath("/estimates");
 
     return { success: true, sentTo: recipientEmail };
 }


### PR DESCRIPTION
## Summary
- **Decimal arithmetic bugs**: 5 report/portal pages silently produced wrong currency values (`$0` or concatenated strings) because Prisma Decimal + number doesn't work in JS. Wrapped all with `Number()`.
- **Dead nav link**: Sidebar "All Estimates" pointed to `/projects/all/estimates` (404). Fixed to `/estimates`. Also fixed 2 `revalidatePath` calls to the same dead route.
- **Expanded E2E coverage**: Added 13 new test routes across quality-gate and new `coverage-expansion.spec.ts` — portal, sub-portal, project sub-pages (messages, settings, timeclock), lead sub-pages, company detail pages.

### Files fixed
| File | Fix |
|------|-----|
| `reports/global-tracker/page.tsx` | `Number()` on 3 Decimal reduces |
| `reports/payments/page.tsx` | `Number()` on amount fields |
| `reports/open-invoices/page.tsx` | `Number()` on balanceDue/totalAmount |
| `portal/page.tsx` | `Number()` on balanceDue |
| `projects/[id]/timeclock/page.tsx` | Convert hourlyRate Decimal before client |
| `Sidebar.tsx` | Dead link → `/estimates` |
| `actions.ts` | 2 revalidatePath calls fixed |

## Test plan
- [x] 105 passed, 3 skipped, 0 failures (local Playwright)
- [x] Global Tracker shows correct `$529,882.64` (was broken)
- [x] Chat bubble visible
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)