### PR TITLE
Mobile/iPad responsive shell + installable PWA (+ QB invoice-link)

### DIFF
--- a/e2e/reconcile-to-qbo.spec.ts
+++ b/e2e/reconcile-to-qbo.spec.ts
@@ -1,0 +1,239 @@
+import { test, expect } from "@playwright/test";
+import { PrismaClient } from "@prisma/client";
+import { reconcileMilestoneToQbo } from "../src/lib/quickbooks-payments";
+
+/**
+ * Deterministic, DB-level coverage for reconcileMilestoneToQbo — the QBO→ProBuild
+ * drift reconcile writer behind "Reconcile & Send". No live QuickBooks is needed:
+ * we call the writer directly against the throwaway CI Postgres (data.setup.ts
+ * guards prod) and assert the invoice-side milestone, the parent invoice totals,
+ * and the mirrored estimate copy all land where they should.
+ *
+ * The project has no unit-test runner (Playwright only), so this lives as an
+ * e2e spec that imports the server function directly — same pattern as
+ * money-pipeline.spec.ts using PrismaClient against the test DB.
+ */
+
+const prisma = new PrismaClient();
+const PFX = "rq-e2e";
+
+type SeedOpts = {
+    suffix: string;
+    depositAmount?: number;
+    finalAmount?: number;
+    taxRate?: number;
+    depositPaid?: boolean;
+    linkDeposit?: boolean; // set the invoice deposit's sourceScheduleId to the estimate copy
+};
+
+// Seed a client+project+estimate+invoice with a linked deposit/final milestone pair.
+// Returns the invoice-side deposit milestone id (the reconcile target).
+async function seedLinked(opts: SeedOpts) {
+    const {
+        suffix,
+        depositAmount = 600,
+        finalAmount = 400,
+        taxRate = 0,
+        depositPaid = false,
+        linkDeposit = true,
+    } = opts;
+    const total = depositAmount + finalAmount;
+    const id = (k: string) => `${PFX}-${k}-${suffix}`;
+
+    await prisma.client.upsert({
+        where: { id: `${PFX}-client` },
+        update: {},
+        create: { id: `${PFX}-client`, name: "RQ Client", initials: "RQ" },
+    });
+    await prisma.project.upsert({
+        where: { id: `${PFX}-project` },
+        update: {},
+        create: { id: `${PFX}-project`, name: "RQ Project", clientId: `${PFX}-client` },
+    });
+
+    await prisma.estimate.create({
+        data: {
+            id: id("est"),
+            title: "RQ Estimate",
+            code: `EST-RQ-${suffix}`,
+            projectId: `${PFX}-project`,
+            status: "Sent",
+            taxExempt: taxRate <= 0,
+            taxRatePercent: taxRate > 0 ? taxRate : null,
+            totalAmount: total,
+            balanceDue: total,
+        },
+    });
+    await prisma.estimatePaymentSchedule.create({
+        data: { id: id("eps-dep"), estimateId: id("est"), name: "RQ Deposit", amount: depositAmount, status: "Pending", order: 1 },
+    });
+    await prisma.estimatePaymentSchedule.create({
+        data: { id: id("eps-fin"), estimateId: id("est"), name: "RQ Final", amount: finalAmount, status: "Pending", order: 2 },
+    });
+
+    const paid = depositPaid ? depositAmount : 0;
+    await prisma.invoice.create({
+        data: {
+            id: id("inv"),
+            code: `INV-RQ-${suffix}`,
+            projectId: `${PFX}-project`,
+            clientId: `${PFX}-client`,
+            estimateId: id("est"),
+            status: depositPaid ? "Partially Paid" : "Issued",
+            taxRate,
+            totalAmount: total,
+            balanceDue: total - paid,
+        },
+    });
+    await prisma.paymentSchedule.create({
+        data: {
+            id: id("ps-dep"),
+            invoiceId: id("inv"),
+            name: "RQ Deposit",
+            amount: depositAmount,
+            status: depositPaid ? "Paid" : "Pending",
+            sourceScheduleId: linkDeposit ? id("eps-dep") : null,
+        },
+    });
+    await prisma.paymentSchedule.create({
+        data: {
+            id: id("ps-fin"),
+            invoiceId: id("inv"),
+            name: "RQ Final",
+            amount: finalAmount,
+            status: "Pending",
+            sourceScheduleId: id("eps-fin"),
+        },
+    });
+    return { depositPsId: id("ps-dep"), depositEpsId: id("eps-dep"), invoiceId: id("inv"), estimateId: id("est") };
+}
+
+const num = (v: unknown) => Number(v);
+
+test.describe.serial("reconcileMilestoneToQbo", () => {
+    test.afterAll(async () => {
+        try {
+            await prisma.paymentSchedule.deleteMany({ where: { id: { startsWith: PFX } } });
+            await prisma.invoice.deleteMany({ where: { id: { startsWith: PFX } } });
+            await prisma.estimatePaymentSchedule.deleteMany({ where: { id: { startsWith: PFX } } });
+            await prisma.estimate.deleteMany({ where: { id: { startsWith: PFX } } });
+            await prisma.project.deleteMany({ where: { id: { startsWith: PFX } } });
+            await prisma.client.deleteMany({ where: { id: { startsWith: PFX } } });
+        } finally {
+            await prisma.$disconnect();
+        }
+    });
+
+    test("higher QBO total (600→648): invoice + estimate both move up", async () => {
+        const s = await seedLinked({ suffix: "higher" });
+        const res = await reconcileMilestoneToQbo(s.depositPsId, 648);
+        expect(res.ok).toBe(true);
+        expect(res.estimateTouched).toBe(true);
+
+        const ps = await prisma.paymentSchedule.findUnique({ where: { id: s.depositPsId } });
+        const inv = await prisma.invoice.findUnique({ where: { id: s.invoiceId } });
+        const eps = await prisma.estimatePaymentSchedule.findUnique({ where: { id: s.depositEpsId } });
+        const est = await prisma.estimate.findUnique({ where: { id: s.estimateId } });
+
+        expect(num(ps!.amount)).toBe(648);
+        expect(num(inv!.totalAmount)).toBe(1048);
+        expect(num(inv!.balanceDue)).toBe(1048); // nothing paid
+        expect(num(eps!.amount)).toBe(648);
+        expect(num(est!.totalAmount)).toBe(1048);
+        expect(num(est!.balanceDue)).toBe(1048);
+    });
+
+    test("lower QBO total (600→550, discount): symmetric move down", async () => {
+        const s = await seedLinked({ suffix: "lower" });
+        const res = await reconcileMilestoneToQbo(s.depositPsId, 550);
+        expect(res.ok).toBe(true);
+
+        const ps = await prisma.paymentSchedule.findUnique({ where: { id: s.depositPsId } });
+        const inv = await prisma.invoice.findUnique({ where: { id: s.invoiceId } });
+        const eps = await prisma.estimatePaymentSchedule.findUnique({ where: { id: s.depositEpsId } });
+        const est = await prisma.estimate.findUnique({ where: { id: s.estimateId } });
+
+        expect(num(ps!.amount)).toBe(550);
+        expect(num(inv!.totalAmount)).toBe(950);
+        expect(num(eps!.amount)).toBe(550);
+        expect(num(est!.totalAmount)).toBe(950);
+    });
+
+    test("tax-inclusive invoice (rate 8): subtotal + tax reconcile to the new total", async () => {
+        const s = await seedLinked({ suffix: "tax", taxRate: 8 });
+        const res = await reconcileMilestoneToQbo(s.depositPsId, 648);
+        expect(res.ok).toBe(true);
+
+        const inv = await prisma.invoice.findUnique({ where: { id: s.invoiceId } });
+        expect(num(inv!.totalAmount)).toBe(1048);
+        // deriveInvoiceTaxFields(1048, 8): tax = round(1048*8/108) = 77.63, subtotal = 970.37
+        expect(num(inv!.taxAmount)).toBeCloseTo(77.63, 2);
+        expect(num(inv!.subtotal)).toBeCloseTo(970.37, 2);
+        expect(num(inv!.subtotal) + num(inv!.taxAmount)).toBeCloseTo(1048, 2);
+    });
+
+    test("paid milestone is refused (ok:false) and nothing is written", async () => {
+        const s = await seedLinked({ suffix: "paid", depositPaid: true });
+        const res = await reconcileMilestoneToQbo(s.depositPsId, 648);
+        expect(res.ok).toBe(false);
+
+        const ps = await prisma.paymentSchedule.findUnique({ where: { id: s.depositPsId } });
+        const inv = await prisma.invoice.findUnique({ where: { id: s.invoiceId } });
+        expect(num(ps!.amount)).toBe(600); // unchanged
+        expect(num(inv!.totalAmount)).toBe(1000); // unchanged
+    });
+
+    test("refuses a $0 / voided QBO total (ok:false, no writes)", async () => {
+        const s = await seedLinked({ suffix: "zero" });
+        const res = await reconcileMilestoneToQbo(s.depositPsId, 0);
+        expect(res.ok).toBe(false);
+
+        const ps = await prisma.paymentSchedule.findUnique({ where: { id: s.depositPsId } });
+        const inv = await prisma.invoice.findUnique({ where: { id: s.invoiceId } });
+        expect(num(ps!.amount)).toBe(600); // unchanged
+        expect(num(inv!.totalAmount)).toBe(1000); // unchanged
+    });
+
+    test("mirror fallback: no sourceScheduleId, single name+amount match → mirrors", async () => {
+        const s = await seedLinked({ suffix: "fallback1", linkDeposit: false });
+        const res = await reconcileMilestoneToQbo(s.depositPsId, 648);
+        expect(res.ok).toBe(true);
+        expect(res.estimateTouched).toBe(true);
+
+        const ps = await prisma.paymentSchedule.findUnique({ where: { id: s.depositPsId } });
+        const eps = await prisma.estimatePaymentSchedule.findUnique({ where: { id: s.depositEpsId } });
+        expect(num(ps!.amount)).toBe(648);
+        expect(num(eps!.amount)).toBe(648); // matched via name "RQ Deposit" + old amount 600
+    });
+
+    test("mirror fallback: ambiguous match (2 candidates) → invoice reconciles, estimate untouched", async () => {
+        const s = await seedLinked({ suffix: "fallback2", linkDeposit: false });
+        // Add a SECOND unpaid estimate milestone with the same name + amount → ambiguous.
+        await prisma.estimatePaymentSchedule.create({
+            data: { id: `${PFX}-eps-dup-fallback2`, estimateId: s.estimateId, name: "RQ Deposit", amount: 600, status: "Pending", order: 3 },
+        });
+        const res = await reconcileMilestoneToQbo(s.depositPsId, 648);
+        expect(res.ok).toBe(true);
+        expect(res.estimateTouched).toBe(false); // conservative: don't guess between 2 candidates
+
+        const ps = await prisma.paymentSchedule.findUnique({ where: { id: s.depositPsId } });
+        const eps1 = await prisma.estimatePaymentSchedule.findUnique({ where: { id: s.depositEpsId } });
+        const eps2 = await prisma.estimatePaymentSchedule.findUnique({ where: { id: `${PFX}-eps-dup-fallback2` } });
+        expect(num(ps!.amount)).toBe(648); // invoice still reconciled
+        expect(num(eps1!.amount)).toBe(600); // both estimate copies untouched
+        expect(num(eps2!.amount)).toBe(600);
+    });
+
+    test("idempotent: re-running with the same QBO total is a no-op", async () => {
+        const s = await seedLinked({ suffix: "idem" });
+        const first = await reconcileMilestoneToQbo(s.depositPsId, 648);
+        expect(first.ok).toBe(true);
+        const second = await reconcileMilestoneToQbo(s.depositPsId, 648);
+        expect(second.ok).toBe(true);
+
+        const inv = await prisma.invoice.findUnique({ where: { id: s.invoiceId } });
+        const ps = await prisma.paymentSchedule.findUnique({ where: { id: s.depositPsId } });
+        expect(num(ps!.amount)).toBe(648); // not doubled
+        expect(num(inv!.totalAmount)).toBe(1048); // not 1096
+    });
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -501,6 +501,8 @@ model PaymentSchedule {
   qbInvoiceLink String? // Intuit-hosted "Review & Pay" page (card/ACH)
   qbPaymentId   String? // QBO Payment txn that settled this milestone (set by the sync poller)
   qbSyncedAt    DateTime?
+  qbInvoiceSentAt DateTime? // last time the QBO invoice email was sent to the client
+  qbSyncError   String? // "voided" | "notFound" — set by the sync poller when the linked QBO invoice is gone/voided; cleared on a successful re-push
 
   // EstimatePaymentSchedule row this milestone was cloned from at invoicing time.
   // Payment mirrors settle/unwind by this link (name+amount matching is the legacy fallback).

--- a/src/app/estimates/EstimatesPageClient.tsx
+++ b/src/app/estimates/EstimatesPageClient.tsx
@@ -67,8 +67,8 @@ export default function EstimatesPageClient({ estimates }: { estimates: Estimate
             {activeTab === "estimates" ? (
                 <div className="p-6 flex-1 flex flex-col">
                     <div className="hui-card flex-1 flex flex-col overflow-hidden">
-                        <div className="border-b border-hui-border p-4 flex items-center gap-4">
-                            <input type="text" placeholder="Search" className="hui-input w-64" />
+                        <div className="border-b border-hui-border p-4 flex flex-wrap items-center gap-3">
+                            <input type="text" placeholder="Search" className="hui-input w-full sm:w-64" />
                             <select className="hui-input w-auto"><option>Date Created: All</option></select>
                             <select className="hui-input w-auto"><option>Type: All</option></select>
                         </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -166,4 +166,50 @@
   html {
     @apply font-sans;
   }
+
+  /* iOS Safari zooms the page when focusing an input whose font-size is < 16px
+     (our .hui-input / search input use 14px). Bump to 16px on touch devices
+     only (pointer: coarse) so desktop density is unchanged. */
+  @media (pointer: coarse) {
+    input,
+    select,
+    textarea {
+      font-size: 16px;
+    }
+  }
+}
+
+/* On no-hover (touch) devices, reveal any control that is otherwise only shown
+   on hover (the `opacity-0 group-hover:opacity-100` reveal pattern used widely
+   for row action buttons). Attribute selectors match the literal Tailwind class
+   token, so this covers every occurrence in one rule instead of adding a
+   per-element [@media(hover:none)] fallback. Unlayered + !important so it wins
+   over the opacity-0 / pointer-events-none utilities. Desktop is unaffected. */
+@media (hover: none) {
+  [class~="group-hover:opacity-100"] {
+    opacity: 1 !important;
+  }
+  [class~="group-hover:pointer-events-auto"] {
+    pointer-events: auto !important;
+  }
+}
+
+/* Mobile nav drawer enter animations. Self-contained keyframes (rather than
+   tw-animate-css's var-based slide-in) so the panel reliably ends at its natural
+   on-screen position — the lib's `enter` keyframe left a residual translateX(-100%). */
+@keyframes nav-drawer-in {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+@keyframes nav-overlay-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Providers from "@/components/Providers";
@@ -22,6 +22,22 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Golden Touch Remodeling | Pro",
   description: "High-end remodeling project management",
+  applicationName: "GTR Pro",
+  appleWebApp: {
+    capable: true,
+    title: "GTR Pro",
+    statusBarStyle: "black-translucent",
+  },
+};
+
+export const viewport: Viewport = {
+  themeColor: "#1e1e1e",
+  width: "device-width",
+  initialScale: 1,
+  // viewportFit:cover is required so env(safe-area-inset-*) resolves to real
+  // values on notched / home-indicator devices. We intentionally leave
+  // maximumScale/userScalable at their defaults to preserve pinch-zoom (WCAG 1.4.4).
+  viewportFit: "cover",
 };
 
 export default async function RootLayout({

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from "next";
+
+// Web App Manifest (served at /manifest.webmanifest) so ProBuild is installable
+// to the iPad / phone home screen and launches full-screen ("standalone").
+//
+// Icons reference the static app/icon.png (192) and app/apple-icon.png (180)
+// that Next already emits. The in-app company logo is dynamic (DB-driven via
+// getCompanySettings().logoUrl) and intentionally NOT used here — A2HS install
+// icons must be static and are cached by the OS at install time.
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Golden Touch Remodeling Pro",
+    short_name: "GTR Pro",
+    start_url: "/",
+    scope: "/",
+    display: "standalone",
+    background_color: "#f8fafc", // matches the slate-50 body background (splash)
+    theme_color: "#1e1e1e", // keep in sync with viewport.themeColor
+    orientation: "any",
+    icons: [
+      { src: "/icon.png", sizes: "192x192", type: "image/png", purpose: "any" },
+      { src: "/apple-icon.png", sizes: "180x180", type: "image/png" },
+    ],
+  };
+}

--- a/src/app/projects/ProjectsClient.tsx
+++ b/src/app/projects/ProjectsClient.tsx
@@ -300,8 +300,58 @@ export default function ProjectsClient({ projects: initialProjects, initialStatu
             {/* List View */}
             {viewMode === "list" && (
                 <>
-                    {/* Table */}
-                    <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
+                    {/* Mobile card list (< lg) — the 10-column table is unreadable on touch */}
+                    <div className="lg:hidden space-y-3">
+                        {sortedProjects.map((project: any) => (
+                            <div key={project.id} className="bg-white rounded-xl shadow-sm border border-slate-200 p-4">
+                                <div className="flex items-start gap-3">
+                                    <div className="w-1.5 self-stretch min-h-[2.5rem] rounded-full" style={{ backgroundColor: project.color || getStatusColor(project.status || "In Progress", statuses).replace("bg-", "").split("-")[0] }} />
+                                    <div className="flex-1 min-w-0">
+                                        <Link href={`/projects/${project.id}`} className="font-semibold text-slate-800 hover:text-indigo-600 transition block truncate">
+                                            {project.name}
+                                        </Link>
+                                        <div className="mt-1 flex items-center gap-2 text-sm text-slate-600">
+                                            <div className="w-5 h-5 rounded-full bg-[#34d399] flex items-center justify-center text-[10px] font-bold text-white shrink-0">
+                                                {(project.client?.name || "?")[0].toUpperCase()}
+                                            </div>
+                                            <span className="truncate">{project.client?.name || "No Client"}</span>
+                                        </div>
+                                        <div className="mt-1 text-xs text-slate-500">
+                                            {project.location ? `${project.location} · ` : ""}{new Date(project.createdAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}
+                                        </div>
+                                    </div>
+                                </div>
+                                <div className="mt-3">
+                                    <select
+                                        value={project.status || "In Progress"}
+                                        onChange={e => handleStatusChange(project.id, e.target.value)}
+                                        disabled={updatingId === project.id}
+                                        className={`w-full text-xs font-semibold rounded-full px-3 py-2 border border-slate-200 focus:ring-2 focus:ring-indigo-200 transition disabled:opacity-50 appearance-none bg-white ${getStatusColor(project.status || "In Progress", statuses).replace("bg-", "text-").replace("100", "700")}`}
+                                    >
+                                        {activeStatuses.map(s => (
+                                            <option key={s.value} value={s.value}>• {s.label}</option>
+                                        ))}
+                                        <option disabled>────────</option>
+                                        <option value="Manage Status">⚙ Manage Status</option>
+                                    </select>
+                                </div>
+                            </div>
+                        ))}
+                        {sortedProjects.length === 0 && (
+                            <div className="bg-white rounded-xl shadow-sm border border-slate-200 py-16 text-center">
+                                <div className="flex flex-col items-center gap-3">
+                                    <div className="w-14 h-14 bg-gradient-to-br from-slate-100 to-slate-50 rounded-2xl flex items-center justify-center">
+                                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" strokeWidth="1.5"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
+                                    </div>
+                                    <p className="text-sm font-medium text-slate-400">No projects match your filters</p>
+                                    <button onClick={() => { setSelectedStatuses(OPEN_PROJECT_STATUSES); setSearch(""); }} className="text-xs text-indigo-600 font-semibold hover:text-indigo-800 transition">Reset filters</button>
+                                </div>
+                            </div>
+                        )}
+                    </div>
+
+                    {/* Table (>= lg) */}
+                    <div className="hidden lg:block bg-white rounded-xl shadow-sm border border-slate-200 overflow-x-auto">
                         <table className="w-full text-left bg-white text-sm">
                             <thead>
                                 <tr className="border-b border-slate-200">

--- a/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
@@ -167,6 +167,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
         initialEstimate.taxRateName ?? defaultTaxRate?.name ?? null
     );
     const [isAiFilling, setIsAiFilling] = useState(false);
+    const [isAiAssigningPhases, setIsAiAssigningPhases] = useState(false);
     const [targetMargin, setTargetMargin] = useState<string>(String(initialEstimate.targetMarginPercent ?? 25));
     const [overwriteExisting, setOverwriteExisting] = useState(false);
     const [expirationDate, setExpirationDate] = useState<string>(initialEstimate.expirationDate ? new Date(initialEstimate.expirationDate).toISOString().split("T")[0] : "");
@@ -1331,6 +1332,72 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
         toast.success("Budgets cleared — PO-committed items kept");
     }
 
+    async function handleAiAssignPhases() {
+        const eligibleItems = items.filter(item => {
+            const isSection = !item.parentId && items.some((i: any) => i.parentId === item.id);
+            return !isSection;
+        });
+
+        if (eligibleItems.length === 0) {
+            toast.info("No items found to assign phases.");
+            return;
+        }
+
+        setIsAiAssigningPhases(true);
+        try {
+            const payloadItems = eligibleItems.map(item => ({
+                id: item.id,
+                name: item.name,
+                description: item.description || ""
+            }));
+
+            const payloadCostCodes = costCodes.map(cc => ({
+                id: cc.id,
+                code: cc.code,
+                name: cc.name
+            }));
+
+            const res = await fetch("/api/ai-estimate/assign-phases", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    items: payloadItems,
+                    costCodes: payloadCostCodes
+                })
+            });
+
+            if (!res.ok) {
+                const errData = await res.json();
+                throw new Error(errData.error || "Failed to auto-assign phases");
+            }
+
+            const { assignments } = await res.json();
+            if (!assignments || !Array.isArray(assignments)) {
+                throw new Error("Invalid response from server");
+            }
+
+            let assignedCount = 0;
+            setItems(prev => {
+                const next = [...prev];
+                for (const ass of assignments) {
+                    const idx = next.findIndex(item => item.id === ass.id);
+                    if (idx >= 0 && ass.costCodeId !== undefined) {
+                        next[idx] = { ...next[idx], costCodeId: ass.costCodeId };
+                        assignedCount++;
+                    }
+                }
+                return next;
+            });
+
+            toast.success(`Successfully matched and assigned phases to ${assignedCount} items.`);
+        } catch (err: any) {
+            console.error("Auto-assign phases error:", err);
+            toast.error(err.message || "Failed to auto-assign phases");
+        } finally {
+            setIsAiAssigningPhases(false);
+        }
+    }
+
     function addPaymentSchedule() {
         setPaymentSchedules([...paymentSchedules, {
             id: generateId(),
@@ -1520,6 +1587,14 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                                     >
                                         <svg className="w-4 h-4 text-purple-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10" /></svg>
                                         Import from ChatGPT
+                                    </button>
+                                    <button
+                                        onClick={() => { handleAiAssignPhases(); setShowMoreMenu(false); }}
+                                        disabled={isAiAssigningPhases}
+                                        className="w-full text-left px-4 py-2.5 hover:bg-purple-50 flex items-center gap-2.5 text-purple-700 disabled:opacity-50"
+                                    >
+                                        <svg className={`w-4 h-4 text-purple-500 ${isAiAssigningPhases ? "animate-pulse" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" /></svg>
+                                        {isAiAssigningPhases ? "Assigning..." : "Auto-assign Phases"}
                                     </button>
                                     <button
                                         onClick={() => { handleHistoricalPricing(); setShowMoreMenu(false); }}
@@ -1732,7 +1807,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
             {/* Assembly Name Modal */}
             {showAssemblyNameModal && (
                 <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center" onClick={() => setShowAssemblyNameModal(false)}>
-                    <div className="bg-white rounded-xl shadow-2xl p-6 w-96" onClick={e => e.stopPropagation()}>
+                    <div className="bg-white rounded-xl shadow-2xl p-6 w-full max-w-sm mx-4" onClick={e => e.stopPropagation()}>
                         <h3 className="text-lg font-bold text-slate-800 mb-1">Save Assembly</h3>
                         <p className="text-sm text-slate-500 mb-4">Name this bundle so you can reuse it across estimates (e.g., &quot;Standard Bathroom Demo&quot;).</p>
                         <input
@@ -1754,8 +1829,8 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                 </div>
             )}
 
-            <div className="flex-1 flex overflow-hidden">
-            <div className="flex-1 p-8 flex justify-center pb-24 overflow-y-auto">
+            <div className="flex-1 flex flex-col lg:flex-row overflow-y-auto lg:overflow-hidden">
+            <div className="flex-1 p-4 lg:p-8 flex justify-center pb-24 overflow-visible lg:overflow-y-auto">
                 {activeTab === "builder" && (
                     <div className="w-full max-w-5xl">
                         {/* Premium Document Wrapper */}
@@ -1800,6 +1875,15 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                                     >
                                         <svg className={`w-4 h-4 ${isAiFilling ? "animate-pulse" : ""}`} viewBox="0 0 24 24" fill="currentColor"><path d="M12 2L9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61z" /></svg>
                                         {isAiFilling ? "Filling…" : "AI fill budgets"}
+                                    </button>
+                                    <button
+                                        onClick={handleAiAssignPhases}
+                                        disabled={isAiAssigningPhases || isAiFilling}
+                                        className="hui-btn hui-btn-secondary text-sm flex items-center gap-2 disabled:opacity-50"
+                                        title="Auto-assign phases using AI."
+                                    >
+                                        <svg className={`w-4 h-4 text-purple-500 ${isAiAssigningPhases ? "animate-pulse" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" /></svg>
+                                        {isAiAssigningPhases ? "Assigning..." : "Auto-assign Phases"}
                                     </button>
                                     <button
                                         onClick={handleClearBudgets}
@@ -2717,7 +2801,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
 
             {/* Right Sidebar */}
             {showSidebar && (
-                <div className="w-96 border-l border-slate-200 bg-white flex flex-col overflow-y-auto overflow-x-hidden shrink-0">
+                <div className="w-full lg:w-96 border-t lg:border-t-0 lg:border-l border-slate-200 bg-white flex flex-col overflow-visible lg:overflow-y-auto overflow-x-hidden lg:shrink-0">
                     {/* Sidebar Tabs */}
                     <div className="flex border-b border-slate-200 sticky top-0 bg-white z-10">
                         <button

--- a/src/app/projects/[id]/invoices/[invoiceId]/InvoiceEditor.tsx
+++ b/src/app/projects/[id]/invoices/[invoiceId]/InvoiceEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { recordPayment, issueInvoice, deleteInvoice, updateInvoiceNotes, addInvoiceMilestone, unrecordPayment, splitInvoiceMilestones, sendPaymentReceipt, createQBPaymentLink, refreshQBPayments, emailInvoiceCopyToMe } from "@/lib/actions";
+import { recordPayment, issueInvoice, deleteInvoice, updateInvoiceNotes, addInvoiceMilestone, unrecordPayment, splitInvoiceMilestones, sendPaymentReceipt, createQBPaymentLink, refreshQBPayments, breakQBInvoiceLink, emailInvoiceCopyToMe } from "@/lib/actions";
 import { useRouter } from "next/navigation";
 import StatusBadge from "@/components/StatusBadge";
 import SendInvoiceModal from "@/components/SendInvoiceModal";
@@ -86,6 +86,32 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                 toast.warning("QuickBooks invoice created, but no pay link — enable QuickBooks Payments in QBO to accept cards/ACH.");
                 router.refresh();
             }
+        } finally {
+            setQbBusy(null);
+        }
+    }
+
+    // Recover a milestone whose QuickBooks invoice was voided/deleted: clear the
+    // stale link so it can be re-created fresh. Money state is untouched.
+    async function handleBreakQBLink(payment: { id: string; name: string }) {
+        const ok = window.confirm(
+            `Break the QuickBooks link for "${payment.name}"?\n\n` +
+            `Use this when the QuickBooks invoice was voided or deleted and this milestone ` +
+            `is stuck on "Pending". It clears the QuickBooks link in ProBuild so you can ` +
+            `re-create it fresh with "QuickBooks Link".\n\n` +
+            `It does NOT change the paid/unpaid status, and does NOT delete the invoice in QuickBooks.`
+        );
+        if (!ok) return;
+        setQbBusy(payment.id);
+        try {
+            const res = await breakQBInvoiceLink(payment.id);
+            if (!res.success) {
+                toast.error(res.error);
+                return;
+            }
+            if (res.warning) toast.warning(res.warning);
+            else toast.success("QuickBooks link cleared — you can now re-create it.");
+            router.refresh();
         } finally {
             setQbBusy(null);
         }
@@ -342,7 +368,7 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                 </div>
             </div>
 
-            <div className="flex-1 overflow-auto p-8 flex justify-center">
+            <div className="flex-1 overflow-auto p-4 lg:p-8 flex justify-center">
                 <div className="w-full max-w-5xl space-y-6">
 
                     {/* Document Header */}
@@ -359,7 +385,7 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                                 </div>
                             </div>
 
-                            <div className="flex gap-12 text-sm">
+                            <div className="flex flex-col sm:flex-row gap-6 sm:gap-12 text-sm">
                                 <div>
                                     <p className="text-[11px] font-semibold tracking-widest uppercase text-slate-400 mb-2">Bill To</p>
                                     <p className="font-semibold text-base text-hui-textMain">{clientName}</p>
@@ -400,7 +426,7 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
 
                             <div className="h-px w-full bg-hui-border my-4"></div>
 
-                            <div className="flex justify-between items-center bg-slate-50 p-5 rounded-lg border border-hui-border">
+                            <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4 bg-slate-50 p-5 rounded-lg border border-hui-border">
                                 <div>
                                     <p className="text-hui-textMuted text-sm mb-1">Total Amount</p>
                                     <p className="text-2xl font-bold text-hui-textMain">{formatCurrency(initialInvoice.totalAmount)}</p>
@@ -529,7 +555,7 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                         )}
                         {showAddMilestone && (
                             <div className="px-6 py-4 border-b border-hui-border bg-amber-50/40">
-                                <div className="grid grid-cols-12 gap-3 items-end">
+                                <div className="grid grid-cols-1 sm:grid-cols-12 gap-3 sm:items-end">
                                     <div className="col-span-5">
                                         <label className="block text-[11px] uppercase tracking-wide text-hui-textMuted mb-1">Description</label>
                                         <input
@@ -576,7 +602,8 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                                 </p>
                             </div>
                         )}
-                        <table className="w-full text-sm text-left">
+                        <div className="overflow-x-auto">
+                        <table className="w-full min-w-[34rem] text-sm text-left">
                             <thead className="bg-white text-hui-textMuted border-b border-hui-border">
                                 <tr>
                                     <th className="px-4 py-3 w-10 text-center">
@@ -664,7 +691,17 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                                                 ) : 'Upon receipt'}
                                             </td>
                                             <td className="px-6 py-4">
-                                                <StatusBadge status={payment.status} />
+                                                <div className="flex items-center gap-2">
+                                                    <StatusBadge status={payment.status} />
+                                                    {payment.status !== 'Paid' && payment.qbSyncError && (
+                                                        <span
+                                                            className="text-[10px] font-bold uppercase text-amber-700 bg-amber-100 px-1.5 py-0.5 rounded"
+                                                            title="The linked QuickBooks invoice appears voided or deleted. Use Break QB Link to clear it, then re-create the invoice."
+                                                        >
+                                                            QB {payment.qbSyncError === 'notFound' ? 'missing' : 'voided'}
+                                                        </span>
+                                                    )}
+                                                </div>
                                             </td>
                                             <td className="px-6 py-4 text-right font-medium text-hui-textMain">
                                                 {formatCurrency(payment.amount)}
@@ -704,6 +741,16 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                                                         >
                                                             Record Payment
                                                         </button>
+                                                        {payment.qbInvoiceId && (
+                                                            <button
+                                                                onClick={() => handleBreakQBLink(payment)}
+                                                                disabled={qbBusy === payment.id}
+                                                                title="QuickBooks invoice voided or deleted? Clear the link so you can re-create it."
+                                                                className="text-xs text-hui-textMuted hover:text-red-600 underline underline-offset-2 disabled:opacity-50 whitespace-nowrap"
+                                                            >
+                                                                {qbBusy === payment.id ? "Working…" : "Break QB Link"}
+                                                            </button>
+                                                        )}
                                                         </>
                                                     )}
                                                     {payment.status === 'Paid' && (
@@ -735,6 +782,7 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                                 })}
                             </tbody>
                         </table>
+                        </div>
                     </div>
 
                 </div>

--- a/src/app/settings/notifications/NotificationsClient.tsx
+++ b/src/app/settings/notifications/NotificationsClient.tsx
@@ -11,6 +11,7 @@ const NOTIFICATION_EVENTS = [
     { key: "invoiceViewed", label: "Invoice Viewed", description: "When a client opens an invoice" },
     { key: "paymentReceived", label: "Payment Received", description: "When a client makes a payment" },
     { key: "messageReceived", label: "New Message", description: "When a client or subcontractor sends a message" },
+    { key: "quickbooksSyncIssue", label: "QuickBooks Sync Issue", description: "When a QuickBooks invoice is voided or deleted and a milestone needs to be re-issued" },
 ];
 
 function parseToggles(raw: string | null): Record<string, boolean> {

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -73,6 +73,16 @@ const ACTION_CONFIG: Record<string, { icon: React.ReactNode; color: string; labe
         color: "bg-indigo-100 text-indigo-600",
         label: "sent",
     },
+    reconciled_milestone_amount: {
+        icon: <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />,
+        color: "bg-amber-100 text-amber-600",
+        label: "reconciled to QuickBooks",
+    },
+    qb_sync_issue: {
+        icon: <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />,
+        color: "bg-amber-100 text-amber-700",
+        label: "invoice was voided or deleted:",
+    },
 };
 
 function getConfig(action: string) {

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname, useRouter } from "next/navigation";
 import Sidebar from "./Sidebar";
+import MobileNavDrawer from "./nav/MobileNavDrawer";
 import Header from "./Header";
 import { useSession, signOut } from "next-auth/react";
 import { useEffect } from "react";
@@ -65,11 +66,12 @@ export default function AppLayout({ children, logoUrl }: { children: React.React
     }
 
     return (
-        <div className="flex h-screen bg-hui-background overflow-hidden">
+        <div className="flex h-[100dvh] bg-hui-background overflow-hidden">
             <Sidebar />
+            <MobileNavDrawer />
             <div className="flex-1 flex flex-col overflow-hidden">
                 <Header />
-                <main className="flex-1 p-6 overflow-y-auto overflow-x-hidden">
+                <main className="flex-1 overflow-y-auto overflow-x-hidden px-4 pt-4 pb-[calc(1rem+env(safe-area-inset-bottom))] lg:p-6">
                     {children}
                 </main>
             </div>

--- a/src/components/FieldUpdatesNavItem.tsx
+++ b/src/components/FieldUpdatesNavItem.tsx
@@ -4,9 +4,17 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { getUnreadFieldUpdatesCount } from "@/lib/actions";
 
+const FieldIcon = ({ className }: { className?: string }) => (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+    </svg>
+);
+
 // Sidebar item with unread badge. Refetches on mount + every 60s so the manager sees
 // new field activity without manual refresh. Not realtime; cheap enough as a poll.
-export default function FieldUpdatesNavItem() {
+// `variant` lets it render as the desktop icon-rail item (default) or a horizontal
+// row inside the mobile nav drawer; the badge/polling is shared either way.
+export default function FieldUpdatesNavItem({ variant = "rail", onNavigate }: { variant?: "rail" | "drawer"; onNavigate?: () => void }) {
     const [count, setCount] = useState<number | null>(null);
 
     useEffect(() => {
@@ -24,18 +32,36 @@ export default function FieldUpdatesNavItem() {
         return () => { cancelled = true; clearInterval(id); };
     }, []);
 
+    const badge = count !== null && count > 0 ? (count > 99 ? "99+" : count) : null;
+
+    if (variant === "drawer") {
+        return (
+            <Link
+                href="/manager/field-updates"
+                onClick={onNavigate}
+                className="relative flex items-center gap-3 px-4 py-3 rounded-lg text-slate-300 hover:bg-[#2a2a2a] hover:text-white transition"
+            >
+                <FieldIcon className="w-5 h-5 shrink-0" />
+                <span className="text-sm font-medium">Field Updates</span>
+                {badge !== null && (
+                    <span className="ml-auto min-w-[20px] h-5 bg-hui-primary text-white text-[11px] font-bold rounded-full flex items-center justify-center px-1.5">
+                        {badge}
+                    </span>
+                )}
+            </Link>
+        );
+    }
+
     return (
         <Link
             href="/manager/field-updates"
             className="relative flex flex-col items-center justify-center w-full py-3 hover:bg-[#2a2a2a] text-slate-400 hover:text-white transition group"
         >
-            <svg className="w-5 h-5 mb-1 group-hover:text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-            </svg>
+            <FieldIcon className="w-5 h-5 mb-1 group-hover:text-white" />
             <span className="text-[10px] uppercase font-semibold text-center leading-tight">Field</span>
-            {count !== null && count > 0 && (
+            {badge !== null && (
                 <span className="absolute top-1.5 right-2.5 min-w-[18px] h-[18px] bg-hui-primary text-white text-[10px] font-bold rounded-full flex items-center justify-center px-1">
-                    {count > 99 ? "99+" : count}
+                    {badge}
                 </span>
             )}
         </Link>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,13 +1,24 @@
 "use client";
 
 import { useSession, signIn, signOut } from "next-auth/react";
+import { Menu } from "lucide-react";
+import { useNavDrawer } from "@/components/nav/navDrawerStore";
 
 export default function Header() {
     const { data: session } = useSession();
+    const toggleNav = useNavDrawer((s) => s.toggle);
 
     return (
-        <header className="bg-white border-b border-hui-border h-16 flex items-center justify-between px-6 shadow-sm">
-            <div className="flex items-center">
+        <header className="bg-white border-b border-hui-border min-h-16 flex items-center justify-between pl-[max(1.5rem,env(safe-area-inset-left))] pr-[max(1.5rem,env(safe-area-inset-right))] pt-[env(safe-area-inset-top)] shadow-sm">
+            <div className="flex items-center gap-2">
+                {/* Hamburger — opens the mobile nav drawer; hidden on desktop where the rail is shown. */}
+                <button
+                    onClick={toggleNav}
+                    aria-label="Open navigation"
+                    className="lg:hidden -ml-2 inline-flex items-center justify-center min-h-11 min-w-11 rounded-md text-slate-600 hover:bg-slate-100 transition"
+                >
+                    <Menu className="w-6 h-6" />
+                </button>
                 <h2 className="text-xl font-semibold text-hui-textMain">Golden Touch</h2>
             </div>
             <div className="flex items-center gap-4">

--- a/src/components/SendMilestonesModal.tsx
+++ b/src/components/SendMilestonesModal.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState } from "react";
+import { sendMilestoneInvoices } from "@/lib/actions";
+import { toast } from "sonner";
+import { formatCurrency } from "@/lib/utils";
+
+type SendResult = Awaited<ReturnType<typeof sendMilestoneInvoices>>;
+type DriftRow = NonNullable<SendResult["driftReview"]>[number];
+
+export default function SendMilestonesModal({
+    invoiceId,
+    clientEmail,
+    selectedPaymentIds,
+    selectedPayments,
+    onClose,
+}: {
+    invoiceId: string;
+    clientEmail?: string;
+    selectedPaymentIds: string[];
+    selectedPayments: any[];
+    onClose: () => void;
+}) {
+    const [isSending, setIsSending] = useState(false);
+    const [sendToEmail, setSendToEmail] = useState(clientEmail || "");
+    const [phase, setPhase] = useState<"compose" | "review">("compose");
+    const [driftRows, setDriftRows] = useState<DriftRow[]>([]);
+
+    const totalAmount = selectedPayments.reduce((sum, p) => sum + Number(p.amount), 0);
+
+    // Single submit path. With no `reconcile` map this is the compose-phase send;
+    // with one it's the review-phase "reconcile & send" for the drifting rows only.
+    async function submit(reconcile?: Record<string, number>) {
+        if (!sendToEmail.trim()) {
+            toast.error("Please enter an email address.");
+            return;
+        }
+        const email = sendToEmail.trim();
+        const ids = reconcile ? driftRows.map(r => r.id) : selectedPaymentIds;
+        setIsSending(true);
+        try {
+            const result = await sendMilestoneInvoices(invoiceId, ids, email, reconcile ? { reconcile } : undefined);
+
+            // Drift detected → enter (or stay in) the review step. Never close here.
+            if (result.needsReview && result.driftReview?.length) {
+                if (result.sent > 0) {
+                    toast.success(`Sent ${result.sent} invoice(s) to ${email}`);
+                }
+                // Surface any NON-drift failures/skips so they aren't lost behind the
+                // review step (the resubmit only carries the drifting milestones).
+                const otherSkips = result.skipped - result.driftReview.length;
+                if (result.failed > 0 || otherSkips > 0) {
+                    const firstFail = result.results.find(r => r.status === "failed");
+                    toast.warning(
+                        `${result.failed} failed${otherSkips > 0 ? `, ${otherSkips} skipped` : ""}` +
+                        (firstFail?.error ? ` — ${firstFail.error}` : "")
+                    );
+                }
+                setDriftRows(result.driftReview);
+                setPhase("review");
+                toast.warning(
+                    reconcile
+                        ? "QuickBooks changed again — please re-review the amounts."
+                        : `${result.driftReview.length} milestone(s) differ from QuickBooks — review below.`
+                );
+                return;
+            }
+
+            // No outstanding drift → normal outcome.
+            if (result.success) {
+                const reconciledCount = result.results.filter(r => r.status === "reconciled").length;
+                toast.success(
+                    reconciledCount > 0
+                        ? `Sent ${result.sent} invoice(s) to ${email} (${reconciledCount} reconciled to QuickBooks)`
+                        : `Successfully sent ${result.sent} invoice(s) to ${email}`
+                );
+                if (result.failed > 0 || result.skipped > 0) {
+                    toast.warning(`Failed: ${result.failed}, Skipped: ${result.skipped}`);
+                }
+            } else {
+                toast.error(result.error || "Failed to send invoices");
+                const firstBad = result.results.find(r => r.status === "failed" || r.status === "skipped");
+                if (firstBad?.error) {
+                    toast.error(`Detail: ${firstBad.error}`);
+                }
+            }
+            onClose();
+        } catch (e: any) {
+            toast.error(e.message || "Failed to send invoices");
+        } finally {
+            setIsSending(false);
+        }
+    }
+
+    return (
+        <div className="fixed inset-0 bg-slate-900/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+            <div className="bg-white rounded-xl shadow-xl max-w-lg w-full overflow-hidden border border-hui-border max-h-[85vh] flex flex-col">
+                <div className="px-6 py-4 border-b border-hui-border flex justify-between items-center shrink-0 bg-gradient-to-r from-emerald-50 to-teal-50">
+                    <div>
+                        <h2 className="text-lg font-bold text-hui-textMain">
+                            {phase === "review" ? "Amounts changed in QuickBooks" : "Send Milestones to Client"}
+                        </h2>
+                        <p className="text-xs text-hui-textMuted mt-0.5">
+                            {phase === "review"
+                                ? "Review the differences below before sending."
+                                : "The client will receive official QuickBooks Online invoice emails to review and pay."}
+                        </p>
+                    </div>
+                    <button onClick={onClose} className="text-hui-textMuted hover:text-hui-textMain transition">
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
+                    </button>
+                </div>
+
+                {phase === "compose" ? (
+                    <div className="p-6 space-y-5 overflow-y-auto flex-1">
+                        {/* Email */}
+                        <div>
+                            <label className="block text-sm font-medium text-hui-textMain mb-1">Sending To</label>
+                            <div className="flex items-center gap-2 bg-slate-50 px-4 py-3 rounded-lg border border-hui-border">
+                                <svg className="w-4 h-4 text-slate-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" /></svg>
+                                <input
+                                    type="email"
+                                    value={sendToEmail}
+                                    onChange={e => setSendToEmail(e.target.value)}
+                                    placeholder="client@email.com"
+                                    className="flex-1 text-sm font-medium text-hui-textMain bg-transparent focus:outline-none"
+                                />
+                            </div>
+                        </div>
+
+                        {/* Milestones List */}
+                        <div>
+                            <label className="block text-sm font-medium text-hui-textMain mb-1">Milestones to Send</label>
+                            <div className="bg-slate-50 rounded-lg border border-hui-border divide-y divide-hui-border text-xs max-h-36 overflow-y-auto">
+                                {selectedPayments.map((p: any) => (
+                                    <div key={p.id} className="flex justify-between items-center px-4 py-2.5">
+                                        <span className="font-medium text-hui-textMain">{p.name}</span>
+                                        <span className="font-semibold text-slate-700">{formatCurrency(Number(p.amount))}</span>
+                                    </div>
+                                ))}
+                            </div>
+                            <div className="flex justify-between items-center px-4 py-2 text-xs font-semibold text-hui-textMain bg-slate-100 rounded-b-lg border-x border-b border-hui-border">
+                                <span>Total Requested</span>
+                                <span>{formatCurrency(totalAmount)}</span>
+                            </div>
+                        </div>
+
+                        {/* What happens */}
+                        <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-4 space-y-2">
+                            <h3 className="text-sm font-semibold text-emerald-800">What happens when you send:</h3>
+                            <ul className="text-xs text-emerald-700 space-y-1.5 list-disc pl-4">
+                                <li>Each milestone will be synced to QuickBooks if not already pushed.</li>
+                                <li>Client receives official QuickBooks Online invoice emails (with {"Review & Pay"} links).</li>
+                                <li>QuickBooks invoice status will be marked as emailed.</li>
+                                <li>Parent invoice status will change to {"Issued"} if currently a Draft.</li>
+                            </ul>
+                        </div>
+                    </div>
+                ) : (
+                    <div className="p-6 space-y-5 overflow-y-auto flex-1">
+                        <div className="bg-amber-50 border border-amber-200 rounded-lg divide-y divide-amber-200 text-xs">
+                            {driftRows.map(row => {
+                                const delta = row.qbTotal - row.probuildAmount;
+                                const higher = row.direction === "higher";
+                                return (
+                                    <div key={row.id} className="px-4 py-3">
+                                        <div className="font-semibold text-hui-textMain mb-1.5">{row.name}</div>
+                                        <div className="flex items-center justify-between gap-2">
+                                            <span className="text-slate-500">
+                                                ProBuild <span className="font-medium text-slate-700">{formatCurrency(row.probuildAmount)}</span>
+                                            </span>
+                                            <svg className="w-4 h-4 text-slate-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5l7 7m0 0l-7 7m7-7H3" /></svg>
+                                            <span className="text-slate-500">
+                                                QuickBooks <span className="font-semibold text-hui-textMain">{formatCurrency(row.qbTotal)}</span>
+                                            </span>
+                                            <span className={`font-semibold whitespace-nowrap ${higher ? "text-amber-700" : "text-blue-700"}`}>
+                                                {higher ? "▲" : "▼"} {formatCurrency(Math.abs(delta))}
+                                            </span>
+                                        </div>
+                                    </div>
+                                );
+                            })}
+                        </div>
+
+                        <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
+                            <p className="text-xs text-amber-800">
+                                QuickBooks is the system of record for what the client is charged. Reconciling
+                                updates the ProBuild milestone (and the linked estimate) to match the QuickBooks
+                                total, then sends the invoice.
+                            </p>
+                        </div>
+                    </div>
+                )}
+
+                <div className="px-6 py-4 border-t border-hui-border flex justify-end gap-3 shrink-0 bg-slate-50">
+                    {phase === "compose" ? (
+                        <>
+                            <button onClick={onClose} className="hui-btn hui-btn-secondary" disabled={isSending}>Cancel</button>
+                            <button onClick={() => submit()} disabled={isSending || !sendToEmail.trim()} className="hui-btn hui-btn-green flex items-center gap-2">
+                                {isSending ? (
+                                    <>
+                                        <svg className="animate-spin w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" /><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" /></svg>
+                                        Sending...
+                                    </>
+                                ) : (
+                                    <>
+                                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" /></svg>
+                                        Send Milestones
+                                    </>
+                                )}
+                            </button>
+                        </>
+                    ) : (
+                        <>
+                            <button onClick={onClose} className="hui-btn hui-btn-secondary" disabled={isSending}>Cancel</button>
+                            <button onClick={() => submit(Object.fromEntries(driftRows.map(r => [r.id, r.qbTotal])))} disabled={isSending} className="hui-btn hui-btn-green flex items-center gap-2">
+                                {isSending ? (
+                                    <>
+                                        <svg className="animate-spin w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" /><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" /></svg>
+                                        Reconciling...
+                                    </>
+                                ) : (
+                                    <>
+                                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
+                                        Reconcile & Send
+                                    </>
+                                )}
+                            </button>
+                        </>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,67 +4,25 @@ import Link from "next/link";
 import { useState } from "react";
 import { usePermissions } from "@/components/PermissionsProvider";
 import FieldUpdatesNavItem from "@/components/FieldUpdatesNavItem";
+import { NAV_ITEMS, SearchIcon } from "@/components/nav/navItems";
+import SearchPanel from "@/components/nav/SearchPanel";
 
 export default function Sidebar({ logoUrl }: { logoUrl?: string }) {
     const [isSearchOpen, setIsSearchOpen] = useState(false);
     const { permissions, loaded } = usePermissions();
 
-    // Permission-gated nav items
     const can = (key: string) => !!permissions[key];
+    const projects = NAV_ITEMS.find((i) => i.key === "projects")!;
 
     return (
-        <aside className="w-20 bg-hui-sidebar text-white flex flex-col min-h-screen items-center py-4 relative z-50">
+        // Desktop / iPad-landscape icon rail. Hidden below lg — the mobile drawer
+        // (MobileNavDrawer) takes over there. Keeping this rail untouched at >= lg
+        // preserves the existing desktop layout pixel-for-pixel.
+        <aside className="hidden lg:flex w-20 bg-hui-sidebar text-white flex-col min-h-screen items-center py-4 relative z-50">
             {/* Search Flyout */}
             {isSearchOpen && (
                 <div className="absolute left-20 top-0 w-64 bg-slate-50 min-h-screen shadow-xl border-r border-slate-200 text-slate-800 flex flex-col z-40">
-                    <div className="p-4 border-b border-slate-200 bg-white">
-                        <h2 className="font-bold text-lg mb-4">Search</h2>
-                        <input type="text" placeholder="Search Projects" className="w-full border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-slate-400" />
-                    </div>
-                    <div className="flex-1 overflow-y-auto w-full p-4 space-y-6">
-                        {!loaded ? (
-                            <div className="text-sm text-slate-400 text-center pt-4">Loading…</div>
-                        ) : (
-                            <>
-                                {/* Planning */}
-                                {(can("contracts") || can("estimates") || can("takeoffs") || can("roomDesigner")) && (
-                                    <div>
-                                        <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">Planning</h3>
-                                        <ul className="space-y-2 text-sm">
-                                            {can("contracts") && <li><Link href="/projects" className="hover:text-hui-primary block transition">All Contracts</Link></li>}
-                                            {can("estimates") && <li><Link href="/estimates" className="hover:text-hui-primary block transition">All Estimates</Link></li>}
-                                            {can("takeoffs") && <li><Link href="/projects" className="hover:text-hui-primary block transition">All Takeoffs</Link></li>}
-                                            {can("roomDesigner") && <li><Link href="/projects" className="hover:text-hui-primary block transition">All Room Designs</Link></li>}
-                                        </ul>
-                                    </div>
-                                )}
-                                {/* Management */}
-                                {(can("schedules") || can("dailyLogs") || can("timeClock") || can("clientCommunication")) && (
-                                    <div>
-                                        <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">Management</h3>
-                                        <ul className="space-y-2 text-sm">
-                                            {can("schedules") && <li><Link href="/manager/schedule" className="hover:text-hui-primary block transition">Schedule Overview</Link></li>}
-                                            {can("schedules") && <li><Link href="/manager/field-updates" className="hover:text-hui-primary block transition">Field Updates</Link></li>}
-                                            {can("dailyLogs") && <li><Link href="/projects" className="hover:text-hui-primary block transition">All Daily Logs</Link></li>}
-                                            {can("timeClock") && <li><Link href="/time-clock" className="hover:text-hui-primary block transition">Time &amp; Expenses</Link></li>}
-                                            {can("clientCommunication") && <li><Link href="/manager/inbox" className="hover:text-hui-primary block transition">Unmatched Inbox</Link></li>}
-                                        </ul>
-                                    </div>
-                                )}
-                                {/* Finance */}
-                                {(can("invoices") || can("changeOrders")) && (
-                                    <div>
-                                        <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">Finance</h3>
-                                        <ul className="space-y-2 text-sm">
-                                            {can("invoices") && <li><Link href="/invoices" className="hover:text-hui-primary block transition">All Invoices</Link></li>}
-                                            {can("changeOrders") && <li><Link href="/projects" className="hover:text-hui-primary block transition">All Change Orders</Link></li>}
-                                            {can("invoices") && <li><Link href="/manager/receipts" className="hover:text-hui-primary block transition">Receipt Queue</Link></li>}
-                                        </ul>
-                                    </div>
-                                )}
-                            </>
-                        )}
-                    </div>
+                    <SearchPanel />
                 </div>
             )}
 
@@ -88,70 +46,31 @@ export default function Sidebar({ logoUrl }: { logoUrl?: string }) {
                     onClick={() => setIsSearchOpen(!isSearchOpen)}
                     className={`flex flex-col items-center justify-center w-full py-3 hover:bg-[#2a2a2a] transition ${isSearchOpen ? 'text-white bg-[#2a2a2a]' : 'text-slate-400'}`}
                 >
-                    <svg className="w-5 h-5 mb-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
+                    <SearchIcon className="w-5 h-5 mb-1" />
                     <span className="text-[10px] uppercase font-semibold">Search</span>
                 </button>
 
                 {/* Projects — always visible (filtered by ProjectAccess on the API side) */}
-                <Link href="/projects" className="flex flex-col items-center justify-center w-full py-3 hover:bg-[#2a2a2a] text-slate-400 hover:text-white transition group">
-                    <svg className="w-5 h-5 mb-1 group-hover:text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" /></svg>
+                <Link href={projects.href} className="flex flex-col items-center justify-center w-full py-3 hover:bg-[#2a2a2a] text-slate-400 hover:text-white transition group">
+                    <projects.Icon className="w-5 h-5 mb-1 group-hover:text-white" />
                     <span className="text-[10px] uppercase font-semibold">Projects</span>
                 </Link>
 
                 {loaded ? (
-                    <>
-                        {/* Leads — gated by leadAccess */}
-                        {can("leadAccess") && (
-                            <Link href="/leads" className="flex flex-col items-center justify-center w-full py-3 hover:bg-[#2a2a2a] text-slate-400 hover:text-white transition group">
-                                <svg className="w-5 h-5 mb-1 group-hover:text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" /></svg>
-                                <span className="text-[10px] uppercase font-semibold">Leads</span>
+                    NAV_ITEMS.filter((item) => item.key !== "projects" && item.show(can)).map((item) =>
+                        item.custom === "fieldUpdates" ? (
+                            <FieldUpdatesNavItem key={item.key} />
+                        ) : (
+                            <Link
+                                key={item.key}
+                                href={item.href}
+                                className="flex flex-col items-center justify-center w-full py-3 hover:bg-[#2a2a2a] text-slate-400 hover:text-white transition group"
+                            >
+                                <item.Icon className="w-5 h-5 mb-1 group-hover:text-white" />
+                                <span className="text-[10px] uppercase font-semibold text-center leading-tight">{item.label}</span>
                             </Link>
-                        )}
-
-
-                        {/* Financials — gated by invoices or financialReports */}
-                        {(can("invoices") || can("financialReports")) && (
-                            <Link href="/invoices" className="flex flex-col items-center justify-center w-full py-3 hover:bg-[#2a2a2a] text-slate-400 hover:text-white transition group">
-                                <svg className="w-5 h-5 mb-1 group-hover:text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" /></svg>
-                                <span className="text-[10px] uppercase font-semibold text-center leading-tight">Financials</span>
-                            </Link>
-                        )}
-
-                        {/* Reports — gated by financialReports */}
-                        {can("financialReports") && (
-                            <Link href="/reports" className="flex flex-col items-center justify-center w-full py-3 hover:bg-[#2a2a2a] text-slate-400 hover:text-white transition group">
-                                <svg className="w-5 h-5 mb-1 group-hover:text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
-                                <span className="text-[10px] uppercase font-semibold text-center leading-tight">Reports</span>
-                            </Link>
-                        )}
-
-                        {/* Field Updates — gated by schedules (manager-facing comment feed) */}
-                        {can("schedules") && <FieldUpdatesNavItem />}
-
-                        {/* Time Clock — gated by timeClock */}
-                        {can("timeClock") && (
-                            <Link href="/time-clock" className="flex flex-col items-center justify-center w-full py-3 hover:bg-[#2a2a2a] text-slate-400 hover:text-white transition group">
-                                <svg className="w-5 h-5 mb-1 group-hover:text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-                                <span className="text-[10px] uppercase font-semibold text-center leading-tight">Time Clock</span>
-                            </Link>
-                        )}
-
-                        {/* Company — gated by manageTeamMembers or companySettings */}
-                        {(can("manageTeamMembers") || can("companySettings")) && (
-                            <Link href="/company/team-members" className="flex flex-col items-center justify-center w-full py-3 hover:bg-[#2a2a2a] text-slate-400 hover:text-white transition group">
-                                <svg className="w-5 h-5 mb-1 group-hover:text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" /></svg>
-                                <span className="text-[10px] uppercase font-semibold text-center leading-tight">Company</span>
-                            </Link>
-                        )}
-
-                        {/* Settings — gated by companySettings */}
-                        {can("companySettings") && (
-                            <Link href="/settings/company" className="flex flex-col items-center justify-center w-full py-3 hover:bg-[#2a2a2a] text-slate-400 hover:text-white transition group">
-                                <svg className="w-5 h-5 mb-1 group-hover:text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
-                                <span className="text-[10px] uppercase font-semibold text-center leading-tight">Settings</span>
-                            </Link>
-                        )}
-                    </>
+                        )
+                    )
                 ) : (
                     Array.from({ length: 5 }).map((_, i) => (
                         <div

--- a/src/components/nav/MobileNavDrawer.tsx
+++ b/src/components/nav/MobileNavDrawer.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+import { X } from "lucide-react";
+import { usePermissions } from "@/components/PermissionsProvider";
+import FieldUpdatesNavItem from "@/components/FieldUpdatesNavItem";
+import { NAV_ITEMS } from "@/components/nav/navItems";
+import SearchPanel from "@/components/nav/SearchPanel";
+import { useNavDrawer } from "@/components/nav/navDrawerStore";
+
+// Off-canvas navigation for iPad-portrait + phones (< lg). The desktop rail
+// (Sidebar) is hidden at these widths. Built on Radix Dialog for focus-trap,
+// body scroll-lock, Esc + overlay-click close, and aria-modal semantics.
+export default function MobileNavDrawer() {
+  const open = useNavDrawer((s) => s.open);
+  const setOpen = useNavDrawer((s) => s.setOpen);
+  const { permissions, loaded } = usePermissions();
+  const can = (key: string) => !!permissions[key];
+  const pathname = usePathname();
+
+  // Close on navigation (belt-and-suspenders with onNavigate on the links).
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname, setOpen]);
+
+  const close = () => setOpen(false);
+  const projects = NAV_ITEMS.find((i) => i.key === "projects")!;
+  const isActive = (href: string) => pathname === href || pathname?.startsWith(href + "/");
+
+  const rowClass = (href: string) =>
+    `flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium transition ${
+      isActive(href) ? "bg-[#2a2a2a] text-white" : "text-slate-300 hover:bg-[#2a2a2a] hover:text-white"
+    }`;
+
+  return (
+    <Dialog.Root open={open} onOpenChange={setOpen}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="lg:hidden fixed inset-0 z-[60] bg-black/50 data-[state=open]:[animation:nav-overlay-in_200ms_ease-out]" />
+        <Dialog.Content
+          className="lg:hidden fixed left-0 top-0 z-[60] h-[100dvh] w-72 max-w-[85vw] bg-hui-sidebar text-white flex flex-col shadow-xl focus:outline-none pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] data-[state=open]:[animation:nav-drawer-in_200ms_ease-out]"
+        >
+          <Dialog.Title className="sr-only">Navigation</Dialog.Title>
+
+          {/* Header */}
+          <div className="flex items-center justify-between px-4 py-3 border-b border-white/10 flex-none">
+            <Link href="/" onClick={close} className="flex items-center gap-2">
+              <div className="w-8 h-8 bg-hui-primary rounded-md flex items-center justify-center font-bold">G</div>
+              <span className="font-semibold">GTR Pro</span>
+            </Link>
+            <Dialog.Close className="p-2 -mr-2 text-slate-300 hover:text-white" aria-label="Close navigation">
+              <X className="w-5 h-5" />
+            </Dialog.Close>
+          </div>
+
+          {/* Primary nav */}
+          <nav className="p-2 space-y-1 flex-none">
+            <Link href={projects.href} onClick={close} className={rowClass(projects.href)}>
+              <projects.Icon className="w-5 h-5 shrink-0" />
+              <span>{projects.label}</span>
+            </Link>
+            {loaded &&
+              NAV_ITEMS.filter((item) => item.key !== "projects" && item.show(can)).map((item) =>
+                item.custom === "fieldUpdates" ? (
+                  <FieldUpdatesNavItem key={item.key} variant="drawer" onNavigate={close} />
+                ) : (
+                  <Link key={item.key} href={item.href} onClick={close} className={rowClass(item.href)}>
+                    <item.Icon className="w-5 h-5 shrink-0" />
+                    <span>{item.label}</span>
+                  </Link>
+                )
+              )}
+          </nav>
+
+          {/* Search + deep links (mirrors the desktop flyout) */}
+          <div className="flex-1 min-h-0 flex flex-col bg-slate-50 text-slate-800 border-t border-white/10">
+            <SearchPanel onNavigate={close} />
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/nav/SearchPanel.tsx
+++ b/src/components/nav/SearchPanel.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import Link from "next/link";
+import { usePermissions } from "@/components/PermissionsProvider";
+
+// The search input + grouped quick-links. Extracted from Sidebar so it can be
+// rendered both inside the desktop rail's flyout and inside the mobile drawer.
+// `onNavigate` lets the drawer close itself when a link is tapped.
+export default function SearchPanel({ onNavigate }: { onNavigate?: () => void }) {
+  const { permissions, loaded } = usePermissions();
+  const can = (key: string) => !!permissions[key];
+
+  return (
+    <>
+      <div className="p-4 border-b border-slate-200 bg-white">
+        <h2 className="font-bold text-lg mb-4">Search</h2>
+        <input
+          type="text"
+          placeholder="Search Projects"
+          className="w-full border border-slate-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-slate-400"
+        />
+      </div>
+      <div className="flex-1 overflow-y-auto w-full p-4 space-y-6">
+        {!loaded ? (
+          <div className="text-sm text-slate-400 text-center pt-4">Loading…</div>
+        ) : (
+          <>
+            {/* Planning */}
+            {(can("contracts") || can("estimates") || can("takeoffs") || can("roomDesigner")) && (
+              <div>
+                <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">Planning</h3>
+                <ul className="space-y-2 text-sm">
+                  {can("contracts") && <li><Link href="/projects" onClick={onNavigate} className="hover:text-hui-primary block transition">All Contracts</Link></li>}
+                  {can("estimates") && <li><Link href="/estimates" onClick={onNavigate} className="hover:text-hui-primary block transition">All Estimates</Link></li>}
+                  {can("takeoffs") && <li><Link href="/projects" onClick={onNavigate} className="hover:text-hui-primary block transition">All Takeoffs</Link></li>}
+                  {can("roomDesigner") && <li><Link href="/projects" onClick={onNavigate} className="hover:text-hui-primary block transition">All Room Designs</Link></li>}
+                </ul>
+              </div>
+            )}
+            {/* Management */}
+            {(can("schedules") || can("dailyLogs") || can("timeClock") || can("clientCommunication")) && (
+              <div>
+                <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">Management</h3>
+                <ul className="space-y-2 text-sm">
+                  {can("schedules") && <li><Link href="/manager/schedule" onClick={onNavigate} className="hover:text-hui-primary block transition">Schedule Overview</Link></li>}
+                  {can("schedules") && <li><Link href="/manager/field-updates" onClick={onNavigate} className="hover:text-hui-primary block transition">Field Updates</Link></li>}
+                  {can("dailyLogs") && <li><Link href="/projects" onClick={onNavigate} className="hover:text-hui-primary block transition">All Daily Logs</Link></li>}
+                  {can("timeClock") && <li><Link href="/time-clock" onClick={onNavigate} className="hover:text-hui-primary block transition">Time &amp; Expenses</Link></li>}
+                  {can("clientCommunication") && <li><Link href="/manager/inbox" onClick={onNavigate} className="hover:text-hui-primary block transition">Unmatched Inbox</Link></li>}
+                </ul>
+              </div>
+            )}
+            {/* Finance */}
+            {(can("invoices") || can("changeOrders")) && (
+              <div>
+                <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">Finance</h3>
+                <ul className="space-y-2 text-sm">
+                  {can("invoices") && <li><Link href="/invoices" onClick={onNavigate} className="hover:text-hui-primary block transition">All Invoices</Link></li>}
+                  {can("changeOrders") && <li><Link href="/projects" onClick={onNavigate} className="hover:text-hui-primary block transition">All Change Orders</Link></li>}
+                  {can("invoices") && <li><Link href="/manager/receipts" onClick={onNavigate} className="hover:text-hui-primary block transition">Receipt Queue</Link></li>}
+                </ul>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/nav/navDrawerStore.ts
+++ b/src/components/nav/navDrawerStore.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { create } from "zustand";
+
+// Shared open/close state for the mobile nav drawer. The hamburger lives in
+// Header.tsx and the drawer in MobileNavDrawer.tsx — they're separate layout
+// regions, so a tiny module-level store (no provider) is the simplest bridge.
+// Mirrors the house zustand pattern in components/studio/store.ts.
+interface NavDrawerState {
+  open: boolean;
+  setOpen: (v: boolean) => void;
+  toggle: () => void;
+}
+
+export const useNavDrawer = create<NavDrawerState>((set) => ({
+  open: false,
+  setOpen: (v) => set({ open: v }),
+  toggle: () => set((s) => ({ open: !s.open })),
+}));

--- a/src/components/nav/navItems.tsx
+++ b/src/components/nav/navItems.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+
+// Single source of truth for the primary navigation, consumed by both the
+// desktop icon rail (Sidebar.tsx) and the mobile drawer (MobileNavDrawer.tsx).
+// Icons are components so each surface can pass its own className (the rail
+// stacks icon+label vertically; the drawer lays them out as horizontal rows).
+
+type IconProps = { className?: string };
+
+const svg = (children: ReactNode) => ({ className }: IconProps) => (
+  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    {children}
+  </svg>
+);
+
+const ProjectsIcon = svg(
+  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+);
+const LeadsIcon = svg(
+  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+);
+const FinancialsIcon = svg(
+  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+);
+const ReportsIcon = svg(
+  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+);
+const TimeClockIcon = svg(
+  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+);
+const CompanyIcon = svg(
+  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+);
+const SettingsIcon = svg(
+  <>
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+  </>
+);
+
+export type NavItem = {
+  key: string;
+  href: string;
+  label: string;
+  Icon: (props: IconProps) => ReactNode;
+  /** Returns whether the current user can see this item. */
+  show: (can: (key: string) => boolean) => boolean;
+  /** Special-cased renderers (e.g. the Field Updates item has a live unread badge). */
+  custom?: "fieldUpdates";
+};
+
+export const NAV_ITEMS: NavItem[] = [
+  // Projects is always visible (the API filters by ProjectAccess).
+  { key: "projects", href: "/projects", label: "Projects", Icon: ProjectsIcon, show: () => true },
+  { key: "leads", href: "/leads", label: "Leads", Icon: LeadsIcon, show: (can) => can("leadAccess") },
+  { key: "financials", href: "/invoices", label: "Financials", Icon: FinancialsIcon, show: (can) => can("invoices") || can("financialReports") },
+  { key: "reports", href: "/reports", label: "Reports", Icon: ReportsIcon, show: (can) => can("financialReports") },
+  { key: "field", href: "/manager/field-updates", label: "Field", Icon: ReportsIcon, show: (can) => can("schedules"), custom: "fieldUpdates" },
+  { key: "timeclock", href: "/time-clock", label: "Time Clock", Icon: TimeClockIcon, show: (can) => can("timeClock") },
+  { key: "company", href: "/company/team-members", label: "Company", Icon: CompanyIcon, show: (can) => can("manageTeamMembers") || can("companySettings") },
+  { key: "settings", href: "/settings/company", label: "Settings", Icon: SettingsIcon, show: (can) => can("companySettings") },
+];
+
+export const SearchIcon = svg(
+  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+);

--- a/src/components/studio/canvas/StudioCanvas.tsx
+++ b/src/components/studio/canvas/StudioCanvas.tsx
@@ -119,6 +119,7 @@ export function StudioCanvas() {
 
   return (
     <Canvas
+      className="touch-none"
       shadows={{ type: THREE.PCFSoftShadowMap }}
       dpr={[1, 1.75]}
       resize={{ scroll: false, debounce: 0 }}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -6,7 +6,7 @@ import { revalidatePath, revalidateTag, unstable_cache } from "next/cache";
 import { cache } from "react";
 import { authOptions, getSessionOrDev } from "./auth";
 import { sendNotification } from "./email";
-import { safeEstimateSelect, toNum } from "./prisma-helpers";
+import { safeEstimateSelect, toNum, deriveInvoiceTaxFields } from "./prisma-helpers";
 import { formatCurrency } from "./utils";
 import { createHmac, timingSafeEqual } from "crypto";
 import { resolveSessionClientId } from "./portal-auth";
@@ -2473,15 +2473,23 @@ export async function sendMilestoneInvoices(
     invoiceId: string,
     paymentScheduleIds: string[],
     overrideEmail?: string,
+    // Per-milestone reconcile intents the user explicitly confirmed in the review
+    // step: scheduleId -> the QBO total they saw and approved. Doubles as an
+    // optimistic-lock token (we only reconcile if the live QBO total still matches).
+    opts?: { reconcile?: Record<string, number> },
 ): Promise<{
     success: boolean;
     sent: number;
     failed: number;
     skipped: number;
-    results: Array<{ id: string; name: string; status: "sent" | "skipped" | "failed"; error?: string; sentTo?: string }>;
+    // True when one or more selected milestones drifted from QBO and were NOT sent;
+    // the modal flips into the side-by-side review step using driftReview.
+    needsReview?: boolean;
+    driftReview?: Array<{ id: string; name: string; probuildAmount: number; qbTotal: number; direction: "higher" | "lower" }>;
+    results: Array<{ id: string; name: string; status: "sent" | "skipped" | "failed" | "reconciled"; error?: string; sentTo?: string }>;
     error?: string;
 }> {
-    await assertInvoicePermission();
+    const actor = await assertInvoicePermission();
 
     try {
         const invoice = await prisma.invoice.findUnique({
@@ -2500,7 +2508,7 @@ export async function sendMilestoneInvoices(
             return { success: false, sent: 0, failed: 0, skipped: 0, results: [], error: "No milestones selected" };
         }
 
-        const { getFreshQBTokens, pushMilestoneToQuickBooks } = await import("./quickbooks-payments");
+        const { getFreshQBTokens, pushMilestoneToQuickBooks, reconcileMilestoneToQbo } = await import("./quickbooks-payments");
         const { sendQBInvoice, getQBInvoiceStatus } = await import("./quickbooks");
 
         let tokens;
@@ -2523,7 +2531,9 @@ export async function sendMilestoneInvoices(
         let sentCount = 0;
         let failedCount = 0;
         let skippedCount = 0;
-        const results: Array<{ id: string; name: string; status: "sent" | "skipped" | "failed"; error?: string; sentTo?: string }> = [];
+        let reconciledEstimate = false;
+        const results: Array<{ id: string; name: string; status: "sent" | "skipped" | "failed" | "reconciled"; error?: string; sentTo?: string }> = [];
+        const driftReview: Array<{ id: string; name: string; probuildAmount: number; qbTotal: number; direction: "higher" | "lower" }> = [];
 
         for (const schedule of selectedPayments) {
             if (schedule.status === "Paid" || schedule.status === "Canceled") {
@@ -2558,17 +2568,78 @@ export async function sendMilestoneInvoices(
                     continue;
                 }
 
-                // Drift Guard
-                if (qbTotal != null && Math.abs(qbTotal - Number(schedule.amount)) > 0.05) {
-                    skippedCount++;
-                    results.push({
-                        id: schedule.id,
-                        name: schedule.name,
-                        status: "skipped",
-                        error: `QuickBooks total $${qbTotal.toFixed(2)} ≠ milestone $${Number(schedule.amount).toFixed(2)} — review before sending`,
-                    });
+                // Fail closed if we couldn't read the QBO total — the Drift Guard can't
+                // vouch for the amount, so don't send an unverified invoice (a transient
+                // QBO read failure must not bypass the guard).
+                if (qbTotal == null) {
+                    failedCount++;
+                    results.push({ id: schedule.id, name: schedule.name, status: "failed", error: "Couldn't read the QuickBooks total to verify the amount — please try again." });
                     continue;
                 }
+                // A $0/negative QBO total means the invoice is voided or deleted.
+                if (qbTotal <= 0) {
+                    failedCount++;
+                    results.push({ id: schedule.id, name: schedule.name, status: "failed", error: "QuickBooks shows $0.00 for this invoice (it may be voided or deleted) — re-push before sending." });
+                    continue;
+                }
+
+                // Drift Guard: QBO is the system of record for what the client is
+                // charged. If it has drifted from the ProBuild milestone, do not send
+                // until the user reviews and explicitly approves reconciling ProBuild
+                // to the QBO total (optimistic-locked to the exact qbTotal they saw).
+                if (Math.abs(qbTotal - Number(schedule.amount)) > 0.05) {
+                    const approved = opts?.reconcile?.[schedule.id];
+                    // Cent-exact match: only reconcile the precise total the user approved.
+                    const userApprovedThisTotal = approved != null && Math.abs(approved - qbTotal) <= 0.005;
+
+                    if (!userApprovedThisTotal) {
+                        // Phase 1 (or a stale confirmation): surface for review, do NOT send.
+                        driftReview.push({
+                            id: schedule.id,
+                            name: schedule.name,
+                            probuildAmount: Number(schedule.amount),
+                            qbTotal,
+                            direction: qbTotal > Number(schedule.amount) ? "higher" : "lower",
+                        });
+                        skippedCount++;
+                        results.push({
+                            id: schedule.id,
+                            name: schedule.name,
+                            status: "skipped",
+                            error: `QuickBooks total $${qbTotal.toFixed(2)} ≠ milestone $${Number(schedule.amount).toFixed(2)} — review before sending`,
+                        });
+                        continue;
+                    }
+
+                    // Phase 2: authorized + confirmed + still current → reconcile ProBuild to QBO.
+                    const recon = await reconcileMilestoneToQbo(schedule.id, qbTotal);
+                    if (!recon.ok) {
+                        failedCount++;
+                        results.push({ id: schedule.id, name: schedule.name, status: "failed", error: recon.error || "Failed to reconcile milestone" });
+                        continue;
+                    }
+                    if (recon.estimateTouched) reconciledEstimate = true;
+
+                    if (invoice.projectId) {
+                        await logActivity({
+                            projectId: invoice.projectId,
+                            actorType: "TEAM",
+                            actorName: actor.name || companyName,
+                            action: "reconciled_milestone_amount",
+                            entityType: "invoice",
+                            entityId: invoiceId,
+                            entityName: `Invoice ${invoice.code}`,
+                            metadata: { milestone: schedule.name, from: recon.oldAmount, to: recon.newAmount, source: "quickbooks" },
+                        });
+                    }
+                    // schedule.amount is now stale in memory; the QBO total matches the
+                    // reconciled amount, so fall through to send. Mark the result below.
+                }
+
+                const approvedTotal = opts?.reconcile?.[schedule.id];
+                const wasReconciled = Math.abs(qbTotal - Number(schedule.amount)) > 0.05
+                    && approvedTotal != null
+                    && Math.abs(approvedTotal - qbTotal) <= 0.005;
 
                 // Send QBO invoice
                 const sendRes = await sendQBInvoice(tokens, qbInvoiceId, recipient);
@@ -2585,7 +2656,7 @@ export async function sendMilestoneInvoices(
                 });
 
                 sentCount++;
-                results.push({ id: schedule.id, name: schedule.name, status: "sent", sentTo: recipient });
+                results.push({ id: schedule.id, name: schedule.name, status: wasReconciled ? "reconciled" : "sent", sentTo: recipient });
 
                 // Log activity per sent milestone
                 if (invoice.projectId) {
@@ -2617,15 +2688,26 @@ export async function sendMilestoneInvoices(
         if (invoice.projectId) {
             revalidatePath(`/projects/${invoice.projectId}/invoices`);
             revalidatePath(`/projects/${invoice.projectId}/invoices/${invoiceId}`);
+            // A reconcile rewrites the linked estimate + its totals — refresh those views too.
+            if (reconciledEstimate) {
+                revalidatePath(`/projects/${invoice.projectId}/estimates`);
+                if (invoice.estimateId) revalidatePath(`/projects/${invoice.projectId}/estimates/${invoice.estimateId}`);
+            }
         }
         revalidatePath(`/invoices`);
         revalidatePath(`/portal`);
+        if (reconciledEstimate) {
+            revalidatePath(`/estimates`);
+            revalidatePath(`/reports/sales-tax`);
+        }
 
         return {
             success: sentCount > 0,
             sent: sentCount,
             failed: failedCount,
             skipped: skippedCount,
+            needsReview: driftReview.length > 0,
+            driftReview: driftReview.length > 0 ? driftReview : undefined,
             results,
         };
     } catch (globalErr: any) {
@@ -3151,18 +3233,6 @@ async function getDefaultSalesTaxRate(): Promise<number> {
     }
 }
 
-// Reverse-out tax from a total (total = subtotal + subtotal * rate/100).
-// If exempt or rate <= 0, the whole amount is subtotal and taxAmount is 0.
-function deriveInvoiceTaxFields(totalAmount: number, ratePercent: number, isExempt: boolean) {
-    if (isExempt || ratePercent <= 0) {
-        return { subtotal: totalAmount, taxRate: 0, taxAmount: 0 };
-    }
-    const factor = ratePercent / (100 + ratePercent);
-    const taxAmount = Math.round(totalAmount * factor * 100) / 100;
-    const subtotal = Math.round((totalAmount - taxAmount) * 100) / 100;
-    return { subtotal, taxRate: ratePercent, taxAmount };
-}
-
 export async function createInvoiceFromEstimate(estimateId: string) {
     const estimate = await prisma.estimate.findUnique({ where: { id: estimateId } });
     if (!estimate) throw new Error("Estimate not found");
@@ -3603,6 +3673,86 @@ export async function refreshQBPayments(invoiceId: string) {
         }
     }
     return result;
+}
+
+/**
+ * Break a milestone's link to a voided/deleted QuickBooks invoice so it can be
+ * re-sent from scratch. Clears the QB tracking fields ONLY — never touches money
+ * state. The Paid/qbPaymentId refusal guards are the money-path safety boundary:
+ * clearing these fields on a Pending milestone changes no status, fires no
+ * notifyMilestonePaid, and doesn't touch the estimate mirror (which has no QB fields).
+ *
+ * `deleteInQBO` is wired for a future "also delete in QuickBooks" toggle but defaults
+ * OFF — we never issue a destructive QBO write (voided invoices are often kept as a
+ * deliberate audit record; a deleted one is already gone).
+ */
+export async function breakQBInvoiceLink(
+    paymentId: string,
+    opts?: { deleteInQBO?: boolean },
+): Promise<{ success: true; warning?: string } | { success: false; error: string }> {
+    await assertInvoicePermission();
+
+    const schedule = await prisma.paymentSchedule.findUnique({
+        where: { id: paymentId },
+        select: {
+            id: true, status: true, qbInvoiceId: true, qbPaymentId: true,
+            invoiceId: true, invoice: { select: { projectId: true } },
+        },
+    });
+    if (!schedule) return { success: false, error: "Milestone not found" };
+    if (schedule.status === "Paid") {
+        return { success: false, error: "This milestone is already paid — unlinking is blocked. Use Undo first if you need to reverse it." };
+    }
+    if (schedule.qbPaymentId) {
+        return { success: false, error: "A QuickBooks payment is recorded against this milestone. Refusing to unlink." };
+    }
+    if (!schedule.qbInvoiceId) {
+        return { success: false, error: "This milestone has no QuickBooks link to break." };
+    }
+
+    // Claim the unlink atomically: the guard fields go in the WHERE, so if the QB
+    // sync settles this milestone (status→Paid, qbPaymentId set) between the read
+    // above and this write, the claim matches 0 rows and we never strip QB fields
+    // off a now-paid row. `qbInvoiceId` is pinned to the value we read so a
+    // concurrent re-push (new id) can't be clobbered either.
+    const cleared = await prisma.paymentSchedule.updateMany({
+        where: {
+            id: schedule.id,
+            status: { not: "Paid" },
+            qbPaymentId: null,
+            qbInvoiceId: schedule.qbInvoiceId,
+        },
+        data: {
+            qbInvoiceId: null,
+            qbInvoiceLink: null,
+            qbInvoiceSentAt: null,
+            qbSyncedAt: null,
+            qbSyncError: null,
+        },
+    });
+    if (cleared.count !== 1) {
+        return { success: false, error: "This milestone changed while unlinking (it may have just been paid or re-synced). Refresh and try again." };
+    }
+
+    // Only after we've claimed the local unlink do we (optionally) clean up QBO.
+    // Default OFF — we never issue a destructive QBO write unless asked.
+    let warning: string | undefined;
+    if (opts?.deleteInQBO === true) {
+        try {
+            const { getFreshQBTokens } = await import("./quickbooks-payments");
+            const { deleteQBInvoice } = await import("./quickbooks");
+            const tokens = await getFreshQBTokens();
+            const deleted = await deleteQBInvoice(tokens, schedule.qbInvoiceId);
+            if (!deleted) warning = "Link cleared in ProBuild, but the QuickBooks invoice could not be deleted (it may already be gone, or has a linked payment — check QuickBooks).";
+        } catch {
+            warning = "Link cleared in ProBuild, but QuickBooks delete could not be attempted (QuickBooks unavailable).";
+        }
+    }
+
+    revalidatePath(`/projects/${schedule.invoice.projectId}/invoices/${schedule.invoiceId}`);
+    revalidatePath(`/invoices`);
+    revalidatePath(`/portal`);
+    return { success: true, warning };
 }
 
 export async function recordEstimatePayment(

--- a/src/lib/payment-notifications.ts
+++ b/src/lib/payment-notifications.ts
@@ -196,6 +196,89 @@ export async function notifyMilestonePaid(paymentScheduleId: string): Promise<{ 
     }
 }
 
+/** One milestone whose linked QBO invoice was found voided/deleted by the sync poller. */
+export type QBSyncIssue = {
+    scheduleId: string;
+    invoiceId: string;
+    invoiceCode: string;
+    milestoneName: string;
+    projectId: string | null;
+    projectName: string | null;
+    state: "voided" | "notFound";
+};
+
+/**
+ * Report milestones whose QuickBooks invoice was voided/deleted (so the cron can
+ * never settle them). Writes a project activity entry per milestone and sends ONE
+ * digest email to the team. Callers pass only NEWLY-flagged rows, so this fires
+ * once per breakage, not every hourly run. Never throws.
+ */
+export async function notifyQBSyncIssues(issues: QBSyncIssue[]): Promise<void> {
+    if (issues.length === 0) return;
+    try {
+        const stateLabel = (s: QBSyncIssue["state"]) => (s === "notFound" ? "deleted/missing" : "voided");
+
+        // 1. Activity feed — one entry per affected milestone (independent of toggles).
+        for (const i of issues) {
+            await prisma.activityLog.create({
+                data: {
+                    projectId: i.projectId,
+                    actorType: "SYSTEM",
+                    actorName: "QuickBooks",
+                    action: "qb_sync_issue",
+                    entityType: "invoice",
+                    entityId: i.invoiceId,
+                    entityName: `Invoice ${i.invoiceCode}`,
+                    metadata: JSON.stringify({ milestone: i.milestoneName, state: i.state }),
+                },
+            }).catch(() => {});
+        }
+
+        // 2. Team digest email (respects Settings → Notifications · quickbooksSyncIssue).
+        const settings = await prisma.companySettings.findUnique({ where: { id: "singleton" } });
+        if (!settings?.notificationEmail || !isToggleOn(settings, "quickbooksSyncIssue")) return;
+
+        const rows = issues.map(i => {
+            const link = i.projectId
+                ? `https://probuild.goldentouchremodeling.com/projects/${i.projectId}/invoices/${i.invoiceId}`
+                : `https://probuild.goldentouchremodeling.com/invoices`;
+            return `<tr>
+                <td style="padding: 6px 8px; border-bottom: 1px solid #fde68a;">${i.invoiceCode}</td>
+                <td style="padding: 6px 8px; border-bottom: 1px solid #fde68a;">${i.milestoneName}</td>
+                <td style="padding: 6px 8px; border-bottom: 1px solid #fde68a;">${i.projectName || "—"}</td>
+                <td style="padding: 6px 8px; border-bottom: 1px solid #fde68a; text-transform: capitalize;">${stateLabel(i.state)}</td>
+                <td style="padding: 6px 8px; border-bottom: 1px solid #fde68a;"><a href="${link}" style="color: #b45309; font-weight: 600;">Open</a></td>
+            </tr>`;
+        }).join("");
+
+        const count = issues.length;
+        await sendNotification(
+            settings.notificationEmail,
+            `⚠ ${count} QuickBooks invoice${count === 1 ? "" : "s"} voided/deleted — milestone${count === 1 ? "" : "s"} need re-issue`,
+            `<div style="font-family: -apple-system, sans-serif; max-width: 640px; margin: 0 auto; padding: 20px;">
+                <div style="background: #fffbeb; border: 1px solid #fde68a; border-radius: 10px; padding: 22px;">
+                    <h2 style="margin: 0 0 8px; color: #b45309; font-size: 18px;">QuickBooks invoices no longer collectible</h2>
+                    <p style="margin: 0 0 14px; font-size: 13px; color: #444;">
+                        The QuickBooks invoice${count === 1 ? "" : "s"} below ${count === 1 ? "was" : "were"} voided or deleted in QuickBooks, so the matching payment milestone${count === 1 ? "" : "s"} can no longer settle and ${count === 1 ? "is" : "are"} stuck on <strong>Pending</strong>. Open each invoice and click <strong>Break QB Link</strong> to clear the link, then re-create it.
+                    </p>
+                    <table style="width: 100%; font-size: 13px; color: #444; border-collapse: collapse;">
+                        <tr style="text-align: left; color: #92400e;">
+                            <th style="padding: 6px 8px; border-bottom: 2px solid #fcd34d;">Invoice</th>
+                            <th style="padding: 6px 8px; border-bottom: 2px solid #fcd34d;">Milestone</th>
+                            <th style="padding: 6px 8px; border-bottom: 2px solid #fcd34d;">Project</th>
+                            <th style="padding: 6px 8px; border-bottom: 2px solid #fcd34d;">State</th>
+                            <th style="padding: 6px 8px; border-bottom: 2px solid #fcd34d;"></th>
+                        </tr>
+                        ${rows}
+                    </table>
+                </div>
+            </div>`
+        );
+    } catch (e) {
+        console.error("[notifyQBSyncIssues] failed:", e);
+    }
+}
+
 /**
  * Send admin alert + customer receipt for a newly-paid invoice milestone.
  * Used by the Stripe webhook (auto) — callers must handle idempotency themselves.

--- a/src/lib/prisma-helpers.ts
+++ b/src/lib/prisma-helpers.ts
@@ -61,3 +61,21 @@ export function toNum(value: unknown): number {
     const n = Number(value);
     return isNaN(n) ? 0 : n;
 }
+
+/**
+ * Reverse-out tax from a tax-inclusive total (total = subtotal + subtotal * rate/100).
+ * If exempt or rate <= 0, the whole amount is subtotal and taxAmount is 0.
+ *
+ * Shared single source of truth for the tax-reversal math. Lives here (a plain
+ * module) rather than actions.ts because "use server" files can only export async
+ * functions — so both actions.ts and the QuickBooks rail import it from here.
+ */
+export function deriveInvoiceTaxFields(totalAmount: number, ratePercent: number, isExempt: boolean) {
+    if (isExempt || ratePercent <= 0) {
+        return { subtotal: totalAmount, taxRate: 0, taxAmount: 0 };
+    }
+    const factor = ratePercent / (100 + ratePercent);
+    const taxAmount = Math.round(totalAmount * factor * 100) / 100;
+    const subtotal = Math.round((totalAmount - taxAmount) * 100) / 100;
+    return { subtotal, taxRate: ratePercent, taxAmount };
+}

--- a/src/lib/quickbooks-payments.ts
+++ b/src/lib/quickbooks-payments.ts
@@ -11,7 +11,7 @@
  * QuickBooks, and the bank in sync, and keeps the sales-tax report truthful.
  */
 import { prisma } from "./prisma";
-import { toNum } from "./prisma-helpers";
+import { toNum, deriveInvoiceTaxFields } from "./prisma-helpers";
 import { getQBSettings, saveQBSettings } from "./integration-store";
 import {
     type QBTokens,
@@ -21,8 +21,10 @@ import {
     createQBMilestoneInvoice,
     getQBInvoicePaymentLink,
     getQBInvoiceStatus,
+    probeQBInvoice,
     getQBPayment,
 } from "./quickbooks";
+import type { QBSyncIssue } from "./payment-notifications";
 
 export class QBNotConnectedError extends Error {
     constructor() {
@@ -78,7 +80,7 @@ export interface MilestonePushResult {
  * Create (or reuse) the QBO invoice for one milestone and return its pay link.
  * Idempotent: a milestone that already has a QBO invoice just refreshes the link.
  */
-export async function pushMilestoneToQuickBooks(paymentScheduleId: string): Promise<MilestonePushResult> {
+export async function pushMilestoneToQuickBooks(paymentScheduleId: string, passedTokens?: QBTokens): Promise<MilestonePushResult> {
     const schedule = await prisma.paymentSchedule.findUnique({
         where: { id: paymentScheduleId },
         include: {
@@ -94,14 +96,23 @@ export async function pushMilestoneToQuickBooks(paymentScheduleId: string): Prom
     if (!schedule) throw new Error("Payment milestone not found");
     if (schedule.status === "Paid") throw new Error("Milestone is already paid");
 
-    const tokens = await getFreshQBTokens();
+    const tokens = passedTokens ?? await getFreshQBTokens();
 
     if (schedule.qbInvoiceId) {
         const payLink = schedule.qbInvoiceLink || (await getQBInvoicePaymentLink(tokens, schedule.qbInvoiceId));
-        if (payLink && payLink !== schedule.qbInvoiceLink) {
-            await prisma.paymentSchedule.update({ where: { id: schedule.id }, data: { qbInvoiceLink: payLink } });
-        }
         const status = await getQBInvoiceStatus(tokens, schedule.qbInvoiceId);
+        const linkChanged = !!payLink && payLink !== schedule.qbInvoiceLink;
+        // A reachable invoice (status read back) clears any stale voided/notFound flag.
+        const clearFlag = !!status && !!schedule.qbSyncError;
+        if (linkChanged || clearFlag) {
+            await prisma.paymentSchedule.update({
+                where: { id: schedule.id },
+                data: {
+                    ...(linkChanged ? { qbInvoiceLink: payLink } : {}),
+                    ...(clearFlag ? { qbSyncError: null } : {}),
+                },
+            });
+        }
         return { qbInvoiceId: schedule.qbInvoiceId, payLink, qbTotal: status?.total };
     }
 
@@ -149,7 +160,8 @@ export async function pushMilestoneToQuickBooks(paymentScheduleId: string): Prom
 
     await prisma.paymentSchedule.update({
         where: { id: schedule.id },
-        data: { qbInvoiceId: qbId, qbInvoiceLink: payLink, qbSyncedAt: new Date() },
+        // qbSyncError: null — a fresh invoice clears any prior voided/notFound flag (self-heal).
+        data: { qbInvoiceId: qbId, qbInvoiceLink: payLink, qbSyncedAt: new Date(), qbSyncError: null },
     });
 
     return { qbInvoiceId: qbId, payLink, qbTotal: total };
@@ -165,6 +177,11 @@ async function markMilestonePaidFromQB(
     payment: { paidAt: Date; referenceNumber: string | null; qbPaymentId: string | null }
 ): Promise<boolean> {
     return prisma.$transaction(async (t) => {
+        // INVARIANT: do NOT pin qbInvoiceId in this claim. A real QBO settlement must
+        // win over a concurrent breakQBInvoiceLink (which nulls qbInvoiceId): pinning it
+        // would drop a genuinely-received payment (the row would be excluded from the next
+        // sync's `pending` query forever → client could be double-billed). The settle
+        // wins; qbPaymentId below preserves the QBO audit link even if the id was cleared.
         const claim = await t.paymentSchedule.updateMany({
             where: { id: paymentScheduleId, status: { not: "Paid" } },
             data: {
@@ -247,6 +264,131 @@ async function markMilestonePaidFromQB(
     });
 }
 
+/**
+ * Reconcile a milestone's ProBuild amount to the QBO grand total, then recompute
+ * the parent invoice (and mirror the estimate copy + recompute the estimate),
+ * all inside one transaction.
+ *
+ * QBO is the system of record for what the client is actually charged. When a
+ * bookkeeper edits a price/tax/discount directly in QuickBooks the QBO total
+ * drifts from the ProBuild milestone; this brings ProBuild back in line so the
+ * books stay truthful before the invoice is (re)sent.
+ *
+ * Recalc/mirror logic is modeled on `markMilestonePaidFromQB` above — link-first
+ * via `sourceScheduleId`, single-candidate name+amount fallback for pre-link
+ * rows, claimed updates that never touch a settled row. Amounts are tax-inclusive
+ * so we recompute the invoice/estimate totals from the milestone amounts and
+ * re-derive the invoice tax fields from the new total at the existing tax rate.
+ */
+export async function reconcileMilestoneToQbo(
+    paymentScheduleId: string,
+    qbTotal: number,
+): Promise<{ ok: boolean; error?: string; oldAmount?: number; newAmount?: number; invoiceId?: string; estimateTouched?: boolean }> {
+    // Round every money figure to whole cents before writing/comparing so float
+    // sums of Decimal amounts can't leave sub-penny residue in balances/status.
+    const r2 = (n: number) => Math.round(n * 100) / 100;
+    const newAmount = r2(qbTotal);
+    // A milestone should never reconcile to $0 — a $0/negative QBO total means the
+    // invoice is voided/deleted, not legitimately free. Refuse rather than zero it
+    // out (which could falsely flip the parent invoice to Paid).
+    if (newAmount <= 0) {
+        return { ok: false, error: "QuickBooks shows a $0 total — the invoice may be voided or deleted. Re-push it before sending." };
+    }
+    return prisma.$transaction(async (t) => {
+        const schedule = await t.paymentSchedule.findUnique({ where: { id: paymentScheduleId } });
+        if (!schedule) return { ok: false, error: "Milestone not found" };
+        // Fast reject for an already-settled milestone — money already moved.
+        if (schedule.status === "Paid" || schedule.status === "Canceled") {
+            return { ok: false, error: "Cannot reconcile a paid or canceled milestone" };
+        }
+
+        const oldAmount = toNum(schedule.amount);
+        // Idempotent: a re-submit with the same QBO total is a no-op.
+        if (Math.abs(oldAmount - newAmount) <= 0.005) {
+            return { ok: true, oldAmount, newAmount, invoiceId: schedule.invoiceId, estimateTouched: false };
+        }
+
+        // 1) Claimed update of the invoice-side amount — mirrors markMilestonePaidFromQB's
+        //    pattern so a concurrent settle (QB sync / Stripe) that marks the row Paid
+        //    between the read above and this write can't have its amount overwritten.
+        const claim = await t.paymentSchedule.updateMany({
+            where: { id: schedule.id, status: { notIn: ["Paid", "Canceled"] } },
+            data: { amount: newAmount, qbSyncedAt: new Date() },
+        });
+        if (claim.count === 0) {
+            return { ok: false, error: "Milestone changed status (paid or canceled) — reload and try again." };
+        }
+
+        // 2) Recompute the parent invoice (mirror markMilestonePaidFromQB's recalc,
+        //    extended to also move totalAmount since an amount change moves the grand total).
+        const invoice = await t.invoice.findUnique({ where: { id: schedule.invoiceId } });
+        if (!invoice) return { ok: false, error: "Invoice not found" };
+        const allSchedules = await t.paymentSchedule.findMany({ where: { invoiceId: schedule.invoiceId } });
+        const newTotal = r2(allSchedules.reduce((sum, s) => sum + toNum(s.amount), 0));
+        const totalPaid = r2(allSchedules.filter(s => s.status === "Paid").reduce((sum, s) => sum + toNum(s.amount), 0));
+        const newBalance = Math.max(0, r2(newTotal - totalPaid));
+        const invoiceRate = toNum(invoice.taxRate);
+        const tax = deriveInvoiceTaxFields(newTotal, invoiceRate, invoiceRate <= 0);
+        await t.invoice.update({
+            where: { id: invoice.id },
+            data: {
+                totalAmount: newTotal,
+                subtotal: tax.subtotal,
+                taxAmount: tax.taxAmount,
+                balanceDue: newBalance,
+                status: newBalance <= 0 ? "Paid" : totalPaid > 0 ? "Partially Paid" : invoice.status,
+            },
+        });
+
+        // 3) Mirror onto the estimate-side copy (link-first via sourceScheduleId,
+        //    name + OLD-amount fallback for pre-link rows; only touch an unpaid copy)
+        //    and recompute the estimate, matching markMilestonePaidFromQB's mirror block.
+        let estimateTouched = false;
+        if (invoice.estimateId) {
+            let estCopy: { id: string } | null = null;
+            if (schedule.sourceScheduleId) {
+                estCopy = await t.estimatePaymentSchedule.findFirst({
+                    where: { id: schedule.sourceScheduleId, estimateId: invoice.estimateId, status: { not: "Paid" } },
+                });
+            } else {
+                // Fallback for pre-link rows: match on name AND the old amount in the
+                // query (not after a take:2), so 3+ same-name rows can't slip a wrong
+                // single match through. Only mirror when exactly one candidate matches.
+                const candidates = await t.estimatePaymentSchedule.findMany({
+                    where: { estimateId: invoice.estimateId, status: { not: "Paid" }, name: schedule.name, amount: oldAmount },
+                    take: 2,
+                });
+                estCopy = candidates.length === 1 ? candidates[0] : null;
+            }
+            if (estCopy) {
+                const mirrorClaim = await t.estimatePaymentSchedule.updateMany({
+                    where: { id: estCopy.id, status: { not: "Paid" } },
+                    data: { amount: newAmount },
+                });
+                if (mirrorClaim.count > 0) {
+                    estimateTouched = true;
+                    const estimate = await t.estimate.findUnique({ where: { id: invoice.estimateId } });
+                    if (estimate) {
+                        const estSiblings = await t.estimatePaymentSchedule.findMany({ where: { estimateId: invoice.estimateId } });
+                        const estTotal = r2(estSiblings.reduce((sum, s) => sum + toNum(s.amount), 0));
+                        const estPaid = r2(estSiblings.filter(s => s.status === "Paid").reduce((sum, s) => sum + toNum(s.amount), 0));
+                        const estBalance = Math.max(0, r2(estTotal - estPaid));
+                        await t.estimate.update({
+                            where: { id: invoice.estimateId },
+                            data: {
+                                totalAmount: estTotal,
+                                balanceDue: estBalance,
+                                status: estBalance <= 0 ? "Paid" : estPaid > 0 ? "Partially Paid" : estimate.status,
+                            },
+                        });
+                    }
+                }
+            }
+        }
+        return { ok: true, oldAmount, newAmount, invoiceId: schedule.invoiceId, estimateTouched };
+    });
+}
+
 export interface QBPaymentSyncResult {
     checked: number;
     settled: number;
@@ -269,7 +411,7 @@ export async function syncQuickBooksPayments(scope?: { invoiceId?: string; proje
             ...(scope?.projectId ? { invoice: { projectId: scope.projectId } } : {}),
         },
         select: {
-            id: true, invoiceId: true, qbInvoiceId: true, name: true, amount: true,
+            id: true, invoiceId: true, qbInvoiceId: true, qbSyncError: true, name: true, amount: true,
             invoice: { select: { code: true, project: { select: { id: true, name: true } }, client: { select: { name: true, email: true } } } },
         },
         take: 100,
@@ -284,15 +426,57 @@ export async function syncQuickBooksPayments(scope?: { invoiceId?: string; proje
         return result;
     }
 
+    // Milestones whose linked QBO invoice was found voided/deleted THIS run (flag was
+    // previously null). Reported once per breakage; a re-push clears the flag and re-arms.
+    const newlyFlagged: QBSyncIssue[] = [];
+
     for (const schedule of pending) {
         result.checked++;
         try {
-            const status = await getQBInvoiceStatus(tokens, schedule.qbInvoiceId!);
-            if (!status) continue;
+            const probe = await probeQBInvoice(tokens, schedule.qbInvoiceId!);
+            // Transient error (token/429/5xx/network) — leave untouched and retry next run.
+            if (probe.state === "error") continue;
 
-            if (status.total > 0 && status.balance <= 0) {
+            if (probe.state === "voided" || probe.state === "notFound") {
+                // The QBO invoice is gone/voided: it can never settle. Flag so the UI can
+                // surface a Break-Link recovery, and report it ONCE so a human re-issues.
+                //
+                // Atomic claim: `qbSyncError: null` is in the WHERE, so exactly one run
+                // (across overlapping cron + on-view syncs) flips null→state and reports.
+                // `status: "Pending"` + pinned `qbInvoiceId` also avoid flagging a row a
+                // concurrent settle/break-link just changed under us.
+                const claim = await prisma.paymentSchedule.updateMany({
+                    where: { id: schedule.id, status: "Pending", qbInvoiceId: schedule.qbInvoiceId, qbSyncError: null },
+                    data: { qbSyncError: probe.state },
+                });
+                if (claim.count === 1) {
+                    newlyFlagged.push({
+                        scheduleId: schedule.id,
+                        invoiceId: schedule.invoiceId,
+                        state: probe.state,
+                        invoiceCode: schedule.invoice.code,
+                        milestoneName: schedule.name,
+                        projectId: schedule.invoice.project?.id ?? null,
+                        projectName: schedule.invoice.project?.name ?? null,
+                    });
+                } else if (schedule.qbSyncError && schedule.qbSyncError !== probe.state) {
+                    // Already flagged, but the state changed (e.g. voided → later deleted):
+                    // refresh the label for the UI badge only — never re-report/re-email.
+                    // Pin qbInvoiceId so a stale run can't relabel a milestone whose link
+                    // was re-pushed or broken out from under us.
+                    await prisma.paymentSchedule.updateMany({
+                        where: { id: schedule.id, status: "Pending", qbInvoiceId: schedule.qbInvoiceId, qbSyncError: { not: null } },
+                        data: { qbSyncError: probe.state },
+                    }).catch(() => {});
+                }
+                result.errors.push(`${schedule.invoice.code}/${schedule.name}: QBO invoice ${probe.state}`);
+                continue;
+            }
+
+            // probe.state === "ok"
+            if (probe.total > 0 && probe.balance <= 0) {
                 // Fully settled in QuickBooks (online payment OR a check Vanessa applied)
-                const paymentId = status.paymentTxnIds[0] || null;
+                const paymentId = probe.paymentTxnIds[0] || null;
                 let paidAt = new Date();
                 let referenceNumber: string | null = null;
                 if (paymentId) {
@@ -310,12 +494,17 @@ export async function syncQuickBooksPayments(scope?: { invoiceId?: string; proje
                     const { notifyMilestonePaid } = await import("./payment-notifications");
                     await notifyMilestonePaid(schedule.id);
                 }
-            } else if (status.balance < status.total) {
+            } else if (probe.balance < probe.total) {
                 result.partiallyPaid++;
             }
         } catch (e) {
             result.errors.push(`${schedule.invoice.code}/${schedule.name}: ${e instanceof Error ? e.message : "sync failed"}`);
         }
+    }
+
+    if (newlyFlagged.length > 0) {
+        const { notifyQBSyncIssues } = await import("./payment-notifications");
+        await notifyQBSyncIssues(newlyFlagged);
     }
 
     return result;

--- a/src/lib/quickbooks.ts
+++ b/src/lib/quickbooks.ts
@@ -267,6 +267,64 @@ export async function getQBInvoiceStatus(tokens: QBTokens, qbInvoiceId: string):
     return { balance: Number(inv.Balance ?? 0), total: Number(inv.TotalAmt ?? 0), paymentTxnIds };
 }
 
+/**
+ * Result of probing a QBO invoice's existence + payable state.
+ * Unlike getQBInvoiceStatus (which collapses every failure into null), this
+ * distinguishes a permanently gone/voided invoice from a transient API error,
+ * so the sync poller can flag stuck milestones without acting on a blip.
+ */
+export type QBInvoiceProbe =
+    | { state: "ok"; balance: number; total: number; paymentTxnIds: string[] }
+    | { state: "voided" } // HTTP 200, exists, total & balance === 0, no linked payments
+    | { state: "notFound" } // HTTP 400 Fault 610 or HTTP 404 (authoritative "gone" only)
+    | { state: "error"; status: number }; // 401/429/5xx/network/malformed — transient, never act on
+
+/**
+ * Probe a QBO invoice and classify it. QBO's behavior for gone invoices is
+ * inconsistent: a *voided* invoice returns 200 with TotalAmt=0; a *deleted* one
+ * may return 400 + Fault code 610 ("Object Not Found"), a 404, or even 200 with
+ * stale data. This folds all of those into a single discriminated result.
+ */
+export async function probeQBInvoice(tokens: QBTokens, qbInvoiceId: string): Promise<QBInvoiceProbe> {
+    let res: Response;
+    try {
+        res = await qbFetch(`/invoice/${qbInvoiceId}`, tokens, { method: "GET" });
+    } catch {
+        return { state: "error", status: 0 };
+    }
+    if (res.ok) {
+        // A 200 should always carry an Invoice. A parse failure or a missing payload
+        // is anomalous — treat it as transient (never as "gone"); only an explicit
+        // 404/610 below is authoritative for notFound.
+        let data: any;
+        try {
+            data = await res.json();
+        } catch {
+            return { state: "error", status: res.status };
+        }
+        const inv = data?.Invoice;
+        if (!inv) return { state: "error", status: res.status };
+        const total = Number(inv.TotalAmt);
+        const balance = Number(inv.Balance);
+        // A well-formed invoice always carries numeric TotalAmt/Balance. Missing or
+        // non-finite values mean a malformed/partial payload — treat as transient,
+        // never as voided (which would false-alarm an otherwise-healthy milestone).
+        if (!Number.isFinite(total) || !Number.isFinite(balance)) return { state: "error", status: res.status };
+        const paymentTxnIds: string[] = (inv.LinkedTxn || [])
+            .filter((t: any) => t.TxnType === "Payment")
+            .map((t: any) => String(t.TxnId));
+        // Voided invoices come back 200 with TotalAmt=0, Balance=0, and no linked payments.
+        if (total === 0 && balance === 0 && paymentTxnIds.length === 0) return { state: "voided" };
+        return { state: "ok", balance, total, paymentTxnIds };
+    }
+    if (res.status === 404) return { state: "notFound" };
+    const body = await res.text().catch(() => "");
+    if (res.status === 400 && /"code"\s*:\s*"610"|Object Not Found/i.test(body)) {
+        return { state: "notFound" };
+    }
+    return { state: "error", status: res.status };
+}
+
 /** Read a QBO payment (date / amount / reference) for receipt details. */
 export async function getQBPayment(
     tokens: QBTokens,
@@ -516,4 +574,22 @@ export async function syncInvoiceToQB(
     const qbId = data.Invoice?.Id;
     const qbUrl = `https://app.qbo.intuit.com/app/invoice?txnId=${qbId}`;
     return { qbId, qbUrl };
+}
+
+/** Send a QBO invoice email to a client. */
+export async function sendQBInvoice(tokens: QBTokens, qbInvoiceId: string, sendTo?: string | null) {
+    const qs = new URLSearchParams({ minorversion: "73" });
+    if (sendTo) qs.set("sendTo", sendTo);
+    const url = `${QB_API_BASE}/${tokens.realmId}/invoice/${qbInvoiceId}/send?${qs}`;
+    const res = await fetch(url, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${tokens.accessToken}`,
+            Accept: "application/json",
+            "Content-Type": "application/octet-stream",
+        },
+    });
+    if (!res.ok) return { ok: false as const, status: res.status, error: await res.text() };
+    const data = await res.json().catch(() => ({}));
+    return { ok: true as const, status: res.status, emailStatus: data.Invoice?.EmailStatus ?? null };
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -46,7 +46,8 @@ export const config = {
          * - _next/static (Static files)
          * - _next/image (Image optimization)
          * - favicon.ico, public folder images, etc
+         * - manifest.webmanifest (PWA manifest — must be fetchable for install)
          */
-        "/((?!api/auth|api/cron|api/twilio|api/webhook|api/payments|api/portal|api/integrations|api/version|api/pdf/estimates|api/pdf/invoices|api/sub-portal|api/mobile|login|portal|sub-portal|share|_next/static|_next/image|favicon.ico|.*\\.png|.*\\.jpg|.*\\.svg).*)",
+        "/((?!api/auth|api/cron|api/twilio|api/webhook|api/payments|api/portal|api/integrations|api/version|api/pdf/estimates|api/pdf/invoices|api/sub-portal|api/mobile|login|portal|sub-portal|share|_next/static|_next/image|favicon.ico|.*\\.png|.*\\.jpg|.*\\.svg|.*\\.webmanifest).*)",
     ],
 };


### PR DESCRIPTION
## Summary
Makes ProBuild usable on iPad/phones and installable as a PWA, plus includes the QuickBooks voided/deleted-invoice detection + Break QB Link recovery feature (committed on this branch).

Already deployed to production and verified (`/manifest.webmanifest` returns 200; clean build passes).

## Commits
- **5229385** `feat`: mobile/iPad-friendly responsive shell + installable PWA — responsive nav drawer, viewport + `manifest.ts`, iOS input-zoom/safe-area/dvh fixes, touch passes on estimate/invoice editors, view-only Studio/Gantt on touch.
- **c79f80e** `fix(pwa)`: exclude `/manifest.webmanifest` from auth middleware so it's fetchable for install.
- **aca626f** `feat(quickbooks)`: detect voided/deleted QBO invoices + Break QB Link recovery.
- **3bdf1a3** `fix(invoices)`: commit `SendMilestonesModal` component (was left untracked, broke standalone build).

## Notes
- Combined PR: the QB feature (`aca626f`) lives on this branch because it shipped to prod together with the iPad work.
- Verify on a real iPad: log in → check hamburger/drawer + responsive layouts → Safari → Share → Add to Home Screen.
- Optional follow-up: add a 512×512 maskable icon for crisper Android/Chrome install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)