### PR TITLE
fix(schedule): re-apply task click → detail panel + add panel rename

### DIFF
--- a/src/app/projects/[id]/schedule/GanttChart.tsx
+++ b/src/app/projects/[id]/schedule/GanttChart.tsx
@@ -597,6 +597,11 @@ export default function GanttChart({ projectId, projectName, initialTasks, estim
                             ))}
                         </div>
                         <button onClick={() => { if (scrollRef.current) scrollRef.current.scrollLeft = Math.max(0, todayOffset - 300); }} className="hui-btn hui-btn-secondary text-xs py-1.5 px-3">Today</button>
+                        <button onClick={() => openNewTaskForm("task")} disabled={isAdding} className="hui-btn hui-btn-primary text-xs">+ Task</button>
+                        <button onClick={() => openNewTaskForm("milestone")} disabled={isAdding} className="hui-btn hui-btn-secondary text-xs flex items-center gap-1">
+                            <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0L10.5 5.5L16 8L10.5 10.5L8 16L5.5 10.5L0 8L5.5 5.5Z"/></svg>
+                            Milestone
+                        </button>
                         {/* Critical Path toggle */}
                         <button
                             onClick={() => setShowCriticalPath(v => !v)}
@@ -653,11 +658,6 @@ export default function GanttChart({ projectId, projectName, initialTasks, estim
                                 </div>
                             )}
                         </div>
-                        <button onClick={() => openNewTaskForm("task")} disabled={isAdding} className="hui-btn hui-btn-primary text-xs">+ Task</button>
-                        <button onClick={() => openNewTaskForm("milestone")} disabled={isAdding} className="hui-btn hui-btn-secondary text-xs flex items-center gap-1">
-                            <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0L10.5 5.5L16 8L10.5 10.5L8 16L5.5 10.5L0 8L5.5 5.5Z"/></svg>
-                            Milestone
-                        </button>
                         {/* More menu */}
                         <div className="relative">
                             <button onClick={() => setShowMoreMenu(!showMoreMenu)} className="hui-btn hui-btn-secondary text-xs py-1.5 px-2">
@@ -746,7 +746,7 @@ export default function GanttChart({ projectId, projectName, initialTasks, estim
                                                         {getInitials(a.user.name, a.user.email)}
                                                     </div>
                                                 ))}
-                                                <button onClick={e => { if (!linkMode) { e.stopPropagation(); setEditingId(task.id); setEditName(task.name); }}} className="text-xs font-medium text-hui-textMain truncate text-left hover:text-hui-primary transition">{task.name}</button>
+                                                <span className="text-xs font-medium text-hui-textMain truncate text-left hover:text-hui-primary transition cursor-pointer">{task.name}</span>
                                                 {task.estimateItem && <span className="ml-1 text-[9px] text-blue-500 bg-blue-50 rounded px-1 shrink-0">$</span>}
                                             </div>
                                         )}
@@ -923,6 +923,7 @@ export default function GanttChart({ projectId, projectName, initialTasks, estim
                         panelTab={panelTab}
                         setPanelTab={setPanelTab}
                         onStatusChange={handleStatusChange}
+                        onNameChange={(taskId, name) => { setTasks(prev => prev.map(t => t.id === taskId ? { ...t, name } : t)); updateScheduleTask(taskId, { name }); }}
                         onDateChange={handleDateChange}
                         onEstimatedHoursChange={(taskId, hours) => { setTasks(prev => prev.map(t => t.id === taskId ? { ...t, estimatedHours: hours } : t)); updateScheduleTask(taskId, { estimatedHours: hours }); }}
                         onDelete={handleDelete}

--- a/src/app/projects/[id]/schedule/TableView.tsx
+++ b/src/app/projects/[id]/schedule/TableView.tsx
@@ -648,6 +648,7 @@ export default function TableView({ projectId, projectName, initialTasks, estima
                         panelTab={panelTab}
                         setPanelTab={setPanelTab}
                         onStatusChange={handleStatusChange}
+                        onNameChange={(taskId, name) => { setTasks(prev => prev.map(t => t.id === taskId ? { ...t, name } : t)); updateScheduleTask(taskId, { name }); }}
                         onDateChange={handleDateChange}
                         onEstimatedHoursChange={(taskId, hours) => { setTasks(prev => prev.map(t => t.id === taskId ? { ...t, estimatedHours: hours } : t)); updateScheduleTask(taskId, { estimatedHours: hours }); }}
                         onDelete={handleDelete}

--- a/src/app/projects/[id]/schedule/TaskDetailPanel.tsx
+++ b/src/app/projects/[id]/schedule/TaskDetailPanel.tsx
@@ -10,6 +10,7 @@ export type TaskDetailPanelProps = {
     panelTab: "details" | "punch" | "conversation";
     setPanelTab: (tab: "details" | "punch" | "conversation") => void;
     onStatusChange: (taskId: string, status: string) => void;
+    onNameChange: (taskId: string, name: string) => void;
     onDateChange: (taskId: string, field: "startDate" | "endDate", value: string) => void;
     onEstimatedHoursChange: (taskId: string, hours: number) => void;
     onDelete: (taskId: string) => void;
@@ -37,7 +38,7 @@ export type TaskDetailPanelProps = {
 
 export default function TaskDetailPanel({
     task, onClose, panelTab, setPanelTab,
-    onStatusChange, onDateChange, onEstimatedHoursChange, onDelete,
+    onStatusChange, onNameChange, onDateChange, onEstimatedHoursChange, onDelete,
     estimateItems, onLinkEstimateItem, onUnlinkEstimateItem, onFetchEstimateItems,
     teamMembers, subcontractors, onAssign, onUnassign, onAssignSub, onUnassignSub,
     punchItems, onAddPunch, onTogglePunch, onDeletePunch, onAiPunchlist, isAiPunching,
@@ -48,6 +49,15 @@ export default function TaskDetailPanel({
     const [showEstimateLinkMenu, setShowEstimateLinkMenu] = useState(false);
     const [newPunchName, setNewPunchName] = useState("");
     const [newComment, setNewComment] = useState("");
+    const [nameDraft, setNameDraft] = useState(task.name);
+    const [nameDirty, setNameDirty] = useState(false);
+
+    function handleNameSave() {
+        const next = nameDraft.trim();
+        if (!nameDirty || !next || next === task.name) { setNameDirty(false); setNameDraft(task.name); return; }
+        onNameChange(task.id, next);
+        setNameDirty(false);
+    }
 
     function handleAddPunchLocal() {
         if (!newPunchName.trim()) return;
@@ -90,6 +100,17 @@ export default function TaskDetailPanel({
             <div className="flex-1 overflow-y-auto p-4">
                 {panelTab === "details" && (
                     <div className="space-y-5">
+                        <div>
+                            <label className="text-[10px] font-bold text-slate-400 uppercase tracking-wider">Task Name</label>
+                            <input
+                                type="text"
+                                value={nameDirty ? nameDraft : task.name}
+                                onChange={e => { setNameDraft(e.target.value); setNameDirty(true); }}
+                                onBlur={handleNameSave}
+                                onKeyDown={e => { if (e.key === "Enter") { (e.target as HTMLInputElement).blur(); } else if (e.key === "Escape") { setNameDraft(task.name); setNameDirty(false); (e.target as HTMLInputElement).blur(); } }}
+                                className="hui-input text-sm mt-1 w-full"
+                            />
+                        </div>
                         <div>
                             <label className="text-[10px] font-bold text-slate-400 uppercase tracking-wider">Status</label>
                             <select value={task.status} onChange={e => onStatusChange(task.id, e.target.value)} className="hui-input text-sm mt-1 w-full">


### PR DESCRIPTION
## Summary

PR #74 (table view feature) reverted a prior fix that made clicking tasks open the detail panel. Re-applies that fix on top of the new `TaskDetailPanel` component.

- Task name in left panel: `<button>` with `onClick`+`stopPropagation` → `<span>`, so single click propagates to row and opens the detail panel
- Add editable **Task Name** input as the first field in the Details tab (replaces inline-rename which is no longer reachable via click). Saves on blur or Enter; Escape cancels.
- Wire `onNameChange` in both `GanttChart` and `TableView` (both render `TaskDetailPanel`)
- Move **+ Task** and **Milestone** buttons earlier in the toolbar (right after "Today") for discoverability — was buried after AI Schedule

## Codex review

This change was previously peer-reviewed by Codex. The high-severity finding (browser fires `click` before `dblclick`, so `onDoubleClick` rename was racing with row click) was the reason for moving rename to the detail panel input — fully addressed in this PR.

## Test plan

- [ ] Click a task name in left panel → detail panel slides in from right with Details/Punch/Comments tabs
- [ ] In detail panel Details tab, edit the Task Name field → Enter or blur saves; Escape reverts
- [ ] Toolbar order: Today → **+ Task** → **Milestone** → Critical Path → AI Risk → Publish → Sync → AI Schedule
- [ ] Click **+ Task** → inline form appears at bottom of task list, create works
- [ ] Color circle, hours, status, delete buttons in task row still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)