### PR TITLE
Warn on payment undo (QBO disconnect) + estimate milestone edits after invoicing

### DIFF
--- a/e2e/money-pipeline.spec.ts
+++ b/e2e/money-pipeline.spec.ts
@@ -213,6 +213,11 @@ test.describe.serial("Money pipeline: sign → convert → invoice → mirror �
 
     const depositRow = page.locator("tr", { hasText: "MP Deposit" });
     await depositRow.locator('button:has-text("Undo")').click();
+
+    // Undo is guarded by the heavy confirmation modal: type UNDO, then confirm.
+    await page.getByPlaceholder("UNDO").fill("UNDO");
+    await page.locator('button:has-text("Undo Payment")').click();
+
     await expect(depositRow.locator('button:has-text("Record Payment")')).toBeVisible({ timeout: 15_000 });
 
     const invCopy = await prisma.paymentSchedule.findFirstOrThrow({ where: { invoiceId, name: "MP Deposit" } });

--- a/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
@@ -120,6 +120,10 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
     const [status, setStatus] = useState(initialEstimate.status);
     const [items, setItems] = useState<any[]>(initialEstimate.items || []);
     const [paymentSchedules, setPaymentSchedules] = useState<any[]>(initialEstimate.paymentSchedules || []);
+    // Invoice generated from this estimate (if any) — milestone edits here do not
+    // cascade to it, so the schedule UI warns when one exists.
+    const linkedInvoice: { id: string; code: string; status: string } | null =
+        initialEstimate.invoices?.[0] || null;
     const [isSaving, setIsSaving] = useState(false);
     const [isCreatingInvoice, setIsCreatingInvoice] = useState(false);
     const [isDeleting, setIsDeleting] = useState(false);
@@ -1444,6 +1448,16 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
     }
 
     function removePaymentSchedule(index: number) {
+        // Invoice-side milestones are snapshots — deleting the estimate copy does
+        // NOT remove it from an already-generated invoice.
+        if (linkedInvoice) {
+            const ok = window.confirm(
+                `This estimate has already been invoiced (${linkedInvoice.code}). ` +
+                `Deleting this milestone will NOT remove it from the invoice — ` +
+                `the invoice must be adjusted separately. Delete anyway?`
+            );
+            if (!ok) return;
+        }
         const newSchedules = [...paymentSchedules];
         newSchedules.splice(index, 1);
         setPaymentSchedules(newSchedules);
@@ -2326,6 +2340,17 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                                 <div className="flex items-center justify-between bg-slate-50/50 border-b border-slate-100 px-8 py-5">
                                     <h3 className="font-bold text-slate-800 tracking-tight">Payment Schedule</h3>
                                 </div>
+                                {linkedInvoice && (
+                                    <div className="flex items-start gap-2.5 bg-amber-50 border-b border-amber-200 px-8 py-3">
+                                        <svg className="w-4 h-4 text-amber-600 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+                                        </svg>
+                                        <p className="text-xs text-amber-800">
+                                            <span className="font-semibold">This estimate has been invoiced ({linkedInvoice.code}).</span>{" "}
+                                            Adding, editing, or deleting milestones here does <strong>not</strong> update the invoice — align the invoice&apos;s payment schedule separately.
+                                        </p>
+                                    </div>
+                                )}
                                 <div className="flex text-[11px] font-bold text-slate-400 bg-white border-b border-slate-100 px-8 py-3 uppercase tracking-wider">
                                     <div className="flex-1">Payment Name</div>
                                     <div className="w-32">Percentage</div>
@@ -3411,6 +3436,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                         paidAt={undoPaymentTarget.paidAt || null}
                         paymentDate={undoPaymentTarget.paymentDate || null}
                         hasStripeIntent={!!undoPaymentTarget.stripePaymentIntentId}
+                        hasQbPayment={undoPaymentTarget.paymentMethod === "quickbooks"}
                         currentBalance={currentBalance}
                         estimateTotal={total}
                         currentStatus={status}

--- a/src/app/projects/[id]/invoices/[invoiceId]/InvoiceEditor.tsx
+++ b/src/app/projects/[id]/invoices/[invoiceId]/InvoiceEditor.tsx
@@ -8,6 +8,7 @@ import SendInvoiceModal from "@/components/SendInvoiceModal";
 import RecordPaymentModal from "@/components/RecordPaymentModal";
 import BulkActionBar from "@/components/BulkActionBar";
 import SendMilestonesModal from "@/components/SendMilestonesModal";
+import UndoPaymentModal from "@/components/UndoPaymentModal";
 import { toast } from "sonner";
 import { formatCurrency } from "@/lib/utils";
 
@@ -41,7 +42,7 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
     const [milestoneAmount, setMilestoneAmount] = useState("");
     const [milestoneDueDate, setMilestoneDueDate] = useState<string>("");
     const [isAddingMilestone, setIsAddingMilestone] = useState(false);
-    const [isUndoing, setIsUndoing] = useState<string | null>(null);
+    const [undoPaymentTarget, setUndoPaymentTarget] = useState<any | null>(null);
     const [recordingFor, setRecordingFor] = useState<{ id: string; name: string; amount: number } | null>(null);
     const [isSendingReceipt, setIsSendingReceipt] = useState<string | null>(null);
     const [qbBusy, setQbBusy] = useState<string | null>(null);
@@ -207,15 +208,13 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
     }
 
     async function handleUnrecord(paymentId: string) {
-        setIsUndoing(paymentId);
         try {
             await unrecordPayment(paymentId, initialInvoice.id);
             toast("Payment unrecorded");
+            setUndoPaymentTarget(null);
             router.refresh();
         } catch (e: any) {
             toast.error(e?.message || "Failed to unrecord payment");
-        } finally {
-            setIsUndoing(null);
         }
     }
 
@@ -766,12 +765,11 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                                                                     : payment.receiptSentAt ? "Resend Receipt" : "Send Receipt"}
                                                             </button>
                                                             <button
-                                                                onClick={() => handleUnrecord(payment.id)}
-                                                                disabled={isUndoing === payment.id}
-                                                                className="text-xs text-hui-textMuted hover:text-red-600 underline underline-offset-2 disabled:opacity-50"
+                                                                onClick={() => setUndoPaymentTarget(payment)}
+                                                                className="text-xs text-hui-textMuted hover:text-red-600 underline underline-offset-2"
                                                                 title="Mark as unpaid"
                                                             >
-                                                                {isUndoing === payment.id ? "Undoing..." : "Undo"}
+                                                                Undo
                                                             </button>
                                                         </>
                                                     )}
@@ -810,6 +808,35 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                     }}
                 />
             )}
+
+            {/* Undo Payment Modal */}
+            {undoPaymentTarget && (() => {
+                const payments = initialInvoice.payments || [];
+                const invoiceTotal = Number(initialInvoice.totalAmount) || 0;
+                const paidSchedules = payments.filter((p: any) => p.status === "Paid");
+                const paidSum = paidSchedules.reduce((sum: number, p: any) => sum + (Number(p.amount) || 0), 0);
+                const currentBalance = Math.max(0, invoiceTotal - paidSum);
+                return (
+                    <UndoPaymentModal
+                        milestoneName={undoPaymentTarget.name || "Payment"}
+                        amount={Number(undoPaymentTarget.amount) || 0}
+                        paymentMethod={undoPaymentTarget.paymentMethod || null}
+                        referenceNumber={undoPaymentTarget.referenceNumber || null}
+                        paidAt={undoPaymentTarget.paidAt || null}
+                        paymentDate={undoPaymentTarget.paymentDate || null}
+                        hasStripeIntent={!!undoPaymentTarget.stripePaymentIntentId}
+                        hasQbPayment={!!undoPaymentTarget.qbPaymentId || undoPaymentTarget.paymentMethod === "quickbooks"}
+                        entityLabel="invoice"
+                        currentBalance={currentBalance}
+                        estimateTotal={invoiceTotal}
+                        currentStatus={initialInvoice.status}
+                        otherPaidCount={paidSchedules.filter((p: any) => p.id !== undoPaymentTarget.id).length}
+                        statusBeforePayment={null}
+                        onClose={() => setUndoPaymentTarget(null)}
+                        onConfirm={() => handleUnrecord(undoPaymentTarget.id)}
+                    />
+                );
+            })()}
 
             {selectedIds.size > 0 && (
                 <BulkActionBar

--- a/src/app/projects/[id]/invoices/[invoiceId]/InvoiceEditor.tsx
+++ b/src/app/projects/[id]/invoices/[invoiceId]/InvoiceEditor.tsx
@@ -209,7 +209,13 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
 
     async function handleUnrecord(paymentId: string) {
         try {
-            await unrecordPayment(paymentId, initialInvoice.id);
+            const res = await unrecordPayment(paymentId, initialInvoice.id);
+            if (!res?.success) {
+                toast.error("Nothing to unrecord — the payment may have already been undone");
+                setUndoPaymentTarget(null);
+                router.refresh();
+                return;
+            }
             toast("Payment unrecorded");
             setUndoPaymentTarget(null);
             router.refresh();
@@ -825,7 +831,7 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                         paidAt={undoPaymentTarget.paidAt || null}
                         paymentDate={undoPaymentTarget.paymentDate || null}
                         hasStripeIntent={!!undoPaymentTarget.stripePaymentIntentId}
-                        hasQbPayment={!!undoPaymentTarget.qbPaymentId || undoPaymentTarget.paymentMethod === "quickbooks"}
+                        hasQbPayment={undoPaymentTarget.paymentMethod === "quickbooks"}
                         entityLabel="invoice"
                         currentBalance={currentBalance}
                         estimateTotal={invoiceTotal}

--- a/src/components/UndoPaymentModal.tsx
+++ b/src/components/UndoPaymentModal.tsx
@@ -49,9 +49,13 @@ export default function UndoPaymentModal({
 
     const paidDate = paidAt || paymentDate;
     const newBalance = Math.min(estimateTotal, currentBalance + amount);
+    // Mirrors unrecordPayment's status ladder: invoices keep Overdue when the
+    // last payment is undone and the invoice was already Overdue.
     const newStatus = otherPaidCount > 0
         ? (newBalance <= 0 ? "Paid" : "Partially Paid")
-        : (statusBeforePayment || (entityLabel === "invoice" ? "Issued" : "Approved"));
+        : entityLabel === "invoice"
+            ? (currentStatus === "Overdue" ? "Overdue" : "Issued")
+            : (statusBeforePayment || "Approved");
     const taxImpact = estimateTotal > 0
         ? Math.round((amount / estimateTotal) * 100)
         : 0;
@@ -59,7 +63,7 @@ export default function UndoPaymentModal({
     const canConfirm = confirmText.toUpperCase() === "UNDO";
 
     async function handleConfirm() {
-        if (!canConfirm) return;
+        if (!canConfirm || isSubmitting) return;
         setIsSubmitting(true);
         try {
             await onConfirm();

--- a/src/components/UndoPaymentModal.tsx
+++ b/src/components/UndoPaymentModal.tsx
@@ -11,6 +11,8 @@ interface UndoPaymentModalProps {
     paidAt: string | null;
     paymentDate: string | null;
     hasStripeIntent: boolean;
+    hasQbPayment?: boolean;
+    entityLabel?: "estimate" | "invoice";
     currentBalance: number;
     estimateTotal: number;
     currentStatus: string;
@@ -23,7 +25,7 @@ interface UndoPaymentModalProps {
 const METHOD_LABELS: Record<string, string> = {
     card: "Card", ach: "ACH", check: "Check", cash: "Cash",
     zelle: "Zelle", venmo: "Venmo", credit_card: "Credit Card",
-    wire: "Wire Transfer", other: "Other",
+    wire: "Wire Transfer", quickbooks: "QuickBooks", other: "Other",
 };
 
 function formatMethod(method: string | null, ref: string | null): string {
@@ -37,6 +39,7 @@ function formatMethod(method: string | null, ref: string | null): string {
 export default function UndoPaymentModal({
     milestoneName, amount, paymentMethod, referenceNumber,
     paidAt, paymentDate, hasStripeIntent,
+    hasQbPayment = false, entityLabel = "estimate",
     currentBalance, estimateTotal, currentStatus,
     otherPaidCount, statusBeforePayment,
     onClose, onConfirm,
@@ -48,7 +51,7 @@ export default function UndoPaymentModal({
     const newBalance = Math.min(estimateTotal, currentBalance + amount);
     const newStatus = otherPaidCount > 0
         ? (newBalance <= 0 ? "Paid" : "Partially Paid")
-        : (statusBeforePayment || "Approved");
+        : (statusBeforePayment || (entityLabel === "invoice" ? "Issued" : "Approved"));
     const taxImpact = estimateTotal > 0
         ? Math.round((amount / estimateTotal) * 100)
         : 0;
@@ -113,6 +116,22 @@ export default function UndoPaymentModal({
                     </div>
                 )}
 
+                {/* QuickBooks warning */}
+                {hasQbPayment && (
+                    <div className="mx-6 mt-4 rounded-lg bg-amber-50 border border-amber-200 px-4 py-3 flex gap-3">
+                        <svg className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+                        </svg>
+                        <div>
+                            <p className="text-sm font-semibold text-amber-800">QuickBooks payment detected</p>
+                            <p className="text-xs text-amber-700 mt-0.5">
+                                Undoing only changes ProBuild — it does <strong>not</strong> void or refund the payment in QuickBooks Online.
+                                Void or refund it in QuickBooks as well; if it stays applied there, the hourly QuickBooks sync will mark this milestone paid again.
+                            </p>
+                        </div>
+                    </div>
+                )}
+
                 {/* Cascading effects */}
                 <div className="mx-6 mt-4 space-y-2">
                     <p className="text-xs font-semibold text-slate-600 uppercase tracking-wide">This will:</p>
@@ -137,7 +156,7 @@ export default function UndoPaymentModal({
                                     <path strokeLinecap="round" strokeLinejoin="round" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01" />
                                 </svg>
                                 <span>
-                                    Change estimate status from <strong className="capitalize">{currentStatus}</strong> to <strong className="capitalize">{newStatus}</strong>
+                                    Change {entityLabel} status from <strong className="capitalize">{currentStatus}</strong> to <strong className="capitalize">{newStatus}</strong>
                                 </span>
                             </li>
                         )}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1366,6 +1366,7 @@ export const getEstimate = cache(async function getEstimate(id: string) {
                 paymentSchedules: { orderBy: { order: "asc" } },
                 expenses: true,
                 files: { orderBy: { createdAt: "desc" } },
+                invoices: { select: { id: true, code: true, status: true } },
             },
         });
     } catch {

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1397,6 +1397,7 @@ export const getEstimate = cache(async function getEstimate(id: string) {
                 },
                 paymentSchedules: { orderBy: { order: "asc" } },
                 expenses: true,
+                invoices: { select: { id: true, code: true, status: true } },
             },
         });
     }


### PR DESCRIPTION
Picks up sessions 03 and 04 from the QBO gap list.

## 03 — Payment Undo disconnect warning
- Invoice editor **Undo** no longer fires instantly — it opens the existing heavy `UndoPaymentModal` (type UNDO to confirm), same as the estimate editor.
- `UndoPaymentModal` gains a **QuickBooks warning** (parallel to the Stripe one): undoing only changes ProBuild — it does not void/refund in QBO, and if the payment stays applied there **the hourly QuickBooks sync will re-mark the milestone paid**.
- Estimate editor passes the QBO flag for mirrored QBO-settled copies; modal wording is entity-aware (estimate/invoice).

## 04 — Estimate milestone changes after invoicing
- `getEstimate` now includes generated invoices (`id/code/status`).
- When an invoice exists, the estimate's Payment Schedule shows an amber banner: milestone changes here do **not** cascade to the invoice.
- Deleting a milestone on an invoiced estimate asks for explicit confirmation naming the invoice.

No server-side money writers changed (only a read include). UI-level guards only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)