### PR TITLE
feat(mobile-api): backend endpoints for mobile app integration (W4)

### DIFF
--- a/MOBILE_API_NOTES.md
+++ b/MOBILE_API_NOTES.md
@@ -1,0 +1,195 @@
+# Mobile API endpoints — W4
+
+Backfill endpoints for the gtr-probuild-mobile cutover. All routes accept either:
+
+- **Mobile JWT** — `Authorization: Bearer <token>` (issued by `/api/mobile/login` or `/api/mobile/google-login`, signed with `NEXTAUTH_SECRET`).
+- **Web session** — NextAuth cookie (so the same routes back the web UI).
+
+`assertProjectAccess` checks: ADMIN/MANAGER pass through; everyone else needs a `ProjectAccess` row, a `Project.crew` assignment, or `permissions.canAccessProject`. Manager-only routes use `userHasRole(user, ["ADMIN", "MANAGER"])`. Employee role/rate edits require ADMIN.
+
+> Set `TOKEN=<jwt>` and `BASE=https://probuild.goldentouchremodeling.com` (or `http://localhost:3000`) before pasting these.
+
+---
+
+## 1. `PATCH /api/time-entries/[id]` — edit past entry with reason
+**Auth:** owner OR ADMIN/MANAGER. **Body:** `{ startTime?, endTime?, editNotes }`. Snapshots originals on first edit, recomputes labor/burden from the **owner's** rates, sets `editedByManagerId`/`editedAt` when a manager edits someone else's entry.
+
+```bash
+curl -s -X PATCH "$BASE/api/time-entries/te_abc123" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"startTime":"2026-04-28T08:00:00Z","endTime":"2026-04-28T16:30:00Z","editNotes":"Forgot to clock out"}'
+```
+```json
+{
+  "id": "te_abc123",
+  "startTime": "2026-04-28T08:00:00.000Z",
+  "endTime": "2026-04-28T16:30:00.000Z",
+  "durationHours": 8.5,
+  "laborCost": "297.50",
+  "burdenCost": "85.00",
+  "isEdited": true,
+  "originalStartTime": "2026-04-28T08:00:00.000Z",
+  "originalEndTime": "2026-04-28T17:00:00.000Z",
+  "editNotes": "Forgot to clock out",
+  "editedByManagerId": null,
+  "editedAt": null
+}
+```
+
+## 2. `DELETE /api/time-entries/[id]` — manager-only
+**Auth:** ADMIN/MANAGER. Cascade handled by Prisma `onDelete`.
+
+```bash
+curl -s -X DELETE "$BASE/api/time-entries/te_abc123" \
+  -H "Authorization: Bearer $TOKEN"
+```
+```json
+{ "ok": true }
+```
+
+## 3. `GET /api/manager/dashboard`
+**Auth:** ADMIN/MANAGER. Returns active workers, week-to-date labor + burden (cents), geofence violations this ISO week (Mon–Sun), and the 25 most recent edited entries.
+
+```bash
+curl -s "$BASE/api/manager/dashboard" \
+  -H "Authorization: Bearer $TOKEN"
+```
+```json
+{
+  "activeWorkers": [
+    {
+      "id": "te_111",
+      "userId": "u_222",
+      "projectId": "p_333",
+      "startTime": "2026-04-29T13:05:00.000Z",
+      "user": { "id": "u_222", "name": "Sam Rivera", "email": "sam@example.com", "role": "FIELD_CREW" },
+      "project": { "id": "p_333", "name": "Smith Kitchen", "location": "123 Main St" }
+    }
+  ],
+  "weeklyLaborCents": 482350,
+  "weeklyBurdenCents": 137800,
+  "geofenceViolationsThisWeek": 2,
+  "recentEdits": []
+}
+```
+
+## 4. `GET /api/manager/jobs` + `POST /api/manager/jobs` + `PATCH /api/manager/jobs/[id]`
+**Auth:** ADMIN/MANAGER. Wraps `Project`. `address` maps to `Project.location`.
+
+```bash
+# list
+curl -s "$BASE/api/manager/jobs?status=In%20Progress" \
+  -H "Authorization: Bearer $TOKEN"
+
+# create
+curl -s -X POST "$BASE/api/manager/jobs" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Smith Kitchen","clientId":"cl_xyz","address":"123 Main St","locationLat":47.6062,"locationLng":-122.3321,"geofenceRadiusMeters":150}'
+
+# update
+curl -s -X PATCH "$BASE/api/manager/jobs/p_333" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"status":"Closed","geofenceRadiusMeters":200}'
+```
+```json
+{
+  "id": "p_333",
+  "name": "Smith Kitchen",
+  "clientId": "cl_xyz",
+  "location": "123 Main St",
+  "locationLat": 47.6062,
+  "locationLng": -122.3321,
+  "geofenceRadiusMeters": 150,
+  "status": "In Progress",
+  "client": { "id": "cl_xyz", "name": "Jane Smith", "companyName": null }
+}
+```
+
+## 5. `GET /api/manager/employees` + `PATCH /api/manager/employees/[id]`
+**Auth:** GET — ADMIN/MANAGER. PATCH — ADMIN only (role + rate + status). `hourlyRate`/`burdenRate` accept numeric strings (parsed via `new Prisma.Decimal(...)`).
+
+```bash
+curl -s "$BASE/api/manager/employees" \
+  -H "Authorization: Bearer $TOKEN"
+
+curl -s -X PATCH "$BASE/api/manager/employees/u_222" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"role":"FIELD_CREW","hourlyRate":"35.00","burdenRate":"10.00"}'
+```
+```json
+{
+  "id": "u_222",
+  "email": "sam@example.com",
+  "name": "Sam Rivera",
+  "role": "FIELD_CREW",
+  "status": "ACTIVATED",
+  "hourlyRate": "35",
+  "burdenRate": "10"
+}
+```
+
+## 6. `GET /api/projects/[id]/tasks`
+**Auth:** project access (manager or assigned). Includes `assignments`, `punchItems`, `dependencies`.
+
+```bash
+curl -s "$BASE/api/projects/p_333/tasks" \
+  -H "Authorization: Bearer $TOKEN"
+```
+```json
+[
+  {
+    "id": "t_aa",
+    "name": "Demo cabinets",
+    "status": "In Progress",
+    "progress": 40,
+    "startDate": "2026-04-25T00:00:00.000Z",
+    "endDate": "2026-04-29T00:00:00.000Z",
+    "assignments": [],
+    "punchItems": [
+      { "id": "pi_1", "name": "Photo of removed sink", "completed": false, "photoUrl": null }
+    ],
+    "dependencies": []
+  }
+]
+```
+
+## 7. `PATCH /api/tasks/[id]/progress`
+**Auth:** project access. `progress` 0–100. Auto-flips `status = "Complete"` at 100.
+
+```bash
+curl -s -X PATCH "$BASE/api/tasks/t_aa/progress" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"progress":100}'
+```
+```json
+{ "id": "t_aa", "progress": 100, "status": "Complete" }
+```
+
+## 8. `POST /api/tasks/[id]/punch-items/[itemId]/complete`
+**Auth:** project access. Sets `completed = true` and stores `photoUrl` if provided.
+
+```bash
+curl -s -X POST "$BASE/api/tasks/t_aa/punch-items/pi_1/complete" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"photoUrl":"https://storage/.../photo.jpg"}'
+```
+```json
+{ "id": "pi_1", "completed": true, "photoUrl": "https://storage/.../photo.jpg" }
+```
+
+---
+
+## Auth helper notes (`src/lib/mobile-auth.ts`)
+
+- `authenticateMobileOrSession(req)` — verifies `Bearer` JWT (`jose.jwtVerify` with HS256 + `NEXTAUTH_SECRET`); falls back to NextAuth `getServerSession`. Returns `{ user }` or `{ error: NextResponse }`. Disabled users (`status === "DISABLED"`) are rejected.
+- `authenticateMobileOnly(req)` — JWT only.
+- `userHasRole(user, roles)` — exact role match.
+- `assertProjectAccess(user, projectId)` — ADMIN/MANAGER pass; otherwise checks `ProjectAccess` row, then `Project.crew` membership; returns `null` (ok) or a `NextResponse` error.
+
+The legacy `Bearer <user-id>` pattern in `src/app/api/time-entries/route.ts` (GET/POST/PUT) is **not** changed by this PR — that's a W1 task. The new routes here use the proper signed-JWT pattern.

--- a/src/app/api/manager/dashboard/route.ts
+++ b/src/app/api/manager/dashboard/route.ts
@@ -1,0 +1,87 @@
+export const dynamic = 'force-dynamic';
+import { NextRequest, NextResponse } from "next/server";
+import { startOfWeek, endOfWeek } from "date-fns";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { authenticateMobileOrSession, userHasRole } from "@/lib/mobile-auth";
+
+const HUNDRED = new Prisma.Decimal(100);
+
+/**
+ * Manager dashboard payload. Replaces ~4 separate Supabase queries the
+ * mobile app used to make. Returns:
+ *  - activeWorkers:                TimeEntry[]   (entries with endTime IS NULL)
+ *  - weeklyLaborCents:             number        (sum laborCost * 100, current ISO week Mon–Sun)
+ *  - weeklyBurdenCents:            number        (sum burdenCost * 100, same window)
+ *  - geofenceViolationsThisWeek:   number        (count where isOffsite = true, same window)
+ *  - recentEdits:                  TimeEntry[]   (last 25 entries with isEdited = true)
+ */
+export async function GET(req: NextRequest) {
+    const auth = await authenticateMobileOrSession(req);
+    if ("error" in auth) return auth.error;
+    const { user } = auth;
+
+    if (!userHasRole(user, ["ADMIN", "MANAGER"])) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const now = new Date();
+    const weekStart = startOfWeek(now, { weekStartsOn: 1 });
+    const weekEnd = endOfWeek(now, { weekStartsOn: 1 });
+
+    const [activeWorkers, weeklyEntries, geofenceViolationsThisWeek, recentEdits] =
+        await Promise.all([
+            prisma.timeEntry.findMany({
+                where: { endTime: null },
+                include: {
+                    user: { select: { id: true, name: true, email: true, role: true } },
+                    project: { select: { id: true, name: true, location: true } },
+                    costCode: { select: { id: true, code: true, name: true } },
+                },
+                orderBy: { startTime: "desc" },
+            }),
+            prisma.timeEntry.findMany({
+                where: {
+                    startTime: { gte: weekStart, lte: weekEnd },
+                    endTime: { not: null },
+                },
+                select: { laborCost: true, burdenCost: true },
+            }),
+            prisma.timeEntry.count({
+                where: {
+                    isOffsite: true,
+                    startTime: { gte: weekStart, lte: weekEnd },
+                },
+            }),
+            prisma.timeEntry.findMany({
+                where: { isEdited: true },
+                include: {
+                    user: { select: { id: true, name: true, email: true } },
+                    project: { select: { id: true, name: true } },
+                },
+                orderBy: { editedAt: "desc" },
+                take: 25,
+            }),
+        ]);
+
+    let laborSum = new Prisma.Decimal(0);
+    let burdenSum = new Prisma.Decimal(0);
+    for (const entry of weeklyEntries) {
+        if (entry.laborCost) laborSum = laborSum.plus(entry.laborCost);
+        if (entry.burdenCost) burdenSum = burdenSum.plus(entry.burdenCost);
+    }
+    const weeklyLaborCents = laborSum.mul(HUNDRED).toDecimalPlaces(0).toNumber();
+    const weeklyBurdenCents = burdenSum.mul(HUNDRED).toDecimalPlaces(0).toNumber();
+
+    return NextResponse.json(
+        JSON.parse(
+            JSON.stringify({
+                activeWorkers,
+                weeklyLaborCents,
+                weeklyBurdenCents,
+                geofenceViolationsThisWeek,
+                recentEdits,
+            }),
+        ),
+    );
+}

--- a/src/app/api/manager/employees/[id]/route.ts
+++ b/src/app/api/manager/employees/[id]/route.ts
@@ -1,0 +1,103 @@
+export const dynamic = 'force-dynamic';
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { authenticateMobileOrSession, userHasRole } from "@/lib/mobile-auth";
+
+type Params = { params: Promise<{ id: string }> };
+
+const ALLOWED_ROLES = new Set(["ADMIN", "MANAGER", "FIELD_CREW", "FINANCE"]);
+const ALLOWED_STATUSES = new Set(["PENDING", "ACTIVATED", "DISABLED"]);
+
+const MAX_RATE = new Prisma.Decimal("100000"); // sanity ceiling, $100k/hr is plenty
+
+function parseDecimal(value: unknown, field: string): Prisma.Decimal | null | undefined | { error: string } {
+    if (value === undefined) return undefined;
+    if (value === null) return null;
+    if (typeof value !== "string" && typeof value !== "number") {
+        return { error: `${field} must be a number or numeric string` };
+    }
+    if (typeof value === "number" && !Number.isFinite(value)) {
+        return { error: `${field} must be finite` };
+    }
+    try {
+        const dec = new Prisma.Decimal(typeof value === "number" ? value.toString() : value);
+        if (!dec.isFinite()) return { error: `${field} must be finite` };
+        if (dec.isNegative()) return { error: `${field} must be >= 0` };
+        if (dec.greaterThan(MAX_RATE)) return { error: `${field} exceeds maximum allowed` };
+        return dec;
+    } catch {
+        return { error: `${field} is not a valid decimal` };
+    }
+}
+
+/** ADMIN-only edits to role + rates + status. */
+export async function PATCH(req: NextRequest, { params }: Params) {
+    const auth = await authenticateMobileOrSession(req);
+    if ("error" in auth) return auth.error;
+    const { user } = auth;
+    if (!userHasRole(user, ["ADMIN"])) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { id } = await params;
+    const body = await req.json().catch(() => null);
+    if (!body || typeof body !== "object") {
+        return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const existing = await prisma.user.findUnique({ where: { id } });
+    if (!existing) {
+        return NextResponse.json({ error: "Employee not found" }, { status: 404 });
+    }
+
+    const { role, hourlyRate, burdenRate, status } = body as {
+        role?: string;
+        hourlyRate?: string | number | null;
+        burdenRate?: string | number | null;
+        status?: string;
+    };
+
+    const data: Prisma.UserUpdateInput = {};
+
+    if (role !== undefined) {
+        if (typeof role !== "string" || !ALLOWED_ROLES.has(role)) {
+            return NextResponse.json({ error: `Invalid role: ${role}` }, { status: 400 });
+        }
+        data.role = role;
+    }
+    if (status !== undefined) {
+        if (typeof status !== "string" || !ALLOWED_STATUSES.has(status)) {
+            return NextResponse.json({ error: `Invalid status: ${status}` }, { status: 400 });
+        }
+        data.status = status;
+    }
+
+    const hourly = parseDecimal(hourlyRate, "hourlyRate");
+    if (hourly && typeof hourly === "object" && "error" in hourly) {
+        return NextResponse.json({ error: hourly.error }, { status: 400 });
+    }
+    if (hourly !== undefined) data.hourlyRate = hourly ?? new Prisma.Decimal(0);
+
+    const burden = parseDecimal(burdenRate, "burdenRate");
+    if (burden && typeof burden === "object" && "error" in burden) {
+        return NextResponse.json({ error: burden.error }, { status: 400 });
+    }
+    if (burden !== undefined) data.burdenRate = burden ?? new Prisma.Decimal(0);
+
+    const updated = await prisma.user.update({
+        where: { id },
+        data,
+        select: {
+            id: true,
+            email: true,
+            name: true,
+            role: true,
+            status: true,
+            hourlyRate: true,
+            burdenRate: true,
+        },
+    });
+
+    return NextResponse.json(JSON.parse(JSON.stringify(updated)));
+}

--- a/src/app/api/manager/employees/route.ts
+++ b/src/app/api/manager/employees/route.ts
@@ -1,0 +1,29 @@
+export const dynamic = 'force-dynamic';
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { authenticateMobileOrSession, userHasRole } from "@/lib/mobile-auth";
+
+export async function GET(req: NextRequest) {
+    const auth = await authenticateMobileOrSession(req);
+    if ("error" in auth) return auth.error;
+    const { user } = auth;
+    if (!userHasRole(user, ["ADMIN", "MANAGER"])) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const employees = await prisma.user.findMany({
+        select: {
+            id: true,
+            email: true,
+            name: true,
+            role: true,
+            status: true,
+            hourlyRate: true,
+            burdenRate: true,
+            invitedAt: true,
+        },
+        orderBy: [{ status: "asc" }, { name: "asc" }],
+    });
+
+    return NextResponse.json(JSON.parse(JSON.stringify(employees)));
+}

--- a/src/app/api/manager/jobs/[id]/route.ts
+++ b/src/app/api/manager/jobs/[id]/route.ts
@@ -1,0 +1,85 @@
+export const dynamic = 'force-dynamic';
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { authenticateMobileOrSession, userHasRole } from "@/lib/mobile-auth";
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function PATCH(req: NextRequest, { params }: Params) {
+    const auth = await authenticateMobileOrSession(req);
+    if ("error" in auth) return auth.error;
+    const { user } = auth;
+    if (!userHasRole(user, ["ADMIN", "MANAGER"])) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { id } = await params;
+    const body = await req.json().catch(() => null);
+    if (!body || typeof body !== "object") {
+        return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const existing = await prisma.project.findUnique({ where: { id } });
+    if (!existing) {
+        return NextResponse.json({ error: "Project not found" }, { status: 404 });
+    }
+
+    const {
+        name,
+        address,
+        locationLat,
+        locationLng,
+        geofenceRadiusMeters,
+        status,
+    } = body as {
+        name?: string;
+        address?: string | null;
+        locationLat?: number | null;
+        locationLng?: number | null;
+        geofenceRadiusMeters?: number | null;
+        status?: string;
+    };
+
+    if (locationLat !== undefined && locationLat !== null) {
+        if (!Number.isFinite(locationLat) || locationLat < -90 || locationLat > 90) {
+            return NextResponse.json({ error: "locationLat must be between -90 and 90" }, { status: 400 });
+        }
+    }
+    if (locationLng !== undefined && locationLng !== null) {
+        if (!Number.isFinite(locationLng) || locationLng < -180 || locationLng > 180) {
+            return NextResponse.json({ error: "locationLng must be between -180 and 180" }, { status: 400 });
+        }
+    }
+    if (geofenceRadiusMeters !== undefined && geofenceRadiusMeters !== null) {
+        if (
+            !Number.isFinite(geofenceRadiusMeters) ||
+            !Number.isInteger(geofenceRadiusMeters) ||
+            geofenceRadiusMeters <= 0
+        ) {
+            return NextResponse.json(
+                { error: "geofenceRadiusMeters must be a positive integer" },
+                { status: 400 },
+            );
+        }
+    }
+
+    const data: Prisma.ProjectUpdateInput = {};
+    if (typeof name === "string" && name.trim()) data.name = name.trim();
+    if (address !== undefined) data.location = address;
+    if (locationLat !== undefined) data.locationLat = locationLat;
+    if (locationLng !== undefined) data.locationLng = locationLng;
+    if (geofenceRadiusMeters !== undefined) data.geofenceRadiusMeters = geofenceRadiusMeters;
+    if (typeof status === "string" && status.trim()) data.status = status;
+
+    const project = await prisma.project.update({
+        where: { id },
+        data,
+        include: {
+            client: { select: { id: true, name: true, companyName: true } },
+            manager: { select: { id: true, name: true, email: true } },
+        },
+    });
+
+    return NextResponse.json(JSON.parse(JSON.stringify(project)));
+}

--- a/src/app/api/manager/jobs/route.ts
+++ b/src/app/api/manager/jobs/route.ts
@@ -1,0 +1,118 @@
+export const dynamic = 'force-dynamic';
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { authenticateMobileOrSession, userHasRole } from "@/lib/mobile-auth";
+
+function validateGeofence(
+    lat: number | undefined,
+    lng: number | undefined,
+    radius: number | undefined,
+): string | null {
+    if (lat !== undefined) {
+        if (!Number.isFinite(lat) || lat < -90 || lat > 90) {
+            return "locationLat must be between -90 and 90";
+        }
+    }
+    if (lng !== undefined) {
+        if (!Number.isFinite(lng) || lng < -180 || lng > 180) {
+            return "locationLng must be between -180 and 180";
+        }
+    }
+    if (radius !== undefined) {
+        if (!Number.isFinite(radius) || !Number.isInteger(radius) || radius <= 0) {
+            return "geofenceRadiusMeters must be a positive integer";
+        }
+    }
+    return null;
+}
+
+export async function GET(req: NextRequest) {
+    const auth = await authenticateMobileOrSession(req);
+    if ("error" in auth) return auth.error;
+    const { user } = auth;
+    if (!userHasRole(user, ["ADMIN", "MANAGER"])) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const status = searchParams.get("status");
+
+    const where: Prisma.ProjectWhereInput = {};
+    if (status) where.status = status;
+
+    const projects = await prisma.project.findMany({
+        where,
+        include: {
+            client: { select: { id: true, name: true, companyName: true } },
+            manager: { select: { id: true, name: true, email: true } },
+        },
+        orderBy: { createdAt: "desc" },
+    });
+
+    return NextResponse.json(JSON.parse(JSON.stringify(projects)));
+}
+
+export async function POST(req: NextRequest) {
+    const auth = await authenticateMobileOrSession(req);
+    if ("error" in auth) return auth.error;
+    const { user } = auth;
+    if (!userHasRole(user, ["ADMIN", "MANAGER"])) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const body = await req.json().catch(() => null);
+    if (!body || typeof body !== "object") {
+        return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const {
+        name,
+        clientId,
+        address,
+        locationLat,
+        locationLng,
+        geofenceRadiusMeters,
+    } = body as {
+        name?: string;
+        clientId?: string;
+        address?: string;
+        locationLat?: number;
+        locationLng?: number;
+        geofenceRadiusMeters?: number;
+    };
+
+    if (!name || typeof name !== "string" || !name.trim()) {
+        return NextResponse.json({ error: "name is required" }, { status: 400 });
+    }
+    if (!clientId || typeof clientId !== "string") {
+        return NextResponse.json({ error: "clientId is required" }, { status: 400 });
+    }
+
+    const geofenceError = validateGeofence(locationLat, locationLng, geofenceRadiusMeters);
+    if (geofenceError) {
+        return NextResponse.json({ error: geofenceError }, { status: 400 });
+    }
+
+    const client = await prisma.client.findUnique({ where: { id: clientId } });
+    if (!client) {
+        return NextResponse.json({ error: "Client not found" }, { status: 400 });
+    }
+
+    const project = await prisma.project.create({
+        data: {
+            name: name.trim(),
+            clientId,
+            location: address ?? undefined,
+            locationLat: typeof locationLat === "number" ? locationLat : undefined,
+            locationLng: typeof locationLng === "number" ? locationLng : undefined,
+            geofenceRadiusMeters:
+                typeof geofenceRadiusMeters === "number" ? geofenceRadiusMeters : undefined,
+        },
+        include: {
+            client: { select: { id: true, name: true, companyName: true } },
+        },
+    });
+
+    return NextResponse.json(JSON.parse(JSON.stringify(project)));
+}

--- a/src/app/api/mobile/login/route.ts
+++ b/src/app/api/mobile/login/route.ts
@@ -2,10 +2,10 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { SignJWT } from "jose";
 import bcrypt from "bcryptjs";
+import { MOBILE_TOKEN_TYPE, getMobileJwtSecret } from "@/lib/mobile-auth";
 
 export const dynamic = 'force-dynamic';
 
-const JWT_SECRET = new TextEncoder().encode(process.env.NEXTAUTH_SECRET);
 const TOKEN_EXPIRY = "24h";
 
 export async function POST(req: Request) {
@@ -27,11 +27,12 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Invalid email or PIN" }, { status: 401 });
         }
 
-        const token = await new SignJWT({ sub: user.id, role: user.role })
+        const token = await new SignJWT({ role: user.role, typ: MOBILE_TOKEN_TYPE })
             .setProtectedHeader({ alg: "HS256" })
+            .setSubject(user.id)
             .setIssuedAt()
             .setExpirationTime(TOKEN_EXPIRY)
-            .sign(JWT_SECRET);
+            .sign(getMobileJwtSecret());
 
         return NextResponse.json({
             user: {

--- a/src/app/api/projects/[id]/tasks/route.ts
+++ b/src/app/api/projects/[id]/tasks/route.ts
@@ -1,0 +1,34 @@
+export const dynamic = 'force-dynamic';
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { authenticateMobileOrSession, assertProjectAccess } from "@/lib/mobile-auth";
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(req: NextRequest, { params }: Params) {
+    const auth = await authenticateMobileOrSession(req);
+    if ("error" in auth) return auth.error;
+    const { user } = auth;
+
+    const { id: projectId } = await params;
+    const projectError = await assertProjectAccess(user, projectId);
+    if (projectError) return projectError;
+
+    const tasks = await prisma.scheduleTask.findMany({
+        where: { projectId },
+        include: {
+            assignments: {
+                include: { user: { select: { id: true, name: true, email: true } } },
+            },
+            punchItems: { orderBy: { order: "asc" } },
+            dependencies: {
+                include: {
+                    predecessor: { select: { id: true, name: true, status: true } },
+                },
+            },
+        },
+        orderBy: [{ order: "asc" }, { startDate: "asc" }],
+    });
+
+    return NextResponse.json(JSON.parse(JSON.stringify(tasks)));
+}

--- a/src/app/api/tasks/[id]/progress/route.ts
+++ b/src/app/api/tasks/[id]/progress/route.ts
@@ -1,0 +1,65 @@
+export const dynamic = 'force-dynamic';
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { authenticateMobileOrSession, assertProjectAccess } from "@/lib/mobile-auth";
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function PATCH(req: NextRequest, { params }: Params) {
+    const auth = await authenticateMobileOrSession(req);
+    if ("error" in auth) return auth.error;
+    const { user } = auth;
+
+    const { id } = await params;
+    const body = await req.json().catch(() => null);
+    if (!body || typeof body !== "object") {
+        return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const { progress, status } = body as { progress?: number; status?: string };
+
+    if (progress !== undefined) {
+        if (typeof progress !== "number" || !Number.isFinite(progress)) {
+            return NextResponse.json({ error: "progress must be a number" }, { status: 400 });
+        }
+        if (progress < 0 || progress > 100) {
+            return NextResponse.json({ error: "progress must be 0–100" }, { status: 400 });
+        }
+    }
+
+    const task = await prisma.scheduleTask.findUnique({
+        where: { id },
+        select: { id: true, projectId: true },
+    });
+    if (!task) return NextResponse.json({ error: "Task not found" }, { status: 404 });
+    if (!task.projectId) {
+        return NextResponse.json({ error: "Task is not linked to a project" }, { status: 400 });
+    }
+
+    const projectError = await assertProjectAccess(user, task.projectId);
+    if (projectError) return projectError;
+
+    const data: Prisma.ScheduleTaskUpdateInput = {};
+    if (progress !== undefined) {
+        data.progress = Math.round(progress);
+    }
+    if (status !== undefined) {
+        if (typeof status !== "string" || !status.trim()) {
+            return NextResponse.json({ error: "status must be a non-empty string" }, { status: 400 });
+        }
+        data.status = status;
+    }
+    // Auto-complete wins: if progress hit 100, force status regardless of any
+    // value the caller supplied alongside it.
+    if (progress !== undefined && progress >= 100) {
+        data.status = "Complete";
+    }
+
+    const updated = await prisma.scheduleTask.update({
+        where: { id },
+        data,
+    });
+
+    return NextResponse.json(JSON.parse(JSON.stringify(updated)));
+}

--- a/src/app/api/tasks/[id]/punch-items/[itemId]/complete/route.ts
+++ b/src/app/api/tasks/[id]/punch-items/[itemId]/complete/route.ts
@@ -1,0 +1,49 @@
+export const dynamic = 'force-dynamic';
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { authenticateMobileOrSession, assertProjectAccess } from "@/lib/mobile-auth";
+
+type Params = { params: Promise<{ id: string; itemId: string }> };
+
+export async function POST(req: NextRequest, { params }: Params) {
+    const auth = await authenticateMobileOrSession(req);
+    if ("error" in auth) return auth.error;
+    const { user } = auth;
+
+    const { id: taskId, itemId } = await params;
+
+    const body = await req.json().catch(() => ({}));
+    const { photoUrl } = (body ?? {}) as { photoUrl?: string };
+
+    const punchItem = await prisma.taskPunchItem.findUnique({
+        where: { id: itemId },
+        include: { task: { select: { id: true, projectId: true } } },
+    });
+    if (!punchItem) {
+        return NextResponse.json({ error: "Punch item not found" }, { status: 404 });
+    }
+    if (punchItem.taskId !== taskId) {
+        return NextResponse.json(
+            { error: "Punch item does not belong to this task" },
+            { status: 400 },
+        );
+    }
+    if (!punchItem.task.projectId) {
+        return NextResponse.json({ error: "Task is not linked to a project" }, { status: 400 });
+    }
+
+    const projectError = await assertProjectAccess(user, punchItem.task.projectId);
+    if (projectError) return projectError;
+
+    const updated = await prisma.taskPunchItem.update({
+        where: { id: itemId },
+        data: {
+            completed: true,
+            ...(typeof photoUrl === "string" && photoUrl.trim()
+                ? { photoUrl: photoUrl.trim() }
+                : {}),
+        },
+    });
+
+    return NextResponse.json(JSON.parse(JSON.stringify(updated)));
+}

--- a/src/app/api/time-entries/[id]/route.ts
+++ b/src/app/api/time-entries/[id]/route.ts
@@ -1,0 +1,136 @@
+export const dynamic = 'force-dynamic';
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { authenticateMobileOrSession, userHasRole } from "@/lib/mobile-auth";
+
+const MS_PER_HOUR = new Prisma.Decimal(1000 * 60 * 60);
+
+type Params = { params: Promise<{ id: string }> };
+
+/**
+ * Edit a past time entry with a reason. Owner or ADMIN/MANAGER may edit.
+ * On the first edit, snapshots `startTime`/`endTime` into
+ * `originalStartTime`/`originalEndTime` and flips `isEdited` to true.
+ * Recomputes `durationHours`/`laborCost`/`burdenCost` from the **owner's**
+ * rates (not the editor's). When a manager edits another user's entry,
+ * sets `editedByManagerId` + `editedAt`.
+ */
+export async function PATCH(req: NextRequest, { params }: Params) {
+    const auth = await authenticateMobileOrSession(req);
+    if ("error" in auth) return auth.error;
+    const { user } = auth;
+
+    const { id } = await params;
+    const body = await req.json().catch(() => null);
+    if (!body || typeof body !== "object") {
+        return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const { startTime, endTime, editNotes } = body as {
+        startTime?: string;
+        endTime?: string | null;
+        editNotes?: string;
+    };
+
+    if (typeof editNotes !== "string" || editNotes.trim().length === 0) {
+        return NextResponse.json({ error: "editNotes is required" }, { status: 400 });
+    }
+
+    const existing = await prisma.timeEntry.findUnique({
+        where: { id },
+        include: { user: true },
+    });
+    if (!existing) {
+        return NextResponse.json({ error: "Time entry not found" }, { status: 404 });
+    }
+
+    const isOwner = existing.userId === user.id;
+    const isManager = userHasRole(user, ["ADMIN", "MANAGER"]);
+    if (!isOwner && !isManager) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const newStart = startTime !== undefined ? new Date(startTime) : existing.startTime;
+    if (Number.isNaN(newStart.getTime())) {
+        return NextResponse.json({ error: "Invalid startTime" }, { status: 400 });
+    }
+
+    let newEnd: Date | null;
+    if (endTime === undefined) {
+        newEnd = existing.endTime;
+    } else if (endTime === null) {
+        newEnd = null;
+    } else {
+        newEnd = new Date(endTime);
+        if (Number.isNaN(newEnd.getTime())) {
+            return NextResponse.json({ error: "Invalid endTime" }, { status: 400 });
+        }
+    }
+
+    if (newEnd && newEnd.getTime() < newStart.getTime()) {
+        return NextResponse.json({ error: "endTime must be after startTime" }, { status: 400 });
+    }
+
+    const update: Prisma.TimeEntryUpdateInput = {
+        startTime: newStart,
+        endTime: newEnd,
+        isEdited: true,
+        editNotes: editNotes.trim(),
+    };
+
+    if (!existing.isEdited) {
+        update.originalStartTime = existing.startTime;
+        update.originalEndTime = existing.endTime;
+    }
+
+    if (newEnd) {
+        const durationMs = Math.max(0, newEnd.getTime() - newStart.getTime());
+        const durationDecimal = new Prisma.Decimal(durationMs).div(MS_PER_HOUR);
+        const ownerHourly = new Prisma.Decimal(existing.user.hourlyRate.toString());
+        const ownerBurden = new Prisma.Decimal(existing.user.burdenRate.toString());
+        update.durationHours = durationDecimal.toNumber();
+        update.laborCost = durationDecimal.mul(ownerHourly);
+        update.burdenCost = durationDecimal.mul(ownerBurden);
+    } else {
+        update.durationHours = null;
+        update.laborCost = null;
+        update.burdenCost = null;
+    }
+
+    if (isManager && !isOwner) {
+        update.editedByManagerId = user.id;
+        update.editedAt = new Date();
+    }
+
+    const updated = await prisma.timeEntry.update({
+        where: { id },
+        data: update,
+        include: { user: true, project: true, costCode: true },
+    });
+
+    return NextResponse.json(JSON.parse(JSON.stringify(updated)));
+}
+
+/**
+ * Manager-only deletion. Cascade deletion is governed by Prisma's
+ * onDelete rules — TimeEntry is a leaf row so no extra cleanup.
+ */
+export async function DELETE(req: NextRequest, { params }: Params) {
+    const auth = await authenticateMobileOrSession(req);
+    if ("error" in auth) return auth.error;
+    const { user } = auth;
+
+    if (!userHasRole(user, ["ADMIN", "MANAGER"])) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { id } = await params;
+    const existing = await prisma.timeEntry.findUnique({ where: { id } });
+    if (!existing) {
+        return NextResponse.json({ error: "Time entry not found" }, { status: 404 });
+    }
+
+    await prisma.timeEntry.delete({ where: { id } });
+    return NextResponse.json({ ok: true });
+}

--- a/src/lib/mobile-auth.ts
+++ b/src/lib/mobile-auth.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { jwtVerify } from "jose";
+import type { User } from "@prisma/client";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { canAccessProject } from "@/lib/permissions";
+
+export const MOBILE_TOKEN_TYPE = "mobile-access";
+
+export function getMobileJwtSecret(): Uint8Array {
+    const secret = process.env.NEXTAUTH_SECRET;
+    if (!secret) {
+        throw new Error("NEXTAUTH_SECRET is not configured");
+    }
+    return new TextEncoder().encode(secret);
+}
+
+export type AuthFailure = NextResponse;
+export type AuthedUser = User;
+export type AuthResult = { user: AuthedUser } | { error: AuthFailure };
+
+function unauthorized(message = "Unauthorized"): AuthFailure {
+    return NextResponse.json({ error: message }, { status: 401 });
+}
+
+function forbidden(message = "Forbidden"): AuthFailure {
+    return NextResponse.json({ error: message }, { status: 403 });
+}
+
+async function userFromBearer(authHeader: string | null): Promise<AuthedUser | null> {
+    if (!authHeader || !authHeader.startsWith("Bearer ")) return null;
+    const token = authHeader.slice("Bearer ".length).trim();
+    if (!token) return null;
+
+    let secret: Uint8Array;
+    try {
+        secret = getMobileJwtSecret();
+    } catch {
+        return null;
+    }
+
+    try {
+        const { payload } = await jwtVerify(token, secret, {
+            algorithms: ["HS256"],
+            requiredClaims: ["exp", "sub"],
+        });
+
+        // Reject any signed JWT minted for a different purpose (sub/client portal tokens
+        // are signed with the same secret but use different shapes; refuse them outright).
+        if (payload.typ !== MOBILE_TOKEN_TYPE) return null;
+
+        const userId = typeof payload.sub === "string" ? payload.sub : null;
+        if (!userId) return null;
+
+        const user = await prisma.user.findUnique({ where: { id: userId } });
+        if (!user || user.status === "DISABLED") return null;
+        return user;
+    } catch {
+        return null;
+    }
+}
+
+async function userFromSession(): Promise<AuthedUser | null> {
+    const session = await getServerSession(authOptions);
+    const email = session?.user?.email;
+    if (!email) return null;
+    const user = await prisma.user.findUnique({ where: { email: email.toLowerCase() } });
+    if (!user || user.status === "DISABLED") return null;
+    return user;
+}
+
+/**
+ * Authenticate a request using either a mobile JWT (Authorization: Bearer)
+ * or an active NextAuth web session. Returns `{ user }` on success or
+ * `{ error }` (a NextResponse) on failure. Routes used by both the mobile
+ * client and the web app should call this.
+ */
+export async function authenticateMobileOrSession(req: Request): Promise<AuthResult> {
+    const bearerUser = await userFromBearer(req.headers.get("authorization"));
+    if (bearerUser) return { user: bearerUser };
+
+    const sessionUser = await userFromSession();
+    if (sessionUser) return { user: sessionUser };
+
+    return { error: unauthorized() };
+}
+
+/**
+ * Authenticate a request using only a mobile JWT (Authorization: Bearer).
+ * Use for endpoints that exist exclusively for the mobile app.
+ */
+export async function authenticateMobileOnly(req: Request): Promise<AuthResult> {
+    const bearerUser = await userFromBearer(req.headers.get("authorization"));
+    if (bearerUser) return { user: bearerUser };
+    return { error: unauthorized() };
+}
+
+/** True if the user holds any of the listed roles. */
+export function userHasRole(user: AuthedUser, roles: string[]): boolean {
+    return roles.includes(user.role);
+}
+
+/**
+ * Confirm the user can read/write a given project. Admins and managers
+ * see everything; field crew + finance must have a `ProjectAccess` row
+ * or be on the `crew` assignment list. Returns null on success or a
+ * NextResponse error to short-circuit the route.
+ */
+export async function assertProjectAccess(
+    user: AuthedUser,
+    projectId: string,
+): Promise<AuthFailure | null> {
+    if (!projectId) return NextResponse.json({ error: "Project id required" }, { status: 400 });
+
+    if (userHasRole(user, ["ADMIN", "MANAGER"])) return null;
+
+    const access = await prisma.projectAccess.findUnique({
+        where: { userId_projectId: { userId: user.id, projectId } },
+    });
+    if (access) return null;
+
+    const project = await prisma.project.findUnique({
+        where: { id: projectId },
+        select: { id: true, crew: { where: { id: user.id }, select: { id: true } } },
+    });
+    if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 });
+    if (project.crew.length > 0) return null;
+
+    if (canAccessProject({ role: user.role, projectAccess: [] }, projectId)) return null;
+
+    return forbidden("You do not have access to this project");
+}


### PR DESCRIPTION
## Summary

Backfills the API surface needed by the gtr-probuild-mobile cutover (W4 of the [mobile integration plan](../blob/main/.claude/plans/c-users-jat00-gemini-antigravity-workspa-gleaming-cosmos.md)). Eight new endpoints, plus the `src/lib/mobile-auth.ts` helpers that W4 depended on.

> **Heads up:** the plan listed the mobile-auth helpers under W1 as already-shipped, but they did not exist on `main`. Rather than re-introduce the legacy `Bearer <user-id>` pattern (explicitly forbidden by the W4 brief), I built the helpers here as part of this PR. The existing `/api/time-entries/route.ts` (GET/POST/PUT) is **not** changed and still uses the legacy pattern — the formal W1 refactor is still its own task.

## Auth helpers — `src/lib/mobile-auth.ts`

- `authenticateMobileOrSession(req)` — verifies `Bearer` JWT (jose, HS256, `NEXTAUTH_SECRET`) with `requiredClaims: ["exp", "sub"]` and a `typ: "mobile-access"` marker, then falls back to NextAuth `getServerSession`. Disabled users are rejected. Returns `{ user }` or `{ error: NextResponse }`.
- `authenticateMobileOnly(req)` — JWT-only variant.
- `userHasRole(user, roles)` — exact role match.
- `assertProjectAccess(user, projectId)` — ADMIN/MANAGER pass; FIELD_CREW/FINANCE need a `ProjectAccess` row or a `Project.crew` assignment.
- `getMobileJwtSecret()` — fails closed when `NEXTAUTH_SECRET` is unset.
- `/api/mobile/login` updated to mint with `typ: "mobile-access"` via `setSubject(...)` and reuse `getMobileJwtSecret()` so login also fails closed when the secret is missing.

The `typ` claim prevents tokens from `/api/sub-portal/login`, `client-portal-auth.ts`, etc. — all signed with the same `NEXTAUTH_SECRET` — from impersonating mobile users.

## Endpoints — auth + permission rules

| Endpoint | Auth | Permission |
|---|---|---|
| `PATCH /api/time-entries/[id]` | Bearer or session | Owner OR ADMIN/MANAGER. Snapshots originals on first edit; recomputes `durationHours`/`laborCost`/`burdenCost` from the **owner's** rates using `Prisma.Decimal` end-to-end; sets `editedByManagerId`/`editedAt` when manager edits another user's entry. |
| `DELETE /api/time-entries/[id]` | Bearer or session | ADMIN/MANAGER only. |
| `GET /api/manager/dashboard` | Bearer or session | ADMIN/MANAGER only. ISO week (Mon–Sun) via `date-fns` with `weekStartsOn: 1`. Cents totals sum `Decimal` then round once. |
| `GET /api/manager/jobs` | Bearer or session | ADMIN/MANAGER only. |
| `POST /api/manager/jobs` | Bearer or session | ADMIN/MANAGER only. Validates lat∈[-90,90], lng∈[-180,180], radius>0; verifies `clientId` exists. |
| `PATCH /api/manager/jobs/[id]` | Bearer or session | ADMIN/MANAGER only. Same geofence bounds. |
| `GET /api/manager/employees` | Bearer or session | ADMIN/MANAGER only. |
| `PATCH /api/manager/employees/[id]` | Bearer or session | **ADMIN-only**. Decimal rates parsed via `new Prisma.Decimal(...)`; rejects non-finite, negative, or values > 100k. |
| `GET /api/projects/[id]/tasks` | Bearer or session | `assertProjectAccess`. |
| `PATCH /api/tasks/[id]/progress` | Bearer or session | `assertProjectAccess` via task → project. Validates 0–100. Auto-sets status `"Complete"` at 100 even when caller supplies a conflicting status. |
| `POST /api/tasks/[id]/punch-items/[itemId]/complete` | Bearer or session | `assertProjectAccess`. Verifies punch item belongs to the task in the URL (anti-IDOR). |

curl examples for each in [`MOBILE_API_NOTES.md`](MOBILE_API_NOTES.md).

## Codex peer review (per project review protocol)

Two rounds against the auth helpers + permission gating + money math. All blockers resolved:
- **R1 #1 — JWT typ marker:** added `typ: "mobile-access"` claim, `requiredClaims: ["exp", "sub"]`.
- **R1 #2 — fail closed on missing secret:** `getMobileJwtSecret()` throws if unset.
- **R1 #3 — money precision drift:** time-entry recompute now `Decimal.div(MS_PER_HOUR).mul(rate)` end-to-end.
- **R1 #4 — server TZ for week bounds:** kept per W4 brief (\"Mon–Sun in the server's TZ\"); the operational risk is acknowledged but matches the spec.
- **R1 #5 — cents double-rounding:** sum `Decimal` first, multiply by 100, round once.
- **R1 nits — geofence bounds, Decimal Infinity, progress=100 ordering:** all addressed.
- **R2 #2 — login route lazy secret:** `/api/mobile/login` now uses `getMobileJwtSecret()` at request time so a misconfigured deployment can't return tokens that auth will always reject.

## Test plan

- [ ] `npm run typecheck` — passes (verified locally, 0 errors)
- [ ] `npm run lint` — no new warnings/errors in changed files
- [ ] Manual curl smoke-test (commands in [MOBILE_API_NOTES.md](MOBILE_API_NOTES.md))
- [ ] Cross-user permission spot-check: FIELD_CREW token hitting `/api/manager/dashboard` returns 403; ADMIN/MANAGER returns 200.
- [ ] PATCH time-entry: confirm `originalStartTime`/`originalEndTime` populated only on first edit; subsequent edits keep the originals.
- [ ] PATCH time-entry by manager on another user's row: confirm `laborCost`/`burdenCost` use the owner's rate, not the manager's.

## Out of scope (deferred per plan)

- W1 refactor of the legacy `Bearer <user-id>` pattern in `src/app/api/time-entries/route.ts` GET/POST/PUT.
- `POST /api/mobile/google-login` (separate W1 deliverable).
- `GET /api/mobile/me` (separate W1 deliverable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)