### PR TITLE
feat(schedule): Calendar punch list + drag-to-move tasks

### DIFF
--- a/src/app/projects/[id]/schedule/CalendarView.tsx
+++ b/src/app/projects/[id]/schedule/CalendarView.tsx
@@ -10,6 +10,7 @@ import {
     PRESET_COLORS,
     addDays,
     formatDate,
+    getDaysBetween,
     getMonday,
     isWeekend,
     getWeekDays,
@@ -66,6 +67,9 @@ export default function CalendarView({ projectId, tasks, setTasks, viewMode, onV
 
     const [editing, setEditing] = useState<{ taskId: string; x: number; y: number } | null>(null);
     const editingTask = useMemo(() => editing ? tasks.find(t => t.id === editing.taskId) ?? null : null, [editing, tasks]);
+
+    const [dragTaskId, setDragTaskId] = useState<string | null>(null);
+    const [dragOverKey, setDragOverKey] = useState<string | null>(null);
 
     const today = todayUTC();
 
@@ -144,6 +148,46 @@ export default function CalendarView({ projectId, tasks, setTasks, viewMode, onV
 
     const tasksForDay = (day: Date) => tasks.filter(t => dayBucket(t, day));
 
+    function handleTaskDragStart(task: Task, e: React.DragEvent) {
+        e.stopPropagation();
+        e.dataTransfer.effectAllowed = "move";
+        e.dataTransfer.setData("text/plain", task.id);
+        setDragTaskId(task.id);
+        setQuickAdd(null);
+        setEditing(null);
+    }
+    function handleTaskDragEnd() {
+        setDragTaskId(null);
+        setDragOverKey(null);
+    }
+    function handleDayDragOver(day: Date, e: React.DragEvent) {
+        if (!dragTaskId) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        const k = formatDate(day);
+        if (k !== dragOverKey) setDragOverKey(k);
+    }
+    function handleDayDragLeave(day: Date) {
+        const k = formatDate(day);
+        setDragOverKey(prev => prev === k ? null : prev);
+    }
+    function handleDayDrop(day: Date, e: React.DragEvent) {
+        e.preventDefault();
+        e.stopPropagation();
+        const taskId = e.dataTransfer.getData("text/plain") || dragTaskId;
+        setDragTaskId(null);
+        setDragOverKey(null);
+        if (!taskId) return;
+        const task = tasks.find(t => t.id === taskId);
+        if (!task) return;
+        const oldStart = parseUTCDate(task.startDate);
+        if (isSameUTCDay(oldStart, day)) return;
+        const duration = Math.max(0, getDaysBetween(oldStart, parseUTCDate(task.endDate)));
+        const newStart = day;
+        const newEnd = addDays(day, duration);
+        patchTask(task.id, { startDate: formatDate(newStart), endDate: formatDate(newEnd) });
+    }
+
     return (
         <div className="flex flex-col h-full bg-hui-background" onClick={() => { setQuickAdd(null); setEditing(null); }}>
             {/* Top toolbar with view toggle + calendar header */}
@@ -194,6 +238,13 @@ export default function CalendarView({ projectId, tasks, setTasks, viewMode, onV
                         tasksForDay={tasksForDay}
                         onCellClick={handleCellClick}
                         onTaskClick={handleTaskClick}
+                        onTaskDragStart={handleTaskDragStart}
+                        onTaskDragEnd={handleTaskDragEnd}
+                        onDayDragOver={handleDayDragOver}
+                        onDayDragLeave={handleDayDragLeave}
+                        onDayDrop={handleDayDrop}
+                        dragTaskId={dragTaskId}
+                        dragOverKey={dragOverKey}
                     />
                 ) : (
                     <MonthGrid
@@ -203,6 +254,13 @@ export default function CalendarView({ projectId, tasks, setTasks, viewMode, onV
                         onCellClick={handleCellClick}
                         onTaskClick={handleTaskClick}
                         onSwitchToWeek={(d) => { setAnchor(d); onSubModeChange("week"); }}
+                        onTaskDragStart={handleTaskDragStart}
+                        onTaskDragEnd={handleTaskDragEnd}
+                        onDayDragOver={handleDayDragOver}
+                        onDayDragLeave={handleDayDragLeave}
+                        onDayDrop={handleDayDrop}
+                        dragTaskId={dragTaskId}
+                        dragOverKey={dragOverKey}
                     />
                 )}
             </div>
@@ -259,12 +317,21 @@ function clamp(v: number, min: number, max: number) { return Math.min(Math.max(v
 
 function WeekGrid({
     anchor, today, tasksForDay, onCellClick, onTaskClick,
+    onTaskDragStart, onTaskDragEnd, onDayDragOver, onDayDragLeave, onDayDrop,
+    dragTaskId, dragOverKey,
 }: {
     anchor: Date;
     today: Date;
     tasksForDay: (d: Date) => Task[];
     onCellClick: (d: Date, e: React.MouseEvent) => void;
     onTaskClick: (t: Task, e: React.MouseEvent) => void;
+    onTaskDragStart: (t: Task, e: React.DragEvent) => void;
+    onTaskDragEnd: () => void;
+    onDayDragOver: (d: Date, e: React.DragEvent) => void;
+    onDayDragLeave: (d: Date) => void;
+    onDayDrop: (d: Date, e: React.DragEvent) => void;
+    dragTaskId: string | null;
+    dragOverKey: string | null;
 }) {
     const days = getWeekDays(anchor);
     return (
@@ -273,10 +340,12 @@ function WeekGrid({
                 const isToday = isSameUTCDay(day, today);
                 const weekend = isWeekend(day);
                 const dayTasks = tasksForDay(day);
+                const dayKey = formatDate(day);
+                const isDropTarget = dragOverKey === dayKey;
                 return (
                     <div
                         key={idx}
-                        className={`flex flex-col border-r last:border-r-0 border-hui-border ${weekend ? "bg-slate-50/60" : "bg-white"} ${isToday ? "ring-1 ring-inset ring-indigo-300" : ""}`}
+                        className={`flex flex-col border-r last:border-r-0 border-hui-border ${weekend ? "bg-slate-50/60" : "bg-white"} ${isToday ? "ring-1 ring-inset ring-indigo-300" : ""} ${isDropTarget ? "ring-2 ring-inset ring-indigo-500 bg-indigo-50/40" : ""}`}
                     >
                         <div className={`sticky top-0 px-3 py-2 border-b border-hui-border bg-white/95 backdrop-blur z-10 ${isToday ? "text-indigo-700" : "text-hui-textMain"}`}>
                             <div className={`text-[10px] font-semibold uppercase tracking-wide ${isToday ? "text-indigo-600" : "text-slate-400"}`}>{WEEKDAY_LABELS[idx]}</div>
@@ -288,13 +357,19 @@ function WeekGrid({
                         <div
                             className="flex-1 min-h-[420px] p-2 cursor-pointer"
                             onClick={e => onCellClick(day, e)}
+                            onDragOver={e => onDayDragOver(day, e)}
+                            onDragLeave={() => onDayDragLeave(day)}
+                            onDrop={e => onDayDrop(day, e)}
                         >
                             <div className="flex flex-col gap-1.5">
                                 {dayTasks.map(t => (
                                     <button
                                         key={t.id}
+                                        draggable
+                                        onDragStart={e => onTaskDragStart(t, e)}
+                                        onDragEnd={onTaskDragEnd}
                                         onClick={e => onTaskClick(t, e)}
-                                        className="text-left px-2 py-1.5 rounded-md text-xs font-medium shadow-sm hover:shadow transition border border-black/5"
+                                        className={`text-left px-2 py-1.5 rounded-md text-xs font-medium shadow-sm hover:shadow transition border border-black/5 cursor-grab active:cursor-grabbing ${dragTaskId === t.id ? "opacity-40" : ""}`}
                                         style={{ backgroundColor: hexWithAlpha(t.color, 0.15), color: t.color, borderLeftColor: t.color, borderLeftWidth: 3 }}
                                     >
                                         <div className="truncate text-slate-800">{t.name}</div>
@@ -305,7 +380,7 @@ function WeekGrid({
                                     </button>
                                 ))}
                                 {dayTasks.length === 0 && (
-                                    <div className="text-[10px] text-slate-300 italic select-none">Click to add</div>
+                                    <div className="text-[10px] text-slate-300 italic select-none">{isDropTarget ? "Drop to move here" : "Click to add"}</div>
                                 )}
                             </div>
                         </div>
@@ -320,6 +395,8 @@ function WeekGrid({
 
 function MonthGrid({
     anchor, today, tasksForDay, onCellClick, onTaskClick, onSwitchToWeek,
+    onTaskDragStart, onTaskDragEnd, onDayDragOver, onDayDragLeave, onDayDrop,
+    dragTaskId, dragOverKey,
 }: {
     anchor: Date;
     today: Date;
@@ -327,6 +404,13 @@ function MonthGrid({
     onCellClick: (d: Date, e: React.MouseEvent) => void;
     onTaskClick: (t: Task, e: React.MouseEvent) => void;
     onSwitchToWeek: (d: Date) => void;
+    onTaskDragStart: (t: Task, e: React.DragEvent) => void;
+    onTaskDragEnd: () => void;
+    onDayDragOver: (d: Date, e: React.DragEvent) => void;
+    onDayDragLeave: (d: Date) => void;
+    onDayDrop: (d: Date, e: React.DragEvent) => void;
+    dragTaskId: string | null;
+    dragOverKey: string | null;
 }) {
     const days = getMonthGrid(anchor);
     const currentMonth = anchor.getUTCMonth();
@@ -346,11 +430,16 @@ function MonthGrid({
                     const dayTasks = tasksForDay(day);
                     const visible = dayTasks.slice(0, MAX_PER_CELL);
                     const overflow = dayTasks.length - visible.length;
+                    const dayKey = formatDate(day);
+                    const isDropTarget = dragOverKey === dayKey;
                     return (
                         <div
                             key={idx}
                             onClick={e => onCellClick(day, e)}
-                            className={`relative border-r border-b border-hui-border last:border-r-0 p-1.5 cursor-pointer min-h-[110px] ${isCurrentMonth ? (weekend ? "bg-slate-50/60" : "bg-white") : "bg-slate-50/40"} ${isToday ? "ring-1 ring-inset ring-indigo-300" : ""}`}
+                            onDragOver={e => onDayDragOver(day, e)}
+                            onDragLeave={() => onDayDragLeave(day)}
+                            onDrop={e => onDayDrop(day, e)}
+                            className={`relative border-r border-b border-hui-border last:border-r-0 p-1.5 cursor-pointer min-h-[110px] ${isCurrentMonth ? (weekend ? "bg-slate-50/60" : "bg-white") : "bg-slate-50/40"} ${isToday ? "ring-1 ring-inset ring-indigo-300" : ""} ${isDropTarget ? "ring-2 ring-inset ring-indigo-500 bg-indigo-50/40" : ""}`}
                         >
                             <div className="flex items-center justify-between">
                                 <span className={`text-xs font-semibold ${isToday ? "inline-flex items-center justify-center w-6 h-6 rounded-full bg-indigo-600 text-white" : isCurrentMonth ? "text-hui-textMain" : "text-slate-400"}`}>
@@ -361,8 +450,11 @@ function MonthGrid({
                                 {visible.map(t => (
                                     <button
                                         key={t.id}
+                                        draggable
+                                        onDragStart={e => onTaskDragStart(t, e)}
+                                        onDragEnd={onTaskDragEnd}
                                         onClick={e => onTaskClick(t, e)}
-                                        className="text-left text-[11px] px-1.5 py-0.5 rounded truncate hover:opacity-90 transition"
+                                        className={`text-left text-[11px] px-1.5 py-0.5 rounded truncate hover:opacity-90 transition cursor-grab active:cursor-grabbing ${dragTaskId === t.id ? "opacity-40" : ""}`}
                                         style={{ backgroundColor: hexWithAlpha(t.color, 0.15), color: t.color, borderLeft: `3px solid ${t.color}` }}
                                     >
                                         <span className="truncate text-slate-800">{t.name}</span>

--- a/src/app/projects/[id]/schedule/CalendarView.tsx
+++ b/src/app/projects/[id]/schedule/CalendarView.tsx
@@ -495,6 +495,8 @@ function QuickEditPopover({
 
     useEffect(() => {
         let cancelled = false;
+        setPunchItems([]);
+        setNewPunch("");
         setPunchLoading(true);
         getTaskPunchItems(task.id)
             .then(items => { if (!cancelled) { setPunchItems(items as PunchItem[]); setPunchLoading(false); } })
@@ -519,23 +521,24 @@ function QuickEditPopover({
     }
 
     async function handleTogglePunch(id: string) {
-        const before = punchItems;
+        if (id.startsWith("temp-")) return;
         setPunchItems(prev => prev.map(p => p.id === id ? { ...p, completed: !p.completed } : p));
         try {
             await togglePunchItem(id);
         } catch {
-            setPunchItems(before);
+            setPunchItems(prev => prev.map(p => p.id === id ? { ...p, completed: !p.completed } : p));
             toast.error("Failed to update item");
         }
     }
 
     async function handleDeletePunch(id: string) {
-        const before = punchItems;
+        if (id.startsWith("temp-")) return;
+        const removed = punchItems.find(p => p.id === id);
         setPunchItems(prev => prev.filter(p => p.id !== id));
         try {
             await deletePunchItem(id);
         } catch {
-            setPunchItems(before);
+            if (removed) setPunchItems(prev => [...prev, removed].sort((a, b) => a.order - b.order));
             toast.error("Failed to delete item");
         }
     }
@@ -631,24 +634,29 @@ function QuickEditPopover({
                         <div className="text-[11px] text-slate-400 italic py-1">No items yet</div>
                     ) : (
                         <ul className="space-y-0.5">
-                            {punchItems.map(item => (
-                                <li key={item.id} className="group flex items-center gap-2 py-0.5">
-                                    <input
-                                        type="checkbox"
-                                        checked={item.completed}
-                                        onChange={() => handleTogglePunch(item.id)}
-                                        className="w-3.5 h-3.5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-400"
-                                    />
-                                    <span className={`flex-1 text-xs ${item.completed ? "line-through text-slate-400" : "text-slate-700"}`}>
-                                        {item.name}
-                                    </span>
-                                    <button
-                                        onClick={() => handleDeletePunch(item.id)}
-                                        aria-label="Delete item"
-                                        className="text-slate-400 hover:text-red-600 text-xs leading-none px-1 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto transition"
-                                    >×</button>
-                                </li>
-                            ))}
+                            {punchItems.map(item => {
+                                const isTemp = item.id.startsWith("temp-");
+                                return (
+                                    <li key={item.id} className={`group flex items-center gap-2 py-0.5 ${isTemp ? "opacity-60" : ""}`}>
+                                        <input
+                                            type="checkbox"
+                                            checked={item.completed}
+                                            onChange={() => handleTogglePunch(item.id)}
+                                            disabled={isTemp}
+                                            className="w-3.5 h-3.5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-400 disabled:cursor-wait"
+                                        />
+                                        <span className={`flex-1 text-xs ${item.completed ? "line-through text-slate-400" : "text-slate-700"}`}>
+                                            {item.name}
+                                        </span>
+                                        <button
+                                            onClick={() => handleDeletePunch(item.id)}
+                                            disabled={isTemp}
+                                            aria-label="Delete item"
+                                            className="text-slate-400 hover:text-red-600 text-xs leading-none px-1 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto transition disabled:cursor-wait"
+                                        >×</button>
+                                    </li>
+                                );
+                            })}
                         </ul>
                     )}
                 </div>

--- a/src/app/projects/[id]/schedule/CalendarView.tsx
+++ b/src/app/projects/[id]/schedule/CalendarView.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState, useTransition, type Dispatch, type SetStateAction } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import type { Task } from "./schedule-types";
+import type { Task, PunchItem } from "./schedule-types";
 import {
     STATUS_OPTIONS,
     STATUS_COLORS,
@@ -18,7 +18,10 @@ import {
     parseUTCDate,
     todayUTC,
 } from "./schedule-utils";
-import { createScheduleTask, updateScheduleTask, deleteScheduleTask } from "@/lib/actions";
+import {
+    createScheduleTask, updateScheduleTask, deleteScheduleTask,
+    addTaskPunchItem, togglePunchItem, deletePunchItem, getTaskPunchItems,
+} from "@/lib/actions";
 
 type ViewMode = "gantt" | "table" | "calendar";
 type SubMode = "month" | "week";
@@ -394,8 +397,59 @@ function QuickEditPopover({
     const [nameDraft, setNameDraft] = useState(task.name);
     useEffect(() => { setNameDraft(task.name); }, [task.id, task.name]);
 
+    const [punchItems, setPunchItems] = useState<PunchItem[]>([]);
+    const [punchLoading, setPunchLoading] = useState(true);
+    const [newPunch, setNewPunch] = useState("");
+
+    useEffect(() => {
+        let cancelled = false;
+        setPunchLoading(true);
+        getTaskPunchItems(task.id)
+            .then(items => { if (!cancelled) { setPunchItems(items as PunchItem[]); setPunchLoading(false); } })
+            .catch(() => { if (!cancelled) setPunchLoading(false); });
+        return () => { cancelled = true; };
+    }, [task.id]);
+
+    async function handleAddPunch() {
+        const name = newPunch.trim();
+        if (!name) return;
+        const tempId = `temp-${Date.now()}`;
+        const optimistic: PunchItem = { id: tempId, name, completed: false, order: punchItems.length };
+        setPunchItems(prev => [...prev, optimistic]);
+        setNewPunch("");
+        try {
+            const created = await addTaskPunchItem(task.id, name);
+            setPunchItems(prev => prev.map(p => p.id === tempId ? (created as PunchItem) : p));
+        } catch {
+            setPunchItems(prev => prev.filter(p => p.id !== tempId));
+            toast.error("Failed to add item");
+        }
+    }
+
+    async function handleTogglePunch(id: string) {
+        const before = punchItems;
+        setPunchItems(prev => prev.map(p => p.id === id ? { ...p, completed: !p.completed } : p));
+        try {
+            await togglePunchItem(id);
+        } catch {
+            setPunchItems(before);
+            toast.error("Failed to update item");
+        }
+    }
+
+    async function handleDeletePunch(id: string) {
+        const before = punchItems;
+        setPunchItems(prev => prev.filter(p => p.id !== id));
+        try {
+            await deletePunchItem(id);
+        } catch {
+            setPunchItems(before);
+            toast.error("Failed to delete item");
+        }
+    }
+
     const left = clamp(x - 160, 8, typeof window !== "undefined" ? window.innerWidth - 328 : 0);
-    const top = clamp(y, 8, typeof window !== "undefined" ? window.innerHeight - 320 : 0);
+    const top = clamp(y, 8, typeof window !== "undefined" ? window.innerHeight - 480 : 0);
 
     return (
         <div
@@ -469,9 +523,62 @@ function QuickEditPopover({
                 </div>
             </div>
 
+            <div className="mt-3 pt-2 border-t border-slate-100">
+                <div className="flex items-center justify-between mb-1.5">
+                    <span className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Punch list</span>
+                    {punchItems.length > 0 && (
+                        <span className="text-[10px] text-slate-400">
+                            {punchItems.filter(p => p.completed).length} / {punchItems.length} done
+                        </span>
+                    )}
+                </div>
+                <div className="max-h-32 overflow-y-auto -mx-1 px-1">
+                    {punchLoading && punchItems.length === 0 ? (
+                        <div className="text-[11px] text-slate-400 italic py-1">Loading…</div>
+                    ) : punchItems.length === 0 ? (
+                        <div className="text-[11px] text-slate-400 italic py-1">No items yet</div>
+                    ) : (
+                        <ul className="space-y-0.5">
+                            {punchItems.map(item => (
+                                <li key={item.id} className="group flex items-center gap-2 py-0.5">
+                                    <input
+                                        type="checkbox"
+                                        checked={item.completed}
+                                        onChange={() => handleTogglePunch(item.id)}
+                                        className="w-3.5 h-3.5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-400"
+                                    />
+                                    <span className={`flex-1 text-xs ${item.completed ? "line-through text-slate-400" : "text-slate-700"}`}>
+                                        {item.name}
+                                    </span>
+                                    <button
+                                        onClick={() => handleDeletePunch(item.id)}
+                                        aria-label="Delete item"
+                                        className="text-slate-400 hover:text-red-600 text-xs leading-none px-1 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto transition"
+                                    >×</button>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+                <div className="mt-1.5 flex items-center gap-1">
+                    <input
+                        value={newPunch}
+                        onChange={e => setNewPunch(e.target.value)}
+                        onKeyDown={e => { if (e.key === "Enter") { e.preventDefault(); handleAddPunch(); } }}
+                        placeholder="Add item…"
+                        className="flex-1 hui-input text-xs py-1"
+                    />
+                    <button
+                        onClick={handleAddPunch}
+                        disabled={!newPunch.trim()}
+                        className="text-xs px-2 py-1 rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed transition"
+                    >Add</button>
+                </div>
+            </div>
+
             <div className="mt-3 pt-2 border-t border-slate-100 flex items-center justify-between">
                 <button onClick={onDelete} className="text-xs text-red-600 hover:text-red-700">Delete</button>
-                <span className="text-[10px] text-slate-400">For dependencies, comments, punch list — switch to Gantt or Table</span>
+                <span className="text-[10px] text-slate-400">For dependencies and comments, switch to Gantt or Table</span>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary

Two Calendar enhancements in one PR:

### 1. Punch list in the Calendar quick-edit popover
Click a task chip → popover now shows a **Punch list** section: check items off, add new ones, delete inline. Wired to the existing `addTaskPunchItem` / `togglePunchItem` / `deletePunchItem` / `getTaskPunchItems` server actions that Gantt and Table use today. Optimistic updates with rollback on failure.

### 2. Drag-to-move tasks between days
Task chips are now HTML5-draggable in both week and month views. Drop on any day cell to shift the task to that date; multi-day tasks preserve their duration. While dragging, the source dims and the hovered day gets an indigo ring + tint. State flows through the lifted `tasks` / `setTasks` (the Gantt/Table sync work), so a Calendar drag updates Gantt and Table instantly. Server persistence via existing `updateScheduleTask` + `router.refresh()` with rollback on error.

No new dependencies. No data model changes. No new server actions.

## Test plan
- [x] Typecheck clean on touched file (`CalendarView.tsx`). Pre-existing TS errors in `sales-tax-report.ts` / `subcontractor-actions.ts` / `time-expense-actions.ts` are on main too, not introduced here.
- [ ] Click a task in Calendar → popover shows punch items, can add / toggle / delete.
- [ ] Drag a 1-day task from Mon to Wed → task moves; verify in Gantt and Table without reload.
- [ ] Drag a multi-day task (e.g. 3-day "Site prep") from May 1 to May 5 → start moves to 5, end moves to 7, duration preserved.
- [ ] Drag onto the same day → no-op (no spurious server call).
- [ ] Hover a row in punch list → × button appears; works on touch (`[@media(hover:none)]` override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)