### PR TITLE
impl(PB-health-001): Add GET /api/health endpoint

### DIFF
--- a/.specs/PB-health-001-health-endpoint.md
+++ b/.specs/PB-health-001-health-endpoint.md
@@ -1,0 +1,38 @@
+# Spec: Add /api/health endpoint
+
+**ID:** PB-health-001
+**Date:** 2026-04-09
+**Status:** draft
+
+## Context
+ProBuild has no health-check endpoint. Vercel deployment checks and external uptime monitors (e.g., BetterUptime, UptimeRobot) need a lightweight, unauthenticated URL to probe. Without one, we rely on loading the full home page to detect outages, which is slow and brittle.
+
+## Goals
+1. `GET /api/health` returns HTTP 200 with JSON body `{ "status": "ok", "ts": "<ISO 8601 timestamp>" }`.
+2. The endpoint requires no authentication.
+3. Response time is under 50ms (no database or external calls).
+
+## Non-Goals
+- Deep health checks (database connectivity, third-party service status).
+- Readiness vs. liveness distinction -- a single endpoint is sufficient for now.
+- Rate limiting or caching headers.
+
+## Approach
+Create a Next.js App Router route handler at `src/app/api/health/route.ts`. Export a single `GET` function that returns `NextResponse.json({ status: "ok", ts: new Date().toISOString() })`. No middleware, no auth, no database access. Mark the route as `dynamic = "force-dynamic"` so Vercel never caches a stale timestamp.
+
+## Files Touched
+- `src/app/api/health/route.ts` (new)
+
+## Data Model Changes
+None
+
+## Test Plan
+1. Run `curl http://localhost:3000/api/health` and confirm HTTP 200 with the expected JSON shape.
+2. Verify `ts` is a valid ISO 8601 string within a few seconds of the request time.
+3. After deploy, hit `https://probuild.vercel.app/api/health` and confirm the same.
+
+## Rollback Plan
+Delete `src/app/api/health/route.ts` and redeploy. No migrations or state to revert.
+
+## Open Questions
+None -- this is self-contained.

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json({ status: "ok", ts: new Date().toISOString() });
+}


### PR DESCRIPTION
## Summary
- Creates `src/app/api/health/route.ts` with a single `GET` handler
- Returns HTTP 200 with `{ status: "ok", ts: <ISO 8601 timestamp> }`
- No authentication, no database calls, marked `force-dynamic` to prevent stale caching

## Test plan
- [ ] `curl http://localhost:3000/api/health` returns HTTP 200 with correct JSON shape
- [ ] `ts` field is a valid ISO 8601 string within a few seconds of request time
- [ ] After Vercel deploy, `https://probuild.vercel.app/api/health` returns the same

Implements spec: `.specs/PB-health-001-health-endpoint.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)