### PR TITLE
fix(schedule): keep Gantt/Table horizontal scrollbar on-screen

### DIFF
--- a/src/app/projects/[id]/schedule/GanttChart.tsx
+++ b/src/app/projects/[id]/schedule/GanttChart.tsx
@@ -9,16 +9,16 @@ import {
     deletePunchItem, getTaskPunchItems, aiGeneratePunchlist,
     assignUserToTask, unassignUserFromTask, assignSubToTask, unassignSubFromTask,
     getEstimateItemsForProject,
-    toggleSchedulePublished, getPortalVisibility,
 } from "@/lib/actions";
 import { toast } from "sonner";
 import type { Task, ZoomLevel, EstimateSummary, EstimateItemSummary, TeamMember, Subcontractor, PunchItem, Comment } from "./schedule-types";
 import { STATUS_OPTIONS, STATUS_COLORS, PRESET_COLORS, getDaysBetween, addDays, formatDate, getMonday, isWeekend, getInitials, formatCurrency, computeCriticalPath } from "./schedule-utils";
 import TaskDetailPanel from "./TaskDetailPanel";
+import SchedulePublishButton from "./SchedulePublishButton";
 
 const DRAG_THRESHOLD_PX = 5;
 
-export default function GanttChart({ projectId, projectName, initialTasks, estimates = [], teamMembers = [], subcontractors = [], currentUserId = "system", viewMode, onViewModeChange }: {
+export default function GanttChart({ projectId, projectName, initialTasks, estimates = [], teamMembers = [], subcontractors = [], currentUserId = "system", initialPublished, viewMode, onViewModeChange }: {
     projectId: string;
     projectName: string;
     initialTasks: Task[];
@@ -26,6 +26,7 @@ export default function GanttChart({ projectId, projectName, initialTasks, estim
     teamMembers?: TeamMember[];
     subcontractors?: Subcontractor[];
     currentUserId?: string;
+    initialPublished: boolean;
     viewMode?: "gantt" | "table";
     onViewModeChange?: (mode: "gantt" | "table") => void;
 }) {
@@ -61,28 +62,11 @@ export default function GanttChart({ projectId, projectName, initialTasks, estim
     const [comments, setComments] = useState<Comment[]>([]);
     const [isAiPunching, setIsAiPunching] = useState(false);
     const [estimateItems, setEstimateItems] = useState<EstimateItemSummary[]>([]);
-    const [isPublished, setIsPublished] = useState(false);
-    const [isPublishing, setIsPublishing] = useState(false);
     const scrollRef = useRef<HTMLDivElement>(null);
     const dragRef = useRef<{ cleanup: () => void } | null>(null);
     const tasksRef = useRef<Task[]>([]);
 
     const selectedTask = tasks.find(t => t.id === selectedTaskId);
-
-    useEffect(() => {
-        getPortalVisibility(projectId).then(v => setIsPublished(v.showSchedule));
-    }, [projectId]);
-
-    async function handleTogglePublish() {
-        setIsPublishing(true);
-        try {
-            const next = !isPublished;
-            await toggleSchedulePublished(projectId, next);
-            setIsPublished(next);
-            toast.success(next ? "Schedule published to client portal" : "Schedule hidden from client portal");
-        } catch { toast.error("Failed to update publish status"); }
-        finally { setIsPublishing(false); }
-    }
 
     // Critical path computation
     const criticalPathIds = useMemo(() => computeCriticalPath(tasks), [tasks]);
@@ -624,15 +608,7 @@ export default function GanttChart({ projectId, projectName, initialTasks, estim
                         >
                             ⚠️ {isAiRisk ? "Analyzing…" : "AI Risk"}
                         </button>
-                        <button
-                            onClick={handleTogglePublish}
-                            disabled={isPublishing}
-                            className={`text-xs flex items-center gap-1.5 px-3 py-1.5 rounded-lg font-medium transition border ${isPublished ? "bg-green-50 text-green-700 border-green-300" : "bg-slate-50 text-slate-600 border-slate-200 hover:bg-slate-100"}`}
-                            title={isPublished ? "Schedule is visible to client — click to hide" : "Publish schedule to client portal"}
-                        >
-                            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={isPublished ? "M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" : "M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M3 3l18 18"} /></svg>
-                            {isPublishing ? "Updating…" : isPublished ? "Published" : "Publish to Client"}
-                        </button>
+                        <SchedulePublishButton projectId={projectId} initialPublished={initialPublished} />
                         <button
                             onClick={() => {
                                 if (tasks.length === 0) { toast.error("No tasks to sync"); return; }
@@ -699,7 +675,7 @@ export default function GanttChart({ projectId, projectName, initialTasks, estim
                 </div>
             )}
 
-            <div className="flex flex-1 overflow-hidden">
+            <div className="flex flex-1 min-h-0 overflow-hidden">
                 {/* Left Panel — Task List */}
                 <div className="w-80 shrink-0 bg-white border-r border-hui-border flex flex-col z-10 shadow-[2px_0_8px_rgba(0,0,0,0.03)]">
                     <div className="flex items-center px-3 py-3 bg-gradient-to-r from-slate-50 to-slate-100/50 border-b border-hui-border text-[10px] font-bold text-slate-400 uppercase tracking-wider h-[44px]">
@@ -708,7 +684,7 @@ export default function GanttChart({ projectId, projectName, initialTasks, estim
                         <div className="w-20 text-center">Status</div>
                         <div className="w-8"></div>
                     </div>
-                    <div className="flex-1 overflow-y-auto">
+                    <div className="flex-1 min-h-0 overflow-y-auto">
                         {tasks.map(task => {
                             const hasTimeData = task.actualHours > 0 && task.estimatedHours;
                             const isCritical = showCriticalPath && criticalPathIds.has(task.id);
@@ -803,7 +779,7 @@ export default function GanttChart({ projectId, projectName, initialTasks, estim
                 </div>
 
                 {/* Middle — Timeline */}
-                <div ref={scrollRef} className="flex-1 overflow-auto bg-slate-50/50 relative">
+                <div ref={scrollRef} className="flex-1 min-h-0 min-w-0 overflow-auto bg-slate-50/50 relative">
                     <div style={{ width: timelineWidth, minHeight: "100%" }} className="relative">
                         <div className="sticky top-0 z-10 flex bg-slate-50 border-b border-hui-border h-[44px]">
                             {headers.map(h => (<div key={h.key} className="text-[10px] font-semibold text-slate-500 border-r border-slate-200/60 flex items-center justify-center shrink-0 uppercase tracking-wider" style={{ width: h.span * colWidth }}>{h.label}</div>))}

--- a/src/app/projects/[id]/schedule/TableView.tsx
+++ b/src/app/projects/[id]/schedule/TableView.tsx
@@ -9,17 +9,17 @@ import {
     deletePunchItem, getTaskPunchItems, aiGeneratePunchlist,
     assignUserToTask, unassignUserFromTask, assignSubToTask, unassignSubFromTask,
     getEstimateItemsForProject,
-    toggleSchedulePublished, getPortalVisibility,
 } from "@/lib/actions";
 import { toast } from "sonner";
 import type { Task, EstimateSummary, EstimateItemSummary, TeamMember, Subcontractor, PunchItem, Comment } from "./schedule-types";
 import { STATUS_OPTIONS, STATUS_COLORS, PRESET_COLORS, getDaysBetween, addDays, formatDate, getInitials, formatCurrency, computeCriticalPath } from "./schedule-utils";
 import TaskDetailPanel from "./TaskDetailPanel";
 import DependencyPicker from "./DependencyPicker";
+import SchedulePublishButton from "./SchedulePublishButton";
 
 type SortKey = "name" | "type" | "startDate" | "endDate" | "duration" | "status" | "progress" | "estimatedHours" | "actualHours";
 
-export default function TableView({ projectId, projectName, initialTasks, estimates = [], teamMembers = [], subcontractors = [], currentUserId = "system", viewMode, onViewModeChange }: {
+export default function TableView({ projectId, projectName, initialTasks, estimates = [], teamMembers = [], subcontractors = [], currentUserId = "system", initialPublished, viewMode, onViewModeChange }: {
     projectId: string;
     projectName: string;
     initialTasks: Task[];
@@ -27,6 +27,7 @@ export default function TableView({ projectId, projectName, initialTasks, estima
     teamMembers?: TeamMember[];
     subcontractors?: Subcontractor[];
     currentUserId?: string;
+    initialPublished: boolean;
     viewMode?: "gantt" | "table";
     onViewModeChange?: (mode: "gantt" | "table") => void;
 }) {
@@ -37,8 +38,6 @@ export default function TableView({ projectId, projectName, initialTasks, estima
     const [comments, setComments] = useState<Comment[]>([]);
     const [isAiPunching, setIsAiPunching] = useState(false);
     const [estimateItems, setEstimateItems] = useState<EstimateItemSummary[]>([]);
-    const [isPublished, setIsPublished] = useState(false);
-    const [isPublishing, setIsPublishing] = useState(false);
     const [isAiGenerating, setIsAiGenerating] = useState(false);
     const [showAiMenu, setShowAiMenu] = useState(false);
     const [isAiRisk, setIsAiRisk] = useState(false);
@@ -69,8 +68,6 @@ export default function TableView({ projectId, projectName, initialTasks, estima
     const selectedTask = tasks.find(t => t.id === selectedTaskId);
     const criticalPathIds = useMemo(() => computeCriticalPath(tasks), [tasks]);
     const today = new Date();
-
-    useEffect(() => { getPortalVisibility(projectId).then(v => setIsPublished(v.showSchedule)); }, [projectId]);
 
     useEffect(() => {
         if (selectedTaskId) {
@@ -104,18 +101,6 @@ export default function TableView({ projectId, projectName, initialTasks, estima
             return sortDir === "asc" ? cmp : -cmp;
         });
     }, [tasks, sortKey, sortDir]);
-
-    // --- Toolbar handlers (same as GanttChart) ---
-    async function handleTogglePublish() {
-        setIsPublishing(true);
-        try {
-            const next = !isPublished;
-            await toggleSchedulePublished(projectId, next);
-            setIsPublished(next);
-            toast.success(next ? "Schedule published to client portal" : "Schedule hidden from client portal");
-        } catch { toast.error("Failed to update publish status"); }
-        finally { setIsPublishing(false); }
-    }
 
     async function handleAiSchedule(estimateId?: string) {
         setIsAiGenerating(true); setShowAiMenu(false);
@@ -475,10 +460,7 @@ export default function TableView({ projectId, projectName, initialTasks, estima
                         <button onClick={handleAiRisk} disabled={isAiRisk || tasks.length === 0} className={`text-xs flex items-center gap-1.5 px-3 py-1.5 rounded-lg font-medium transition border ${isAiRisk ? "bg-amber-500 text-white border-amber-600 animate-pulse" : "bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-100"}`} title="AI schedule risk analysis">
                             ⚠️ {isAiRisk ? "Analyzing…" : "AI Risk"}
                         </button>
-                        <button onClick={handleTogglePublish} disabled={isPublishing} className={`text-xs flex items-center gap-1.5 px-3 py-1.5 rounded-lg font-medium transition border ${isPublished ? "bg-green-50 text-green-700 border-green-300" : "bg-slate-50 text-slate-600 border-slate-200 hover:bg-slate-100"}`} title={isPublished ? "Schedule is visible to client — click to hide" : "Publish schedule to client portal"}>
-                            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={isPublished ? "M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" : "M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M3 3l18 18"} /></svg>
-                            {isPublishing ? "Updating…" : isPublished ? "Published" : "Publish to Client"}
-                        </button>
+                        <SchedulePublishButton projectId={projectId} initialPublished={initialPublished} />
                         <button onClick={() => { if (tasks.length === 0) { toast.error("No tasks to sync"); return; } const a = document.createElement("a"); a.href = `/api/calendar/sync?projectId=${projectId}`; a.download = "schedule.ics"; a.click(); toast.success("Calendar file downloaded"); }} disabled={tasks.length === 0} className="text-xs flex items-center gap-1.5 px-3 py-1.5 rounded-lg font-medium transition border bg-blue-50 text-blue-700 border-blue-200 hover:bg-blue-100 disabled:opacity-40" title="Download .ics file">
                             <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>Sync
                         </button>
@@ -528,8 +510,8 @@ export default function TableView({ projectId, projectName, initialTasks, estima
             )}
 
             {/* Table + Detail panel */}
-            <div className="flex flex-1 overflow-hidden">
-                <div className="flex-1 overflow-auto">
+            <div className="flex flex-1 min-h-0 overflow-hidden">
+                <div className="flex-1 min-h-0 min-w-0 overflow-auto">
                     <table className="w-full text-xs border-collapse min-w-[900px]">
                         <thead className="sticky top-0 bg-slate-50 z-10 border-b border-hui-border">
                             <tr>

--- a/src/app/projects/[id]/schedule/page.tsx
+++ b/src/app/projects/[id]/schedule/page.tsx
@@ -1,7 +1,6 @@
 import { getProject, getScheduleTasks, getTeamMembers, getActiveSubcontractors, getPortalVisibility } from "@/lib/actions";
 import { getSessionOrDev } from "@/lib/auth";
 import ScheduleView from "./ScheduleView";
-import SchedulePublishButton from "./SchedulePublishButton";
 
 export const dynamic = "force-dynamic";
 
@@ -46,27 +45,16 @@ export default async function SchedulePage({ params }: { params: Promise<{ id: s
 
     return (
         <div className="flex flex-col h-[calc(100vh-64px)] -m-6 overflow-hidden bg-hui-background">
-            <div className="flex items-center justify-between px-4 py-2 border-b border-hui-border bg-white">
-                <div className="flex items-center gap-2">
-                    <h2 className="text-sm font-semibold text-hui-textMain">Schedule</h2>
-                    <span className="text-xs text-hui-textMuted">({tasks.length} tasks)</span>
-                </div>
-                <SchedulePublishButton
-                    projectId={id}
-                    initialPublished={portalVisibility.showSchedule}
-                />
-            </div>
-            <div className="flex-1 overflow-hidden">
-                <ScheduleView
-                    projectId={id}
-                    projectName={project.name}
-                    initialTasks={tasks}
-                    estimates={estimates}
-                    teamMembers={teamMembers as any}
-                    subcontractors={subcontractors as any}
-                    currentUserId={currentUserId}
-                />
-            </div>
+            <ScheduleView
+                projectId={id}
+                projectName={project.name}
+                initialTasks={tasks}
+                estimates={estimates}
+                teamMembers={teamMembers as any}
+                subcontractors={subcontractors as any}
+                currentUserId={currentUserId}
+                initialPublished={portalVisibility.showSchedule}
+            />
         </div>
     );
 }

--- a/src/app/projects/[id]/schedule/schedule-types.ts
+++ b/src/app/projects/[id]/schedule/schedule-types.ts
@@ -41,4 +41,5 @@ export type ScheduleViewProps = {
     teamMembers?: TeamMember[];
     subcontractors?: Subcontractor[];
     currentUserId?: string;
+    initialPublished: boolean;
 };


### PR DESCRIPTION
## Summary
- Add `min-h-0` (+ `min-w-0` on the horizontal axis) to the nested flex chain in `GanttChart.tsx` and `TableView.tsx` so `overflow-auto` actually scrolls within the viewport — fixes the bug where the horizontal scrollbar slid below the fold.
- Remove the redundant page-level Schedule header bar (its title, task count, and Publish button were already in the Gantt/Table toolbar) and route both toolbars through the existing `SchedulePublishButton` component so the **Notify Client via Email** action is preserved and the publish state is SSR-driven (eliminating a useEffect race).

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run build` — Next compilation passes (the trailing NEXTAUTH_SECRET error is a worktree-only env issue, not from these edits; Vercel has the env var set in prod)
- [x] At 1440×900, 1280×720, and 1024×768 — page does not overflow, timeline/table bottom sits exactly at the viewport bottom (distance = 0px), horizontal scrollbar stays on-screen
- [x] Publish menu opens with **Publish to Client Portal** option (and **Notify Client via Email** when published) in both Gantt and Table modes
- [ ] On prod after deploy: confirm the schedule page on a real project still toggles publish state and shows the notify option when published

🤖 Generated with [Claude Code](https://claude.com/claude-code)