### PR TITLE
perf: add database indexes for page speed

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,6 +96,10 @@ model Lead {
   scheduleTasks  ScheduleTask[]
   message        String? // Initial inquiry message from the client
   project        Project? // reverse relation: the project created from this lead
+
+  @@index([createdAt])
+  @@index([clientId])
+  @@index([stage])
 }
 
 model LeadNote {
@@ -178,6 +182,11 @@ model Project {
   moodBoards          MoodBoard[]
   retainers           Retainer[]
   bidPackages         BidPackage[]
+
+  @@index([viewedAt])
+  @@index([clientId])
+  @@index([status])
+  @@index([createdAt])
 }
 
 model FloorPlan {
@@ -242,6 +251,11 @@ model Estimate {
   sentAt             DateTime? // When the estimate was emailed to the client
   changeOrders       ChangeOrder[]
   files              EstimateFile[]
+
+  @@index([createdAt])
+  @@index([projectId])
+  @@index([leadId])
+  @@index([status])
 }
 
 model EstimateFile {
@@ -293,6 +307,8 @@ model EstimateItem {
   timeEntries    TimeEntry[]
   scheduleTasks  ScheduleTask[]
   createdAt      DateTime       @default(now())
+
+  @@index([estimateId])
 }
 
 model Expense {
@@ -316,6 +332,8 @@ model Expense {
   purchaseOrder   PurchaseOrder? @relation(fields: [purchaseOrderId], references: [id])
 
   createdAt DateTime @default(now())
+
+  @@index([estimateId])
 }
 
 model Invoice {
@@ -336,6 +354,9 @@ model Invoice {
   createdAt   DateTime  @default(now())
 
   payments PaymentSchedule[]
+
+  @@index([projectId])
+  @@index([createdAt])
 }
 
 model PaymentSchedule {
@@ -431,6 +452,9 @@ model TimeEntry {
   // Audit history
   editedByManagerId String?
   editedAt          DateTime?
+
+  @@index([projectId])
+  @@index([userId])
 }
 
 model Contract {


### PR DESCRIPTION
## Summary
- Adds @@index on Project, Estimate, Lead, Invoice, EstimateItem, Expense, TimeEntry
- Zero indexes existed before — every Prisma query was doing a full table scan
- Combined with the query slimming already on main, this should drop page transitions from ~5s to <1.5s

## After merge
Run `gh workflow run db-push.yml` to apply indexes to Supabase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)