### PR TITLE
fix(contracts): smart PDF pagination + signed copy access

### DIFF
--- a/src/app/portal/contracts/[id]/PortalContractClient.tsx
+++ b/src/app/portal/contracts/[id]/PortalContractClient.tsx
@@ -176,15 +176,29 @@ export default function PortalContractClient({
         initBtns.forEach(btn => syncBtn(btn, initials, initDefaultHtml));
     }, [signatures, initials, error, isSigned]);
 
-    // Mark top-level block elements with data-pdf-row for smart pagination
+    // Mark elements with data-pdf-row for smart pagination. Lists and tables
+    // are marked at the row level (li/tr) instead of the container so a long
+    // list/table doesn't become one oversized row that forces pathological
+    // page advances. The buildPdf algorithm filters out nested rows, so it's
+    // safe to mark both a paragraph and a child element — but we don't mark
+    // doc-block-btn buttons since they're typically inline within paragraphs.
     useEffect(() => {
         if (!contractBodyRef.current) return;
-        const children = Array.from(contractBodyRef.current.children) as HTMLElement[];
+        const root = contractBodyRef.current;
+        const children = Array.from(root.children) as HTMLElement[];
         children.forEach(child => {
-            child.setAttribute("data-pdf-row", "true");
-        });
-        contractBodyRef.current.querySelectorAll(".doc-block-btn").forEach(el => {
-            (el as HTMLElement).setAttribute("data-pdf-row", "true");
+            const tag = child.tagName.toLowerCase();
+            if (tag === "ul" || tag === "ol") {
+                Array.from(child.children).forEach(li => {
+                    (li as HTMLElement).setAttribute("data-pdf-row", "true");
+                });
+            } else if (tag === "table") {
+                child.querySelectorAll("tr").forEach(tr => {
+                    (tr as HTMLElement).setAttribute("data-pdf-row", "true");
+                });
+            } else {
+                child.setAttribute("data-pdf-row", "true");
+            }
         });
     }, [parsedBody, signatures, initials]);
 
@@ -558,7 +572,7 @@ export default function PortalContractClient({
 
                     {/* Final Submission Block */}
                     {!isSigned && (
-                        <div className="px-10 pb-10 print:hidden">
+                        <div data-pdf-skip="true" className="px-10 pb-10 print:hidden">
                             <div className="border-t-2 border-slate-200 pt-8">
                                 {awaitingContractor && (
                                     <div className="bg-amber-50 border border-amber-200 p-4 rounded-xl mb-4 flex items-center gap-3">

--- a/src/app/portal/contracts/[id]/PortalContractClient.tsx
+++ b/src/app/portal/contracts/[id]/PortalContractClient.tsx
@@ -5,8 +5,7 @@ import DOMPurify from "dompurify";
 import { approveContract, markContractViewed } from "@/lib/actions";
 import DocumentSignModal from "@/components/DocumentSignModal";
 import { toast } from "sonner";
-import { toJpeg } from "html-to-image";
-import { jsPDF } from "jspdf";
+import { buildPdf } from "@/lib/build-pdf";
 import { CONTRACT_PROSE_CLASSES } from "@/lib/contract-styles";
 import DocumentLetterhead from "@/components/DocumentLetterhead";
 import { buildLetterheadConfig } from "@/lib/letterhead";
@@ -177,6 +176,18 @@ export default function PortalContractClient({
         initBtns.forEach(btn => syncBtn(btn, initials, initDefaultHtml));
     }, [signatures, initials, error, isSigned]);
 
+    // Mark top-level block elements with data-pdf-row for smart pagination
+    useEffect(() => {
+        if (!contractBodyRef.current) return;
+        const children = Array.from(contractBodyRef.current.children) as HTMLElement[];
+        children.forEach(child => {
+            child.setAttribute("data-pdf-row", "true");
+        });
+        contractBodyRef.current.querySelectorAll(".doc-block-btn").forEach(el => {
+            (el as HTMLElement).setAttribute("data-pdf-row", "true");
+        });
+    }, [parsedBody, signatures, initials]);
+
     // Handle Modal Finish
     const handleSignBlock = (dataUrl: string, typedName: string) => {
         if (!activeBlockId) return;
@@ -244,32 +255,9 @@ export default function PortalContractClient({
                 element.style.border = "none";
                 element.style.overflow = "visible";
 
-                if (element.scrollHeight > element.offsetHeight + 1) {
-                    console.debug(
-                        "[contract-pdf] wrapper is shorter than its content",
-                        { offsetHeight: element.offsetHeight, scrollHeight: element.scrollHeight }
-                    );
-                }
-
-                const imgData = await toJpeg(element, { quality: 0.92, pixelRatio: 1.5 });
-
-                const pdf = new jsPDF({ unit: "pt", format: "a4", compress: true });
-                const pageW = pdf.internal.pageSize.getWidth();
-                const pageH = pdf.internal.pageSize.getHeight();
-                const margin = 20;
-                const usableH = pageH - margin;
-                const imgProps = pdf.getImageProperties(imgData);
-                const scaledTotalH = (imgProps.height * pageW) / imgProps.width;
-
-                let rendered = 0;
-                let pageIdx = 0;
-                while (rendered < scaledTotalH && pageIdx < 30) {
-                    if (pageIdx > 0) pdf.addPage();
-                    pdf.addImage(imgData, "JPEG", 0, -rendered, pageW, scaledTotalH);
-                    rendered += usableH;
-                    pageIdx++;
-                }
-
+                const pdf = await buildPdf(element, {
+                    bannerText: `${companyName}  •  ${initialContract.title}  (continued)`,
+                });
                 pdfBlob = pdf.output('blob');
             } finally {
                 element.style.boxShadow = prevShadow;
@@ -434,7 +422,7 @@ export default function PortalContractClient({
 
                     {/* Signed Badge */}
                     {isSigned && initialContract.approvedBy && (
-                        <div className="mx-10 mt-6 p-5 bg-green-50 border border-green-200 rounded-lg">
+                        <div data-pdf-row="true" className="mx-10 mt-6 p-5 bg-green-50 border border-green-200 rounded-lg">
                             <div className="flex items-start gap-3">
                                 <div className="w-8 h-8 bg-green-100 rounded-full flex items-center justify-center shrink-0">
                                     <svg className="h-4 w-4 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M5 13l4 4L19 7" /></svg>
@@ -454,7 +442,7 @@ export default function PortalContractClient({
                     )}
 
                     {/* Contract Title */}
-                    <div className="px-10 pt-8 pb-2">
+                    <div data-pdf-row="true" className="px-10 pt-8 pb-2">
                         <h2 className="text-xl font-bold text-slate-800 text-center">{initialContract.title}</h2>
                         <div className="w-16 h-0.5 bg-slate-300 mx-auto mt-3"></div>
                     </div>
@@ -607,7 +595,7 @@ export default function PortalContractClient({
                     )}
 
                     {/* Footer */}
-                    <div className="bg-slate-50 border-t border-slate-200 px-10 py-4 text-center">
+                    <div data-pdf-row="true" className="bg-slate-50 border-t border-slate-200 px-10 py-4 text-center">
                         <p className="text-xs text-slate-400">
                             This document was prepared by {companyName}. {companyPhone && `Contact: ${companyPhone}.`} {companyEmail && `Email: ${companyEmail}.`}
                         </p>

--- a/src/app/portal/estimates/[id]/PortalEstimateClient.tsx
+++ b/src/app/portal/estimates/[id]/PortalEstimateClient.tsx
@@ -10,6 +10,7 @@ import PortalPayInFullButton from "@/components/PortalPayInFullButton";
 import { formatCurrency } from "@/lib/utils";
 import DocumentLetterhead from "@/components/DocumentLetterhead";
 import { buildLetterheadConfig } from "@/lib/letterhead";
+import { buildPdf } from "@/lib/build-pdf";
 
 class PaymentSectionErrorBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean }> {
     constructor(props: { children: React.ReactNode }) {
@@ -64,123 +65,7 @@ export default function PortalEstimateClient({ initialEstimate, companySettings 
         }
     }, [initialEstimate.id, isCapture]);
 
-    // Shared helper: build a paginated jsPDF from an element
-    async function buildPdf(element: HTMLElement): Promise<import("jspdf").jsPDF> {
-        const { toJpeg } = await import("html-to-image");
-        const { jsPDF } = await import("jspdf");
-
-        const pdf = new jsPDF("p", "mm", "a4");
-        const pageW = pdf.internal.pageSize.getWidth();   // 210 mm
-        const pageH = pdf.internal.pageSize.getHeight();  // 297 mm
-        const marginTop = 0;
-        const marginBottom = 6;   // just enough for page number at bottom
-        const bannerH = 8;        // continuation banner height on pages 2+
-        const usableH = pageH - marginBottom; // ~291 mm per page
-        const effectiveH = usableH - bannerH; // 283 mm — accounts for banner on page 2+
-
-        // ── Step 1: Measure row positions BEFORE rendering ────────────────
-        // CSS px relative to the element's top-left — scroll-independent
-        const elTop = element.getBoundingClientRect().top + window.scrollY;
-        const cssToMm = pageW / element.offsetWidth;
-        const totalHeightMm = element.offsetHeight * cssToMm;
-
-        // Every element with data-pdf-row must not be cut through
-        const rowEls = Array.from(element.querySelectorAll("[data-pdf-row]"));
-        const rowsMm = rowEls.map(row => {
-            const r = row.getBoundingClientRect();
-            return {
-                top:    (r.top    + window.scrollY - elTop) * cssToMm,
-                bottom: (r.bottom + window.scrollY - elTop) * cssToMm,
-            };
-        });
-
-        // ── Step 2: Find safe page-break points (always between rows) ─────
-        const breaks: number[] = [0]; // start-mm of each page's content slice
-        let cursor = 0;
-        while (cursor < totalHeightMm) {
-            const limit = cursor + effectiveH;
-            if (limit >= totalHeightMm) break;
-
-            // Walk rows: track the bottom of the last row that fits entirely,
-            // then snap the break there (not to row.top-1, which can cut the previous row).
-            let safeBreak = limit;
-            let lastFitBottom = cursor;
-            for (const row of rowsMm) {
-                if (row.top <= cursor) continue; // already past
-                if (row.bottom <= limit) {
-                    lastFitBottom = row.bottom;  // this row fits — remember it
-                } else {
-                    // This row overflows — break after the last row that fit
-                    safeBreak = Math.max(cursor + 1, lastFitBottom);
-                    break;
-                }
-            }
-            // Guard: if no rows fit (single row taller than effectiveH), force a full-page
-            // advance so the while loop doesn't stall at cursor+1 indefinitely.
-            if (safeBreak <= cursor) safeBreak = limit;
-            breaks.push(safeBreak);
-            cursor = safeBreak;
-        }
-        breaks.push(totalHeightMm);
-
-        // ── Step 3: Render full element at 2× ────────────────────────────
-        const imgData = await toJpeg(element, { quality: 0.95, pixelRatio: 2 });
-
-        const img = new Image();
-        img.src = imgData;
-        await new Promise<void>((resolve, reject) => {
-            img.onload = () => resolve();
-            img.onerror = () => reject(new Error("img load failed"));
-        });
-
-        const pxPerMm = img.width / pageW; // rendered px per mm
-        const totalPages = breaks.length - 1;
-
-        // ── Step 4: Slice at safe break points and add pages ─────────────
-        for (let page = 0; page < totalPages; page++) {
-            if (page > 0) pdf.addPage();
-
-            const startMm = breaks[page];
-            const sliceHMm = breaks[page + 1] - startMm;
-            const srcY = Math.round(startMm * pxPerMm);
-            const srcH = Math.round(sliceHMm * pxPerMm);
-
-            const slice = document.createElement("canvas");
-            slice.width  = img.width;
-            slice.height = Math.max(1, srcH);
-            const ctx = slice.getContext("2d")!;
-            ctx.fillStyle = "#ffffff";
-            ctx.fillRect(0, 0, slice.width, slice.height);
-            ctx.drawImage(img, 0, srcY, img.width, srcH, 0, 0, img.width, srcH);
-
-            // Content starts below banner on pages 2+ so banner doesn't overlap it
-            const contentY = page > 0 ? bannerH : 0;
-            pdf.addImage(slice.toDataURL("image/jpeg", 0.92), "JPEG", 0, contentY, pageW, sliceHMm);
-
-            // Page number — small text in bottom margin strip
-            pdf.setFont("helvetica", "normal");
-            pdf.setFontSize(7);
-            pdf.setTextColor(180, 180, 180);
-            pdf.text(`Page ${page + 1} of ${totalPages}`, pageW / 2, pageH - 1.5, { align: "center" });
-
-            // Continuation banner on pages 2+ — overlaid on top of content
-            if (page > 0) {
-                pdf.setFillColor(248, 249, 250);
-                pdf.rect(0, 0, pageW, 8, "F");
-                pdf.setDrawColor(220, 220, 220);
-                pdf.line(0, 8, pageW, 8);
-                pdf.setFont("helvetica", "bold");
-                pdf.setFontSize(7);
-                pdf.setTextColor(110, 110, 110);
-                pdf.text(
-                    `${companyName}  •  Estimate ${initialEstimate.code}  (continued)`,
-                    pageW / 2, 5, { align: "center" }
-                );
-            }
-        }
-
-        return pdf;
-    }
+    const estimateBannerText = `${companySettings?.companyName || "Golden Touch Remodeling"}  •  Estimate ${initialEstimate.code}  (continued)`;
 
     // Capture mode: auto-capture DOM and postMessage PDF to parent
     // C6 — use document.fonts.ready + requestAnimationFrame instead of a hardcoded delay
@@ -214,7 +99,7 @@ export default function PortalEstimateClient({ initialEstimate, companySettings 
                 return;
             }
             try {
-                const pdf = await buildPdf(element);
+                const pdf = await buildPdf(element, { bannerText: estimateBannerText });
                 const dataUrl = pdf.output("datauristring");
                 // Include the upload token so the parent can authenticate the storage upload
                 window.parent.postMessage({ type: "estimate-capture-done", dataUrl, uploadToken: uploadTokenParam }, window.location.origin);
@@ -236,7 +121,7 @@ export default function PortalEstimateClient({ initialEstimate, companySettings 
             const prevBorder = element.style.border;
             element.style.boxShadow = "none";
             element.style.border = "none";
-            const pdf = await buildPdf(element);
+            const pdf = await buildPdf(element, { bannerText: estimateBannerText });
             element.style.boxShadow = prevShadow;
             element.style.border = prevBorder;
             pdf.save(`Estimate_${initialEstimate.code || initialEstimate.id}.pdf`);
@@ -280,7 +165,7 @@ export default function PortalEstimateClient({ initialEstimate, companySettings 
             const element = document.getElementById("estimate-document-wrapper");
             if (element) {
                 try {
-                    const pdf = await buildPdf(element);
+                    const pdf = await buildPdf(element, { bannerText: estimateBannerText });
                     const blob = pdf.output("blob");
                     const fd = new FormData();
                     fd.append("pdf", blob, `Signed_Estimate_${initialEstimate.code || initialEstimate.id}.pdf`);

--- a/src/lib/build-pdf.ts
+++ b/src/lib/build-pdf.ts
@@ -21,12 +21,25 @@ export async function buildPdf(
     const usableH = pageH - marginBottom;
     const effectiveH = usableH - bannerH;
 
-    // Step 1: Measure row positions BEFORE rendering
+    // Step 1: Measure row positions BEFORE rendering. Filter rules:
+    // - Skip elements with [data-pdf-skip] (e.g. action buttons not meant to be captured)
+    // - Skip elements whose ancestor is also marked as a row (prevents nested-row
+    //   shrinkage: a paragraph fits, then its child button shows a smaller bottom
+    //   and breaks land inside the paragraph)
     const elTop = element.getBoundingClientRect().top + window.scrollY;
     const cssToMm = pageW / element.offsetWidth;
     const totalHeightMm = element.offsetHeight * cssToMm;
 
-    const rowEls = Array.from(element.querySelectorAll("[data-pdf-row]"));
+    const allRowEls = Array.from(element.querySelectorAll("[data-pdf-row]")) as HTMLElement[];
+    const rowEls = allRowEls.filter(el => {
+        if (el.closest("[data-pdf-skip]")) return false;
+        let parent = el.parentElement;
+        while (parent && parent !== element) {
+            if (parent.hasAttribute("data-pdf-row")) return false;
+            parent = parent.parentElement;
+        }
+        return true;
+    });
     const rowsMm = rowEls.map(row => {
         const r = row.getBoundingClientRect();
         return {
@@ -44,12 +57,17 @@ export async function buildPdf(
 
         let safeBreak = limit;
         let lastFitBottom = cursor;
+        let anyRowFit = false;
         for (const row of rowsMm) {
             if (row.top <= cursor) continue;
             if (row.bottom <= limit) {
-                lastFitBottom = row.bottom;
+                lastFitBottom = Math.max(lastFitBottom, row.bottom);
+                anyRowFit = true;
             } else {
-                safeBreak = Math.max(cursor + 1, lastFitBottom);
+                // Row overflows. If any row fit on this page, break after the last
+                // one. If none fit (oversized first row), fall back to the fixed
+                // page advance to avoid 1mm-at-a-time pathological pagination.
+                safeBreak = anyRowFit ? lastFitBottom : limit;
                 break;
             }
         }
@@ -59,8 +77,14 @@ export async function buildPdf(
     }
     breaks.push(totalHeightMm);
 
-    // Step 3: Render full element at high resolution
-    const imgData = await toJpeg(element, { quality, pixelRatio });
+    // Step 3: Render full element at high resolution. Filter excludes
+    // [data-pdf-skip] subtrees from the captured image.
+    const imgData = await toJpeg(element, {
+        quality,
+        pixelRatio,
+        filter: (node: HTMLElement) =>
+            !(node.nodeType === 1 && node.hasAttribute && node.hasAttribute("data-pdf-skip")),
+    });
 
     const img = new Image();
     img.src = imgData;

--- a/src/lib/build-pdf.ts
+++ b/src/lib/build-pdf.ts
@@ -1,0 +1,113 @@
+export interface BuildPdfOptions {
+    bannerText?: string;
+    pixelRatio?: number;
+    quality?: number;
+}
+
+export async function buildPdf(
+    element: HTMLElement,
+    options: BuildPdfOptions = {}
+): Promise<import("jspdf").jsPDF> {
+    const { toJpeg } = await import("html-to-image");
+    const { jsPDF } = await import("jspdf");
+
+    const { bannerText, pixelRatio = 2, quality = 0.95 } = options;
+
+    const pdf = new jsPDF("p", "mm", "a4");
+    const pageW = pdf.internal.pageSize.getWidth();
+    const pageH = pdf.internal.pageSize.getHeight();
+    const marginBottom = 6;
+    const bannerH = 8;
+    const usableH = pageH - marginBottom;
+    const effectiveH = usableH - bannerH;
+
+    // Step 1: Measure row positions BEFORE rendering
+    const elTop = element.getBoundingClientRect().top + window.scrollY;
+    const cssToMm = pageW / element.offsetWidth;
+    const totalHeightMm = element.offsetHeight * cssToMm;
+
+    const rowEls = Array.from(element.querySelectorAll("[data-pdf-row]"));
+    const rowsMm = rowEls.map(row => {
+        const r = row.getBoundingClientRect();
+        return {
+            top:    (r.top    + window.scrollY - elTop) * cssToMm,
+            bottom: (r.bottom + window.scrollY - elTop) * cssToMm,
+        };
+    });
+
+    // Step 2: Find safe page-break points (always between rows)
+    const breaks: number[] = [0];
+    let cursor = 0;
+    while (cursor < totalHeightMm) {
+        const limit = cursor + effectiveH;
+        if (limit >= totalHeightMm) break;
+
+        let safeBreak = limit;
+        let lastFitBottom = cursor;
+        for (const row of rowsMm) {
+            if (row.top <= cursor) continue;
+            if (row.bottom <= limit) {
+                lastFitBottom = row.bottom;
+            } else {
+                safeBreak = Math.max(cursor + 1, lastFitBottom);
+                break;
+            }
+        }
+        if (safeBreak <= cursor) safeBreak = limit;
+        breaks.push(safeBreak);
+        cursor = safeBreak;
+    }
+    breaks.push(totalHeightMm);
+
+    // Step 3: Render full element at high resolution
+    const imgData = await toJpeg(element, { quality, pixelRatio });
+
+    const img = new Image();
+    img.src = imgData;
+    await new Promise<void>((resolve, reject) => {
+        img.onload = () => resolve();
+        img.onerror = () => reject(new Error("img load failed"));
+    });
+
+    const pxPerMm = img.width / pageW;
+    const totalPages = breaks.length - 1;
+
+    // Step 4: Slice at safe break points and add pages
+    for (let page = 0; page < totalPages; page++) {
+        if (page > 0) pdf.addPage();
+
+        const startMm = breaks[page];
+        const sliceHMm = breaks[page + 1] - startMm;
+        const srcY = Math.round(startMm * pxPerMm);
+        const srcH = Math.round(sliceHMm * pxPerMm);
+
+        const slice = document.createElement("canvas");
+        slice.width  = img.width;
+        slice.height = Math.max(1, srcH);
+        const ctx = slice.getContext("2d")!;
+        ctx.fillStyle = "#ffffff";
+        ctx.fillRect(0, 0, slice.width, slice.height);
+        ctx.drawImage(img, 0, srcY, img.width, srcH, 0, 0, img.width, srcH);
+
+        const contentY = page > 0 ? bannerH : 0;
+        pdf.addImage(slice.toDataURL("image/jpeg", 0.92), "JPEG", 0, contentY, pageW, sliceHMm);
+
+        pdf.setFont("helvetica", "normal");
+        pdf.setFontSize(7);
+        pdf.setTextColor(180, 180, 180);
+        pdf.text(`Page ${page + 1} of ${totalPages}`, pageW / 2, pageH - 1.5, { align: "center" });
+
+        if (page > 0 && bannerText) {
+            pdf.setFillColor(248, 249, 250);
+            pdf.rect(0, 0, pageW, 8, "F");
+            pdf.setDrawColor(220, 220, 220);
+            pdf.line(0, 8, pageW, 8);
+            pdf.setFont("helvetica", "bold");
+            pdf.setFontSize(7);
+            pdf.setTextColor(110, 110, 110);
+            pdf.text(bannerText, pageW / 2, 5, { align: "center" });
+        }
+    }
+
+    return pdf;
+}


### PR DESCRIPTION
## Summary
- Replaces the contract PDF generator's naive fixed-height image slicing with the estimate's proven smart pagination algorithm (extracted into shared `src/lib/build-pdf.ts`)
- Generated PDFs no longer cut text/signatures/tables at page boundaries; pages get numbers and a continuation banner on pages 2+
- The previously generated 37-page contract PDF was a symptom of pathological 1mm-at-a-time slicing on oversized rows — fixed
- The signed copy storage flow was already correct; the unusable PDF made it appear missing. Fixing the pagination fixes both reported issues.

## Round-2 fixes after Codex peer review
- **Nested `data-pdf-row` markers**: filter excludes rows with another marked ancestor; `lastFitBottom` uses `Math.max` so it can't shrink
- **Oversized rows**: `anyRowFit` flag falls back to a full-page advance when no row fits, instead of incrementing 1mm at a time
- **Submit UI captured in PDF**: `data-pdf-skip="true"` on the Final Submission Block; `buildPdf` filters `[data-pdf-skip]` from both row collection and the `toJpeg` capture
- Marks `<li>` and `<tr>` inside top-level `<ul>`/`<ol>`/`<table>` instead of the container so long lists/tables don't become single oversized rows

## Test plan
- [ ] Open an unsigned contract in the portal at `/portal/contracts/[id]`
- [ ] Sign all required signature blocks and click Submit
- [ ] Download the resulting PDF and verify:
  - [ ] No content cut at page boundaries (no half-sentences, half-headings, half-signature blocks)
  - [ ] Page numbers in footer (e.g. "Page 1 of 4")
  - [ ] Continuation banner on pages 2+
  - [ ] No "Submit Signed Document" button visible in the PDF
  - [ ] Signature images render clearly
- [ ] Reload the contract page after signing — verify the green "Download Executed PDF" banner appears
- [ ] Visit `/portal/projects/[id]/files` — verify the executed contract appears in the file list
- [ ] Verify the email attachment matches the downloaded PDF
- [ ] Smoke-test estimate PDF download at `/portal/estimates/[id]` — should still produce clean paginated output (refactored to use the same shared utility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)