### PR TITLE
feat(estimates): ChatGPT MCP connector — push draft estimates into ProBuild

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,6 @@ ANTHROPIC_API_KEY=your_anthropic_api_key_here
 GITHUB_TOKEN=ghp_your_github_token_here
 GITHUB_REPO=Clarion1631/probuild
 PHANTOM_WEBHOOK_SECRET=generate_a_strong_random_secret_here
+
+# Shared secret for the ChatGPT MCP connector (/api/mcp) — any long random string
+MCP_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ qa-screenshots/
 
 # Google OAuth token cache (dev only - prod uses GMAIL_REFRESH_TOKEN env)
 .gmail-token.json
+
+# ChatGPT MCP connector local secret
+.mcp-secret

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "jose": "^6.2.2",
         "jspdf": "^4.2.1",
         "lucide-react": "^0.577.0",
+        "mcp-handler": "^1.1.0",
         "next": "16.1.6",
         "next-auth": "^4.24.13",
         "next-safe-action": "^8.3.0",
@@ -2374,9 +2375,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -4759,6 +4760,71 @@
       "peerDependencies": {
         "@types/three": ">=0.144.0",
         "three": ">=0.144.0"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -7704,6 +7770,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/code-block-writer": {
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
@@ -9910,6 +9985,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/gensync": {
@@ -12263,6 +12347,55 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mcp-handler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mcp-handler/-/mcp-handler-1.1.0.tgz",
+      "integrity": "sha512-MVCES7g18gcoZy+R/3v5nadkUMzMAWdos8jRl6DyljOKvd2/ZKDmwlCjL6zp4vo+7FeCXOYL1uWinHWlkKAAUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^11.1.0",
+        "redis": "^4.6.0"
+      },
+      "bin": {
+        "create-mcp-route": "dist/cli/index.js",
+        "mcp-adapter": "dist/cli/index.js",
+        "mcp-handler": "dist/cli/index.js"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "1.26.0",
+        "next": ">=13.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": false
+        },
+        "next": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mcp-handler/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/mcp-handler/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -14557,6 +14690,23 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
       }
     },
     "node_modules/redux": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "jose": "^6.2.2",
     "jspdf": "^4.2.1",
     "lucide-react": "^0.577.0",
+    "mcp-handler": "^1.1.0",
     "next": "16.1.6",
     "next-auth": "^4.24.13",
     "next-safe-action": "^8.3.0",

--- a/scripts/verify-gpt-estimate.ts
+++ b/scripts/verify-gpt-estimate.ts
@@ -1,0 +1,87 @@
+// One-off E2E check for createEstimateFromPhases: creates a draft estimate against
+// a real lead, verifies items/groups/codes/milestones, then deletes it (cascade).
+import { prisma } from "../src/lib/prisma";
+import { createEstimateFromPhases } from "../src/lib/gpt-estimate";
+
+async function main() {
+    const lead = await prisma.lead.findFirst({ select: { id: true, name: true } });
+    if (!lead) throw new Error("No lead found to test against");
+    console.log(`Testing against lead: ${lead.name} (${lead.id})`);
+
+    const result = await createEstimateFromPhases({
+        title: "MCP VERIFY — DELETE ME",
+        leadId: lead.id,
+        phases: [
+            {
+                phaseName: "Demolition",
+                phaseCode: "01-DEMO",
+                items: [
+                    { name: "Demo cabinets", costType: "Labor", quantity: 8, unit: "hours", unitCost: 85 },
+                    { name: "Dumpster", costCode: "20-CLEAN", costType: "Equipment", quantity: 1, unit: "each", unitCost: 450 },
+                ],
+            },
+            {
+                phaseName: "Cabinetry",
+                phaseCode: "11-CABINET",
+                items: [
+                    { name: "Base cabinets", costCode: "11-CABINET", costType: "Material", quantity: 12, unit: "lf", unitCost: 210 },
+                    { name: "Bad code item", costCode: "99-NOPE", costType: "Material", quantity: 1, unitCost: 100 },
+                    { name: "Fractional item", costType: "Material", quantity: 3, unitCost: 33.333 },
+                ],
+            },
+        ],
+        paymentMilestones: [
+            { name: "Deposit", percentage: 30 },
+            { name: "Completion", percentage: 70 },
+        ],
+    });
+
+    if (!result.ok) throw new Error(`create failed: ${result.error}`);
+    console.log("Created:", result.estimateId, result.code, "total:", result.totalAmount);
+    console.log("Warnings:", result.warnings);
+
+    const est = await prisma.estimate.findUnique({
+        where: { id: result.estimateId },
+        include: {
+            items: { orderBy: { order: "asc" }, include: { costCode: true, costType: true } },
+            paymentSchedules: { orderBy: { order: "asc" } },
+        },
+    });
+    if (!est) throw new Error("estimate not found after create");
+
+    const sections = est.items.filter(i => i.type === "Section");
+    const milestoneSum = est.paymentSchedules.reduce((s, m) => s + Number(m.amount), 0);
+    const checks: [string, boolean][] = [
+        ["status Draft", est.status === "Draft"],
+        ["privacy Private", est.privacy === "Private"],
+        ["code is EST-<number>", /^EST-\d{5}$/.test(est.code)],
+        ["7 items (2 sections + 5 lines)", est.items.length === 7],
+        ["2 section rows", sections.length === 2],
+        ["children linked to parents", est.items.filter(i => i.parentId).length === 5],
+        ["demo item inherits phase code 01-DEMO", est.items.find(i => i.name === "Demo cabinets")?.costCode?.code === "01-DEMO"],
+        ["dumpster overrides to 20-CLEAN", est.items.find(i => i.name === "Dumpster")?.costCode?.code === "20-CLEAN"],
+        ["labor cost type mapped", est.items.find(i => i.name === "Demo cabinets")?.costType?.name === "Labor"],
+        ["bad explicit code stays uncoded", est.items.find(i => i.name === "Bad code item")?.costCodeId === null],
+        ["bad code warned", result.warnings.some(w => w.includes("99-NOPE"))],
+        ["fractional line rounded to cents", Number(est.items.find(i => i.name === "Fractional item")?.total) === 99.99],
+        ["section totals = sum of children", sections.every(s => Math.abs(Number(s.total) - est.items.filter(i => i.parentId === s.id).reduce((sum, c) => sum + Number(c.total), 0)) < 0.005)],
+        ["2 milestones", est.paymentSchedules.length === 2],
+        ["milestones sum exactly to total", Math.abs(milestoneSum - Number(est.totalAmount)) < 0.005],
+        ["totalAmount matches", Math.abs(Number(est.totalAmount) - result.totalAmount) < 0.01],
+    ];
+
+    let failed = 0;
+    for (const [label, ok] of checks) {
+        console.log(`${ok ? "PASS" : "FAIL"}  ${label}`);
+        if (!ok) failed++;
+    }
+
+    await prisma.estimate.delete({ where: { id: result.estimateId } });
+    const gone = await prisma.estimateItem.count({ where: { estimateId: result.estimateId } });
+    console.log(`Cleanup: estimate deleted, remaining items: ${gone}`);
+
+    if (failed > 0) throw new Error(`${failed} checks failed`);
+    console.log("ALL CHECKS PASSED");
+}
+
+main().then(() => process.exit(0)).catch(e => { console.error(e); process.exit(1); });

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -1,0 +1,162 @@
+import { createHash, timingSafeEqual } from "crypto";
+import { createMcpHandler } from "mcp-handler";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { createEstimateFromPhases, CLOSED_PROJECT_STATUSES, CLOSED_LEAD_STAGES } from "@/lib/gpt-estimate";
+
+// MCP connector for ChatGPT (streamable HTTP at POST /api/mcp/mcp).
+//
+// Lets an external AI assistant draft estimates and push them into ProBuild as
+// Draft/Private estimates. Read surface is deliberately small (project + lead
+// names, cost codes); the only write is create_estimate.
+//
+// Auth: shared secret in the query string (?key=<MCP_SECRET>), same
+// machine-to-machine pattern as /api/integrations. ChatGPT custom connectors
+// offer only OAuth or no-auth, so the secret rides in the connector URL.
+// /api/mcp is excluded from the session-redirect matcher in src/proxy.ts.
+
+export const maxDuration = 60;
+
+function textResult(data: unknown) {
+    return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+const phaseItemSchema = z.object({
+    name: z.string().min(1).max(300).describe("Line item name, e.g. 'Demo existing cabinets'"),
+    description: z.string().max(2000).optional(),
+    costCode: z.string().max(50).optional().describe("ProBuild cost code (the 'code' value from get_estimating_codes, e.g. '01-DEMO'). Set on every item."),
+    costType: z.string().max(50).optional().describe("ProBuild cost type name from get_estimating_codes, e.g. 'Labor' or 'Material'."),
+    quantity: z.number().positive().max(1_000_000).describe("Quantity in the given unit"),
+    unit: z.string().max(30).optional().describe("e.g. 'sq ft', 'hours', 'job'"),
+    unitCost: z.number().min(0).max(10_000_000).describe("Sell price per unit in USD"),
+});
+
+const phaseSchema = z.object({
+    phaseName: z.string().min(1).max(300).describe("Phase heading, e.g. 'Demolition'"),
+    phaseCode: z.string().max(50).optional().describe("Default cost code for the phase; items without their own costCode inherit it."),
+    items: z.array(phaseItemSchema).min(1).max(200),
+});
+
+const milestoneSchema = z.object({
+    name: z.string().min(1).max(300).describe("e.g. 'Deposit'"),
+    percentage: z.number().positive().max(100).describe("Percent of the estimate total; all milestones together must sum to exactly 100"),
+});
+
+const handler = createMcpHandler(
+    server => {
+        server.registerTool(
+            "list_projects",
+            {
+                title: "List ProBuild projects",
+                description: "List open projects (id, name, client, status). Use the id as create_estimate's projectId.",
+                inputSchema: {},
+            },
+            async () => {
+                const projects = await prisma.project.findMany({
+                    where: { status: { notIn: CLOSED_PROJECT_STATUSES } },
+                    take: 200,
+                    orderBy: { createdAt: "desc" },
+                    select: { id: true, name: true, status: true, type: true, location: true, client: { select: { name: true } } },
+                });
+                return textResult(projects.map(p => ({
+                    id: p.id, name: p.name, client: p.client?.name ?? null, status: p.status, type: p.type, location: p.location,
+                })));
+            },
+        );
+
+        server.registerTool(
+            "list_leads",
+            {
+                title: "List ProBuild leads",
+                description: "List open leads (id, name, client, stage). Use the id as create_estimate's leadId when the job has no project yet.",
+                inputSchema: {},
+            },
+            async () => {
+                const leads = await prisma.lead.findMany({
+                    where: { stage: { notIn: CLOSED_LEAD_STAGES } },
+                    take: 200,
+                    orderBy: { createdAt: "desc" },
+                    select: { id: true, name: true, stage: true, projectType: true, location: true, client: { select: { name: true } } },
+                });
+                return textResult(leads.map(l => ({
+                    id: l.id, name: l.name, client: l.client?.name ?? null, stage: l.stage, projectType: l.projectType, location: l.location,
+                })));
+            },
+        );
+
+        server.registerTool(
+            "get_estimating_codes",
+            {
+                title: "Get ProBuild cost codes and cost types",
+                description: "Returns the active cost codes and cost types. ALWAYS call this before create_estimate and put a valid costCode + costType on every line item.",
+                inputSchema: {},
+            },
+            async () => {
+                const [costCodes, costTypes] = await Promise.all([
+                    prisma.costCode.findMany({ where: { isActive: true }, orderBy: { code: "asc" }, select: { code: true, name: true, description: true } }),
+                    prisma.costType.findMany({ where: { isActive: true }, orderBy: { name: "asc" }, select: { name: true } }),
+                ]);
+                return textResult({ costCodes, costTypes: costTypes.map(t => t.name) });
+            },
+        );
+
+        server.registerTool(
+            "create_estimate",
+            {
+                title: "Create a draft estimate in ProBuild",
+                description:
+                    "Push a phase-grouped estimate into ProBuild against one project OR one lead. " +
+                    "Creates it as Draft/Private for human review — it is not customer-visible until shared. " +
+                    "Workflow: get_estimating_codes first, then list_projects or list_leads to resolve the target, then call this once. " +
+                    "Returns the ProBuild URL of the new estimate plus warnings for any cost codes that didn't match.",
+                inputSchema: {
+                    title: z.string().min(1).max(300).describe("Estimate title, e.g. 'Hamilton Kitchen Remodel'"),
+                    projectId: z.string().max(50).optional().describe("Target project id from list_projects (omit if using leadId)"),
+                    leadId: z.string().max(50).optional().describe("Target lead id from list_leads (omit if using projectId)"),
+                    phases: z.array(phaseSchema).min(1).max(50),
+                    paymentMilestones: z.array(milestoneSchema).max(20).optional(),
+                },
+            },
+            async args => {
+                const result = await createEstimateFromPhases(args);
+                if (!result.ok) {
+                    return { ...textResult({ error: result.error }), isError: true };
+                }
+                return textResult(result);
+            },
+        );
+    },
+    {
+        serverInfo: { name: "probuild", version: "1.0.0" },
+        capabilities: { tools: {} },
+        instructions:
+            "ProBuild is Golden Touch Remodeling's construction management system. " +
+            "To build an estimate: call get_estimating_codes, draft phases with line items using those cost codes and cost types, " +
+            "confirm the target project or lead with the user (list_projects / list_leads), then create_estimate. " +
+            "All prices are USD sell prices. Estimates arrive as private drafts for review in ProBuild.",
+    },
+    { basePath: "/api/mcp", maxDuration: 60 },
+);
+
+// Shared-secret gate. Hash both sides to a fixed length before the timing-safe
+// compare so neither content nor secret length leaks through timing.
+function authorized(req: Request): boolean {
+    const secret = process.env.MCP_SECRET;
+    if (!secret) return false;
+    const key = new URL(req.url).searchParams.get("key") ?? "";
+    const a = createHash("sha256").update(key).digest();
+    const b = createHash("sha256").update(secret).digest();
+    return timingSafeEqual(a, b);
+}
+
+function guarded(req: Request) {
+    if (!process.env.MCP_SECRET) {
+        return Response.json({ error: "MCP connector not configured" }, { status: 503 });
+    }
+    if (!authorized(req)) {
+        return Response.json({ error: "unauthorized" }, { status: 401 });
+    }
+    return handler(req);
+}
+
+export { guarded as GET, guarded as POST, guarded as DELETE };

--- a/src/lib/ai-estimate-transform.ts
+++ b/src/lib/ai-estimate-transform.ts
@@ -11,6 +11,7 @@ export type AiPhaseItem = {
     name?: string;
     description?: string;
     costType?: string;
+    costCode?: string; // per-item cost code (e.g. "01-DEMO"); falls back to the phase's phaseCode
     quantity?: number | string;
     unit?: string;
     unitCost?: number | string;
@@ -31,6 +32,11 @@ function toNum(v: unknown): number {
         return isFinite(n) ? n : 0;
     }
     return 0;
+}
+
+/** Round to cents so Decimal columns never accumulate float drift. */
+function toCents(n: number): number {
+    return Math.round(n * 100) / 100;
 }
 
 function makeItem(i: {
@@ -74,7 +80,35 @@ export function transformPhasesToItems(
         const phase = aiPhases[pi];
         const parentId = `imp_${ts}_p${pi}`;
         const phaseItems = phase.items || [];
-        const phaseTotal = phaseItems.reduce((s, it) => s + (toNum(it.quantity) || 1) * toNum(it.unitCost), 0);
+        const parentOrder = order++;
+
+        // Child rows first: each line total is rounded to cents, and the phase total
+        // is the sum of those rounded totals so parent and children always agree.
+        const children: ReturnType<typeof makeItem>[] = [];
+        for (let ii = 0; ii < phaseItems.length; ii++) {
+            const item = phaseItems[ii];
+            const qty = toNum(item.quantity) || 1;
+            const uc = toCents(toNum(item.unitCost));
+            children.push(makeItem({
+                id: `imp_${ts}_p${pi}_i${ii}`,
+                name: item.name || "Item",
+                description: item.description || "",
+                type: item.costType || "Material",
+                quantity: qty,
+                unitCost: uc,
+                total: toCents(qty * uc),
+                parentId,
+                // An explicit item costCode wins outright: if it doesn't match a real
+                // code the item stays uncoded (callers warn) rather than silently
+                // inheriting the phase code. Only absent costCode falls back.
+                costCodeId: item.costCode
+                    ? (codeMap[item.costCode] ?? null)
+                    : (phase.phaseCode ? (codeMap[phase.phaseCode] ?? null) : null),
+                costTypeId: item.costType ? (typeMap[item.costType] ?? null) : null,
+                order: order++,
+            }));
+        }
+        const phaseTotal = toCents(children.reduce((s, c) => s + c.total, 0));
 
         // Parent row — phase header (type "Section" so editor renders it as a collapsible group).
         // unitCost = phaseTotal so qty(1) * unitCost = total survives the save-path recomputation.
@@ -89,41 +123,37 @@ export function transformPhasesToItems(
             parentId: null,
             costCodeId: phase.phaseCode ? (codeMap[phase.phaseCode] ?? null) : null,
             costTypeId: null,
-            order: order++,
+            order: parentOrder,
         }));
-
-        // Child rows
-        for (let ii = 0; ii < phaseItems.length; ii++) {
-            const item = phaseItems[ii];
-            const qty = toNum(item.quantity) || 1;
-            const uc = toNum(item.unitCost);
-            estimateItems.push(makeItem({
-                id: `imp_${ts}_p${pi}_i${ii}`,
-                name: item.name || "Item",
-                description: item.description || "",
-                type: item.costType || "Material",
-                quantity: qty,
-                unitCost: uc,
-                total: qty * uc,
-                parentId,
-                costCodeId: phase.phaseCode ? (codeMap[phase.phaseCode] ?? null) : null,
-                costTypeId: item.costType ? (typeMap[item.costType] ?? null) : null,
-                order: order++,
-            }));
-        }
+        estimateItems.push(...children);
     }
 
-    const totalEstimate = estimateItems
+    const totalEstimate = toCents(estimateItems
         .filter(i => !i.parentId) // sum phase totals only
-        .reduce((s, i) => s + i.total, 0);
+        .reduce((s, i) => s + i.total, 0));
 
+    // Milestone amounts are rounded to cents. When the percentages genuinely cover
+    // the whole estimate, the last milestone absorbs the rounding residual so the
+    // schedule sums to the estimate total exactly.
+    // Round the percentage sum to 2dp before comparing so float noise (33.33*3
+    // = 99.99000000000001) can't push a boundary case outside the tolerance.
+    // Must stay consistent with the milestone validation in gpt-estimate.ts.
+    const pcts = aiMilestones.map(m => toNum(m.percentage));
+    const pctSum = toCents(pcts.reduce((s, p) => s + p, 0));
+    const coversTotal = aiMilestones.length > 0 && Math.abs(pctSum - 100) <= 0.01;
+    let allocated = 0;
     const paymentMilestones = aiMilestones.map((m, idx) => {
-        const pct = toNum(m.percentage);
+        const pct = pcts[idx];
+        const isLast = idx === aiMilestones.length - 1;
+        const amount = coversTotal && isLast
+            ? toCents(totalEstimate - allocated)
+            : toCents(pct / 100 * totalEstimate);
+        allocated = toCents(allocated + amount);
         return {
             id: `pm_${ts}_${idx}`,
             name: m.name || `Payment ${idx + 1}`,
             percentage: String(pct || 0),
-            amount: (pct / 100 * totalEstimate).toFixed(2),
+            amount: amount.toFixed(2),
             dueDate: "",
         };
     });

--- a/src/lib/gpt-estimate.ts
+++ b/src/lib/gpt-estimate.ts
@@ -1,0 +1,203 @@
+import { randomUUID } from "crypto";
+import { prisma } from "@/lib/prisma";
+import { transformPhasesToItems, type AiData } from "@/lib/ai-estimate-transform";
+
+// Persists a phase-grouped estimate payload (the shape ChatGPT emits via the MCP
+// connector) as a real Estimate. Reuses transformPhasesToItems so the MCP path,
+// the editor's paste-import and the AI generator can never drift, then writes the
+// grouped items with real parent/child links (unlike the flat takeoff conversion).
+//
+// Estimates land as status "Draft" / privacy "Private" so nothing AI-priced is
+// visible in the customer portal until a human reviews and shares it.
+
+// Shared with the MCP list tools: create_estimate only accepts targets those
+// tools would surface.
+export const CLOSED_PROJECT_STATUSES = ["Closed Complete", "Closed Lost"];
+export const CLOSED_LEAD_STAGES = ["Won", "Closed Lost"];
+
+export type CreateEstimateInput = {
+    title: string;
+    projectId?: string;
+    leadId?: string;
+    phases: AiData["phases"];
+    paymentMilestones?: AiData["paymentMilestones"];
+};
+
+export type CreateEstimateResult =
+    | {
+          ok: true;
+          estimateId: string;
+          code: string;
+          title: string;
+          totalAmount: number;
+          itemCount: number;
+          url: string;
+          warnings: string[];
+      }
+    | { ok: false; error: string };
+
+// Validation failures raised inside the transaction; mapped to { ok: false }.
+class EstimateInputError extends Error {}
+
+export async function createEstimateFromPhases(input: CreateEstimateInput): Promise<CreateEstimateResult> {
+    const { title, projectId, leadId, phases, paymentMilestones } = input;
+
+    if (!title?.trim()) return { ok: false, error: "title is required" };
+    if ((projectId ? 1 : 0) + (leadId ? 1 : 0) !== 1) {
+        return { ok: false, error: "Provide exactly one of projectId or leadId (use list_projects / list_leads to find the right one)." };
+    }
+    if (!Array.isArray(phases) || phases.length === 0) {
+        return { ok: false, error: 'phases must be a non-empty array of { phaseName, items: [...] }.' };
+    }
+    const hasItems = phases.some(p => Array.isArray(p?.items) && p.items.length > 0);
+    if (!hasItems) return { ok: false, error: "No phase contains line items — each phase needs an items array." };
+
+    if (paymentMilestones && paymentMilestones.length > 0) {
+        // Same rounded-to-2dp predicate as the transform's coversTotal check, so a
+        // set that passes here always gets the residual-absorbing last milestone.
+        const pctSum = Math.round(paymentMilestones.reduce((s, m) => s + (Number(m.percentage) || 0), 0) * 100) / 100;
+        if (Math.abs(pctSum - 100) > 0.01) {
+            return { ok: false, error: `paymentMilestones percentages must sum to 100 (got ${pctSum}).` };
+        }
+    }
+
+    const [costCodes, costTypes] = await Promise.all([
+        prisma.costCode.findMany({ where: { isActive: true }, select: { id: true, code: true, name: true } }),
+        prisma.costType.findMany({ where: { isActive: true }, select: { id: true, name: true } }),
+    ]);
+
+    // Surface unmatched codes/types as warnings rather than failing the import —
+    // the transform leaves those items uncoded and the editor can fix them.
+    const knownCodes = new Set(costCodes.map(c => c.code));
+    const knownTypes = new Set(costTypes.map(t => t.name));
+    const warnings: string[] = [];
+    for (const phase of phases) {
+        if (phase?.phaseCode && !knownCodes.has(phase.phaseCode)) {
+            warnings.push(`Unknown phase cost code "${phase.phaseCode}" (phase "${phase.phaseName ?? "?"}") — left uncoded.`);
+        }
+        for (const item of phase?.items ?? []) {
+            if (item?.costCode && !knownCodes.has(item.costCode)) {
+                warnings.push(`Unknown cost code "${item.costCode}" on item "${item.name ?? "?"}" — left uncoded.`);
+            }
+            if (item?.costType && !knownTypes.has(item.costType)) {
+                warnings.push(`Unknown cost type "${item.costType}" on item "${item.name ?? "?"}" — left uncoded.`);
+            }
+        }
+    }
+
+    const transformed = transformPhasesToItems(
+        { phases, paymentMilestones: paymentMilestones ?? [] },
+        costCodes,
+        costTypes,
+    );
+
+    // The transform emits placeholder ids (imp_<ts>_p0, ...) with parentId references;
+    // remap them to fresh ids so they can be persisted with real parent links.
+    const idMap = new Map<string, string>();
+    for (const item of transformed.items) idMap.set(item.id, randomUUID());
+    const mapParentId = (tempId: string): string => {
+        const mapped = idMap.get(tempId);
+        if (!mapped) throw new Error(`transform produced item with unknown parentId "${tempId}"`);
+        return mapped;
+    };
+
+    let estimate;
+    try {
+        estimate = await prisma.$transaction(async tx => {
+            // Target checks live inside the transaction so a concurrent delete can't
+            // slip between validation and insert, and only open records qualify —
+            // the same filter list_projects / list_leads apply. A status change in
+            // the instant between this check and commit is accepted: worst case is
+            // a Draft/Private estimate on a just-closed record, which is harmless
+            // and not worth a row lock.
+            if (projectId) {
+                const project = await tx.project.findFirst({
+                    where: { id: projectId, status: { notIn: CLOSED_PROJECT_STATUSES } },
+                    select: { id: true },
+                });
+                if (!project) throw new EstimateInputError(`No open project with id ${projectId}. Call list_projects for valid ids.`);
+            } else if (leadId) {
+                const lead = await tx.lead.findFirst({
+                    where: { id: leadId, stage: { notIn: CLOSED_LEAD_STAGES } },
+                    select: { id: true },
+                });
+                if (!lead) throw new EstimateInputError(`No open lead with id ${leadId}. Call list_leads for valid ids.`);
+            }
+
+            // EST-TEMP then rename from the autoincrement `number` — the same
+            // collision-free pattern the app's own estimate creation uses.
+            const created = await tx.estimate.create({
+                data: {
+                    title: title.trim(),
+                    projectId: projectId ?? null,
+                    leadId: leadId ?? null,
+                    code: "EST-TEMP",
+                    status: "Draft",
+                    privacy: "Private",
+                    totalAmount: transformed.totalEstimate,
+                    balanceDue: transformed.totalEstimate,
+                },
+            });
+            const est = await tx.estimate.update({
+                where: { id: created.id },
+                data: { code: `EST-${String(created.number).padStart(5, "0")}` },
+            });
+
+            const parents = transformed.items.filter(i => !i.parentId);
+            const children = transformed.items.filter(i => i.parentId);
+            for (const group of [parents, children]) {
+                if (group.length === 0) continue;
+                await tx.estimateItem.createMany({
+                    data: group.map(i => ({
+                        id: idMap.get(i.id)!,
+                        estimateId: est.id,
+                        name: i.name,
+                        description: i.description || null,
+                        type: i.type,
+                        quantity: i.quantity,
+                        baseCost: i.baseCost,
+                        markupPercent: i.markupPercent,
+                        unitCost: i.unitCost,
+                        total: i.total,
+                        order: i.order,
+                        parentId: i.parentId ? mapParentId(i.parentId) : null,
+                        costCodeId: i.costCodeId,
+                        costTypeId: i.costTypeId,
+                    })),
+                });
+            }
+
+            if (transformed.paymentMilestones.length > 0) {
+                await tx.estimatePaymentSchedule.createMany({
+                    data: transformed.paymentMilestones.map((m, idx) => ({
+                        estimateId: est.id,
+                        name: m.name,
+                        percentage: parseFloat(m.percentage) || 0,
+                        amount: parseFloat(m.amount) || 0,
+                        order: idx,
+                    })),
+                });
+            }
+
+            return est;
+        });
+    } catch (err) {
+        if (err instanceof EstimateInputError) return { ok: false, error: err.message };
+        throw err;
+    }
+
+    const url = projectId
+        ? `https://probuild.goldentouchremodeling.com/projects/${projectId}/estimates/${estimate.id}`
+        : `https://probuild.goldentouchremodeling.com/leads/${leadId}/estimates/${estimate.id}`;
+
+    return {
+        ok: true,
+        estimateId: estimate.id,
+        code: estimate.code,
+        title: estimate.title,
+        totalAmount: transformed.totalEstimate,
+        itemCount: transformed.items.length,
+        url,
+        warnings,
+    };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -38,6 +38,7 @@ export const config = {
          * - api/payments (Client portal payment sessions)
          * - api/portal (Public backend handlers for documents)
          * - api/integrations (Machine-to-machine ingest — own shared-secret auth)
+         * - api/mcp (ChatGPT MCP connector — own shared-secret auth)
          * - api/version (Deployment-id probe for the stale-tab refresh banner)
          * - login (The login page itself)
          * - portal (Client portal, if public/token-based)
@@ -48,6 +49,6 @@ export const config = {
          * - favicon.ico, public folder images, etc
          * - manifest.webmanifest (PWA manifest — must be fetchable for install)
          */
-        "/((?!api/auth|api/cron|api/twilio|api/webhook|api/payments|api/portal|api/integrations|api/version|api/pdf/estimates|api/pdf/invoices|api/sub-portal|api/mobile|login|portal|sub-portal|share|_next/static|_next/image|favicon.ico|.*\\.png|.*\\.jpg|.*\\.svg|.*\\.webmanifest).*)",
+        "/((?!api/auth|api/cron|api/twilio|api/webhook|api/payments|api/portal|api/integrations|api/mcp/|api/version|api/pdf/estimates|api/pdf/invoices|api/sub-portal|api/mobile|login|portal|sub-portal|share|_next/static|_next/image|favicon.ico|.*\\.png|.*\\.jpg|.*\\.svg|.*\\.webmanifest).*)",
     ],
 };


### PR DESCRIPTION
## What

Adds an MCP (Model Context Protocol) connector endpoint so ChatGPT (Richard's ChatGPT Projects, via a custom connector) can build estimates conversationally and push them straight into ProBuild.

- `POST /api/mcp/mcp` via mcp-handler (streamable HTTP), shared-secret auth (`?key=` vs `MCP_SECRET`, sha256 + timingSafeEqual), excluded from session middleware with a segment-terminated matcher entry (`api/mcp/`)
- Tools: `list_projects`, `list_leads` (open records only, capped at 200), `get_estimating_codes`, `create_estimate`
- `create_estimate` reuses the shared `transformPhasesToItems` (same path as the editor's paste-import), persists phase Sections + child items with real parent links, maps per-item cost codes (explicit `costCode` wins; unknown codes warn and stay uncoded), writes cents-exact totals (last milestone absorbs rounding residue), numbers estimates collision-free via `EST-TEMP` → `EST-<number>`, and always lands as **Draft / Private** so nothing is customer-visible until reviewed
- `MCP_SECRET` already set in Vercel production env

## Review

Two Codex rounds (gpt-5.5, xhigh). Round 1 findings all fixed (matcher scoping, EST-code collisions, money rounding, zod input bounds, open-target validation inside the transaction, fail-fast parent mapping, hashed timing-safe compare, gitignored local secret). Round 2: no blockers; milestone float-epsilon tolerance fixed, TOCTOU on target status accepted (worst case: private draft on a just-closed record).

## Verification

- `npm run build` (typecheck + next build) passes
- E2E script `scripts/verify-gpt-estimate.ts` (creates → verifies → deletes a real estimate): 16/16 checks — phase grouping, cost-code inherit/override/unknown handling, cents rounding, milestone sum = estimate total, EST-code format
- Live JSON-RPC smoke test: 401 without key; initialize/tools/list/tools-call all work with key

🤖 Generated with [Claude Code](https://claude.com/claude-code)
