### PR TITLE
fix(schedule): sync Gantt bar positions with date headers

### DIFF
--- a/src/app/projects/[id]/schedule/GanttChart.tsx
+++ b/src/app/projects/[id]/schedule/GanttChart.tsx
@@ -146,7 +146,8 @@ export default function GanttChart({ projectId, projectName, initialTasks, estim
     const allDates = tasks.flatMap(t => [new Date(t.startDate), new Date(t.endDate)]);
     const today = new Date();
     if (allDates.length === 0) { allDates.push(addDays(today, -14), addDays(today, 60)); }
-    const minDate = addDays(new Date(Math.min(...allDates.map(d => d.getTime()))), -14);
+    const rawMin = addDays(new Date(Math.min(...allDates.map(d => d.getTime()))), -14);
+    const minDate = getMonday(rawMin); // Snap to Monday so bars and week headers share the same origin
     const maxDate = addDays(new Date(Math.max(...allDates.map(d => d.getTime()))), 30);
     const totalDays = getDaysBetween(minDate, maxDate);
     const colWidth = zoom === "day" ? 40 : zoom === "week" ? 20 : 8;
@@ -156,23 +157,23 @@ export default function GanttChart({ projectId, projectName, initialTasks, estim
     function getHeaders() {
         const headers: { label: string; span: number; key: string }[] = [];
         if (zoom === "month") {
-            let cursor = new Date(minDate);
+            let cursor = new Date(minDate.getTime());
             while (cursor < maxDate) {
-                const monthEnd = new Date(cursor.getFullYear(), cursor.getMonth() + 1, 0);
+                const monthEnd = new Date(Date.UTC(cursor.getUTCFullYear(), cursor.getUTCMonth() + 1, 0));
                 const end = monthEnd > maxDate ? maxDate : monthEnd;
-                headers.push({ label: cursor.toLocaleString("en", { month: "short" }), span: getDaysBetween(cursor, end) + 1, key: `m-${cursor.getMonth()}-${cursor.getFullYear()}` });
-                cursor = new Date(cursor.getFullYear(), cursor.getMonth() + 1, 1);
+                headers.push({ label: cursor.toLocaleString("en", { month: "short", timeZone: "UTC" }), span: getDaysBetween(cursor, end) + 1, key: `m-${cursor.getUTCMonth()}-${cursor.getUTCFullYear()}` });
+                cursor = new Date(Date.UTC(cursor.getUTCFullYear(), cursor.getUTCMonth() + 1, 1));
             }
         } else if (zoom === "week") {
-            let cursor = getMonday(new Date(minDate));
+            let cursor = new Date(minDate.getTime()); // minDate is already snapped to Monday
             while (cursor < maxDate) {
-                headers.push({ label: cursor.toLocaleDateString("en", { month: "short", day: "numeric" }).toUpperCase(), span: 7, key: `w-${formatDate(cursor)}` });
+                headers.push({ label: cursor.toLocaleDateString("en", { month: "short", day: "numeric", timeZone: "UTC" }).toUpperCase(), span: 7, key: `w-${formatDate(cursor)}` });
                 cursor = addDays(cursor, 7);
             }
         } else {
-            let cursor = new Date(minDate);
+            let cursor = new Date(minDate.getTime());
             while (cursor < maxDate) {
-                headers.push({ label: cursor.getDate().toString(), span: 1, key: `d-${formatDate(cursor)}` });
+                headers.push({ label: cursor.getUTCDate().toString(), span: 1, key: `d-${formatDate(cursor)}` });
                 cursor = addDays(cursor, 1);
             }
         }


### PR DESCRIPTION
## Summary
- Gantt chart bars were misaligned with the timeline date headers by up to 6+ days
- **Root cause 1:** Week headers started from `getMonday(minDate)` but bars were positioned from `minDate` — different coordinate origins caused bars to shift left
- **Root cause 2:** Header label calculations used local-time Date methods (`getDate`, `getMonth`) on UTC-parsed dates, causing server/client rendering differences
- Fix: snap `minDate` to Monday so both headers and bars share the same origin; use UTC methods (`getUTCDate`, `Date.UTC`, `timeZone:"UTC"`) for all header calculations

## Test plan
- [ ] Hard refresh schedule page — bars should align with their date header columns
- [ ] Click a task — panel dates should match the bar's position on the timeline
- [ ] Test Day, Week, and Month zoom levels — all should show correct alignment
- [ ] Change a task's date in the panel — bar should move to the correct position

🤖 Generated with [Claude Code](https://claude.com/claude-code)