### PR TITLE
fix(schedule): sync Gantt and Table views via shared task state

### DIFF
--- a/src/app/projects/[id]/schedule/GanttChart.tsx
+++ b/src/app/projects/[id]/schedule/GanttChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useCallback, useEffect, useMemo } from "react";
+import { useState, useRef, useCallback, useEffect, useMemo, type Dispatch, type SetStateAction } from "react";
 import {
     createScheduleTask, updateScheduleTask, deleteScheduleTask,
     importEstimateToSchedule, linkTasks, unlinkTasks, clearAllTasks,
@@ -18,10 +18,11 @@ import SchedulePublishButton from "./SchedulePublishButton";
 
 const DRAG_THRESHOLD_PX = 5;
 
-export default function GanttChart({ projectId, projectName, initialTasks, estimates = [], teamMembers = [], subcontractors = [], currentUserId = "system", initialPublished, viewMode, onViewModeChange }: {
+export default function GanttChart({ projectId, projectName, tasks, setTasks, estimates = [], teamMembers = [], subcontractors = [], currentUserId = "system", initialPublished, viewMode, onViewModeChange }: {
     projectId: string;
     projectName: string;
-    initialTasks: Task[];
+    tasks: Task[];
+    setTasks: Dispatch<SetStateAction<Task[]>>;
     estimates?: EstimateSummary[];
     teamMembers?: TeamMember[];
     subcontractors?: Subcontractor[];
@@ -30,7 +31,6 @@ export default function GanttChart({ projectId, projectName, initialTasks, estim
     viewMode?: "gantt" | "table";
     onViewModeChange?: (mode: "gantt" | "table") => void;
 }) {
-    const [tasks, setTasks] = useState<Task[]>(initialTasks);
     const [zoom, setZoom] = useState<ZoomLevel>("week");
     const [editingId, setEditingId] = useState<string | null>(null);
     const [editName, setEditName] = useState("");

--- a/src/app/projects/[id]/schedule/ScheduleView.tsx
+++ b/src/app/projects/[id]/schedule/ScheduleView.tsx
@@ -1,16 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import GanttChart from "./GanttChart";
 import TableView from "./TableView";
-import type { ScheduleViewProps } from "./schedule-types";
+import type { ScheduleViewProps, Task } from "./schedule-types";
 
-export default function ScheduleView(props: ScheduleViewProps) {
+export default function ScheduleView({ initialTasks, ...rest }: ScheduleViewProps) {
     const [viewMode, setViewMode] = useState<"gantt" | "table">("gantt");
+    const [tasks, setTasks] = useState<Task[]>(initialTasks);
 
-    return viewMode === "gantt" ? (
-        <GanttChart {...props} viewMode={viewMode} onViewModeChange={setViewMode} />
-    ) : (
-        <TableView {...props} viewMode={viewMode} onViewModeChange={setViewMode} />
-    );
+    // Re-sync when the server passes new initialTasks (router.refresh / page revisit).
+    useEffect(() => { setTasks(initialTasks); }, [initialTasks]);
+
+    const shared = { ...rest, tasks, setTasks, viewMode, onViewModeChange: setViewMode };
+    return viewMode === "gantt" ? <GanttChart {...shared} /> : <TableView {...shared} />;
 }

--- a/src/app/projects/[id]/schedule/TableView.tsx
+++ b/src/app/projects/[id]/schedule/TableView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo, useRef, useCallback } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback, type Dispatch, type SetStateAction } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { DragDropContext, Droppable, Draggable, type DropResult } from "@hello-pangea/dnd";
 import {
@@ -38,10 +38,11 @@ const SORT_OPTIONS: { key: SortKey; dir: SortDir; label: string }[] = [
     { key: "name", dir: "desc", label: "Name (Z → A)" },
 ];
 
-export default function TableView({ projectId, projectName, initialTasks, estimates = [], teamMembers = [], subcontractors = [], currentUserId = "system", initialPublished, viewMode, onViewModeChange }: {
+export default function TableView({ projectId, projectName, tasks, setTasks, estimates = [], teamMembers = [], subcontractors = [], currentUserId = "system", initialPublished, viewMode, onViewModeChange }: {
     projectId: string;
     projectName: string;
-    initialTasks: Task[];
+    tasks: Task[];
+    setTasks: Dispatch<SetStateAction<Task[]>>;
     estimates?: EstimateSummary[];
     teamMembers?: TeamMember[];
     subcontractors?: Subcontractor[];
@@ -50,7 +51,6 @@ export default function TableView({ projectId, projectName, initialTasks, estima
     viewMode?: "gantt" | "table";
     onViewModeChange?: (mode: "gantt" | "table") => void;
 }) {
-    const [tasks, setTasks] = useState<Task[]>(initialTasks);
     const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
     const [panelTab, setPanelTab] = useState<"details" | "punch" | "conversation">("details");
     const [punchItems, setPunchItems] = useState<PunchItem[]>([]);


### PR DESCRIPTION
## Summary
- Lifts `tasks` state from `GanttChart`/`TableView` up to their shared parent `ScheduleView`, so both views read and write the same array.
- Edits made in either view (drag/resize, cell edit, add, delete, dependency link, cascade) now show up in the other view immediately on toggle — no more full page reload required.
- Adds a `useEffect([initialTasks])` in `ScheduleView` to re-sync from the server on `router.refresh()` or page revisit.

## Root cause
`ScheduleView` toggled between `<GanttChart {...props} />` and `<TableView {...props} />`. Each child held its own `useState<Task[]>(initialTasks)`. On view-toggle, the previous child unmounted and the new one mounted with the original (stale) `initialTasks` server prop, masking persisted edits.

## Test plan
- [x] `npm run typecheck` (clean)
- [x] `next build` compile (clean — unrelated `NEXTAUTH_SECRET` env error during page-data collection is pre-existing)
- [x] **Table → Gantt:** Added a task in Table view → toggled to Gantt → bar appeared
- [x] **Gantt → Table:** Changed end date in Gantt detail panel from 5/14 → 5/30 → toggled to Table → row updated, duration recomputed to 21d
- [x] **Delete sync:** Deleted in Table → removed from Gantt
- [x] No console errors during exercise

🤖 Generated with [Claude Code](https://claude.com/claude-code)