### PR TITLE
fix(schedule): fixed-position toolbar dropdowns to escape stacking context

### DIFF
--- a/src/app/projects/[id]/schedule/SchedulePublishButton.tsx
+++ b/src/app/projects/[id]/schedule/SchedulePublishButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useRef, useTransition } from "react";
 import { toggleSchedulePublished, emailPortalLinkToClient } from "@/lib/actions";
 import { toast } from "sonner";
 
@@ -14,6 +14,8 @@ export default function SchedulePublishButton({
     const [published, setPublished] = useState(initialPublished);
     const [showMenu, setShowMenu] = useState(false);
     const [isPending, startTransition] = useTransition();
+    const btnRef = useRef<HTMLButtonElement>(null);
+    const [menuPos, setMenuPos] = useState({ top: 0, right: 0 });
 
     function handleToggle() {
         const next = !published;
@@ -33,10 +35,19 @@ export default function SchedulePublishButton({
         });
     }
 
+    function handleToggleMenu() {
+        if (!showMenu && btnRef.current) {
+            const rect = btnRef.current.getBoundingClientRect();
+            setMenuPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
+        }
+        setShowMenu(!showMenu);
+    }
+
     return (
         <div className="relative">
             <button
-                onClick={() => setShowMenu(!showMenu)}
+                ref={btnRef}
+                onClick={handleToggleMenu}
                 disabled={isPending}
                 className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-md border transition ${
                     published
@@ -63,7 +74,7 @@ export default function SchedulePublishButton({
             {showMenu && (
                 <>
                     <div className="fixed inset-0 z-40" onClick={() => setShowMenu(false)} />
-                    <div className="absolute right-0 top-full mt-1 w-56 bg-white border border-slate-200 rounded-lg shadow-xl z-50 py-1">
+                    <div className="fixed w-56 bg-white border border-slate-200 rounded-lg shadow-xl z-50 py-1" style={{ top: menuPos.top, right: menuPos.right }}>
                         <button
                             onClick={handleToggle}
                             disabled={isPending}

--- a/src/app/projects/[id]/schedule/ScheduleToolbar.tsx
+++ b/src/app/projects/[id]/schedule/ScheduleToolbar.tsx
@@ -46,6 +46,8 @@ export default function ScheduleToolbar({
     const [newTaskStart, setNewTaskStart] = useState("");
     const [newTaskEnd, setNewTaskEnd] = useState("");
     const menuRef = useRef<HTMLDivElement>(null);
+    const moreBtnRef = useRef<HTMLButtonElement>(null);
+    const [moreMenuPos, setMoreMenuPos] = useState({ top: 0, right: 0 });
 
     useEffect(() => {
         if (!showMoreMenu) setExpandedSection(null);
@@ -201,7 +203,14 @@ export default function ScheduleToolbar({
                         {/* More menu */}
                         <div className="relative" ref={menuRef}>
                             <button
-                                onClick={() => setShowMoreMenu(!showMoreMenu)}
+                                ref={moreBtnRef}
+                                onClick={() => {
+                                    if (!showMoreMenu && moreBtnRef.current) {
+                                        const rect = moreBtnRef.current.getBoundingClientRect();
+                                        setMoreMenuPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
+                                    }
+                                    setShowMoreMenu(!showMoreMenu);
+                                }}
                                 className={`hui-btn hui-btn-secondary text-xs py-1.5 px-2 relative ${hasActiveFeature ? "ring-2 ring-indigo-300" : ""}`}
                                 title="More actions"
                             >
@@ -211,7 +220,7 @@ export default function ScheduleToolbar({
                                 )}
                             </button>
                             {showMoreMenu && (
-                                <div className="absolute right-0 top-full mt-1 bg-white border border-hui-border rounded-lg shadow-xl z-50 min-w-[240px] py-1 animate-in fade-in">
+                                <div className="fixed bg-white border border-hui-border rounded-lg shadow-xl z-50 min-w-[240px] py-1 animate-in fade-in" style={{ top: moreMenuPos.top, right: moreMenuPos.right }}>
                                     {/* TOOLS section */}
                                     <div className="px-3 py-1.5 text-[10px] text-slate-400 uppercase font-semibold tracking-wider">Tools</div>
                                     <button

--- a/src/app/projects/[id]/schedule/ScheduleToolbar.tsx
+++ b/src/app/projects/[id]/schedule/ScheduleToolbar.tsx
@@ -146,7 +146,7 @@ export default function ScheduleToolbar({
 
     return (
         <>
-            <div className="bg-white border-b border-hui-border shrink-0 z-20 relative">
+            <div className="bg-white border-b border-hui-border shrink-0 z-30 relative">
                 <div className="h-1 bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500" />
                 <div className="px-6 py-3 flex items-center justify-between flex-wrap gap-2">
                     {/* Left: title + progress */}


### PR DESCRIPTION
## Summary
- Toolbar dropdowns (Published, More menu) were clipped by the sticky table header because the toolbar's `z-30` stacking context capped their effective z-index
- Switched both dropdowns from `position: absolute` to `position: fixed` with dynamically computed coordinates from `getBoundingClientRect()`
- Fixed-position elements escape all parent stacking contexts, so they render at z-50 in the root context — always above other page elements

## Files changed
- `SchedulePublishButton.tsx` — Published dropdown: `absolute` → `fixed` with computed position
- `ScheduleToolbar.tsx` — More menu dropdown: `absolute` → `fixed` with computed position

## Test plan
- [ ] Table view: click **Published** ✓ — dropdown fully visible, all items clickable
- [ ] Table view: click **⋮ More** menu — dropdown fully visible above table header and detail panel
- [ ] Gantt view: click **Published** ✓ — dropdown visible above task detail panel
- [ ] Gantt view: click **⋮ More** menu — dropdown visible, all sections expand correctly
- [ ] Calendar view: same checks
- [ ] Click outside dropdown → closes correctly
- [ ] Resize window → reopen dropdown → positions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)