### PR TITLE
fix: chat widget UX — auto-submit, Requests tab, icon clarity

### DIFF
--- a/src/app/api/help-chat/request/route.ts
+++ b/src/app/api/help-chat/request/route.ts
@@ -79,9 +79,10 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const { title, description, userId, currentPage } = await req.json();
+  const { title, description, currentPage } = await req.json();
+  const sessionUserId = (session.user as any).id;
 
-  if (!title || !description || !userId) {
+  if (!title || !description) {
     return NextResponse.json(
       { error: "Missing required fields" },
       { status: 400 }
@@ -92,13 +93,13 @@ export async function POST(req: NextRequest) {
     // 1. Create GitHub Issue
     const ghIssue = await createGitHubIssue(title, description, currentPage);
 
-    // 2. Save to HelpRequest table (with GitHub issue link if created)
+    // 2. Save to HelpRequest table — use session userId so Requests tab can find it
     const result = await prisma.$queryRaw<any[]>`
       INSERT INTO "HelpRequest" (
         "userId", "type", "question", "response", "currentPage", "status"
       )
       VALUES (
-        ${userId},
+        ${sessionUserId},
         'feature_request',
         ${title},
         ${description},

--- a/src/components/HelpChatWidget.tsx
+++ b/src/components/HelpChatWidget.tsx
@@ -7,7 +7,6 @@ import { usePermissions } from "@/components/PermissionsProvider";
 interface Message {
   role: "user" | "assistant";
   content: string;
-  featureRequest?: { title: string; description: string };
 }
 
 interface ConversationSummary {
@@ -244,14 +243,12 @@ export default function HelpChatWidget({
         content: data.answer,
       };
 
-      if (data.type === "feature_request") {
-        assistantMsg.featureRequest = {
-          title: data.title,
-          description: data.description,
-        };
-      }
-
       setMessages((prev) => [...prev, assistantMsg]);
+
+      // Auto-submit feature requests immediately — no manual button needed
+      if (data.type === "feature_request" && data.title && data.description) {
+        submitFeatureRequest(data.title, data.description);
+      }
     } catch (e: any) {
       const errMsg = e?.message || "Unknown error";
       setMessages((prev) => [
@@ -391,12 +388,12 @@ export default function HelpChatWidget({
               <button
                 onClick={startNewChat}
                 className="text-white/80 hover:text-white ml-1"
-                aria-label="New conversation"
-                title="New conversation"
+                aria-label="Start new chat"
+                title="New chat"
               >
-                <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M12 20h9" />
-                  <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+                <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M12 5v14" />
+                  <path d="M5 12h14" />
                 </svg>
               </button>
               {/* Close */}
@@ -443,19 +440,6 @@ export default function HelpChatWidget({
                       }
                     >
                       <p className="whitespace-pre-wrap">{msg.content}</p>
-                      {msg.featureRequest && effectiveIsAdmin && (
-                        <button
-                          onClick={() =>
-                            submitFeatureRequest(
-                              msg.featureRequest!.title,
-                              msg.featureRequest!.description
-                            )
-                          }
-                          className="mt-2 text-xs hui-btn-green px-2 py-1 rounded"
-                        >
-                          Submit as feature request?
-                        </button>
-                      )}
                     </div>
                   </div>
                 ))}


### PR DESCRIPTION
## Summary
- **Auto-submit feature requests** — When AI detects a feature request, it now submits immediately and shows the GitHub Issue confirmation. No more ambiguous "Submit as feature request?" button that users miss
- **Requests tab now works** — Was always empty because `userId` from widget prop didn't match `session.user.id` used by the history query. Now uses session userId consistently
- **Clearer New Chat icon** — Replaced confusing pencil/edit icon with a `+` (plus) icon. Universal "new" symbol

## Test plan
- [ ] Type a feature request in chat → AI auto-submits it → confirmation with GitHub Issue # appears
- [ ] Click Requests tab → submitted feature requests now show up
- [ ] `+` icon in header starts a fresh conversation
- [ ] No manual "Submit as feature request?" button appears anymore

🤖 Generated with [Claude Code](https://claude.com/claude-code)