### PR TITLE
fix(schedule): correct height calc for ProjectLayout nesting

### DIFF
--- a/src/app/projects/[id]/schedule/page.tsx
+++ b/src/app/projects/[id]/schedule/page.tsx
@@ -44,7 +44,7 @@ export default async function SchedulePage({ params }: { params: Promise<{ id: s
     const estimates = (project.estimates || []).map((e: any) => ({ id: e.id, title: e.title, status: e.status }));
 
     return (
-        <div className="flex flex-col h-[calc(100vh-64px)] -m-6 overflow-hidden bg-hui-background">
+        <div className="flex flex-col h-[calc(100%+48px)] -m-6 overflow-hidden bg-hui-background">
             <ScheduleView
                 projectId={id}
                 projectName={project.name}


### PR DESCRIPTION
## Summary
Follow-up to #81. The schedule page was sized to the wrong container — it used the viewport-minus-AppLayout-header height, but actually renders inside `ProjectLayout` whose content div adds **another** `p-6 + overflow-y-auto`. Net effect: 48px overflow → ProjectLayout's content div scrolled, and users had to scroll down to reach the timeline's horizontal scrollbar.

Switch the schedule wrapper from `h-[calc(100vh-64px)]` to `h-[calc(100%+48px)]` so it fills its actual parent's element box (content box + the `p-6` it escapes via `-m-6`), giving an edge-to-edge fit with no overflow.

## Test plan
- [x] At 1920×910: ProjectLayout no longer scrolls; horizontal scrollbar at viewport bottom
- [x] At 1366×650: same — no overflow, scrollbar reachable
- [x] `npm run typecheck` passes
- [ ] On prod after deploy: confirm schedule page no longer requires page scrolling to reach the horizontal scrollbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)