### PR TITLE
feat: deploy infrastructure (auto-deploy off, /deploy-prod, Codex-gated CI)

### DIFF
--- a/.claude/commands/deploy-prod.md
+++ b/.claude/commands/deploy-prod.md
@@ -1,0 +1,80 @@
+---
+description: Codex-reviewed production deploy — verify build, peer-review the diff, and ship via Vercel CLI only if clean.
+---
+
+You are about to run the **only blessed path to production** for this project. Auto-deploy is intentionally OFF (Vercel billed $250 from push-triggered builds). This command gates every deploy on a Codex peer review so we catch bugs before they hit prod.
+
+If the user passes `--skip-review` as an argument, skip step 4 only and explain you're doing so. Use that for genuine emergencies (security hotfix, prod fully down).
+
+## Step 1 — Pre-flight checks
+
+Run from the **main repo** (`C:\Users\jat00\.gemini\antigravity\workspaces\gtr-probuild-site`), NOT a worktree.
+
+- `git -C "C:\Users\jat00\.gemini\antigravity\workspaces\gtr-probuild-site" status --porcelain` — must be empty. If dirty (especially `UU` for unresolved merge), abort and tell the user what's blocking them.
+- `git -C "<main-repo>" rev-list --count origin/main..HEAD` — if 0, abort: nothing new to deploy.
+- Stash untracked junk if needed but never commit on the user's behalf.
+
+## Step 2 — Build verification
+
+```powershell
+Set-Location "C:\Users\jat00\.gemini\antigravity\workspaces\gtr-probuild-site"
+npm run build
+```
+
+On non-zero exit, abort and surface the error verbatim. Do not deploy a build that fails locally — Vercel will fail too and you'll have wasted build minutes.
+
+## Step 3 — Capture the diff to review
+
+The "fix" being reviewed is everything between `origin/main` and `HEAD` (the commits that this deploy will ship to prod).
+
+```powershell
+git -C "<main-repo>" log origin/main..HEAD --oneline
+git -C "<main-repo>" diff origin/main..HEAD --stat
+```
+
+If the diff is empty, abort.
+
+## Step 4 — Codex peer review (gate)
+
+Spawn the `codex-peer-review:codex-peer-reviewer` subagent. In the prompt, include:
+- The full diff (`git diff origin/main..HEAD`)
+- A note that this is a **production deploy gate** — focus on blockers, not nits
+- Reviewer should grade each concern as BLOCKER / MAJOR / MINOR / NIT
+- Reviewer must explicitly say "PASS" or "FAIL" at the end
+
+Also flag the high-risk areas from the global review protocol (money math, date math, auth, SQL joins, external API integrations).
+
+After the review returns, parse the output:
+- If it contains "FAIL" or any BLOCKER findings → **abort the deploy**. List the blockers to the user, do NOT continue.
+- If MAJOR findings exist → show them and **ask the user** whether to proceed (ExitPlanMode-style) before deploying.
+- If only MINOR/NIT → mention them in the summary but proceed.
+- If clean → proceed.
+
+If the user passed `--skip-review`, skip this step and add a `[REVIEW SKIPPED]` note to the final summary.
+
+## Step 5 — Deploy via Vercel CLI
+
+```powershell
+vercel --prod --token $env:VERCEL_TOKEN --yes --archive=tgz --cwd "C:\Users\jat00\.gemini\antigravity\workspaces\gtr-probuild-site"
+```
+
+- Run in background (Bash with `run_in_background: true`) — the build takes 3-8 minutes
+- When the background task completes, read the output. Look for `"readyState": "READY"` (success) or `"readyState": "ERROR"` (failure)
+- On error, surface the Vercel build log lines so the user can debug
+
+## Step 6 — Verify production
+
+After the deploy reports READY:
+- WebFetch `https://probuild.goldentouchremodeling.com` — confirm it loads (login page expected)
+- Check the latest deploy in `vercel ls probuild --token $env:VERCEL_TOKEN --scope justins-projects-a2347a8d`
+
+## Step 7 — Final summary
+
+Print:
+- Commits deployed (the SHA list from step 3)
+- Deploy URL (`probuild-{hash}-justins-projects-a2347a8d.vercel.app`)
+- Codex review summary (PASS / number of MAJOR issues acknowledged / any skipped)
+- Production verification result
+- Any new gotchas worth saving to memory
+
+If a new deploy-related gotcha emerged, save it to memory as a `feedback` type.

--- a/.claude/commands/deploy-prod.md
+++ b/.claude/commands/deploy-prod.md
@@ -68,13 +68,31 @@ After the deploy reports READY:
 - WebFetch `https://probuild.goldentouchremodeling.com` — confirm it loads (login page expected)
 - Check the latest deploy in `vercel ls probuild --token $env:VERCEL_TOKEN --scope justins-projects-a2347a8d`
 
-## Step 7 — Final summary
+## Step 7 — Session report
 
-Print:
-- Commits deployed (the SHA list from step 3)
+Output a clear, structured summary the user can read and act on. Use these exact section headers:
+
+### What you asked for
+One short paragraph restating the user's original request from the start of this session. Pull from the user's first/anchoring messages — what problem were they solving, what feature/fix did they want? Be specific, not generic ("you asked me to add a Table view alongside the Gantt chart on the schedule page" — not "you asked me to add a feature").
+
+### What shipped
+- Commits deployed (SHA list from step 3, with commit subject lines)
+- Top-level files changed (just paths, not full diff — e.g. `src/app/projects/[id]/schedule/TableView.tsx (new), src/app/projects/[id]/schedule/page.tsx`)
 - Deploy URL (`probuild-{hash}-justins-projects-a2347a8d.vercel.app`)
-- Codex review summary (PASS / number of MAJOR issues acknowledged / any skipped)
-- Production verification result
-- Any new gotchas worth saving to memory
+- Production alias: https://probuild.goldentouchremodeling.com
+- Codex review: PASS / X BLOCKER / X MAJOR (acknowledged) / X MINOR
 
-If a new deploy-related gotcha emerged, save it to memory as a `feedback` type.
+### How to test (do this now)
+Concrete, numbered steps the user can follow to verify the change. Be specific:
+1. Exact URL to navigate to, e.g. `https://probuild.goldentouchremodeling.com/projects/<some-real-project-id>/schedule`
+2. The action to take, e.g. "Click the **Table** button in the top-right of the schedule view"
+3. The expected result, e.g. "Tasks appear as rows with columns: Name, Owner, Start, End, Duration, Status"
+4. One edge case to try, e.g. "Switch back to **Gantt** — verify task bars still render correctly"
+5. If applicable: a destructive/data-changing test, e.g. "Drag a task to change its date — refresh the page, verify it persisted"
+
+If the change touches money/dates/auth/data, give one extra test that exercises that risky path specifically.
+
+### Notes / follow-ups
+- Known limitations or open questions
+- Any deploy-time gotchas — if persistent, save to memory as a `feedback` type doc
+- Anything the user should keep an eye on for the next 24 hours

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,271 @@
+# Codex-gated production deploy
+#
+# WHAT THIS DOES
+#   1. Runs an AI code review (gpt-5-codex via OpenAI API) on the diff
+#   2. If verdict is PASS, deploys to Vercel production via CLI
+#   3. If verdict is FAIL, blocks the deploy and surfaces the blockers
+#
+# REQUIRED GITHUB SECRETS
+#   OPENAI_API_KEY    — for the Codex review
+#   VERCEL_TOKEN      — already in the repo for other workflows? confirm in Settings → Secrets
+#   VERCEL_ORG_ID     — set to: team_ncLyFAIeSMFmfr3FS9L9vlMt
+#   VERCEL_PROJECT_ID — set to: prj_sd7R3WIYZCRMnu5IhAudBdc4vuIL
+#
+# HOW TO ENABLE
+#   Step 1: Add the four secrets above at https://github.com/Clarion1631/probuild/settings/secrets/actions
+#   Step 2: Test by clicking "Run workflow" at https://github.com/Clarion1631/probuild/actions/workflows/deploy-prod.yml
+#           (defaults to manual-only — workflow_dispatch — so this is safe)
+#   Step 3: When confident, uncomment the `push:` trigger below to deploy automatically on every push to main
+#
+# COST NOTES
+#   - Codex review: ~$0.50–$2 per run depending on diff size (gpt-5-codex)
+#   - Vercel build: same as before, only fires when review passes
+#   - GitHub Actions: well within the 2,000 free min/mo
+#   - Auto-deploy on Vercel side stays OFF (vercel.json: deploymentEnabled: false). Do not re-enable it.
+
+name: Codex Review + Production Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip-review:
+        description: "Skip Codex review (emergencies only — prod down, security hotfix)"
+        type: boolean
+        default: false
+  # Uncomment the block below once you've tested manually and trust the gate.
+  # Auto-deploy on every push to main, gated by Codex review:
+  #
+  # push:
+  #   branches: [main]
+  #   paths-ignore:
+  #     - '**.md'
+  #     - 'docs/**'
+  #     - '.gitignore'
+  #     - '.vercelignore'
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false  # never kill an in-flight deploy
+
+jobs:
+  codex-review:
+    name: Codex review
+    runs-on: ubuntu-latest
+    # Skip the review job entirely if user passed --skip-review on a manual run
+    if: ${{ inputs.skip-review != true }}
+    outputs:
+      verdict: ${{ steps.review.outputs.verdict }}
+
+    steps:
+      - name: Checkout (full history for diff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Compute diff to review
+        id: diff
+        run: |
+          set -e
+
+          # Determine the diff range:
+          #   push event:    diff between commits in this push
+          #   manual run:    diff between HEAD~1 and HEAD (last commit only)
+          if [ "${{ github.event_name }}" = "push" ] && [ -n "${{ github.event.before }}" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.event.after }}"
+          else
+            BASE="HEAD~1"
+            HEAD="HEAD"
+          fi
+
+          echo "Reviewing $BASE..$HEAD"
+          git log --oneline "$BASE..$HEAD" | head -20
+
+          # Capture full diff
+          git diff "$BASE..$HEAD" > /tmp/full.diff
+          DIFF_SIZE=$(wc -c < /tmp/full.diff)
+          echo "Diff size: $DIFF_SIZE bytes"
+
+          # If diff is empty (e.g. merge commit only), bail early — nothing to review
+          if [ "$DIFF_SIZE" -eq 0 ]; then
+            echo "Empty diff — nothing to review."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Truncate to 120k chars so we stay under model context window
+          # (gpt-5-codex handles ~200k tokens but we want headroom for system+output)
+          MAX_CHARS=120000
+          if [ "$DIFF_SIZE" -gt "$MAX_CHARS" ]; then
+            head -c "$MAX_CHARS" /tmp/full.diff > /tmp/truncated.diff
+            echo "" >> /tmp/truncated.diff
+            echo "[... DIFF TRUNCATED at $MAX_CHARS chars / $DIFF_SIZE total ...]" >> /tmp/truncated.diff
+            mv /tmp/truncated.diff /tmp/full.diff
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+          echo "head=$HEAD" >> "$GITHUB_OUTPUT"
+
+      - name: Codex review (gpt-5-codex)
+        id: review
+        if: steps.diff.outputs.skip != 'true'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -e
+
+          # Build JSON request body. jq handles all the escaping.
+          jq -n \
+            --rawfile diff /tmp/full.diff \
+            '{
+              model: "gpt-5-codex",
+              response_format: { type: "json_object" },
+              messages: [
+                {
+                  role: "system",
+                  content: "You are a strict senior code reviewer gating production deploys for a Next.js 16 + Prisma 5 + Supabase + Stripe + Twilio app. Your output schema is fixed:\n\n{\"verdict\": \"PASS\" | \"FAIL\", \"blockers\": string[], \"majors\": string[], \"minors\": string[], \"summary\": string}\n\nVerdict rules:\n- FAIL if there is at least one item in `blockers`.\n- PASS otherwise (majors and minors do not block).\n\nFlag as BLOCKER only:\n- Bugs that break functionality on the deployed routes\n- Security issues (auth, leaked secrets, SQL injection, RLS bypass)\n- Data integrity bugs (money math, date math, currency, timezone, rounding)\n- Race conditions or deadlocks in critical flows\n- Missing/incorrect Prisma migrations for schema changes\n- Hardcoded production secrets or PII in code\n- Auth role checks missing on sensitive endpoints\n- Stripe/payment integration bugs\n\nFlag as MAJOR (do not block):\n- Missing error handling that could degrade UX but not break things\n- Performance regressions in non-critical paths\n- TypeScript escape hatches (`any`, `as`) on important data\n- Missing tests on new logic\n\nFlag as MINOR (mention only):\n- Style, naming, dead code, refactor opportunities\n\nBe terse — one sentence per finding, with file:line where possible. Do NOT include code suggestions in findings — those go in `summary` if useful."
+                },
+                {
+                  role: "user",
+                  content: ("Review this diff for production deploy:\n\n```diff\n" + $diff + "\n```")
+                }
+              ]
+            }' > /tmp/request.json
+
+          # Call OpenAI API
+          HTTP_CODE=$(curl -s -o /tmp/response.json -w "%{http_code}" \
+            -X POST https://api.openai.com/v1/chat/completions \
+            -H "Authorization: Bearer $OPENAI_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d @/tmp/request.json)
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::OpenAI API returned HTTP $HTTP_CODE"
+            cat /tmp/response.json
+            exit 1
+          fi
+
+          # Extract the assistant's JSON response
+          jq -r '.choices[0].message.content' /tmp/response.json > /tmp/review.json
+
+          # Validate it parses as JSON
+          if ! jq empty /tmp/review.json 2>/dev/null; then
+            echo "::error::Codex returned non-JSON output:"
+            cat /tmp/review.json
+            exit 1
+          fi
+
+          VERDICT=$(jq -r .verdict /tmp/review.json)
+          echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
+
+          # Build the workflow summary
+          {
+            echo "## 🤖 Codex Review (gpt-5-codex)"
+            echo ""
+            echo "**Range:** \`${{ steps.diff.outputs.base }}..${{ steps.diff.outputs.head }}\`"
+            echo ""
+            if [ "$VERDICT" = "PASS" ]; then
+              echo "**Verdict:** ✅ PASS — safe to deploy"
+            else
+              echo "**Verdict:** 🚫 FAIL — deploy blocked"
+            fi
+            echo ""
+
+            BLOCKER_COUNT=$(jq -r '.blockers | length' /tmp/review.json)
+            MAJOR_COUNT=$(jq -r '.majors | length' /tmp/review.json)
+            MINOR_COUNT=$(jq -r '.minors | length' /tmp/review.json)
+
+            if [ "$BLOCKER_COUNT" -gt 0 ]; then
+              echo "### 🚫 Blockers ($BLOCKER_COUNT)"
+              jq -r '.blockers[] | "- " + .' /tmp/review.json
+              echo ""
+            fi
+
+            if [ "$MAJOR_COUNT" -gt 0 ]; then
+              echo "### ⚠️ Majors ($MAJOR_COUNT) — deploy proceeds, fix soon"
+              jq -r '.majors[] | "- " + .' /tmp/review.json
+              echo ""
+            fi
+
+            if [ "$MINOR_COUNT" -gt 0 ]; then
+              echo "### 💡 Minors ($MINOR_COUNT)"
+              jq -r '.minors[] | "- " + .' /tmp/review.json
+              echo ""
+            fi
+
+            echo "### Summary"
+            jq -r .summary /tmp/review.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail the job if Codex blocked the deploy
+        if: steps.review.outputs.verdict == 'FAIL'
+        run: |
+          echo "::error::Codex review found blockers — see workflow summary"
+          exit 1
+
+  deploy:
+    name: Deploy to Vercel production
+    needs: codex-review
+    # Run if Codex passed OR was skipped (--skip-review emergency path)
+    if: |
+      always() &&
+      (needs.codex-review.result == 'success' || needs.codex-review.result == 'skipped')
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel@latest
+
+      - name: Pull Vercel production config
+        run: vercel pull --yes --environment=production --token=$VERCEL_TOKEN
+
+      - name: Build for Vercel
+        run: vercel build --prod --token=$VERCEL_TOKEN
+
+      - name: Deploy prebuilt artifact to production
+        id: deploy
+        run: |
+          URL=$(vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN)
+          echo "Deployment URL: $URL"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Verify production responds
+        run: |
+          for i in 1 2 3 4 5; do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://probuild.goldentouchremodeling.com || echo "000")
+            if [ "$STATUS" = "200" ] || [ "$STATUS" = "302" ] || [ "$STATUS" = "307" ]; then
+              echo "✅ Production responds with HTTP $STATUS"
+              exit 0
+            fi
+            echo "Attempt $i: got HTTP $STATUS — retrying in 15s"
+            sleep 15
+          done
+          echo "::error::Production did not respond with 2xx/3xx after 5 attempts"
+          exit 1
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## 🚀 Deploy summary"
+            echo ""
+            echo "- Deployment URL: ${{ steps.deploy.outputs.url }}"
+            echo "- Production alias: https://probuild.goldentouchremodeling.com"
+            echo "- Preview alias: https://probuild-amber.vercel.app"
+            if [ "${{ inputs.skip-review }}" = "true" ]; then
+              echo ""
+              echo "> ⚠️ Codex review was **skipped** for this deploy"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,8 @@ Sessions 1–2 + Gantt polish are complete. Each session lists specific files, a
 1. Pick next session from ProbuildTodo.md
 2. Make changes
 3. npm run build          # must pass 0 errors
-4. git push origin main
-5. vercel --prod --token $env:VERCEL_TOKEN   # deploy only when ready
+4. git push origin main   # does NOT auto-deploy (auto-deploy is OFF)
+5. Deploy via CLI — see "Deploying to Vercel" section below
 6. Click through affected pages on prod to verify
 7. Mark items done in ProbuildTodo.md
 ```
@@ -63,15 +63,38 @@ stripe trigger payment_intent.succeeded
 ```
 
 ## Deploying to Vercel (CLI only — auto-deploy is OFF)
+
+**One command — copy/paste exactly:**
 ```powershell
-# Production deploy (from the main repo dir, not a worktree):
 vercel --prod --token $env:VERCEL_TOKEN --yes --archive=tgz --cwd "C:\Users\jat00\.gemini\antigravity\workspaces\gtr-probuild-site"
 ```
-- Auto-deploy was disabled in `vercel.json` to avoid runaway build costs ($250 bill from frequent pushes)
-- `--archive=tgz` is required — project exceeds Vercel's 15,000-file limit without it
-- `--cwd` points to the main repo — deploy from there, not from worktrees (worktrees lack the `.vercel` link)
-- Only deploy when changes are verified locally via `npm run build`
-- Do NOT re-enable auto-deploy in vercel.json or the Vercel dashboard
+
+**Why these specific flags:**
+- `--prod` — deploys to production (no flag = preview deploy)
+- `--token $env:VERCEL_TOKEN` — auth via env var (already set in Windows)
+- `--yes` — skip interactive confirmation prompts
+- `--archive=tgz` — **required** because project has >15,000 files (Vercel API limit)
+- `--cwd "C:\..."` — **must point to the main repo**, NOT a worktree. Worktrees aren't linked to the Vercel project, so deploys from them create junk projects (e.g. the orphan `loving-snyder-*` projects).
+
+**Why auto-deploy is disabled:**
+- `vercel.json` has `"git": { "deploymentEnabled": false }` — set after a $250 Vercel bill from `git push` triggering builds on every commit
+- `git push origin main` no longer triggers a deploy. You MUST run the CLI command above.
+- Do NOT re-enable auto-deploy in `vercel.json` or the Vercel dashboard
+
+**Pre-deploy checklist:**
+1. `npm run build` passes locally with 0 errors
+2. Latest changes committed and pushed to `main`
+3. Run the deploy command above from any directory (the `--cwd` handles location)
+4. Wait ~3-5 minutes for typecheck + Next.js build + deploy
+5. Verify live: https://probuild.goldentouchremodeling.com
+
+**What's excluded from the upload:** see `.vercelignore` in the repo root. Excludes `.claude/` (20GB of worktrees), `node_modules`, `.next`, test artifacts. Without this, uploads are 1.2GB+; with it, ~25MB.
+
+**Troubleshooting:**
+- "missing_archive: files should NOT have more than 15000 items" — you forgot `--archive=tgz`
+- "missing_scope" — token works, but add `--scope justins-projects-a2347a8d` if it can't auto-detect
+- Deploy creates a new project named after the directory (e.g. `loving-snyder-740c8b`) — you ran from a worktree, not the main repo. Delete the junk project on Vercel and re-run with correct `--cwd`.
+- "NEXTAUTH_SECRET must be set" — same root cause as above; you deployed to a wrong project that lacks env vars
 
 ## Dev server — clean start
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,17 @@ In Claude Code, type `/deploy-prod`. This runs the safe-deploy workflow defined 
 
 For a genuine emergency only (prod down, security hotfix), pass `--skip-review` to bypass step 3.
 
-**Manual fallback — direct Vercel CLI:**
+**Automated path (CI) — `.github/workflows/deploy-prod.yml`:**
+
+GitHub Actions workflow that runs Codex review + Vercel deploy on demand or on push to main. Disabled by default until you add the secrets and uncomment the `push:` trigger.
+
+- Trigger manually: https://github.com/Clarion1631/probuild/actions/workflows/deploy-prod.yml → "Run workflow"
+- Required GitHub secrets: `OPENAI_API_KEY`, `VERCEL_TOKEN`, `VERCEL_ORG_ID` (= `team_ncLyFAIeSMFmfr3FS9L9vlMt`), `VERCEL_PROJECT_ID` (= `prj_sd7R3WIYZCRMnu5IhAudBdc4vuIL`)
+- To enable auto-deploy on push to main: uncomment the `push:` block at the top of the workflow file
+- Uses `gpt-5-codex` model via OpenAI API for review (~$0.50–$2 per run); blocks deploy if any BLOCKER findings
+- Uses `vercel pull → vercel build → vercel deploy --prebuilt` so no `--archive=tgz` workaround needed in CI
+
+**Manual fallback — direct Vercel CLI from your machine:**
 ```powershell
 vercel --prod --token $env:VERCEL_TOKEN --yes --archive=tgz --cwd "C:\Users\jat00\.gemini\antigravity\workspaces\gtr-probuild-site"
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Sessions 1–2 + Gantt polish are complete. Each session lists specific files, a
 2. Make changes
 3. npm run build          # must pass 0 errors
 4. git push origin main   # does NOT auto-deploy (auto-deploy is OFF)
-5. Deploy via CLI — see "Deploying to Vercel" section below
+5. /deploy-prod           # Codex review → ship to prod (see "Deploying to Vercel")
 6. Click through affected pages on prod to verify
 7. Mark items done in ProbuildTodo.md
 ```
@@ -62,9 +62,21 @@ stripe listen --forward-to localhost:3000/api/webhooks/stripe --output json
 stripe trigger payment_intent.succeeded
 ```
 
-## Deploying to Vercel (CLI only — auto-deploy is OFF)
+## Deploying to Vercel (CLI only — auto-deploy is OFF, Codex-gated)
 
-**One command — copy/paste exactly:**
+**Default path — use `/deploy-prod`:**
+
+In Claude Code, type `/deploy-prod`. This runs the safe-deploy workflow defined in `.claude/commands/deploy-prod.md`:
+1. Verifies clean working tree in main repo
+2. `npm run build` (must pass 0 errors locally first)
+3. Spawns the `codex-peer-review:codex-peer-reviewer` subagent on the diff
+4. **Aborts on BLOCKER findings**, asks before proceeding on MAJOR, proceeds clean on MINOR/NIT
+5. Runs Vercel CLI deploy
+6. Verifies production URL responds
+
+For a genuine emergency only (prod down, security hotfix), pass `--skip-review` to bypass step 3.
+
+**Manual fallback — direct Vercel CLI:**
 ```powershell
 vercel --prod --token $env:VERCEL_TOKEN --yes --archive=tgz --cwd "C:\Users\jat00\.gemini\antigravity\workspaces\gtr-probuild-site"
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,27 @@ stripe listen --forward-to localhost:3000/api/webhooks/stripe --output json
 stripe trigger payment_intent.succeeded
 ```
 
+## End-of-session workflow (the standing rule)
+
+When the user signals work is ready to ship — phrases like "deploy", "ship it", "ship", "done", "review and deploy", "we're good", "let's ship this", or you've completed every task in the current request and the user has stopped giving new instructions — run **`/deploy-prod`**.
+
+`/deploy-prod` runs this fixed chain:
+1. **Codex peer review** on the diff vs `origin/main` — abort on any BLOCKER, ask before proceeding on MAJOR, proceed on MINOR/NIT
+2. **Vercel CLI deploy** if review is clean
+3. **Production URL verification** — confirm `https://probuild.goldentouchremodeling.com` responds
+4. **Session report** with these exact sections:
+   - **What you asked for** — restatement of the user's original ask from this session
+   - **What shipped** — commits, files changed, deploy URL, Codex verdict
+   - **How to test (do this now)** — numbered, concrete steps with real URLs/buttons/expected results
+   - **Notes / follow-ups** — known limitations, gotchas, things to watch
+
+Skip `/deploy-prod` when:
+- Changes are docs-only (`*.md`, `CLAUDE.md`, comments) or test-only
+- The session is mid-feature and the user is iterating
+- Build is failing locally — fix that first, then run /deploy-prod
+
+Never run `/deploy-prod` between sub-tasks of an in-progress feature. Wait for an explicit "done" signal or task completion.
+
 ## Deploying to Vercel (CLI only — auto-deploy is OFF, Codex-gated)
 
 **Default path — use `/deploy-prod`:**


### PR DESCRIPTION
## Summary

Builds out the production deploy infrastructure that came out of today's session, including the GitHub Actions workflow you asked for ("Flavor 3").

- **`vercel.json`** — `git.deploymentEnabled: false` to stop Vercel's native auto-deploy from billing on every commit (the $250 incident)
- **`.vercelignore`** — excludes `.claude/` (20 GB of worktrees), test artifacts, etc. Cuts CLI uploads from 1.2 GB → 24 MB
- **`.claude/commands/deploy-prod.md`** — `/deploy-prod` slash command that runs build → Codex review → deploy in one shot from any Claude Code session
- **`.github/workflows/deploy-prod.yml`** — GitHub Actions workflow that runs `gpt-5-codex` review then deploys via Vercel CLI on success. Disabled by default (manual `workflow_dispatch` only) until secrets are added and the `push:` trigger is uncommented
- **`CLAUDE.md`** — documents all three paths (slash command, GH Action, manual CLI) plus the reasoning behind disabling auto-deploy

## To enable the GH Action

1. Add these secrets at https://github.com/Clarion1631/probuild/settings/secrets/actions:
   - `OPENAI_API_KEY`
   - `VERCEL_TOKEN` (you already have this locally)
   - `VERCEL_ORG_ID` = `team_ncLyFAIeSMFmfr3FS9L9vlMt`
   - `VERCEL_PROJECT_ID` = `prj_sd7R3WIYZCRMnu5IhAudBdc4vuIL`
2. Trigger a manual run from the Actions tab to verify it works end-to-end
3. When confident, uncomment the `push:` block at the top of `.github/workflows/deploy-prod.yml`

## Test plan

- [ ] Add the four GitHub secrets above
- [ ] Run the workflow manually on this branch (or any branch) and confirm Codex review + deploy work
- [ ] Verify production loads after the test deploy
- [ ] Optionally enable the `push:` trigger for full auto-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
