### PR TITLE
fix(payments): validate selectedMethod against CompanySettings

### DIFF
--- a/src/app/api/payments/create-session/route.ts
+++ b/src/app/api/payments/create-session/route.ts
@@ -28,6 +28,21 @@ export async function POST(req: Request) {
             : (await prisma.paymentSchedule.findUnique({ where: { id: paymentScheduleId }, select: { amount: true } }))?.amount?.toString() || "0";
         const idempotencyKey = `pay-session:${paymentScheduleId}:${selectedMethod || "default"}:${scheduleAmount}`;
 
+        // Validate selectedMethod is enabled in company settings
+        if (selectedMethod && typeof selectedMethod !== "string") {
+            return new NextResponse("Invalid selectedMethod", { status: 400 });
+        }
+        if (selectedMethod) {
+            const methodAllowed =
+                (selectedMethod === "card" && settings?.enableCard !== false) ||
+                (selectedMethod === "us_bank_account" && settings?.enableBankTransfer === true) ||
+                (selectedMethod === "affirm" && settings?.enableAffirm === true) ||
+                (selectedMethod === "klarna" && settings?.enableKlarna === true);
+            if (!methodAllowed) {
+                return new NextResponse(`Payment method "${selectedMethod}" is not enabled`, { status: 400 });
+            }
+        }
+
         // Build payment method types
         const paymentMethodTypes: any[] = [];
         if (selectedMethod) {

--- a/src/components/PortalPayInFullButton.tsx
+++ b/src/components/PortalPayInFullButton.tsx
@@ -59,7 +59,7 @@ export default function PortalPayInFullButton({
             <div className="border border-indigo-200 rounded-lg bg-indigo-50 px-6 py-5 flex flex-wrap items-center justify-between gap-4">
                 <div>
                     <p className="text-sm font-semibold text-indigo-900">Ready to pay?</p>
-                    <p className="text-xs text-indigo-700 mt-0.5">Secure checkout via Stripe — card or bank transfer accepted.</p>
+                    <p className="text-xs text-indigo-700 mt-0.5">Secure checkout via Stripe — card payment accepted.</p>
                 </div>
                 <div className="flex items-center gap-4">
                     <span className="text-lg font-bold text-indigo-900">{formatCurrency(displayAmount)}</span>


### PR DESCRIPTION
## Summary
- Server-side validation: when a client POSTs `selectedMethod` to `/api/payments/create-session`, it's now checked against the company's `CompanySettings` flags before the Stripe session is created — bypassing a disabled method returns 400
- Non-string `selectedMethod` values get an explicit 400 guard before comparison
- Fixed `PortalPayInFullButton` copy from "card or bank transfer accepted" → "card payment accepted" (the flow is card-only)

## Test plan
- [ ] POST `selectedMethod: "card"` when `enableCard: false` → expect 400
- [ ] POST `selectedMethod: "us_bank_account"` when `enableBankTransfer: false` → expect 400
- [ ] POST with no `selectedMethod` → settings-driven method list, unaffected
- [ ] POST with a non-string `selectedMethod` → 400
- [ ] Normal card payment flow → unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)