### PR TITLE
fix(projects): correct height calc on estimates + change-orders pages

### DIFF
--- a/src/app/projects/[id]/change-orders/[coId]/page.tsx
+++ b/src/app/projects/[id]/change-orders/[coId]/page.tsx
@@ -19,7 +19,7 @@ export default async function ChangeOrderPage({
     }
 
     return (
-        <div className="flex h-[calc(100vh-64px)] -m-6 overflow-hidden">
+        <div className="flex h-[calc(100%+48px)] -m-6 overflow-hidden">
             <div className="flex-1 bg-slate-50 overflow-hidden flex flex-col">
                 <ChangeOrderEditor
                     context={{

--- a/src/app/projects/[id]/estimates/page.tsx
+++ b/src/app/projects/[id]/estimates/page.tsx
@@ -45,7 +45,7 @@ export default async function EstimatesPage({ params }: { params: Promise<{ id: 
     }
 
     return (
-        <div className="flex h-full -m-6 h-[calc(100vh-64px)] overflow-hidden">
+        <div className="flex -m-6 h-[calc(100%+48px)] overflow-hidden">
             <div className="flex-1 overflow-auto bg-gradient-to-br from-slate-50 via-white to-slate-50/50">
                 <div className="p-8 max-w-6xl mx-auto">
                     {/* Header */}


### PR DESCRIPTION
## Summary
- Two project sub-pages had the same height-calc bug fixed on the schedule page in [#84](https://github.com/Clarion1631/probuild/pull/84) (commit `cbf9f49`): `h-[calc(100vh-64px)]` made the wrapper 48px taller than its parent (`ProjectLayout` adds `p-6 + overflow-y-auto`), so the content area scrolled vertically by exactly 48px.
- Switched to `h-[calc(100%+48px)]` on both pages so the wrapper fills the parent content box plus the `p-6` padding it escapes via `-m-6` — same fix shape as the schedule page.
- Also dropped a redundant `h-full` on the estimates wrapper that was already being overridden by the calc.

Files changed:
- `src/app/projects/[id]/estimates/page.tsx`
- `src/app/projects/[id]/change-orders/[coId]/page.tsx`

## Test plan
- [x] `npm run typecheck` passes
- [x] `/projects/[id]/estimates` at 1366×650: `main .flex-1.p-6.overflow-y-auto` has `scrollHeight === clientHeight` (538 = 538), no vertical scroll
- [x] Served HTML contains `h-[calc(100%+48px)]` and no longer contains `h-[calc(100vh-64px)]`
- [ ] `/projects/[id]/change-orders/[coId]` — could not render in dev preview (no change-order records seeded). Fix is one-class identical to the verified schedule + estimates fixes; same parent layout context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)