### PR TITLE
chore(e2e): isolate tests from the live DB — throwaway CI Postgres, prod guard, teardown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,9 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     env:
-      DATABASE_URL: postgresql://probuild:probuild@localhost:5432/probuild_e2e
+      # pgbouncer=true is required by src/lib/prisma.ts's URL check; on vanilla
+      # Postgres it just disables prepared statements (harmless).
+      DATABASE_URL: postgresql://probuild:probuild@localhost:5432/probuild_e2e?pgbouncer=true
       DIRECT_URL: postgresql://probuild:probuild@localhost:5432/probuild_e2e
       NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
       NEXTAUTH_URL: http://localhost:3000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,26 @@ jobs:
     name: Playwright E2E Tests
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    # E2E runs against a throwaway Postgres service container — NEVER the live
+    # Supabase DB. (This job used to point at prod and filled /leads with QA
+    # artifacts — see docs/TESTING.md.)
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: probuild
+          POSTGRES_PASSWORD: probuild
+          POSTGRES_DB: probuild_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     env:
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      DATABASE_URL: postgresql://probuild:probuild@localhost:5432/probuild_e2e
+      DIRECT_URL: postgresql://probuild:probuild@localhost:5432/probuild_e2e
       NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
       NEXTAUTH_URL: http://localhost:3000
       NEXT_PUBLIC_APP_URL: http://localhost:3000
@@ -112,6 +129,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Create schema in throwaway Postgres
+        run: npx prisma db push --skip-generate
+
       - name: Build application
         run: npm run build
         env:
@@ -137,3 +157,4 @@ jobs:
           echo "## Playwright E2E Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Server:** localhost:3000 (production build)" >> $GITHUB_STEP_SUMMARY
+          echo "**Database:** throwaway Postgres service container (no live data)" >> $GITHUB_STEP_SUMMARY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,13 @@ vercel --prod --token $env:VERCEL_TOKEN --yes --archive=tgz --cwd "C:\Users\jat0
 - Only deploy when changes are verified locally via `npm run build`
 - Do NOT re-enable auto-deploy in vercel.json or the Vercel dashboard
 
+## E2E testing — never against the live DB
+See **docs/TESTING.md**. E2E creates leads/estimates/invoices, so:
+- CI runs e2e in a throwaway Postgres container (`.github/workflows/ci.yml`)
+- `e2e/data.setup.ts` refuses to run when DATABASE_URL looks like Supabase (override: `ALLOW_PROD_E2E=1`)
+- Specs that create data must tear it down in `afterAll` (see `qa-lead-estimate-invoice.spec.ts`)
+- History: QA runs against prod once filled /leads with "Master Bath Renovation - Henderson" junk (cleaned 2026-06-11)
+
 ## Dev server — clean start
 ```bash
 kill -9 $(lsof -ti tcp:3000,3001,3002) 2>/dev/null; rm -f .next/dev/lock; sleep 2

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -54,8 +54,10 @@ Auth uses the NextAuth credentials provider that only activates when
 docker run --rm -d --name probuild-e2e -p 5433:5432 -e POSTGRES_PASSWORD=probuild postgres:16
 
 # 2. Create schema + run tests against it
-$env:DATABASE_URL = "postgresql://postgres:probuild@localhost:5433/postgres"
-$env:DIRECT_URL   = $env:DATABASE_URL
+# (pgbouncer=true is mandatory — src/lib/prisma.ts refuses URLs without it;
+#  on vanilla Postgres it just disables prepared statements)
+$env:DATABASE_URL = "postgresql://postgres:probuild@localhost:5433/postgres?pgbouncer=true"
+$env:DIRECT_URL   = "postgresql://postgres:probuild@localhost:5433/postgres"
 $env:PLAYWRIGHT_TEST_SECRET = "any-local-secret"
 npx prisma db push --skip-generate
 npx playwright test

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,79 @@
+# E2E Testing — Test Grounds & Ground Rules
+
+> **The one rule: e2e tests never write to the live database.**
+> The suite creates leads, estimates, and invoices. Pointed at prod, it fills
+> real screens with junk.
+
+## Why this doc exists (the Henderson-lead incident, June 2026)
+
+`e2e/qa-lead-estimate-invoice.spec.ts` creates a lead named
+**"Master Bath Renovation - Henderson"** (client *Mike Henderson*) on every
+run. Until June 2026 the CI Playwright job pointed `DATABASE_URL` at the
+**production** Supabase DB, and automated PRs (Bolt/Sentinel/Palette/
+Dependabot) triggered it almost daily. Result: 12 junk leads + 31 empty
+estimates accumulated in the live `/leads` list before anyone noticed. They
+were cleaned up by hand on 2026-06-11.
+
+Three safeguards now exist — keep all three intact:
+
+1. **CI uses a throwaway Postgres service container.**
+   `.github/workflows/ci.yml` (playwright job) spins up `postgres:16`, runs
+   `npx prisma db push` to create the schema, and points
+   `DATABASE_URL`/`DIRECT_URL` at it. No Supabase secret is exposed to the
+   e2e job. The DB dies with the runner.
+
+2. **`e2e/data.setup.ts` refuses to run against the live DB.**
+   It aborts if `DATABASE_URL` (env or `.env`) looks like Supabase, unless
+   `ALLOW_PROD_E2E=1` is explicitly set. Local `.env` points at prod, so a
+   bare `npx playwright test` on a dev machine fails fast by design.
+
+3. **Specs tear down what they create.**
+   `qa-lead-estimate-invoice.spec.ts` has a `test.afterAll` that deletes the
+   created lead/estimates (plus any strays matching the exact test signature)
+   and the auto-created client. New specs that create data MUST follow the
+   same pattern: track created IDs, delete dependents then parents in
+   `afterAll`, and keep fill values in shared constants so the cleanup
+   signature can't drift.
+
+## Seeded fixtures (created by `e2e/data.setup.ts`, idempotent upserts)
+
+| Fixture | ID / key |
+|---|---|
+| Admin user (credentials login) | `jadkins@goldentouchremodeling.com` |
+| Test client | `test-client-do-not-delete` |
+| Test project | `cmml6vt3y000lpwrh0p9p3k12` |
+| Baseline estimate | `cmml6vtx7001dpwrh8n65xzy6` |
+
+Auth uses the NextAuth credentials provider that only activates when
+`PLAYWRIGHT_TEST_SECRET` is set (see `src/lib/auth.ts`).
+
+## Running e2e locally (safe path)
+
+```powershell
+# 1. Disposable Postgres (Docker)
+docker run --rm -d --name probuild-e2e -p 5433:5432 -e POSTGRES_PASSWORD=probuild postgres:16
+
+# 2. Create schema + run tests against it
+$env:DATABASE_URL = "postgresql://postgres:probuild@localhost:5433/postgres"
+$env:DIRECT_URL   = $env:DATABASE_URL
+$env:PLAYWRIGHT_TEST_SECRET = "any-local-secret"
+npx prisma db push --skip-generate
+npx playwright test
+```
+
+The dev server started by Playwright inherits these env vars, so app writes
+land in the container too.
+
+## Prod smoke QA (`playwright.config.prod.ts`)
+
+`npx playwright test --config=playwright.config.prod.ts` runs the `qa-*`
+specs against the **live** deployment on purpose (read-mostly smoke checks).
+Know what you're doing before running it: the lead spec will create and then
+tear down a real lead in prod. Teardown connects via the local `.env`
+`DATABASE_URL`, which must therefore match the deployment being tested.
+
+## QA agent runs (QA_AGENT_PROMPT.md)
+
+If an agent executes the manual QA workflows against a live URL, it must end
+the session by deleting everything listed under "Test Data Created" in its
+report — the report section is not decorative.

--- a/e2e/data.setup.ts
+++ b/e2e/data.setup.ts
@@ -1,20 +1,70 @@
 import { test as setup } from "@playwright/test";
 import { PrismaClient } from "@prisma/client";
-import { writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
 const PROJECT_ID = "cmml6vt3y000lpwrh0p9p3k12";
+const ESTIMATE_ID = "cmml6vtx7001dpwrh8n65xzy6";
 const TEST_CLIENT_ID = "test-client-do-not-delete";
+const ADMIN_EMAIL = "jadkins@goldentouchremodeling.com";
 const SENTINEL_PATH = resolve(__dirname, ".anthropic-status");
 
-setup("seed test data + probe anthropic", async () => {
+// Substrings that identify the LIVE database. The e2e suite creates leads,
+// estimates, and invoices — it must never do that against production data.
+// See docs/TESTING.md (the Henderson-lead incident, June 2026).
+const PROD_DB_MARKERS = ["supabase.co", "supabase.com", "ghzdbzdnwjxazvmcefbh"];
+
+function resolveDatabaseUrl(): string {
+    if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+    // Plain Playwright processes don't load .env — mirror what the dev server
+    // (and Prisma Client) will resolve so the guard checks the real target.
+    const envPath = resolve(__dirname, "..", ".env");
+    if (existsSync(envPath)) {
+        const line = readFileSync(envPath, "utf8")
+            .split(/\r?\n/)
+            .find((l) => /^\s*DATABASE_URL\s*=/.test(l));
+        if (line) return line.split("=").slice(1).join("=").trim().replace(/^["']|["']$/g, "");
+    }
+    return "";
+}
+
+setup("guard prod DB + seed test data + probe anthropic", async () => {
     setup.setTimeout(60_000);
 
-    console.log("[data.setup] DATABASE_URL set:", !!process.env.DATABASE_URL);
-    console.log("[data.setup] DATABASE_URL host:", (process.env.DATABASE_URL || "").match(/@([^:/?]+)/)?.[1] ?? "(none)");
+    const dbUrl = resolveDatabaseUrl();
+    const dbHost = dbUrl.match(/@([^:/?]+)/)?.[1] ?? "(none)";
+    console.log("[data.setup] DATABASE_URL host:", dbHost);
+
+    if (PROD_DB_MARKERS.some((m) => dbUrl.includes(m)) && process.env.ALLOW_PROD_E2E !== "1") {
+        throw new Error(
+            `[data.setup] REFUSING TO RUN: DATABASE_URL points at the live database (${dbHost}).\n` +
+                `E2E tests create leads/estimates/invoices and must run against a disposable DB.\n` +
+                `Options:\n` +
+                `  - CI: already uses a throwaway Postgres service container (see .github/workflows/ci.yml)\n` +
+                `  - Local: docker run --rm -d -p 5433:5432 -e POSTGRES_PASSWORD=probuild postgres:16\n` +
+                `           then DATABASE_URL=postgresql://postgres:probuild@localhost:5433/postgres npx prisma db push\n` +
+                `           and run Playwright with that same DATABASE_URL.\n` +
+                `  - Override (discouraged; teardown will clean up): set ALLOW_PROD_E2E=1\n` +
+                `See docs/TESTING.md.`
+        );
+    }
 
     const prisma = new PrismaClient();
     try {
+        // Admin user — required by the PLAYWRIGHT_TEST_SECRET credentials
+        // provider (auth.setup.ts logs in as this email).
+        const admin = await prisma.user.upsert({
+            where: { email: ADMIN_EMAIL },
+            update: {},
+            create: {
+                email: ADMIN_EMAIL,
+                name: "Justin Adkins",
+                role: "ADMIN",
+                status: "ACTIVATED",
+            },
+        });
+        console.log("[data.setup] admin user upserted:", { id: admin.id, email: admin.email });
+
         const client = await prisma.client.upsert({
             where: { id: TEST_CLIENT_ID },
             update: {},
@@ -38,6 +88,22 @@ setup("seed test data + probe anthropic", async () => {
             },
         });
         console.log("[data.setup] project upserted:", { id: project.id, name: project.name, clientId: project.clientId });
+
+        // Baseline estimate — several specs navigate to this ID as a fallback.
+        const estimate = await prisma.estimate.upsert({
+            where: { id: ESTIMATE_ID },
+            update: {},
+            create: {
+                id: ESTIMATE_ID,
+                title: "E2E Baseline Estimate — DO NOT DELETE",
+                code: "EST-E2E",
+                status: "Sent",
+                projectId: PROJECT_ID,
+                totalAmount: 0,
+                balanceDue: 0,
+            },
+        });
+        console.log("[data.setup] estimate upserted:", { id: estimate.id, title: estimate.title });
 
         const verify = await prisma.project.findUnique({ where: { id: PROJECT_ID }, select: { id: true, name: true } });
         console.log("[data.setup] verify project exists:", verify);

--- a/e2e/qa-lead-estimate-invoice.spec.ts
+++ b/e2e/qa-lead-estimate-invoice.spec.ts
@@ -90,10 +90,9 @@ test.describe.serial("Workflows 1-3: Lead → Estimate → Invoice", () => {
 
     await capture(page, testInfo, 1, 2, "form-filled");
 
-    // Submit
-    const submitBtn = page.locator(
-      'button:has-text("Create Lead"), button:has-text("Add Lead"):not([disabled])'
-    ).last();
+    // Submit — the modal's submit button is the only type=submit "Create Lead";
+    // a text-based .last() can grab the empty-state "Add Lead" behind the modal.
+    const submitBtn = page.locator('button[type="submit"]:has-text("Create Lead")');
     await submitBtn.click();
 
     // Wait for redirect to lead detail

--- a/e2e/qa-lead-estimate-invoice.spec.ts
+++ b/e2e/qa-lead-estimate-invoice.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { PrismaClient } from "@prisma/client";
 import {
   assertCleanNavigation,
   assertNoCrashUI,
@@ -8,6 +9,12 @@ import {
   parseCurrency,
   capture,
 } from "./helpers/fail-loud";
+
+// Test-data signature — the teardown below deletes by these exact values, so
+// keep the form fills and the cleanup in sync by always using the constants.
+const TEST_LEAD_NAME = "Master Bath Renovation - Henderson";
+const TEST_CLIENT_NAME = "Mike Henderson";
+const TEST_CLIENT_EMAIL = "mike.henderson@gmail.com";
 
 // Shared state across serial tests
 let createdLeadId: string;
@@ -45,22 +52,22 @@ test.describe.serial("Workflows 1-3: Lead → Estimate → Invoice", () => {
     await capture(page, testInfo, 1, 2, "add-lead-modal");
 
     // Fill form
-    await page.locator('input[name="name"]').fill("Master Bath Renovation - Henderson");
+    await page.locator('input[name="name"]').fill(TEST_LEAD_NAME);
 
     // Client name — combobox: type and pick or create
     const clientInput = page.locator('input[name="clientName"]');
     if (await clientInput.isVisible()) {
-      await clientInput.fill("Mike Henderson");
+      await clientInput.fill(TEST_CLIENT_NAME);
       // Wait for dropdown and click first option or just leave the typed value
       await page.waitForTimeout(500);
-      const option = page.locator('[role="option"]:has-text("Mike Henderson")');
+      const option = page.locator(`[role="option"]:has-text("${TEST_CLIENT_NAME}")`);
       if (await option.isVisible({ timeout: 2000 }).catch(() => false)) {
         await option.click();
       }
     }
 
     // Fill remaining fields
-    await page.locator('input[name="clientEmail"]').fill("mike.henderson@gmail.com");
+    await page.locator('input[name="clientEmail"]').fill(TEST_CLIENT_EMAIL);
     await page.locator('input[name="clientPhone"]').fill("360-412-8837");
     // Job site address is optional and uses a Google Maps autocomplete + structured
     // city/state/zip fields without name attributes; leave it empty for this test.
@@ -375,6 +382,72 @@ test.describe.serial("Workflows 1-3: Lead → Estimate → Invoice", () => {
         `[${testInfo.title}] ${consoleErrors.length} console error(s):`,
         consoleErrors
       );
+    }
+  });
+
+  // ===========================================================================
+  // TEARDOWN — delete everything this suite created, plus any leads matching
+  // the exact test signature leaked by earlier aborted runs. Without this, QA
+  // runs accumulate junk in whatever DB they target (see docs/TESTING.md).
+  // ===========================================================================
+  test.afterAll(async () => {
+    const prisma = new PrismaClient();
+    try {
+      const strays = await prisma.lead.findMany({
+        where: {
+          name: TEST_LEAD_NAME,
+          stage: "New",
+          project: { is: null },
+          client: { email: TEST_CLIENT_EMAIL },
+        },
+        select: { id: true },
+      });
+      const leadIds = new Set<string>(strays.map((s) => s.id));
+      if (createdLeadId) leadIds.add(createdLeadId);
+
+      for (const leadId of leadIds) {
+        const estimates = await prisma.estimate.findMany({
+          where: { leadId },
+          select: { id: true },
+        });
+        const estimateIds = estimates.map((e) => e.id);
+        if (estimateIds.length > 0) {
+          await prisma.estimateItem.deleteMany({ where: { estimateId: { in: estimateIds } } });
+          await prisma.estimatePaymentSchedule.deleteMany({ where: { estimateId: { in: estimateIds } } });
+          await prisma.estimate.deleteMany({ where: { id: { in: estimateIds } } });
+        }
+        await prisma.clientMessage.deleteMany({ where: { leadId } });
+        await prisma.leadTask.deleteMany({ where: { leadId } });
+        await prisma.leadNote.deleteMany({ where: { leadId } });
+        await prisma.leadMeeting.deleteMany({ where: { leadId } });
+        await prisma.scheduleTask.deleteMany({ where: { leadId } });
+        await prisma.takeoff.deleteMany({ where: { leadId } });
+        await prisma.roomDesign.deleteMany({ where: { leadId } });
+        await prisma.contract.deleteMany({ where: { leadId } });
+        await prisma.projectFile.deleteMany({ where: { leadId } });
+        await prisma.fileFolder.deleteMany({ where: { leadId } });
+        await prisma.lead.delete({ where: { id: leadId } });
+      }
+
+      // Drop the auto-created test client once nothing references it.
+      const client = await prisma.client.findFirst({
+        where: { email: TEST_CLIENT_EMAIL },
+        include: {
+          _count: { select: { leads: true, projects: true, invoices: true, retainers: true } },
+        },
+      });
+      if (
+        client &&
+        client._count.leads + client._count.projects + client._count.invoices + client._count.retainers === 0
+      ) {
+        await prisma.clientMessage.deleteMany({ where: { clientId: client.id } });
+        await prisma.client.delete({ where: { id: client.id } });
+      }
+      console.log(`[teardown] removed ${leadIds.size} test lead(s)`);
+    } catch (e) {
+      console.warn("[teardown] cleanup failed (non-fatal):", (e as Error).message);
+    } finally {
+      await prisma.$disconnect();
     }
   });
 });

--- a/e2e/qa-lead-estimate-invoice.spec.ts
+++ b/e2e/qa-lead-estimate-invoice.spec.ts
@@ -44,8 +44,9 @@ test.describe.serial("Workflows 1-3: Lead → Estimate → Invoice", () => {
     await page.goto("/leads", { waitUntil: "networkidle" });
     await capture(page, testInfo, 1, 2, "before-add-lead");
 
-    // Click Add Lead
-    const addBtn = page.locator('button:has-text("Add Lead")');
+    // Click Add Lead — .first(): an empty leads list renders a second
+    // "Add Lead" button in the empty state alongside the header one.
+    const addBtn = page.locator('button:has-text("Add Lead")').first();
     await expect(addBtn, "Add Lead button not found").toBeVisible();
     await addBtn.click();
     await page.waitForTimeout(1000);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,6 +22,8 @@ export default defineConfig({
     {
       name: "setup",
       testMatch: /(^|[\\/])auth\.setup\.ts$/,
+      // data first: on a fresh test DB the admin user must exist before login
+      dependencies: ["data"],
     },
     {
       name: "chromium",


### PR DESCRIPTION
## Why

Every bot PR (Bolt/Sentinel/Palette/Dependabot) ran the Playwright e2e suite against the **production** database (`secrets.DATABASE_URL`), and `qa-lead-estimate-invoice.spec.ts` creates a lead per run with no cleanup. Result: 12 junk "Master Bath Renovation - Henderson" leads + 31 empty estimates accumulated in the live /leads list. (Cleaned up manually on 2026-06-11.)

## What

- **CI playwright job → throwaway `postgres:16` service container.** Schema created via `prisma db push`; the prod `DATABASE_URL`/`DIRECT_URL` secrets are no longer exposed to the e2e job.
- **`e2e/data.setup.ts` guard:** refuses to run when `DATABASE_URL` looks like Supabase (override: `ALLOW_PROD_E2E=1`). Also seeds the admin user + baseline estimate so a fresh DB supports credentials login and the hardcoded fixture IDs used across specs.
- **`auth.setup` now depends on `data.setup`** — on a fresh DB the admin user must exist before login.
- **Teardown** in `qa-lead-estimate-invoice.spec.ts`: deletes the created lead/estimates (+ signature-matched strays from aborted runs) and the auto-created client.
- **`docs/TESTING.md`**: test-grounds guide + incident write-up; CLAUDE.md points to it.

## Verification

The Playwright job on **this PR** is the end-to-end proof: it must go green using only the ephemeral container (no prod secrets in the job env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)