### PR TITLE
feat(schedule): make task dependencies editable from panel + table

### DIFF
--- a/src/app/projects/[id]/schedule/DependencyPicker.tsx
+++ b/src/app/projects/[id]/schedule/DependencyPicker.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Task } from "./schedule-types";
+
+export type DependencyPickerProps = {
+    task: Task;
+    allTasks: Task[];
+    onPick: (predecessorId: string) => void;
+    onClose: () => void;
+    align?: "left" | "right";
+};
+
+// Walk the dependents graph from `taskId` and collect every reachable id.
+// Used to exclude tasks that would create a cycle if linked as a predecessor.
+function getReachableSuccessors(taskId: string, tasks: Task[]): Set<string> {
+    const reachable = new Set<string>();
+    const map = new Map(tasks.map(t => [t.id, t] as const));
+    const stack: string[] = [taskId];
+    while (stack.length > 0) {
+        const cur = stack.pop()!;
+        const t = map.get(cur);
+        if (!t) continue;
+        for (const dep of t.dependents) {
+            if (!reachable.has(dep.dependentId)) {
+                reachable.add(dep.dependentId);
+                stack.push(dep.dependentId);
+            }
+        }
+    }
+    return reachable;
+}
+
+export default function DependencyPicker({ task, allTasks, onPick, onClose, align = "right" }: DependencyPickerProps) {
+    const [query, setQuery] = useState("");
+    const ref = useRef<HTMLDivElement>(null);
+
+    const candidates = useMemo(() => {
+        const existing = new Set(task.dependencies.map(d => d.predecessorId));
+        const successors = getReachableSuccessors(task.id, allTasks);
+        const q = query.trim().toLowerCase();
+        return allTasks.filter(t =>
+            t.id !== task.id &&
+            !existing.has(t.id) &&
+            !successors.has(t.id) &&
+            (q === "" || t.name.toLowerCase().includes(q))
+        );
+    }, [task.id, task.dependencies, allTasks, query]);
+
+    useEffect(() => {
+        function handleClickOutside(e: MouseEvent) {
+            if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+        }
+        function handleKey(e: KeyboardEvent) { if (e.key === "Escape") onClose(); }
+        document.addEventListener("mousedown", handleClickOutside);
+        document.addEventListener("keydown", handleKey);
+        return () => {
+            document.removeEventListener("mousedown", handleClickOutside);
+            document.removeEventListener("keydown", handleKey);
+        };
+    }, [onClose]);
+
+    return (
+        <div
+            ref={ref}
+            className={`absolute ${align === "right" ? "right-0" : "left-0"} top-full mt-1 bg-white border border-hui-border rounded-lg shadow-xl z-50 min-w-[260px] max-h-72 overflow-hidden flex flex-col animate-in fade-in`}
+            onClick={e => e.stopPropagation()}
+        >
+            <div className="p-2 border-b border-slate-100">
+                <input
+                    autoFocus
+                    type="text"
+                    value={query}
+                    onChange={e => setQuery(e.target.value)}
+                    placeholder="Search tasks…"
+                    className="hui-input text-xs w-full py-1"
+                />
+            </div>
+            <div className="overflow-y-auto py-1">
+                {candidates.length === 0 ? (
+                    <div className="px-3 py-2 text-xs text-slate-400 italic">
+                        {allTasks.length <= 1
+                            ? "Add another task first to create a link."
+                            : query.trim()
+                                ? "No matching tasks."
+                                : "No eligible tasks — others would create a cycle or are already linked."}
+                    </div>
+                ) : (
+                    candidates.map(t => (
+                        <button
+                            key={t.id}
+                            onClick={() => { onPick(t.id); onClose(); }}
+                            className="w-full text-left px-3 py-2 hover:bg-slate-50 transition flex items-center gap-2 text-xs"
+                        >
+                            {t.type === "milestone" ? (
+                                <div className="w-2.5 h-2.5 rotate-45 shrink-0" style={{ backgroundColor: t.color }} />
+                            ) : (
+                                <div className="w-2.5 h-2.5 rounded-full shrink-0" style={{ backgroundColor: t.color }} />
+                            )}
+                            <span className="font-medium truncate flex-1">{t.name}</span>
+                            <span className="text-[9px] text-slate-400">{t.startDate}</span>
+                        </button>
+                    ))
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/app/projects/[id]/schedule/GanttChart.tsx
+++ b/src/app/projects/[id]/schedule/GanttChart.tsx
@@ -606,6 +606,15 @@ export default function GanttChart({ projectId, projectName, initialTasks, estim
                             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
                             Critical Path
                         </button>
+                        {/* Link Tasks toggle */}
+                        <button
+                            onClick={() => setLinkMode(linkMode ? null : "__awaiting__")}
+                            className={`text-xs flex items-center gap-1.5 px-3 py-1.5 rounded-lg font-medium transition border ${linkMode ? "bg-amber-100 text-amber-800 border-amber-300" : "bg-slate-50 text-slate-600 border-slate-200 hover:bg-slate-100"}`}
+                            title={linkMode ? "Cancel linking" : "Click two tasks to create a Finish-to-Start dependency"}
+                        >
+                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+                            {linkMode ? "Cancel Link" : "Link Tasks"}
+                        </button>
                         <button
                             onClick={handleAiRisk}
                             disabled={isAiRisk || tasks.length === 0}
@@ -660,22 +669,17 @@ export default function GanttChart({ projectId, projectName, initialTasks, estim
                             </button>
                             {showMoreMenu && (
                                 <div className="absolute right-0 top-full mt-1 bg-white border border-hui-border rounded-lg shadow-xl z-50 min-w-[200px] py-1 animate-in fade-in">
-                                    <button onClick={() => { setLinkMode(linkMode ? null : "__awaiting__"); setShowMoreMenu(false); }} className="w-full text-left px-3 py-2 hover:bg-slate-50 transition text-sm flex items-center gap-2">
-                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
-                                        {linkMode ? "Cancel Linking" : "Link Tasks"}
-                                    </button>
                                     {estimates.length > 0 && (
                                         <>
-                                            <div className="border-t border-slate-100 my-1" />
                                             <div className="px-3 py-1 text-[10px] text-slate-400 uppercase font-semibold">Import from Estimate</div>
                                             {estimates.map(est => (
                                                 <button key={est.id} onClick={() => { handleImportEstimate(est.id); setShowMoreMenu(false); }} className="w-full text-left px-3 py-2 hover:bg-slate-50 transition text-sm flex items-center gap-2">
                                                     📋 {est.title}
                                                 </button>
                                             ))}
+                                            <div className="border-t border-slate-100 my-1" />
                                         </>
                                     )}
-                                    <div className="border-t border-slate-100 my-1" />
                                     <button onClick={async () => { if (confirm('Delete ALL tasks from this schedule? This cannot be undone.')) { setShowMoreMenu(false); await clearAllTasks(projectId); setTasks([]); setSelectedTaskId(null); toast.success('Schedule cleared'); } }} className="w-full text-left px-3 py-2 hover:bg-red-50 transition text-sm flex items-center gap-2 text-red-600">
                                         🗑️ Clear All Tasks
                                     </button>
@@ -935,6 +939,30 @@ export default function GanttChart({ projectId, projectName, initialTasks, estim
                         onAddComment={handleAddComment}
                         showCriticalPath={showCriticalPath}
                         criticalPathIds={criticalPathIds}
+                        allTasks={tasks}
+                        onLinkPredecessor={async (predId) => {
+                            if (!selectedTaskId) return;
+                            try {
+                                const dep = await linkTasks(predId, selectedTaskId);
+                                setTasks(prev => prev.map(t => {
+                                    if (t.id === selectedTaskId) return { ...t, dependencies: [...t.dependencies, { id: dep.id, predecessorId: predId, dependentId: selectedTaskId }] };
+                                    if (t.id === predId) return { ...t, dependents: [...t.dependents, { id: dep.id, predecessorId: predId, dependentId: selectedTaskId }] };
+                                    return t;
+                                }));
+                                toast.success("Predecessor added");
+                            } catch { toast.error("Already linked or invalid"); }
+                        }}
+                        onUnlinkPredecessor={async (predId) => {
+                            if (!selectedTaskId) return;
+                            await unlinkTasks(predId, selectedTaskId);
+                            setTasks(prev => prev.map(t => ({
+                                ...t,
+                                dependencies: t.dependencies.filter(d => !(d.predecessorId === predId && d.dependentId === selectedTaskId)),
+                                dependents: t.dependents.filter(d => !(d.predecessorId === predId && d.dependentId === selectedTaskId)),
+                            })));
+                            toast.success("Predecessor removed");
+                        }}
+                        onSelectTask={(taskId) => { setSelectedTaskId(taskId); setPanelTab("details"); }}
                     />
                 )}
             </div>

--- a/src/app/projects/[id]/schedule/TableView.tsx
+++ b/src/app/projects/[id]/schedule/TableView.tsx
@@ -15,6 +15,7 @@ import { toast } from "sonner";
 import type { Task, EstimateSummary, EstimateItemSummary, TeamMember, Subcontractor, PunchItem, Comment } from "./schedule-types";
 import { STATUS_OPTIONS, STATUS_COLORS, PRESET_COLORS, getDaysBetween, addDays, formatDate, getInitials, formatCurrency, computeCriticalPath } from "./schedule-utils";
 import TaskDetailPanel from "./TaskDetailPanel";
+import DependencyPicker from "./DependencyPicker";
 
 type SortKey = "name" | "type" | "startDate" | "endDate" | "duration" | "status" | "progress" | "estimatedHours" | "actualHours";
 
@@ -59,6 +60,8 @@ export default function TableView({ projectId, projectName, initialTasks, estima
     const [editingCell, setEditingCell] = useState<{ taskId: string; field: string } | null>(null);
     const [editValue, setEditValue] = useState("");
     const [colorPickerId, setColorPickerId] = useState<string | null>(null);
+    const [depsPopoverId, setDepsPopoverId] = useState<string | null>(null);
+    const [depsPickerId, setDepsPickerId] = useState<string | null>(null);
     const editRef = useRef<HTMLInputElement | HTMLSelectElement>(null);
     const tasksRef = useRef(tasks);
     useEffect(() => { tasksRef.current = tasks; });
@@ -252,6 +255,27 @@ export default function TableView({ projectId, projectName, initialTasks, estima
         setLinkMode(null);
     }
 
+    async function addPredecessor(dependentId: string, predecessorId: string) {
+        try {
+            const dep = await linkTasks(predecessorId, dependentId);
+            setTasks(prev => prev.map(t => {
+                if (t.id === dependentId) return { ...t, dependencies: [...t.dependencies, { id: dep.id, predecessorId, dependentId }] };
+                if (t.id === predecessorId) return { ...t, dependents: [...t.dependents, { id: dep.id, predecessorId, dependentId }] };
+                return t;
+            }));
+            toast.success("Predecessor added");
+        } catch { toast.error("Already linked or invalid"); }
+    }
+    async function removePredecessor(dependentId: string, predecessorId: string) {
+        await unlinkTasks(predecessorId, dependentId);
+        setTasks(prev => prev.map(t => ({
+            ...t,
+            dependencies: t.dependencies.filter(d => !(d.predecessorId === predecessorId && d.dependentId === dependentId)),
+            dependents: t.dependents.filter(d => !(d.predecessorId === predecessorId && d.dependentId === dependentId)),
+        })));
+        toast.success("Predecessor removed");
+    }
+
     // --- Estimate linking ---
     async function handleLinkEstimateItem(taskId: string, item: EstimateItemSummary) {
         setTasks(prev => prev.map(t => t.id === taskId ? { ...t, estimateItemId: item.id, estimateItem: item } : t));
@@ -440,6 +464,14 @@ export default function TableView({ projectId, projectName, initialTasks, estima
                         <button onClick={() => setShowCriticalPath(v => !v)} className={`text-xs flex items-center gap-1.5 px-3 py-1.5 rounded-lg font-medium transition border ${showCriticalPath ? "bg-red-50 text-red-700 border-red-300" : "bg-slate-50 text-slate-600 border-slate-200 hover:bg-slate-100"}`} title="Highlight critical path">
                             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>Critical Path
                         </button>
+                        <button
+                            onClick={() => setLinkMode(linkMode ? null : "__awaiting__")}
+                            className={`text-xs flex items-center gap-1.5 px-3 py-1.5 rounded-lg font-medium transition border ${linkMode ? "bg-amber-100 text-amber-800 border-amber-300" : "bg-slate-50 text-slate-600 border-slate-200 hover:bg-slate-100"}`}
+                            title={linkMode ? "Cancel linking" : "Click two tasks to create a Finish-to-Start dependency"}
+                        >
+                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+                            {linkMode ? "Cancel Link" : "Link Tasks"}
+                        </button>
                         <button onClick={handleAiRisk} disabled={isAiRisk || tasks.length === 0} className={`text-xs flex items-center gap-1.5 px-3 py-1.5 rounded-lg font-medium transition border ${isAiRisk ? "bg-amber-500 text-white border-amber-600 animate-pulse" : "bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-100"}`} title="AI schedule risk analysis">
                             ⚠️ {isAiRisk ? "Analyzing…" : "AI Risk"}
                         </button>
@@ -472,18 +504,13 @@ export default function TableView({ projectId, projectName, initialTasks, estima
                             </button>
                             {showMoreMenu && (
                                 <div className="absolute right-0 top-full mt-1 bg-white border border-hui-border rounded-lg shadow-xl z-50 min-w-[200px] py-1 animate-in fade-in">
-                                    <button onClick={() => { setLinkMode(linkMode ? null : "__awaiting__"); setShowMoreMenu(false); }} className="w-full text-left px-3 py-2 hover:bg-slate-50 transition text-sm flex items-center gap-2">
-                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
-                                        {linkMode ? "Cancel Linking" : "Link Tasks"}
-                                    </button>
                                     {estimates.length > 0 && (
                                         <>
-                                            <div className="border-t border-slate-100 my-1" />
                                             <div className="px-3 py-1 text-[10px] text-slate-400 uppercase font-semibold">Import from Estimate</div>
                                             {estimates.map(est => (<button key={est.id} onClick={() => { handleImportEstimate(est.id); setShowMoreMenu(false); }} className="w-full text-left px-3 py-2 hover:bg-slate-50 transition text-sm flex items-center gap-2">📋 {est.title}</button>))}
+                                            <div className="border-t border-slate-100 my-1" />
                                         </>
                                     )}
-                                    <div className="border-t border-slate-100 my-1" />
                                     <button onClick={async () => { if (confirm('Delete ALL tasks from this schedule? This cannot be undone.')) { setShowMoreMenu(false); await clearAllTasks(projectId); setTasks([]); setSelectedTaskId(null); toast.success('Schedule cleared'); } }} className="w-full text-left px-3 py-2 hover:bg-red-50 transition text-sm flex items-center gap-2 text-red-600">🗑️ Clear All Tasks</button>
                                 </div>
                             )}
@@ -621,11 +648,65 @@ export default function TableView({ projectId, projectName, initialTasks, estima
                                         <td className="px-3 py-2 text-right text-hui-textMuted">{task.actualHours > 0 ? `${task.actualHours.toFixed(1)}h` : "—"}</td>
                                         {/* Dependencies */}
                                         <td className="px-3 py-2">
-                                            {task.dependencies.length > 0 ? (
-                                                <span className="text-[10px] bg-slate-100 text-slate-600 px-1.5 py-0.5 rounded font-medium">{task.dependencies.length} dep{task.dependencies.length !== 1 ? "s" : ""}</span>
-                                            ) : (
-                                                <span className="text-slate-300">—</span>
-                                            )}
+                                            <div className="relative inline-block" onClick={e => e.stopPropagation()}>
+                                                <button
+                                                    onClick={() => { setDepsPopoverId(depsPopoverId === task.id ? null : task.id); setDepsPickerId(null); }}
+                                                    className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition ${task.dependencies.length > 0 ? "bg-slate-100 text-slate-600 hover:bg-indigo-100 hover:text-indigo-700" : "text-slate-300 hover:text-indigo-600 hover:bg-indigo-50"}`}
+                                                    title={task.dependencies.length > 0 ? "View / edit predecessors" : "Add a predecessor"}
+                                                >
+                                                    {task.dependencies.length > 0 ? `${task.dependencies.length} dep${task.dependencies.length !== 1 ? "s" : ""}` : "+ Link"}
+                                                </button>
+                                                {depsPopoverId === task.id && (
+                                                    <div className="absolute left-0 top-full mt-1 bg-white border border-hui-border rounded-lg shadow-xl z-50 min-w-[240px] py-1 animate-in fade-in">
+                                                        <div className="px-3 py-1.5 text-[10px] font-bold text-slate-400 uppercase tracking-wider bg-slate-50 flex items-center justify-between">
+                                                            <span>Predecessors</span>
+                                                            <button onClick={() => setDepsPopoverId(null)} className="text-slate-400 hover:text-slate-700">
+                                                                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6 6 18M6 6l12 12" /></svg>
+                                                            </button>
+                                                        </div>
+                                                        {task.dependencies.length === 0 ? (
+                                                            <div className="px-3 py-2 text-xs text-slate-400 italic">No predecessors yet.</div>
+                                                        ) : (
+                                                            task.dependencies.map(d => {
+                                                                const pred = tasks.find(t => t.id === d.predecessorId);
+                                                                if (!pred) return null;
+                                                                return (
+                                                                    <div key={d.id} className="px-3 py-1.5 hover:bg-slate-50 flex items-center gap-2 text-xs group/dep">
+                                                                        {pred.type === "milestone" ? (
+                                                                            <div className="w-2 h-2 rotate-45 shrink-0" style={{ backgroundColor: pred.color }} />
+                                                                        ) : (
+                                                                            <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: pred.color }} />
+                                                                        )}
+                                                                        <span className="font-medium truncate flex-1">{pred.name}</span>
+                                                                        <span className="text-[9px] text-slate-400 font-semibold">FS</span>
+                                                                        <button onClick={() => removePredecessor(task.id, pred.id)} className="text-slate-300 hover:text-red-500 transition shrink-0" title="Remove">
+                                                                            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6 6 18M6 6l12 12" /></svg>
+                                                                        </button>
+                                                                    </div>
+                                                                );
+                                                            })
+                                                        )}
+                                                        <div className="border-t border-slate-100 my-1" />
+                                                        <div className="px-1 relative">
+                                                            <button
+                                                                onClick={() => setDepsPickerId(depsPickerId === task.id ? null : task.id)}
+                                                                className="w-full text-left px-2 py-1.5 hover:bg-indigo-50 transition text-xs text-indigo-600 font-semibold rounded"
+                                                            >
+                                                                + Add predecessor
+                                                            </button>
+                                                            {depsPickerId === task.id && (
+                                                                <DependencyPicker
+                                                                    task={task}
+                                                                    allTasks={tasks}
+                                                                    onPick={(predId) => addPredecessor(task.id, predId)}
+                                                                    onClose={() => setDepsPickerId(null)}
+                                                                    align="left"
+                                                                />
+                                                            )}
+                                                        </div>
+                                                    </div>
+                                                )}
+                                            </div>
                                         </td>
                                         {/* Actions */}
                                         <td className="px-2 py-2">
@@ -672,6 +753,14 @@ export default function TableView({ projectId, projectName, initialTasks, estima
                         onAddComment={handleAddComment}
                         showCriticalPath={showCriticalPath}
                         criticalPathIds={criticalPathIds}
+                        allTasks={tasks}
+                        onLinkPredecessor={async (predId) => {
+                            if (selectedTaskId) await addPredecessor(selectedTaskId, predId);
+                        }}
+                        onUnlinkPredecessor={async (predId) => {
+                            if (selectedTaskId) await removePredecessor(selectedTaskId, predId);
+                        }}
+                        onSelectTask={(taskId) => { setSelectedTaskId(taskId); setPanelTab("details"); }}
                     />
                 )}
             </div>

--- a/src/app/projects/[id]/schedule/TaskDetailPanel.tsx
+++ b/src/app/projects/[id]/schedule/TaskDetailPanel.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import type { Task, PunchItem, Comment, TeamMember, Subcontractor, EstimateItemSummary } from "./schedule-types";
 import { STATUS_OPTIONS, getInitials, formatCurrency } from "./schedule-utils";
+import DependencyPicker from "./DependencyPicker";
 
 export type TaskDetailPanelProps = {
     task: Task;
@@ -34,6 +35,10 @@ export type TaskDetailPanelProps = {
     onAddComment: (text: string) => void;
     showCriticalPath: boolean;
     criticalPathIds: Set<string>;
+    allTasks: Task[];
+    onLinkPredecessor: (predecessorId: string) => void;
+    onUnlinkPredecessor: (predecessorId: string) => void;
+    onSelectTask?: (taskId: string) => void;
 };
 
 export default function TaskDetailPanel({
@@ -44,13 +49,23 @@ export default function TaskDetailPanel({
     punchItems, onAddPunch, onTogglePunch, onDeletePunch, onAiPunchlist, isAiPunching,
     comments, onAddComment,
     showCriticalPath, criticalPathIds,
+    allTasks, onLinkPredecessor, onUnlinkPredecessor, onSelectTask,
 }: TaskDetailPanelProps) {
     const [showAssignMenu, setShowAssignMenu] = useState(false);
     const [showEstimateLinkMenu, setShowEstimateLinkMenu] = useState(false);
+    const [showPredecessorMenu, setShowPredecessorMenu] = useState(false);
     const [newPunchName, setNewPunchName] = useState("");
     const [newComment, setNewComment] = useState("");
     const [nameDraft, setNameDraft] = useState(task.name);
     const [nameDirty, setNameDirty] = useState(false);
+
+    const taskMap = new Map(allTasks.map(t => [t.id, t] as const));
+    const predecessors = task.dependencies
+        .map(d => ({ depId: d.id, predId: d.predecessorId, task: taskMap.get(d.predecessorId) }))
+        .filter(p => p.task);
+    const successors = task.dependents
+        .map(d => ({ depId: d.id, succId: d.dependentId, task: taskMap.get(d.dependentId) }))
+        .filter(s => s.task);
 
     function handleNameSave() {
         const next = nameDraft.trim();
@@ -186,6 +201,74 @@ export default function TaskDetailPanel({
                                 </div>
                             ) : (
                                 <p className="text-xs text-slate-400 italic">Not linked to an estimate item</p>
+                            )}
+                        </div>
+                        {/* Dependencies */}
+                        <div>
+                            <div className="flex items-center justify-between mb-2">
+                                <label className="text-[10px] font-bold text-slate-400 uppercase tracking-wider">Predecessors</label>
+                                <div className="relative">
+                                    <button onClick={() => setShowPredecessorMenu(v => !v)} className="text-[10px] text-indigo-600 font-semibold hover:text-indigo-800 transition">+ Add</button>
+                                    {showPredecessorMenu && (
+                                        <DependencyPicker
+                                            task={task}
+                                            allTasks={allTasks}
+                                            onPick={(predId) => onLinkPredecessor(predId)}
+                                            onClose={() => setShowPredecessorMenu(false)}
+                                        />
+                                    )}
+                                </div>
+                            </div>
+                            <div className="space-y-1.5">
+                                {predecessors.length === 0 ? (
+                                    <p className="text-xs text-slate-400 italic">No predecessors. Add one to make this task wait for another to finish.</p>
+                                ) : (
+                                    predecessors.map(p => (
+                                        <div key={p.depId} className="flex items-center gap-2 bg-slate-50 rounded-lg px-3 py-2 group/dep">
+                                            {p.task!.type === "milestone" ? (
+                                                <div className="w-2.5 h-2.5 rotate-45 shrink-0" style={{ backgroundColor: p.task!.color }} />
+                                            ) : (
+                                                <div className="w-2.5 h-2.5 rounded-full shrink-0" style={{ backgroundColor: p.task!.color }} />
+                                            )}
+                                            <button
+                                                type="button"
+                                                onClick={() => onSelectTask?.(p.predId)}
+                                                className="text-xs font-medium text-hui-textMain flex-1 truncate text-left hover:text-indigo-600 transition cursor-pointer"
+                                                title="Open this task"
+                                            >
+                                                {p.task!.name}
+                                            </button>
+                                            <span className="text-[9px] text-slate-400 font-semibold uppercase tracking-wide" title="Finish-to-Start: this task starts after the predecessor finishes">FS</span>
+                                            <button onClick={() => onUnlinkPredecessor(p.predId)} className="text-slate-300 hover:text-red-500 transition shrink-0" title="Remove dependency">
+                                                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6 6 18M6 6l12 12" /></svg>
+                                            </button>
+                                        </div>
+                                    ))
+                                )}
+                            </div>
+                            {successors.length > 0 && (
+                                <div className="mt-3">
+                                    <label className="text-[10px] font-bold text-slate-400 uppercase tracking-wider">Successors</label>
+                                    <div className="space-y-1 mt-1.5">
+                                        {successors.map(s => (
+                                            <button
+                                                key={s.depId}
+                                                type="button"
+                                                onClick={() => onSelectTask?.(s.succId)}
+                                                className="flex items-center gap-2 px-3 py-1.5 text-[11px] text-slate-500 hover:bg-slate-50 rounded transition w-full text-left"
+                                                title="Open this task to manage its predecessors"
+                                            >
+                                                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-slate-300 shrink-0"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+                                                {s.task!.type === "milestone" ? (
+                                                    <div className="w-2 h-2 rotate-45 shrink-0" style={{ backgroundColor: s.task!.color }} />
+                                                ) : (
+                                                    <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: s.task!.color }} />
+                                                )}
+                                                <span className="truncate">{s.task!.name}</span>
+                                            </button>
+                                        ))}
+                                    </div>
+                                </div>
                             )}
                         </div>
                         {/* Critical Path indicator */}


### PR DESCRIPTION
## Summary

Task linking already worked at the data layer (`TaskDependency` table, `linkTasks`/`unlinkTasks` server actions, Gantt arrows) but was hidden — the "Link Tasks" button was buried in the kebab `⋮` menu and the side panel that opens on a normal click had no dependencies UI, so the gestures most people would try led nowhere.

Three changes, one PR:

- **Detail panel** (shared by Gantt and Table) — new Predecessors section in the Details tab with FS pills, ×-to-unlink, and a `+ Add` picker. Successors render as a smaller read-only list whose entries open the successor task so its predecessors can be edited symmetrically.
- **Toolbar** — "Link Tasks" promoted out of the kebab into the main toolbar next to Critical Path in both Gantt and Table views; turns amber when active.
- **Table view** — the static "N deps" pill is now an interactive popover with a predecessor list, remove buttons, and an inline `+ Add predecessor` picker.

New shared `DependencyPicker` component is reused by panel and table. It filters out self, existing predecessors, and reachable successors so the picker cannot create a cycle (which would infinite-loop `cascadeDependents`).

No schema changes, no server-action changes — pure UI over existing data.

## Test plan

- [ ] Open `/projects/<id>/schedule` for a project with at least 3 tasks
- [ ] Click any task → confirm Predecessors section appears in the Details tab
- [ ] Click `+ Add` → confirm picker shows other tasks, excludes self and existing predecessors
- [ ] Pick a predecessor → confirm pill appears in panel, dashed arrow renders in Gantt, "Deps" count updates in Table
- [ ] Click `×` on a predecessor pill → confirm removal everywhere (panel, Gantt arrow, Table count)
- [ ] Confirm "Link Tasks" appears in the toolbar (not buried in `⋮`) in both views, turns amber when active, banner appears, two-click flow still works
- [ ] In Table view, click the `Deps` / `+ Link` pill in any row → confirm popover with predecessor list and `+ Add predecessor` opens
- [ ] Try to add task A as a predecessor of task B when B is already a predecessor of A → confirm A is hidden from the picker (cycle guard)
- [ ] Switch view (Gantt ↔ Table) after editing → confirm dependencies persist
- [ ] Click a successor name in the panel → confirm it opens that task's panel with focus on its predecessors

🤖 Generated with [Claude Code](https://claude.com/claude-code)