### PR TITLE
feat(portal): tabbed project view + cleaner header

### DIFF
--- a/src/app/api/portal/signout/route.ts
+++ b/src/app/api/portal/signout/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+
+export async function POST() {
+    const response = NextResponse.json({ ok: true });
+    response.cookies.set("client_portal_token", "", {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+        path: "/",
+        maxAge: 0,
+    });
+    return response;
+}

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -1,8 +1,37 @@
-export default function PortalLayout({ children }: { children: React.ReactNode }) {
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { resolveSessionClientId } from "@/lib/portal-auth";
+import PortalUserMenu from "@/components/PortalUserMenu";
+
+export default async function PortalLayout({ children }: { children: React.ReactNode }) {
+    const session = await getServerSession(authOptions);
+    const isStaff = ["ADMIN", "MANAGER"].includes((session?.user as any)?.role);
+
+    let displayName: string | null = null;
+    let hasClientSession = false;
+    if (!isStaff) {
+        const clientId = await resolveSessionClientId();
+        hasClientSession = Boolean(clientId);
+        if (clientId) {
+            const client = await prisma.client.findUnique({
+                where: { id: clientId },
+                select: { name: true },
+            });
+            displayName = client?.name ?? session?.user?.name ?? null;
+        } else {
+            displayName = session?.user?.name ?? null;
+        }
+    }
+
+    // Show the user menu for staff (NextAuth), email-based clients (NextAuth), and token-based clients.
+    const isAuthed = Boolean(session?.user) || hasClientSession;
+
     return (
         <div className="min-h-screen bg-hui-background flex flex-col">
-            <header className="bg-white border-b border-hui-border px-8 py-4 flex items-center shadow-sm">
+            <header className="bg-white border-b border-hui-border px-4 md:px-8 py-4 flex items-center justify-between shadow-sm">
                 <div className="font-bold text-xl text-hui-textMain tracking-tight">ProBuild</div>
+                {isAuthed && <PortalUserMenu displayName={displayName} isStaff={isStaff} />}
             </header>
             <main className="flex-1 w-full max-w-5xl mx-auto p-4 md:p-8">
                 {children}

--- a/src/app/portal/projects/[id]/page.tsx
+++ b/src/app/portal/projects/[id]/page.tsx
@@ -3,15 +3,26 @@ import Link from 'next/link';
 import { notFound } from "next/navigation";
 import StatusBadge, { StatusType } from "@/components/StatusBadge";
 import PortalPayButton from "@/components/PortalPayButton";
-import { getPortalVisibility } from "@/lib/actions";
+import PortalProjectTabs, { type PortalTab } from "@/components/PortalProjectTabs";
+import { getPortalVisibility, getScheduleTasks } from "@/lib/actions";
 import { formatCurrency } from "@/lib/utils";
 import PortalVisitTracker from "@/components/PortalVisitTracker";
 import { resolveSessionClientId } from "@/lib/portal-auth";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 
-export default async function PortalProjectDetail(props: { params: Promise<{ id: string }> }) {
+const ALLOWED_TABS = [
+    "overview", "estimates", "schedule", "invoices",
+    "updates", "files", "selections", "designs", "change-orders"
+] as const;
+type TabId = (typeof ALLOWED_TABS)[number];
+
+export default async function PortalProjectDetail(props: {
+    params: Promise<{ id: string }>;
+    searchParams: Promise<{ tab?: string }>;
+}) {
     const params = await props.params;
+    const searchParams = await props.searchParams;
     const projectId = params.id;
 
     const staffSession = await getServerSession(authOptions);
@@ -43,9 +54,7 @@ export default async function PortalProjectDetail(props: { params: Promise<{ id:
                 where: { status: { not: 'Draft' } },
                 orderBy: { issueDate: 'desc' },
                 include: {
-                    payments: {
-                        orderBy: { createdAt: 'asc' }
-                    }
+                    payments: { orderBy: { createdAt: 'asc' } }
                 }
             },
             changeOrders: {
@@ -53,7 +62,6 @@ export default async function PortalProjectDetail(props: { params: Promise<{ id:
                 orderBy: { createdAt: 'desc' },
                 include: { estimate: { select: { id: true, code: true, title: true, status: true, totalAmount: true } } }
             },
-            // Room Designer data is Stage 4 (client share links) — intentionally not exposed in the portal yet.
             dailyLogs: {
                 orderBy: { date: 'desc' },
                 include: {
@@ -64,14 +72,13 @@ export default async function PortalProjectDetail(props: { params: Promise<{ id:
         }
     });
 
-
     if (!project) return notFound();
 
-    const settings = await prisma.companySettings.findUnique({ where: { id: "singleton" } });
-    const visibility = await getPortalVisibility(projectId);
-
-    const clientName = project.client?.name || "Client";
-    const clientEmail = project.client?.email || "";
+    const [settings, visibility, scheduleTasks] = await Promise.all([
+        prisma.companySettings.findUnique({ where: { id: "singleton" } }),
+        getPortalVisibility(projectId),
+        getScheduleTasks(projectId).catch(() => [] as any[]),
+    ]);
 
     if (!visibility.isPortalEnabled) {
         return (
@@ -92,8 +99,82 @@ export default async function PortalProjectDetail(props: { params: Promise<{ id:
         );
     }
 
+    // ---- Compute counts and tab config ----
+    const estimateCount = project.estimates.length;
+    const invoiceCount = project.invoices.length;
+    const updateCount = (project.dailyLogs || []).length;
+    const changeOrderCount = (project.changeOrders || []).length;
+
+    // All overview-derived data must respect the same visibility flag as the section it surfaces.
+    const pendingPayments: { invoiceId: string; payment: any }[] = [];
+    if (visibility.showInvoices) {
+        for (const inv of project.invoices) {
+            for (const p of (inv.payments || [])) {
+                if (p.status === 'Pending') pendingPayments.push({ invoiceId: inv.id, payment: p });
+            }
+        }
+    }
+    const totalDue = pendingPayments.reduce((sum, x) => sum + Number(x.payment.amount), 0);
+
+    const sentEstimatesAwaitingSignature = visibility.showEstimates
+        ? project.estimates.filter((e: any) => e.status === 'Sent' && !e.approvedAt)
+        : [];
+    const pendingChangeOrders = (visibility as any).showChangeOrders !== false
+        ? (project.changeOrders || []).filter((co: any) => co.status === 'Sent')
+        : [];
+
+    const showChangeOrders = (visibility as any).showChangeOrders !== false;
+
+    const tabsConfig: Array<{ id: TabId; label: string; count?: number; visible: boolean }> = [
+        { id: "overview", label: "Overview", visible: true },
+        { id: "estimates", label: "Estimates", count: estimateCount, visible: visibility.showEstimates && estimateCount > 0 },
+        { id: "schedule", label: "Schedule", visible: visibility.showSchedule },
+        { id: "invoices", label: "Invoices", count: invoiceCount, visible: visibility.showInvoices && invoiceCount > 0 },
+        { id: "updates", label: "Updates", count: updateCount, visible: visibility.showDailyLogs && updateCount > 0 },
+        { id: "files", label: "Files", visible: visibility.showFiles },
+        { id: "selections", label: "Selections", visible: visibility.showSelections },
+        { id: "designs", label: "Designs", visible: visibility.showMoodBoards },
+        { id: "change-orders", label: "Change Orders", count: changeOrderCount, visible: showChangeOrders && changeOrderCount > 0 },
+    ];
+
+    const visibleTabs = tabsConfig.filter(t => t.visible);
+    const visibleTabIds = new Set(visibleTabs.map(t => t.id));
+
+    const requestedTab = (searchParams.tab || "overview") as TabId;
+    const activeTab: TabId = visibleTabIds.has(requestedTab) ? requestedTab : "overview";
+
+    const tabs: PortalTab[] = visibleTabs.map(t => ({
+        id: t.id,
+        label: t.label,
+        count: t.count,
+        href: t.id === "overview"
+            ? `/portal/projects/${projectId}`
+            : `/portal/projects/${projectId}?tab=${t.id}`,
+    }));
+
+    // ---- Schedule summary for Overview + Schedule tab ----
+    const isTaskComplete = (t: any) => (t.progress ?? 0) >= 100 || t.status === 'Complete';
+    const totalTasks = scheduleTasks.length;
+    const completedTasks = scheduleTasks.filter(isTaskComplete).length;
+    const inProgressTask = scheduleTasks.find((t: any) =>
+        !isTaskComplete(t) && ((t.progress ?? 0) > 0 || t.status === 'In Progress')
+    );
+    const upcomingTasks = scheduleTasks
+        .filter((t: any) => !isTaskComplete(t))
+        .slice()
+        .sort((a: any, b: any) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime())
+        .slice(0, 4);
+    const overallProgress = totalTasks > 0
+        ? Math.round((completedTasks / totalTasks) * 100)
+        : 0;
+
+    const latestLog = (visibility.showDailyLogs && project.dailyLogs && project.dailyLogs.length > 0)
+        ? project.dailyLogs[0]
+        : null;
+    const hasScheduleData = visibility.showSchedule && totalTasks > 0;
+
     return (
-        <div className="max-w-5xl mx-auto py-8">
+        <div className="max-w-5xl mx-auto">
             {!isStaff && <PortalVisitTracker projectId={projectId} clientName={project.client?.name || "Client"} />}
             {isStaff && (
                 <div className="mb-4 px-4 py-2 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-800 flex items-center gap-2">
@@ -104,340 +185,420 @@ export default async function PortalProjectDetail(props: { params: Promise<{ id:
                     Staff Preview — this is what the client sees
                 </div>
             )}
-            <div className="mb-6">
+
+            <div className="mb-4">
                 <Link href="/portal" className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-hui-textMain bg-white border border-hui-border rounded-md hover:bg-slate-50 transition shadow-sm w-fit">
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" /></svg>
                     Back to Dashboard
                 </Link>
             </div>
 
-            <div className="hui-card p-8 mb-8">
-                <div className="flex justify-between items-start">
-                    <div>
-                        <h1 className="text-3xl font-bold text-hui-textMain mb-2">{project.name}</h1>
-                        <div className="flex gap-4 text-sm text-hui-textMuted">
-                            {project.location && <span>{project.location}</span>}
-                            <span>•</span>
+            <div className="hui-card p-6 md:p-8 mb-6">
+                <div className="flex justify-between items-start gap-4">
+                    <div className="min-w-0">
+                        <h1 className="text-2xl md:text-3xl font-bold text-hui-textMain mb-2 truncate">{project.name}</h1>
+                        <div className="flex gap-2 md:gap-3 text-sm text-hui-textMuted flex-wrap items-center">
+                            {project.location && <span className="truncate">{project.location}</span>}
+                            {project.location && <span aria-hidden>•</span>}
                             <span>Started {new Date(project.createdAt).toLocaleDateString()}</span>
                         </div>
                     </div>
-                    <StatusBadge status={project.status as StatusType} />
+                    <div className="shrink-0">
+                        <StatusBadge status={project.status as StatusType} />
+                    </div>
                 </div>
             </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                {/* Estimates Section */}
-                {visibility.showEstimates && (
-                <div>
-                    <h2 className="text-xl font-bold text-hui-textMain mb-4 flex items-center gap-2">
-                        <svg className="w-5 h-5 text-hui-textMuted" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
-                        Estimates &amp; Proposals
-                    </h2>
-                    {project.estimates.length === 0 ? (
-                        <div className="bg-hui-background border border-hui-border rounded-lg p-6 text-center text-hui-textMuted text-sm">
-                            No shared estimates available yet.
-                        </div>
-                    ) : (
-                        <div className="space-y-3">
-                            {project.estimates.map(est => (
-                                <Link href={`/portal/estimates/${est.id}`} key={est.id} className="block hui-card p-4 hover:border-blue-300 hover:shadow-sm transition">
-                                    <div className="flex justify-between items-start mb-2">
-                                        <h3 className="font-semibold text-hui-textMain truncate pr-2">{est.title}</h3>
-                                        <span className={`text-xs px-2 py-1 rounded-full font-medium ${est.status === 'Approved' ? 'bg-green-100 text-green-700' : 'bg-blue-100 text-blue-700'}`}>
-                                            {est.status}
-                                        </span>
+            <PortalProjectTabs tabs={tabs} activeTab={activeTab} />
+
+            <div
+                role="tabpanel"
+                id={`panel-${activeTab}`}
+                aria-labelledby={`tab-${activeTab}`}
+                key={activeTab}
+                className="pb-8"
+            >
+                {activeTab === "overview" && (
+                    <div className="space-y-6">
+                        {/* Payment Due callout */}
+                        {pendingPayments.length > 0 && (
+                            <div className="bg-green-50 border border-green-200 rounded-xl p-5 md:p-6">
+                                <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+                                    <div>
+                                        <div className="flex items-center gap-2 text-green-800 font-semibold mb-1">
+                                            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                                            Payment Due
+                                        </div>
+                                        <p className="text-2xl md:text-3xl font-bold text-green-900">{formatCurrency(totalDue)}</p>
+                                        <p className="text-sm text-green-700 mt-1">
+                                            {pendingPayments.length === 1
+                                                ? `Due ${pendingPayments[0].payment.dueDate ? new Date(pendingPayments[0].payment.dueDate).toLocaleDateString() : 'soon'}`
+                                                : `${pendingPayments.length} payments awaiting your approval`
+                                            }
+                                        </p>
                                     </div>
-                                    <div className="flex justify-between text-sm text-hui-textMuted">
-                                        <span>Total: {formatCurrency(est.totalAmount)}</span>
-                                        <span>{new Date(est.createdAt).toLocaleDateString()}</span>
+                                    <div className="shrink-0">
+                                        {pendingPayments.length === 1 ? (
+                                            <PortalPayButton
+                                                invoiceId={pendingPayments[0].invoiceId}
+                                                paymentScheduleId={pendingPayments[0].payment.id}
+                                                amount={Number(pendingPayments[0].payment.amount)}
+                                                label="Pay Now"
+                                                settings={settings}
+                                            />
+                                        ) : (
+                                            <Link
+                                                href={`/portal/projects/${projectId}?tab=invoices`}
+                                                className="inline-flex items-center justify-center gap-2 hui-btn hui-btn-green"
+                                            >
+                                                View Invoices
+                                                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" /></svg>
+                                            </Link>
+                                        )}
                                     </div>
+                                </div>
+                            </div>
+                        )}
+
+                        {/* Action needed alerts */}
+                        {(sentEstimatesAwaitingSignature.length > 0 || pendingChangeOrders.length > 0) && (
+                            <div className="bg-amber-50 border border-amber-200 rounded-xl p-5">
+                                <h3 className="font-semibold text-amber-900 mb-3 flex items-center gap-2">
+                                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
+                                    Action Needed
+                                </h3>
+                                <ul className="space-y-2">
+                                    {sentEstimatesAwaitingSignature.map((est: any) => (
+                                        <li key={est.id}>
+                                            <Link href={`/portal/estimates/${est.id}`} className="flex items-center justify-between gap-3 text-sm text-amber-900 hover:text-amber-700 transition">
+                                                <span className="truncate"><span className="font-medium">{est.title}</span> awaiting signature</span>
+                                                <span className="text-xs font-semibold underline shrink-0">Review →</span>
+                                            </Link>
+                                        </li>
+                                    ))}
+                                    {pendingChangeOrders.map((co: any) => (
+                                        <li key={co.id}>
+                                            <Link href={`/portal/change-orders/${co.id}`} className="flex items-center justify-between gap-3 text-sm text-amber-900 hover:text-amber-700 transition">
+                                                <span className="truncate"><span className="font-medium">Change Order: {co.title}</span> awaiting approval</span>
+                                                <span className="text-xs font-semibold underline shrink-0">Review →</span>
+                                            </Link>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        )}
+
+                        {/* Schedule + Latest Update row */}
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            {/* Schedule mini summary */}
+                            {hasScheduleData && (
+                                <Link
+                                    href={`/portal/projects/${projectId}?tab=schedule`}
+                                    className="hui-card p-5 hover:shadow-md hover:border-blue-300 transition"
+                                >
+                                    <div className="flex items-center justify-between mb-3">
+                                        <h3 className="font-semibold text-hui-textMain flex items-center gap-2">
+                                            <svg className="w-5 h-5 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
+                                            Schedule
+                                        </h3>
+                                        <span className="text-xs font-semibold text-blue-500">{overallProgress}%</span>
+                                    </div>
+                                    <div className="w-full bg-slate-100 rounded-full h-2 mb-3">
+                                        <div className="bg-blue-500 h-2 rounded-full transition-all" style={{ width: `${overallProgress}%` }} />
+                                    </div>
+                                    <p className="text-sm text-hui-textMuted">
+                                        {completedTasks} of {totalTasks} tasks complete
+                                        {inProgressTask && <> · Now: <span className="text-hui-textMain font-medium">{inProgressTask.name}</span></>}
+                                    </p>
                                 </Link>
-                            ))}
-                        </div>
-                    )}
-                </div>
-                )}
+                            )}
 
-                {/* Schedule Section */}
-                {visibility.showSchedule && (
-                <div className="md:col-span-2">
-                    <div className="flex items-center justify-between mb-4">
-                        <h2 className="text-xl font-bold text-hui-textMain flex items-center gap-2">
-                            <svg className="w-5 h-5 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
-                            Project Schedule
-                        </h2>
-                        <Link href={`/portal/projects/${projectId}/schedule`} className="text-sm font-semibold text-blue-500 hover:text-blue-700 transition">
-                            View Timeline →
-                        </Link>
-                    </div>
-                    <Link href={`/portal/projects/${projectId}/schedule`} className="block hui-card p-6 hover:border-blue-500 hover:shadow-md transition text-center border-dashed">
-                        <div className="w-12 h-12 bg-blue-50 rounded-full flex items-center justify-center mx-auto mb-3">
-                            <svg className="w-6 h-6 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" /></svg>
-                        </div>
-                        <h3 className="text-base font-bold text-slate-800">View Project Timeline</h3>
-                        <p className="text-sm text-slate-500 mt-1">Check the sequence of tasks and overall progress.</p>
-                    </Link>
-                </div>
-                )}
-
-                {/* Change Orders Section */}
-                <div>
-                    <h2 className="text-xl font-bold text-hui-textMain mb-4 flex items-center gap-2">
-                        <svg className="w-5 h-5 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" /></svg>
-                        Change Orders
-                    </h2>
-                    {(project.changeOrders || []).length === 0 ? (
-                        <div className="bg-hui-background border border-hui-border rounded-lg p-6 text-center text-hui-textMuted text-sm">
-                            No active Change Orders for this project.
-                        </div>
-                    ) : (
-                        <div className="space-y-3">
-                            {project.changeOrders.map((co: any) => (
-                                <Link href={`/portal/change-orders/${co.id}`} key={co.id} className="block hui-card p-4 hover:border-amber-300 hover:shadow-sm transition">
-                                    <div className="flex justify-between items-start mb-2">
-                                        <h3 className="font-semibold text-hui-textMain truncate pr-2">{co.title}</h3>
-                                        <span className={`text-xs px-2 py-1 rounded-full font-medium ${co.status === 'Approved' ? 'bg-green-100 text-green-700' : 'bg-blue-100 text-blue-700'}`}>
-                                            {co.status}
-                                        </span>
+                            {/* Latest update preview */}
+                            {visibility.showDailyLogs && latestLog && (
+                                <Link
+                                    href={`/portal/projects/${projectId}?tab=updates`}
+                                    className="hui-card p-5 hover:shadow-md hover:border-purple-300 transition"
+                                >
+                                    <div className="flex items-center justify-between mb-2">
+                                        <h3 className="font-semibold text-hui-textMain flex items-center gap-2">
+                                            <svg className="w-5 h-5 text-purple-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
+                                            Latest Update
+                                        </h3>
+                                        <span className="text-xs text-hui-textMuted">{new Date(latestLog.date).toLocaleDateString()}</span>
                                     </div>
-                                    <div className="flex justify-between text-sm text-hui-textMuted">
-                                        <span>Amount: {formatCurrency(co.totalAmount)}</span>
-                                        <span>{new Date(co.createdAt).toLocaleDateString()}</span>
-                                    </div>
-                                    <div className="mt-2 text-xs text-slate-400 truncate">
-                                        Original Est: {co.estimate?.title || co.estimate?.code}
-                                    </div>
-                                </Link>
-                            ))}
-                        </div>
-                    )}
-                </div>
-
-                {/* Invoices Section */}
-                {visibility.showInvoices && (
-                <div>
-                    <h2 className="text-xl font-bold text-hui-textMain mb-4 flex items-center gap-2">
-                        <svg className="w-5 h-5 text-hui-textMuted" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" /></svg>
-                        Invoices
-                    </h2>
-                    {project.invoices.length === 0 ? (
-                        <div className="bg-hui-background border border-hui-border rounded-lg p-6 text-center text-hui-textMuted text-sm">
-                            No invoices available yet.
-                        </div>
-                    ) : (
-                        <div className="space-y-3">
-                            {project.invoices.map(inv => (
-                                <div key={inv.id} className="block hui-card p-4">
-                                    <div className="flex justify-between items-start mb-2">
-                                        <h3 className="font-semibold text-hui-textMain">Invoice #{inv.code}</h3>
-                                        <span className={`text-xs px-2 py-1 rounded-full font-medium ${inv.status === 'Paid' ? 'bg-green-100 text-green-700' :
-                                                inv.status === 'Overdue' ? 'bg-red-100 text-red-700' : 'bg-yellow-100 text-yellow-800'
-                                            }`}>
-                                            {inv.status}
-                                        </span>
-                                    </div>
-                                    <div className="flex justify-between text-sm mb-4">
-                                        <span className="text-hui-textMuted">Amount: {formatCurrency(inv.totalAmount)}</span>
-                                        <span className="font-medium text-hui-textMain">Due: {formatCurrency(inv.balanceDue)}</span>
-                                    </div>
-                                    
-                                    {inv.payments && inv.payments.length > 0 && (
-                                        <div className="space-y-2 border-t border-hui-border pt-3 mt-3">
-                                            {inv.payments.map((payment: any) => (
-                                                <div key={payment.id} className="flex flex-col sm:flex-row sm:items-center justify-between p-3 bg-slate-50 rounded-md border border-slate-100 gap-3">
-                                                    <div>
-                                                        <p className="text-sm font-semibold text-hui-textMain flex items-center gap-2">
-                                                            {payment.name}
-                                                            {payment.status === 'Paid' && (
-                                                                <span className="inline-flex items-center text-xs text-green-600 bg-green-50 px-1.5 py-0.5 rounded-full border border-green-200">
-                                                                    <svg className="w-3 h-3 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
-                                                                    Paid {payment.paymentMethod ? `via ${payment.paymentMethod.toUpperCase()}` : ''}
-                                                                </span>
-                                                            )}
-                                                            {payment.status === 'Processing' && (
-                                                                <span className="text-xs text-yellow-600 bg-yellow-50 px-1.5 py-0.5 rounded-md border border-yellow-200">
-                                                                    Processing ACH
-                                                                </span>
-                                                            )}
-                                                        </p>
-                                                        {payment.dueDate && (
-                                                            <p className="text-xs text-hui-textMuted mt-0.5">Due: {new Date(payment.dueDate).toLocaleDateString()}</p>
-                                                        )}
-                                                    </div>
-                                                    
-                                                    <div className="flex flex-col sm:items-end w-full sm:w-auto mt-2 sm:mt-0">
-                                                        {payment.status === 'Pending' ? (
-                                                            <PortalPayButton 
-                                                                invoiceId={inv.id} 
-                                                                paymentScheduleId={payment.id} 
-                                                                amount={payment.amount}
-                                                                label="Pay Now"
-                                                                settings={settings}
-                                                            />
-                                                        ) : (
-                                                            <span className="text-sm font-medium text-hui-textMain">{formatCurrency(payment.amount)}</span>
-                                                        )}
-                                                    </div>
+                                    <p className="text-sm text-hui-textMain line-clamp-2 mb-3">
+                                        {latestLog.workPerformed}
+                                    </p>
+                                    {latestLog.photos && latestLog.photos.length > 0 && (
+                                        <div className="flex gap-2">
+                                            {latestLog.photos.slice(0, 4).map((photo: any) => (
+                                                <div key={photo.id} className="w-12 h-12 rounded overflow-hidden border border-slate-200 shrink-0">
+                                                    <img src={photo.url} alt="" className="w-full h-full object-cover" />
                                                 </div>
                                             ))}
+                                            {latestLog.photos.length > 4 && (
+                                                <div className="w-12 h-12 rounded bg-slate-50 border border-slate-200 flex items-center justify-center text-xs font-semibold text-slate-500">
+                                                    +{latestLog.photos.length - 4}
+                                                </div>
+                                            )}
+                                        </div>
+                                    )}
+                                </Link>
+                            )}
+                        </div>
+
+                        {/* Empty overview fallback — based on what would actually render */}
+                        {pendingPayments.length === 0
+                            && sentEstimatesAwaitingSignature.length === 0
+                            && pendingChangeOrders.length === 0
+                            && !latestLog
+                            && !hasScheduleData
+                            && (
+                                <div className="hui-card p-8 text-center">
+                                    <div className="w-12 h-12 bg-blue-50 rounded-full flex items-center justify-center mx-auto mb-3">
+                                        <svg className="w-6 h-6 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                                    </div>
+                                    <h3 className="font-semibold text-hui-textMain mb-1">Your project is set up</h3>
+                                    <p className="text-sm text-hui-textMuted max-w-md mx-auto">
+                                        Your contractor will share updates, estimates, and schedule details here as the project progresses.
+                                    </p>
+                                </div>
+                            )}
+                    </div>
+                )}
+
+                {activeTab === "estimates" && (
+                    <div className="space-y-3">
+                        {project.estimates.map(est => (
+                            <Link href={`/portal/estimates/${est.id}`} key={est.id} className="block hui-card p-4 hover:border-blue-300 hover:shadow-sm transition">
+                                <div className="flex justify-between items-start mb-2 gap-2">
+                                    <h3 className="font-semibold text-hui-textMain truncate">{est.title}</h3>
+                                    <span className={`text-xs px-2 py-1 rounded-full font-medium shrink-0 ${est.status === 'Approved' ? 'bg-green-100 text-green-700' : 'bg-blue-100 text-blue-700'}`}>
+                                        {est.status}
+                                    </span>
+                                </div>
+                                <div className="flex justify-between text-sm text-hui-textMuted">
+                                    <span>Total: {formatCurrency(est.totalAmount)}</span>
+                                    <span>{new Date(est.createdAt).toLocaleDateString()}</span>
+                                </div>
+                            </Link>
+                        ))}
+                    </div>
+                )}
+
+                {activeTab === "schedule" && (
+                    <div className="space-y-4">
+                        {totalTasks === 0 ? (
+                            <div className="bg-hui-background border border-hui-border rounded-lg p-6 text-center text-hui-textMuted text-sm">
+                                No schedule shared yet.
+                            </div>
+                        ) : (
+                            <>
+                                <div className="hui-card p-5">
+                                    <div className="flex items-center justify-between mb-2">
+                                        <h3 className="font-semibold text-hui-textMain">Overall Progress</h3>
+                                        <span className="text-sm font-semibold text-blue-600">{overallProgress}%</span>
+                                    </div>
+                                    <div className="w-full bg-slate-100 rounded-full h-3 mb-2">
+                                        <div className="bg-blue-500 h-3 rounded-full transition-all" style={{ width: `${overallProgress}%` }} />
+                                    </div>
+                                    <p className="text-sm text-hui-textMuted">
+                                        {completedTasks} of {totalTasks} tasks complete
+                                        {inProgressTask && (
+                                            <> · Now: <span className="text-hui-textMain font-medium">{inProgressTask.name}</span></>
+                                        )}
+                                    </p>
+                                </div>
+
+                                {upcomingTasks.length > 0 && (
+                                    <div className="hui-card p-5">
+                                        <h3 className="font-semibold text-hui-textMain mb-3">Upcoming Tasks</h3>
+                                        <ul className="divide-y divide-hui-border">
+                                            {upcomingTasks.map((task: any) => (
+                                                <li key={task.id} className="py-3 flex items-center justify-between gap-3">
+                                                    <div className="min-w-0">
+                                                        <p className="text-sm font-medium text-hui-textMain truncate">{task.name}</p>
+                                                        <p className="text-xs text-hui-textMuted">
+                                                            {new Date(task.startDate).toLocaleDateString()} – {new Date(task.endDate).toLocaleDateString()}
+                                                        </p>
+                                                    </div>
+                                                    <span className="text-xs px-2 py-1 rounded-full font-medium bg-slate-100 text-slate-600 shrink-0">
+                                                        {task.status || "Not Started"}
+                                                    </span>
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    </div>
+                                )}
+
+                                <Link
+                                    href={`/portal/projects/${projectId}/schedule`}
+                                    className="inline-flex items-center gap-1.5 text-sm font-semibold text-blue-600 hover:text-blue-700 transition"
+                                >
+                                    View full timeline
+                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" /></svg>
+                                </Link>
+                            </>
+                        )}
+                    </div>
+                )}
+
+                {activeTab === "invoices" && (
+                    <div className="space-y-3">
+                        {project.invoices.map(inv => (
+                            <div key={inv.id} className="hui-card p-4">
+                                <div className="flex justify-between items-start mb-2 gap-2">
+                                    <h3 className="font-semibold text-hui-textMain">Invoice #{inv.code}</h3>
+                                    <span className={`text-xs px-2 py-1 rounded-full font-medium shrink-0 ${inv.status === 'Paid' ? 'bg-green-100 text-green-700' :
+                                            inv.status === 'Overdue' ? 'bg-red-100 text-red-700' : 'bg-yellow-100 text-yellow-800'
+                                        }`}>
+                                        {inv.status}
+                                    </span>
+                                </div>
+                                <div className="flex justify-between text-sm mb-4">
+                                    <span className="text-hui-textMuted">Amount: {formatCurrency(inv.totalAmount)}</span>
+                                    <span className="font-medium text-hui-textMain">Due: {formatCurrency(inv.balanceDue)}</span>
+                                </div>
+
+                                {inv.payments && inv.payments.length > 0 && (
+                                    <div className="space-y-2 border-t border-hui-border pt-3 mt-3">
+                                        {inv.payments.map((payment: any) => (
+                                            <div key={payment.id} className="flex flex-col sm:flex-row sm:items-center justify-between p-3 bg-slate-50 rounded-md border border-slate-100 gap-3">
+                                                <div>
+                                                    <p className="text-sm font-semibold text-hui-textMain flex items-center gap-2">
+                                                        {payment.name}
+                                                        {payment.status === 'Paid' && (
+                                                            <span className="inline-flex items-center text-xs text-green-600 bg-green-50 px-1.5 py-0.5 rounded-full border border-green-200">
+                                                                <svg className="w-3 h-3 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
+                                                                Paid {payment.paymentMethod ? `via ${payment.paymentMethod.toUpperCase()}` : ''}
+                                                            </span>
+                                                        )}
+                                                        {payment.status === 'Processing' && (
+                                                            <span className="text-xs text-yellow-600 bg-yellow-50 px-1.5 py-0.5 rounded-md border border-yellow-200">
+                                                                Processing ACH
+                                                            </span>
+                                                        )}
+                                                    </p>
+                                                    {payment.dueDate && (
+                                                        <p className="text-xs text-hui-textMuted mt-0.5">Due: {new Date(payment.dueDate).toLocaleDateString()}</p>
+                                                    )}
+                                                </div>
+                                                <div className="flex flex-col sm:items-end w-full sm:w-auto mt-2 sm:mt-0">
+                                                    {payment.status === 'Pending' ? (
+                                                        <PortalPayButton
+                                                            invoiceId={inv.id}
+                                                            paymentScheduleId={payment.id}
+                                                            amount={Number(payment.amount)}
+                                                            label="Pay Now"
+                                                            settings={settings}
+                                                        />
+                                                    ) : (
+                                                        <span className="text-sm font-medium text-hui-textMain">{formatCurrency(payment.amount)}</span>
+                                                    )}
+                                                </div>
+                                            </div>
+                                        ))}
+                                    </div>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                )}
+
+                {activeTab === "updates" && (
+                    <div className="space-y-4">
+                        {project.dailyLogs.map((log: any) => (
+                            <div key={log.id} className="hui-card p-5 border-l-4 border-l-purple-500">
+                                <div className="flex items-start justify-between mb-3 border-b border-slate-100 pb-3 flex-wrap gap-2">
+                                    <div>
+                                        <h3 className="font-bold text-hui-textMain text-base md:text-lg">
+                                            {new Date(log.date).toLocaleDateString("en-US", { weekday: "long", year: "numeric", month: "long", day: "numeric" })}
+                                        </h3>
+                                        <p className="text-xs text-hui-textMuted mt-1">
+                                            Logged by {log.createdBy.name || log.createdBy.email}
+                                        </p>
+                                    </div>
+                                    <div className="flex items-center gap-2 flex-wrap">
+                                        {log.weather && (
+                                            <span className="inline-flex items-center gap-1 text-xs bg-blue-50 text-blue-700 px-2 py-1 rounded-full border border-blue-100">
+                                                ☁️ {log.weather}
+                                            </span>
+                                        )}
+                                        {log.crewOnSite && (
+                                            <span className="inline-flex items-center gap-1 text-xs bg-green-50 text-green-700 px-2 py-1 rounded-full border border-green-100">
+                                                👥 Crew on Site
+                                            </span>
+                                        )}
+                                    </div>
+                                </div>
+
+                                <div className="space-y-4">
+                                    <div>
+                                        <p className="text-xs font-bold text-hui-textMuted uppercase tracking-wider mb-1">Work Performed</p>
+                                        <div className="text-sm text-hui-textMain bg-slate-50 p-3 rounded-lg border border-slate-100 whitespace-pre-wrap leading-relaxed">
+                                            {log.workPerformed}
+                                        </div>
+                                    </div>
+
+                                    {log.materialsDelivered && (
+                                        <div>
+                                            <p className="text-xs font-bold text-amber-600 uppercase tracking-wider mb-1">Materials Delivered</p>
+                                            <div className="text-sm text-hui-textMain bg-amber-50/50 p-3 rounded-lg border border-amber-100/50 whitespace-pre-wrap">
+                                                {log.materialsDelivered}
+                                            </div>
+                                        </div>
+                                    )}
+
+                                    {log.issues && (
+                                        <div>
+                                            <p className="text-xs font-bold text-red-600 uppercase tracking-wider mb-1">⚠️ Issues / Delays</p>
+                                            <div className="text-sm text-hui-textMain bg-red-50/50 p-3 rounded-lg border border-red-100/50 whitespace-pre-wrap">
+                                                {log.issues}
+                                            </div>
+                                        </div>
+                                    )}
+
+                                    {log.photos && log.photos.length > 0 && (
+                                        <div>
+                                            <p className="text-xs font-bold text-hui-textMuted uppercase tracking-wider mb-2">Photos</p>
+                                            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+                                                {log.photos.map((photo: any) => (
+                                                    <div key={photo.id} className="relative aspect-square rounded-lg overflow-hidden border border-slate-200">
+                                                        <img src={photo.url} alt="Daily Log Image" className="w-full h-full object-cover" />
+                                                    </div>
+                                                ))}
+                                            </div>
                                         </div>
                                     )}
                                 </div>
-                            ))}
-                        </div>
-                    )}
-                </div>
+                            </div>
+                        ))}
+                    </div>
                 )}
 
-                {/* Room Designer portal view is Stage 4 (client share links). Not rendered in Stage 0. */}
-
-                {/* Files & Documents Section */}
-                {visibility.showFiles && (
-                <div className="md:col-span-2 mt-4">
-                    <div className="flex items-center justify-between mb-4">
-                        <h2 className="text-xl font-bold text-hui-textMain flex items-center gap-2">
-                            <svg className="w-5 h-5 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"/></svg>
-                            Files & Documents
-                        </h2>
-                        <Link href={`/portal/projects/${projectId}/files`} className="text-sm font-semibold text-blue-500 hover:text-blue-700 transition">
-                            View All Files →
-                        </Link>
-                    </div>
+                {activeTab === "files" && (
                     <Link href={`/portal/projects/${projectId}/files`} className="block hui-card p-6 hover:border-blue-500 hover:shadow-md transition text-center border-dashed">
                         <div className="w-12 h-12 bg-blue-50 rounded-full flex items-center justify-center mx-auto mb-3">
-                            <svg className="w-6 h-6 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"/></svg>
+                            <svg className="w-6 h-6 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z" /></svg>
                         </div>
                         <h3 className="text-base font-bold text-slate-800">View Shared Files</h3>
                         <p className="text-sm text-slate-500 mt-1">Access project documents, plans, and photos shared by your contractor.</p>
                     </Link>
-                </div>
                 )}
 
-                {/* Daily Logs Section */}
-                {visibility.showDailyLogs && (
-                <div className="md:col-span-2 mt-4">
-                    <h2 className="text-xl font-bold text-hui-textMain mb-4 flex items-center gap-2">
-                        <svg className="w-5 h-5 text-purple-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
-                        Daily Logs
-                    </h2>
-                    {(!project.dailyLogs || project.dailyLogs.length === 0) ? (
-                        <div className="bg-hui-background border border-hui-border rounded-lg p-6 text-center text-hui-textMuted text-sm">
-                            No daily logs have been published yet.
-                        </div>
-                    ) : (
-                        <div className="space-y-4">
-                            {project.dailyLogs.map((log: any) => (
-                                <div key={log.id} className="hui-card p-5 border-l-4 border-l-purple-500">
-                                    <div className="flex items-start justify-between mb-3 border-b border-slate-100 pb-3">
-                                        <div>
-                                            <h3 className="font-bold text-hui-textMain text-lg">
-                                                {new Date(log.date).toLocaleDateString("en-US", { weekday: "long", year: "numeric", month: "long", day: "numeric" })}
-                                            </h3>
-                                            <p className="text-xs text-hui-textMuted mt-1">
-                                                Logged by {log.createdBy.name || log.createdBy.email}
-                                            </p>
-                                        </div>
-                                        {/* Badges */}
-                                        <div className="flex items-center gap-2 flex-wrap justify-end">
-                                            {log.weather && (
-                                                <span className="inline-flex items-center gap-1 text-xs bg-blue-50 text-blue-700 px-2 py-1 rounded-full border border-blue-100">
-                                                    ☁️ {log.weather}
-                                                </span>
-                                            )}
-                                            {log.crewOnSite && (
-                                                <span className="inline-flex items-center gap-1 text-xs bg-green-50 text-green-700 px-2 py-1 rounded-full border border-green-100">
-                                                    👥 Crew on Site
-                                                </span>
-                                            )}
-                                        </div>
-                                    </div>
-                                    
-                                    <div className="space-y-4">
-                                        <div>
-                                            <p className="text-xs font-bold text-hui-textMuted uppercase tracking-wider mb-1">Work Performed</p>
-                                            <div className="text-sm text-hui-textMain bg-slate-50 p-3 rounded-lg border border-slate-100 whitespace-pre-wrap leading-relaxed">
-                                                {log.workPerformed}
-                                            </div>
-                                        </div>
-                                        
-                                        {log.materialsDelivered && (
-                                            <div>
-                                                <p className="text-xs font-bold text-amber-600 uppercase tracking-wider mb-1">Materials Delivered</p>
-                                                <div className="text-sm text-hui-textMain bg-amber-50/50 p-3 rounded-lg border border-amber-100/50 whitespace-pre-wrap">
-                                                    {log.materialsDelivered}
-                                                </div>
-                                            </div>
-                                        )}
-
-                                        {log.issues && (
-                                            <div>
-                                                <p className="text-xs font-bold text-red-600 uppercase tracking-wider mb-1">⚠️ Issues / Delays</p>
-                                                <div className="text-sm text-hui-textMain bg-red-50/50 p-3 rounded-lg border border-red-100/50 whitespace-pre-wrap">
-                                                    {log.issues}
-                                                </div>
-                                            </div>
-                                        )}
-
-                                        {log.photos && log.photos.length > 0 && (
-                                            <div>
-                                                <p className="text-xs font-bold text-hui-textMuted uppercase tracking-wider mb-2">Photos</p>
-                                                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
-                                                    {log.photos.map((photo: any) => (
-                                                        <div key={photo.id} className="relative aspect-square rounded-lg overflow-hidden border border-slate-200">
-                                                            <img src={photo.url} alt="Daily Log Image" className="w-full h-full object-cover" />
-                                                        </div>
-                                                    ))}
-                                                </div>
-                                            </div>
-                                        )}
-                                    </div>
-                                </div>
-                            ))}
-                        </div>
-                    )}
-                </div>
-                )}
-
-                {/* Selections / Mood Boards Section */}
-                {visibility.showSelections && (
-                <div className="md:col-span-2 mt-4">
-                    <div className="flex items-center justify-between mb-4">
-                        <h2 className="text-xl font-bold text-hui-textMain flex items-center gap-2">
-                            <svg className="w-5 h-5 text-hui-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                            </svg>
-                            Selections
-                        </h2>
-                        <Link href={`/portal/projects/${projectId}/selections`} className="text-sm font-semibold text-hui-primary hover:text-hui-primaryHover transition">
-                            View All →
-                        </Link>
-                    </div>
+                {activeTab === "selections" && (
                     <Link href={`/portal/projects/${projectId}/selections`} className="block hui-card p-6 hover:border-hui-primary hover:shadow-md transition text-center border-dashed">
                         <div className="w-12 h-12 bg-green-50 rounded-full flex items-center justify-center mx-auto mb-3">
                             <svg className="w-6 h-6 text-hui-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                             </svg>
                         </div>
                         <h3 className="text-base font-bold text-slate-800">Review Project Selections</h3>
                         <p className="text-sm text-slate-500 mt-1">Make your choices for finishes, materials, and fixtures.</p>
                     </Link>
-                </div>
                 )}
 
-                {/* Mood Boards Section */}
-                {visibility.showMoodBoards && (
-                <div className="md:col-span-2 mt-4">
-                    <div className="flex items-center justify-between mb-4">
-                        <h2 className="text-xl font-bold text-hui-textMain flex items-center gap-2">
-                            <svg className="w-5 h-5 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                            </svg>
-                            Visual Mood Boards
-                        </h2>
-                        <Link href={`/portal/projects/${projectId}/mood-boards`} className="text-sm font-semibold text-indigo-500 hover:text-indigo-700 transition">
-                            View All →
-                        </Link>
-                    </div>
+                {activeTab === "designs" && (
                     <Link href={`/portal/projects/${projectId}/mood-boards`} className="block hui-card p-6 hover:border-indigo-500 hover:shadow-md transition text-center border-dashed">
                         <div className="w-12 h-12 bg-indigo-50 rounded-full flex items-center justify-center mx-auto mb-3">
                             <svg className="w-6 h-6 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -447,9 +608,29 @@ export default async function PortalProjectDetail(props: { params: Promise<{ id:
                         <h3 className="text-base font-bold text-slate-800">View Design Concepts</h3>
                         <p className="text-sm text-slate-500 mt-1">Explore visual layouts and material choices for your space.</p>
                     </Link>
-                </div>
                 )}
 
+                {activeTab === "change-orders" && (
+                    <div className="space-y-3">
+                        {project.changeOrders.map((co: any) => (
+                            <Link href={`/portal/change-orders/${co.id}`} key={co.id} className="block hui-card p-4 hover:border-amber-300 hover:shadow-sm transition">
+                                <div className="flex justify-between items-start mb-2 gap-2">
+                                    <h3 className="font-semibold text-hui-textMain truncate">{co.title}</h3>
+                                    <span className={`text-xs px-2 py-1 rounded-full font-medium shrink-0 ${co.status === 'Approved' ? 'bg-green-100 text-green-700' : 'bg-blue-100 text-blue-700'}`}>
+                                        {co.status}
+                                    </span>
+                                </div>
+                                <div className="flex justify-between text-sm text-hui-textMuted">
+                                    <span>Amount: {formatCurrency(co.totalAmount)}</span>
+                                    <span>{new Date(co.createdAt).toLocaleDateString()}</span>
+                                </div>
+                                <div className="mt-2 text-xs text-slate-400 truncate">
+                                    Original Est: {co.estimate?.title || co.estimate?.code}
+                                </div>
+                            </Link>
+                        ))}
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/src/components/PortalProjectTabs.tsx
+++ b/src/components/PortalProjectTabs.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import Link from "next/link";
+import { useRef, KeyboardEvent } from "react";
+
+export interface PortalTab {
+    id: string;
+    label: string;
+    count?: number;
+    href: string;
+}
+
+interface Props {
+    tabs: PortalTab[];
+    activeTab: string;
+}
+
+export default function PortalProjectTabs({ tabs, activeTab }: Props) {
+    const listRef = useRef<HTMLDivElement>(null);
+
+    const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+        const buttons = listRef.current?.querySelectorAll<HTMLAnchorElement>('[role="tab"]');
+        if (!buttons || buttons.length === 0) return;
+
+        const currentIndex = Array.from(buttons).findIndex(b => b === document.activeElement);
+        if (currentIndex === -1) return;
+
+        // Space activates the focused tab (Enter is handled natively by the link).
+        if (e.key === " " || e.key === "Spacebar") {
+            e.preventDefault();
+            buttons[currentIndex].click();
+            return;
+        }
+
+        let nextIndex = currentIndex;
+        switch (e.key) {
+            case "ArrowRight":
+                nextIndex = (currentIndex + 1) % buttons.length;
+                break;
+            case "ArrowLeft":
+                nextIndex = (currentIndex - 1 + buttons.length) % buttons.length;
+                break;
+            case "Home":
+                nextIndex = 0;
+                break;
+            case "End":
+                nextIndex = buttons.length - 1;
+                break;
+            default:
+                return;
+        }
+        e.preventDefault();
+        buttons[nextIndex].focus();
+    };
+
+    return (
+        <div className="sticky top-0 z-30 -mx-4 md:-mx-8 px-4 md:px-8 bg-white/95 backdrop-blur border-b border-hui-border mb-6">
+            <div
+                ref={listRef}
+                role="tablist"
+                aria-label="Project sections"
+                onKeyDown={handleKeyDown}
+                className="flex gap-1 overflow-x-auto snap-x [&::-webkit-scrollbar]:hidden"
+                style={{ scrollbarWidth: "none" }}
+            >
+                {tabs.map(tab => {
+                    const isActive = tab.id === activeTab;
+                    return (
+                        <Link
+                            key={tab.id}
+                            id={`tab-${tab.id}`}
+                            href={tab.href}
+                            scroll={false}
+                            replace
+                            role="tab"
+                            aria-selected={isActive}
+                            aria-controls={`panel-${tab.id}`}
+                            tabIndex={isActive ? 0 : -1}
+                            className={`
+                                shrink-0 snap-start
+                                inline-flex items-center gap-2
+                                px-4 py-3 text-sm font-medium
+                                border-b-2 transition
+                                focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary focus-visible:ring-offset-1
+                                ${isActive
+                                    ? "border-hui-primary text-hui-primary font-semibold"
+                                    : "border-transparent text-hui-textMuted hover:text-hui-textMain hover:border-slate-300"
+                                }
+                            `}
+                        >
+                            <span>{tab.label}</span>
+                            {typeof tab.count === "number" && tab.count > 0 && (
+                                <span className={`
+                                    text-xs px-1.5 py-0.5 rounded-full font-semibold
+                                    ${isActive
+                                        ? "bg-green-100 text-green-700"
+                                        : "bg-slate-100 text-slate-600"
+                                    }
+                                `}>
+                                    {tab.count}
+                                </span>
+                            )}
+                        </Link>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}

--- a/src/components/PortalUserMenu.tsx
+++ b/src/components/PortalUserMenu.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { signOut } from "next-auth/react";
+import Avatar from "./Avatar";
+
+interface Props {
+    displayName: string | null;
+    isStaff: boolean;
+}
+
+export default function PortalUserMenu({ displayName, isStaff }: Props) {
+    const label = isStaff ? "Staff Preview" : (displayName || "Account");
+    const firstName = isStaff ? "Staff" : (displayName?.split(" ")[0] || "");
+    const avatarName = isStaff ? "Staff" : (displayName || "?");
+
+    const handleSignOut = async () => {
+        // Clear the magic-link cookie for portal-token clients before NextAuth signOut.
+        try {
+            await fetch("/api/portal/signout", { method: "POST" });
+        } catch {}
+        await signOut({ callbackUrl: "/login" });
+    };
+
+    return (
+        <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2">
+                <Avatar name={avatarName} color={isStaff ? "orange" : "blue"} size="sm" />
+                <span className="hidden sm:inline text-sm font-medium text-hui-textMain max-w-[140px] truncate" title={label}>
+                    {firstName || label}
+                </span>
+            </div>
+            <button
+                onClick={handleSignOut}
+                className="text-sm font-medium text-red-600 hover:text-red-700 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 rounded px-1"
+            >
+                Sign out
+            </button>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- Refactor `/portal/projects/[id]` from an 8-section endless scroll into a sticky tabbed view (Overview, Estimates, Schedule, Invoices, Updates, Files, Selections, Designs, Change Orders).
- Smart Overview tab surfaces Payment Due (with Pay Now CTA), action-needed alerts, schedule mini-progress, and latest daily-log preview — what the customer most likely came for.
- Tabs only render when the contractor's visibility flag is on AND there's content, so empty / hidden sections disappear instead of cluttering the view.
- Portal header gains client name + sign out, working for both NextAuth and magic-link clients (`/api/portal/signout` clears the token cookie).

## What changed
| File | Change |
|---|---|
| [src/app/portal/projects/[id]/page.tsx](src/app/portal/projects/%5Bid%5D/page.tsx) | Tabbed view + smart Overview, URL state via `?tab=X` |
| [src/app/portal/layout.tsx](src/app/portal/layout.tsx) | Avatar + name + sign-out in header, gated for both auth paths |
| [src/components/PortalProjectTabs.tsx](src/components/PortalProjectTabs.tsx) | New: sticky tab bar with W3C tablist a11y, keyboard nav incl. Space, mobile horizontal scroll |
| [src/components/PortalUserMenu.tsx](src/components/PortalUserMenu.tsx) | New: clears both NextAuth and magic-link cookie |
| [src/app/api/portal/signout/route.ts](src/app/api/portal/signout/route.ts) | New: clears `client_portal_token` cookie |

## Test plan
- [ ] `npm run build` passes (verified: exit 0)
- [ ] Visit `/portal/projects/<id>` — clicking each tab updates `?tab=X` without full reload; only active section renders
- [ ] Mobile (DevTools iPhone 12): tab bar scrolls horizontally, active tab stays visible
- [ ] Keyboard: Tab into tab bar → Arrow Left/Right moves focus → Enter / Space activates → focus ring visible
- [ ] Project with a pending payment: Overview shows green "Payment Due" callout with correct total + Pay Now CTA
- [ ] Brand-new project (no estimates / invoices / logs): Overview shows friendly empty-state fallback; only Overview tab visible
- [ ] Sign out from layout header → redirects to `/login`; magic-link cookie cleared
- [ ] Staff (ADMIN/MANAGER) preview: amber "Staff Preview" banner still appears, user menu shows "Staff" label
- [ ] Visibility-respect: with `showInvoices: false` set, Payment Due callout does NOT appear on Overview (covered by Codex review fix)
- [ ] Regression: clicking "View full timeline →" in Schedule tab still loads `/portal/projects/[id]/schedule`

## Review notes
Independent Codex peer review caught 2 blockers + 7 issues — all addressed in this PR. Notable fixes:
- Overview was leaking invoice/estimate/change-order data even when those sections were disabled in `portalVisibility`.
- Tab `id` was missing for `aria-labelledby`; added matching `id={tab-X}`.
- Schedule completion now considers both `progress >= 100` AND `status === 'Complete'`.
- Upcoming tasks sorted by `startDate` rather than display order.
- `isAuthed` now covers token-based portal clients (not just NextAuth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)