### PR TITLE
fix(estimates): persist milestone amount when recording payment

### DIFF
--- a/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
@@ -2872,8 +2872,18 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                     amount={recordingEstPayment.amount}
                     onClose={() => setRecordingEstPayment(null)}
                     onSubmit={async (input) => {
-                        const result = await recordEstimatePayment(recordingEstPayment.id, initialEstimate.id, input);
-                        if (result.success) router.refresh();
+                        const result = await recordEstimatePayment(recordingEstPayment.id, initialEstimate.id, {
+                            ...input,
+                            amount: recordingEstPayment.amount,
+                        });
+                        if (result.success) {
+                            setPaymentSchedules(prev => prev.map(s =>
+                                s.id === recordingEstPayment.id
+                                    ? { ...s, status: "Paid", amount: String(recordingEstPayment.amount), paymentMethod: input.method, referenceNumber: input.referenceNumber || null, paymentDate: input.paymentDate, paidAt: new Date().toISOString(), notes: input.notes || null }
+                                    : s
+                            ));
+                            router.refresh();
+                        }
                         return { success: result.success, error: (result as any).error };
                     }}
                 />
@@ -2902,6 +2912,11 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                             try {
                                 const res = await unrecordEstimatePayment(undoPaymentTarget.id, initialEstimate.id);
                                 if (!res?.success) { toast.error("Nothing to unrecord"); return; }
+                                setPaymentSchedules(prev => prev.map(s =>
+                                    s.id === undoPaymentTarget.id
+                                        ? { ...s, status: "Pending", paymentMethod: null, referenceNumber: null, paymentDate: null, paidAt: null, notes: null }
+                                        : s
+                                ));
                                 toast("Payment unrecorded");
                                 setUndoPaymentTarget(null);
                                 router.refresh();

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -2559,6 +2559,7 @@ export async function recordEstimatePayment(
         method: string;
         referenceNumber?: string | null;
         notes?: string | null;
+        amount?: number;
     },
 ) {
     const user = await getCurrentUserWithPermissions();
@@ -2595,6 +2596,7 @@ export async function recordEstimatePayment(
                 paymentMethod: method,
                 referenceNumber,
                 notes,
+                ...(input.amount != null && { amount: input.amount }),
             },
         });
         if (claim.count === 0) return { success: false as const, error: "Milestone already paid" as const };


### PR DESCRIPTION
## Summary
- **`recordEstimatePayment` now saves the milestone amount** to the DB when a payment is recorded, locking the dollar value at the moment of payment
- **Local state updates immediately** after recording or undoing a payment — no stale UI requiring page reload
- **Undo callback resets to Pending** — milestone becomes editable again after undo

## Why this matters
Once a payment is recorded, we may have already remitted sales tax on that revenue. The dollar value must be immutable once paid. Previously, only payment metadata (method, date, reference) was saved — the amount field was untouched, leaving whatever stale value was in the DB.

## Test plan
- [ ] Record a payment on a milestone → verify amount is locked and shows as Paid
- [ ] Reload page → verify amount persists correctly
- [ ] Save estimate → verify balance calculation uses the locked paid amount
- [ ] Undo payment (type "UNDO") → verify milestone returns to editable Pending state

🤖 Generated with [Claude Code](https://claude.com/claude-code)