### PR TITLE
fix(proxy): allow mobile API traffic through NextAuth middleware

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -9,6 +9,14 @@ export default async function middleware(req: any, event: any) {
         return NextResponse.next();
     }
 
+    // API requests carrying `Authorization: Bearer <jwt>` are mobile clients. Their
+    // route handlers verify the JWT via authenticateMobileOrSession themselves; redirecting
+    // them to /login (a browser flow) would 307-redirect every mobile API call.
+    const authHeader = req.headers?.get?.("authorization");
+    if (typeof authHeader === "string" && authHeader.toLowerCase().startsWith("bearer ")) {
+        return NextResponse.next();
+    }
+
     // Existing authentication logic for other environments
     const authMiddleware = withAuth({
         pages: {
@@ -36,6 +44,6 @@ export const config = {
          * - _next/image (Image optimization)
          * - favicon.ico, public folder images, etc
          */
-        "/((?!api/auth|api/cron|api/twilio|api/webhook|api/payments|api/portal|api/pdf/estimates|api/pdf/invoices|api/sub-portal|login|portal|sub-portal|_next/static|_next/image|favicon.ico|.*\\.png|.*\\.jpg|.*\\.svg).*)",
+        "/((?!api/auth|api/cron|api/twilio|api/webhook|api/payments|api/portal|api/pdf/estimates|api/pdf/invoices|api/sub-portal|api/mobile|login|portal|sub-portal|_next/static|_next/image|favicon.ico|.*\\.png|.*\\.jpg|.*\\.svg).*)",
     ],
 };


### PR DESCRIPTION
## Summary
- Adds `Authorization: Bearer ...` bypass to `src/proxy.ts` so mobile API calls don't get 307'd to `/login`
- Adds `api/mobile` to the matcher exclusion (login endpoints are pre-auth, can't carry a Bearer token)

## Why
PR #70 added `/api/mobile/*` and `/api/manager/*` routes but didn't update the proxy's allowlist. Result: every mobile request hit `withAuth` and got redirected to `/login`. Codex review missed this because Codex doesn't see middleware/proxy by default.

Reproduced live: `curl -X POST https://probuild.goldentouchremodeling.com/api/mobile/google-login` returns `HTTP/1.1 307 Temporary Redirect` with `Location: /login?callbackUrl=%2Fapi%2Fmobile%2Fgoogle-login` until this lands.

## Test plan
- [x] Web flow unaffected (still session-cookie gated)
- [x] `npm run typecheck` clean
- [ ] Post-deploy: `curl -X POST -d '{}' .../api/mobile/google-login` returns **400** (not 307)