### PR TITLE
fix(schedule): increase +Task button size

### DIFF
--- a/src/app/projects/[id]/schedule/ScheduleToolbar.tsx
+++ b/src/app/projects/[id]/schedule/ScheduleToolbar.tsx
@@ -59,8 +59,8 @@ function AddTaskDropdown({ isAdding, onAddTask, onAddMilestone }: { isAdding: bo
     const [pos, setPos] = useState({ top: 0, right: 0 });
     return (
         <div className="relative">
-            <div className="inline-flex items-center rounded-md shadow-sm">
-                <button onClick={onAddTask} disabled={isAdding} className="inline-flex items-center justify-center px-3 py-1.5 text-xs font-medium bg-slate-900 text-white hover:bg-slate-800 transition-colors rounded-l-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-slate-900 focus:z-10">+ Task</button>
+            <div className="inline-flex items-center rounded-lg shadow-sm">
+                <button onClick={onAddTask} disabled={isAdding} className="inline-flex items-center justify-center px-4 py-2 text-sm font-medium bg-slate-900 text-white hover:bg-slate-800 transition-colors rounded-l-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-slate-900 focus:z-10">+ Task</button>
                 <button
                     ref={btnRef}
                     onClick={() => {
@@ -71,7 +71,7 @@ function AddTaskDropdown({ isAdding, onAddTask, onAddMilestone }: { isAdding: bo
                         setOpen(v => !v);
                     }}
                     disabled={isAdding}
-                    className="inline-flex items-center justify-center px-2 py-1.5 text-xs font-medium bg-slate-900 text-white hover:bg-slate-800 transition-colors rounded-r-md border-l border-indigo-400/40 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-slate-900 focus:z-10"
+                    className="inline-flex items-center justify-center px-2.5 py-2 text-sm font-medium bg-slate-900 text-white hover:bg-slate-800 transition-colors rounded-r-lg border-l border-indigo-400/40 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-slate-900 focus:z-10"
                 >
                     <svg width="8" height="8" viewBox="0 0 12 12" fill="currentColor"><path d="M6 8.5L1.5 4h9z"/></svg>
                 </button>


### PR DESCRIPTION
## Summary
- Increases the schedule toolbar's "+ Task" split button from `text-xs/py-1.5` to `text-sm/py-2/px-4` with `rounded-lg`
- Button now matches standard `hui-btn` sizing and looks properly prominent alongside other toolbar controls

Follow-up to PR #100 which fixed the split button shape.

## Test plan
- [ ] Navigate to any project's schedule page
- [ ] Confirm "+ Task" button is visually prominent and properly sized
- [ ] Click "+ Task" and dropdown arrow — both should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)