### PR TITLE
feat(estimates): standard phase templates + ChatGPT template tools

### DIFF
--- a/scripts/estimate-template-seeds.ts
+++ b/scripts/estimate-template-seeds.ts
@@ -1,0 +1,329 @@
+// Source of truth for GTR's standard estimate templates ("chunks" + room templates).
+// Structure mirrors the proven "Bathroom Remodel" template: phases (Section rows with
+// a cost code) containing typed line items with real-world starting rates drawn from
+// estimate history (labor $55-65/hr, subs $105-115/hr, dust control ~$2k, dumpster $450...).
+// Phase order follows the Project Book production sequence (Phase 0 Precon -> 14 Completion).
+// Applied to the DB by seed-estimate-templates.ts (idempotent upsert by template name).
+
+export type SeedItem = {
+    name: string;
+    type: "Labor" | "Material" | "Allowance" | "Subcontractor" | "Equipment" | "Other";
+    quantity: number;
+    unitCost: number;
+    description?: string;
+    costCode?: string; // overrides the phase cost code
+};
+
+export type SeedPhase = {
+    name: string;
+    costCode: string;
+    items: SeedItem[];
+};
+
+export type SeedTemplate = {
+    name: string;
+    phases: SeedPhase[];
+};
+
+// ── Shared chunks: the repeatable procedure blocks nearly every job includes ──
+
+const SUPPORT_CHUNK: SeedPhase[] = [
+    {
+        name: "Project Support & Site Services",
+        costCode: "20-CLEAN",
+        items: [
+            { name: "Floor & Wall Protection / Dust Containment", type: "Labor", quantity: 1, unitCost: 1200, costCode: "28-MISC" },
+            { name: "Dust Control Package", type: "Material", quantity: 1, unitCost: 850, costCode: "28-MISC" },
+            { name: "Portable Toilet Rental (monthly)", type: "Equipment", quantity: 1, unitCost: 140 },
+            { name: "Dumpster / Debris Removal", type: "Equipment", quantity: 1, unitCost: 450 },
+            { name: "Progress Job Site Cleanup", type: "Labor", quantity: 8, unitCost: 55 },
+        ],
+    },
+];
+
+const PERMITS_CHUNK: SeedPhase[] = [
+    {
+        name: "Permits & Design",
+        costCode: "21-PERMITS",
+        items: [
+            { name: "Building Permit", type: "Other", quantity: 1, unitCost: 850 },
+            { name: "Permit Expediting & Coordination", type: "Labor", quantity: 3, unitCost: 65 },
+            { name: "Design & Engineering Allowance", type: "Allowance", quantity: 1, unitCost: 1500, costCode: "22-DESIGN" },
+        ],
+    },
+];
+
+const DEMO_CHUNK: SeedPhase[] = [
+    {
+        name: "Demolition",
+        costCode: "01-DEMO",
+        items: [
+            { name: "Demolition - Labor", type: "Labor", quantity: 16, unitCost: 55 },
+            { name: "Dumpster / Debris Removal", type: "Equipment", quantity: 1, unitCost: 450 },
+            { name: "Dump Fees & Disposal", type: "Other", quantity: 1, unitCost: 175 },
+        ],
+    },
+];
+
+const MEP_ROUGH_CHUNK: SeedPhase[] = [
+    {
+        name: "Plumbing Rough-In",
+        costCode: "03-PLUMB",
+        items: [
+            { name: "Rough-In Plumbing", type: "Subcontractor", quantity: 12, unitCost: 115 },
+            { name: "Plumbing Rough Materials", type: "Material", quantity: 1, unitCost: 420 },
+        ],
+    },
+    {
+        name: "Electrical Rough-In",
+        costCode: "04-ELEC",
+        items: [
+            { name: "Electrical Rough-In", type: "Subcontractor", quantity: 8, unitCost: 105 },
+            { name: "Electrical Rough Materials", type: "Material", quantity: 1, unitCost: 280 },
+        ],
+    },
+    {
+        name: "HVAC Rough-In",
+        costCode: "05-HVAC",
+        items: [
+            { name: "HVAC Rough-In / Duct Modifications", type: "Subcontractor", quantity: 6, unitCost: 105 },
+        ],
+    },
+];
+
+const MEP_FINISH_CHUNK: SeedPhase[] = [
+    {
+        name: "Plumbing Finish",
+        costCode: "03-PLUMB",
+        items: [
+            { name: "Plumbing Trim-Out", type: "Subcontractor", quantity: 6, unitCost: 115 },
+            { name: "Plumbing Fixture Allowance", type: "Allowance", quantity: 1, unitCost: 2100, costCode: "19-FIXTURE" },
+        ],
+    },
+    {
+        name: "Electrical Finish",
+        costCode: "04-ELEC",
+        items: [
+            { name: "Electrical Trim-Out", type: "Subcontractor", quantity: 4, unitCost: 105 },
+            { name: "Electrical Finish Items Allowance", type: "Allowance", quantity: 1, unitCost: 1000, costCode: "19-FIXTURE" },
+        ],
+    },
+];
+
+const CLOSEOUT_CHUNK: SeedPhase[] = [
+    {
+        name: "Closeout & Punch List",
+        costCode: "28-MISC",
+        items: [
+            { name: "Punch List Labor", type: "Labor", quantity: 12, unitCost: 55 },
+            { name: "Touch-Up Paint & Materials", type: "Material", quantity: 1, unitCost: 250, costCode: "08-PAINT" },
+            { name: "Final Clean", type: "Subcontractor", quantity: 1, unitCost: 450, costCode: "20-CLEAN" },
+        ],
+    },
+];
+
+// ── Room templates ──
+
+const KITCHEN_REMODEL: SeedPhase[] = [
+    ...PERMITS_CHUNK,
+    ...SUPPORT_CHUNK,
+    ...DEMO_CHUNK,
+    {
+        name: "Framing & Blocking",
+        costCode: "02-FRAME",
+        items: [
+            { name: "Blocking & Backing / Wall Modifications", type: "Labor", quantity: 8, unitCost: 65 },
+            { name: "Framing Materials", type: "Material", quantity: 1, unitCost: 250 },
+        ],
+    },
+    ...MEP_ROUGH_CHUNK,
+    {
+        name: "Drywall",
+        costCode: "07-DRYWALL",
+        items: [
+            { name: "Drywall Hang, Tape & Finish", type: "Subcontractor", quantity: 1, unitCost: 1990 },
+            { name: "Drywall Materials", type: "Material", quantity: 1, unitCost: 350 },
+        ],
+    },
+    {
+        name: "Paint",
+        costCode: "08-PAINT",
+        items: [
+            { name: "Paint Kitchen (walls, ceiling, trim)", type: "Subcontractor", quantity: 1, unitCost: 1600 },
+        ],
+    },
+    {
+        name: "Cabinetry",
+        costCode: "11-CABINET",
+        items: [
+            { name: "Cabinet Allowance", type: "Allowance", quantity: 1, unitCost: 12000 },
+            { name: "Cabinet Installation", type: "Labor", quantity: 24, unitCost: 65 },
+        ],
+    },
+    {
+        name: "Countertops",
+        costCode: "12-COUNTER",
+        items: [
+            { name: "Countertop Allowance (quartz/granite)", type: "Allowance", quantity: 1, unitCost: 4500 },
+        ],
+    },
+    {
+        name: "Tile Backsplash",
+        costCode: "10-TILE",
+        items: [
+            { name: "Backsplash Tile Allowance", type: "Allowance", quantity: 1, unitCost: 650 },
+            { name: "Backsplash Installation", type: "Labor", quantity: 12, unitCost: 65 },
+        ],
+    },
+    {
+        name: "Flooring",
+        costCode: "09-FLOOR",
+        items: [
+            { name: "Flooring Allowance", type: "Allowance", quantity: 1, unitCost: 1800 },
+            { name: "Flooring Installation", type: "Labor", quantity: 1, unitCost: 1100 },
+            { name: "Underlayment", type: "Material", quantity: 1, unitCost: 300 },
+        ],
+    },
+    ...MEP_FINISH_CHUNK,
+    {
+        name: "Appliances",
+        costCode: "18-APPLIANCE",
+        items: [
+            { name: "Appliance Allowance", type: "Allowance", quantity: 1, unitCost: 6000 },
+            { name: "Appliance Install & Hookup", type: "Labor", quantity: 6, unitCost: 65 },
+        ],
+    },
+    ...CLOSEOUT_CHUNK,
+];
+
+const SINGLE_ROOM_REMODEL: SeedPhase[] = [
+    ...SUPPORT_CHUNK,
+    ...DEMO_CHUNK,
+    {
+        name: "Drywall Repair",
+        costCode: "07-DRYWALL",
+        items: [
+            { name: "Drywall Repair & Skim", type: "Labor", quantity: 8, unitCost: 55 },
+            { name: "Drywall Materials", type: "Material", quantity: 1, unitCost: 180 },
+        ],
+    },
+    {
+        name: "Paint",
+        costCode: "08-PAINT",
+        items: [
+            { name: "Paint Room (walls, ceiling, trim)", type: "Subcontractor", quantity: 1, unitCost: 1200 },
+        ],
+    },
+    {
+        name: "Flooring",
+        costCode: "09-FLOOR",
+        items: [
+            { name: "Flooring Allowance (LVP/carpet)", type: "Allowance", quantity: 1, unitCost: 1400 },
+            { name: "Flooring Installation", type: "Labor", quantity: 1, unitCost: 800 },
+            { name: "Underlayment", type: "Material", quantity: 1, unitCost: 200 },
+        ],
+    },
+    {
+        name: "Trim & Millwork",
+        costCode: "13-TRIM",
+        items: [
+            { name: "Baseboard & Casing Install", type: "Labor", quantity: 8, unitCost: 65 },
+            { name: "Millwork Materials", type: "Material", quantity: 1, unitCost: 350 },
+        ],
+    },
+    {
+        name: "Electrical Finish",
+        costCode: "04-ELEC",
+        items: [
+            { name: "Electrical R&R (outlets, switches, fixtures)", type: "Subcontractor", quantity: 4, unitCost: 105 },
+            { name: "Lighting Fixture Allowance", type: "Allowance", quantity: 1, unitCost: 500, costCode: "19-FIXTURE" },
+        ],
+    },
+    ...CLOSEOUT_CHUNK,
+];
+
+const WHOLE_HOUSE_REMODEL: SeedPhase[] = [
+    ...PERMITS_CHUNK,
+    ...SUPPORT_CHUNK,
+    {
+        name: "Strategic Demolition",
+        costCode: "01-DEMO",
+        items: [
+            { name: "Whole House Demolition - Labor", type: "Labor", quantity: 80, unitCost: 55 },
+            { name: "Dumpsters / Debris Removal", type: "Equipment", quantity: 4, unitCost: 450 },
+            { name: "Dump Fees & Disposal", type: "Other", quantity: 4, unitCost: 175 },
+        ],
+    },
+    {
+        name: "Floor System & Structural",
+        costCode: "02-FRAME",
+        items: [
+            { name: "Structural Framing Package", type: "Subcontractor", quantity: 1, unitCost: 6200 },
+            { name: "Structural Materials", type: "Material", quantity: 1, unitCost: 2400 },
+            { name: "Engineering Allowance", type: "Allowance", quantity: 1, unitCost: 1200, costCode: "22-DESIGN" },
+        ],
+    },
+    {
+        name: "Wall Framing",
+        costCode: "02-FRAME",
+        items: [
+            { name: "Wall Framing - Labor", type: "Labor", quantity: 60, unitCost: 65 },
+            { name: "Framing Materials", type: "Material", quantity: 1, unitCost: 1800 },
+        ],
+    },
+    ...MEP_ROUGH_CHUNK,
+    {
+        name: "Insulation",
+        costCode: "06-INSUL",
+        items: [
+            { name: "Insulation (walls & ceiling)", type: "Subcontractor", quantity: 1, unitCost: 2200 },
+        ],
+    },
+    {
+        name: "Drywall",
+        costCode: "07-DRYWALL",
+        items: [
+            { name: "Drywall Hang, Tape & Finish - Whole House", type: "Subcontractor", quantity: 1, unitCost: 9500 },
+            { name: "Drywall Materials", type: "Material", quantity: 1, unitCost: 2100 },
+        ],
+    },
+    {
+        name: "Paint",
+        costCode: "08-PAINT",
+        items: [
+            { name: "Paint - Whole House Interior", type: "Subcontractor", quantity: 1, unitCost: 7500 },
+        ],
+    },
+    {
+        name: "Interior Finishes - Flooring",
+        costCode: "09-FLOOR",
+        items: [
+            { name: "Flooring Allowance - Whole House", type: "Allowance", quantity: 1, unitCost: 9000 },
+            { name: "Flooring Installation", type: "Labor", quantity: 1, unitCost: 4500 },
+            { name: "Underlayment", type: "Material", quantity: 1, unitCost: 1200 },
+        ],
+    },
+    {
+        name: "Interior Finishes - Trim & Doors",
+        costCode: "13-TRIM",
+        items: [
+            { name: "Trim & Millwork Package", type: "Labor", quantity: 60, unitCost: 65 },
+            { name: "Millwork Materials", type: "Material", quantity: 1, unitCost: 2800 },
+            { name: "Interior Door Allowance", type: "Allowance", quantity: 1, unitCost: 2400, costCode: "14-DOOR" },
+        ],
+    },
+    ...MEP_FINISH_CHUNK,
+    ...CLOSEOUT_CHUNK,
+];
+
+export const SEED_TEMPLATES: SeedTemplate[] = [
+    { name: "Chunk — Project Support & Site Services", phases: SUPPORT_CHUNK },
+    { name: "Chunk — Permits & Design", phases: PERMITS_CHUNK },
+    { name: "Chunk — Demolition", phases: DEMO_CHUNK },
+    { name: "Chunk — MEP Rough-In", phases: MEP_ROUGH_CHUNK },
+    { name: "Chunk — MEP Finish", phases: MEP_FINISH_CHUNK },
+    { name: "Chunk — Closeout & Punch List", phases: CLOSEOUT_CHUNK },
+    { name: "Kitchen Remodel", phases: KITCHEN_REMODEL },
+    { name: "Single Room Remodel", phases: SINGLE_ROOM_REMODEL },
+    { name: "Whole House Remodel", phases: WHOLE_HOUSE_REMODEL },
+];

--- a/scripts/seed-estimate-templates.ts
+++ b/scripts/seed-estimate-templates.ts
@@ -1,0 +1,86 @@
+// Seeds/updates GTR's standard estimate templates from estimate-template-seeds.ts.
+// Idempotent: existing templates with the same name are replaced wholesale (items
+// cascade-delete), so re-running after editing the seed data is always safe.
+// The legacy "Bathroom Remodel" template is intentionally untouched.
+//
+// Run: npx tsx --env-file=.env.local scripts/seed-estimate-templates.ts
+import { randomUUID } from "crypto";
+import { prisma } from "../src/lib/prisma";
+import { SEED_TEMPLATES } from "./estimate-template-seeds";
+
+async function main() {
+    const costCodes = await prisma.costCode.findMany({ select: { id: true, code: true } });
+    const codeMap = new Map(costCodes.map(c => [c.code, c.id]));
+
+    // Fail fast on typo'd cost codes rather than seeding uncoded items.
+    const missing = new Set<string>();
+    for (const t of SEED_TEMPLATES) {
+        for (const p of t.phases) {
+            if (!codeMap.has(p.costCode)) missing.add(p.costCode);
+            for (const i of p.items) if (i.costCode && !codeMap.has(i.costCode)) missing.add(i.costCode);
+        }
+    }
+    if (missing.size > 0) throw new Error(`Unknown cost codes in seed data: ${[...missing].join(", ")}`);
+
+    for (const seed of SEED_TEMPLATES) {
+        await prisma.$transaction(async tx => {
+            // Case-insensitive: get_template resolves names insensitively, so a stray
+            // "kitchen remodel" duplicate would make lookups ambiguous.
+            const existing = await tx.estimateTemplate.findMany({
+                where: { name: { equals: seed.name, mode: "insensitive" } },
+                select: { id: true },
+            });
+            if (existing.length > 0) {
+                await tx.estimateTemplate.deleteMany({ where: { id: { in: existing.map(e => e.id) } } });
+            }
+
+            const template = await tx.estimateTemplate.create({ data: { name: seed.name } });
+
+            let order = 0;
+            const rows: Parameters<typeof tx.estimateTemplateItem.createMany>[0]["data"] = [];
+            for (const phase of seed.phases) {
+                const sectionId = randomUUID();
+                const phaseTotal = Math.round(phase.items.reduce((s, i) => s + i.quantity * i.unitCost, 0) * 100) / 100;
+                rows.push({
+                    id: sectionId,
+                    templateId: template.id,
+                    name: phase.name,
+                    description: null,
+                    type: "Section",
+                    quantity: 1,
+                    baseCost: null,
+                    markupPercent: 0,
+                    unitCost: phaseTotal,
+                    order: order++,
+                    parentId: null,
+                    costCodeId: codeMap.get(phase.costCode)!,
+                    costTypeId: null,
+                });
+                for (const item of phase.items) {
+                    rows.push({
+                        id: randomUUID(),
+                        templateId: template.id,
+                        name: item.name,
+                        description: item.description ?? null,
+                        type: item.type,
+                        quantity: item.quantity,
+                        baseCost: null,
+                        markupPercent: 25,
+                        unitCost: item.unitCost,
+                        order: order++,
+                        parentId: sectionId,
+                        costCodeId: codeMap.get(item.costCode ?? phase.costCode)!,
+                        costTypeId: null,
+                    });
+                }
+            }
+            await tx.estimateTemplateItem.createMany({ data: rows });
+            console.log(`seeded: ${seed.name} (${rows.length} items, ${seed.phases.length} phases)`);
+        });
+    }
+
+    const count = await prisma.estimateTemplate.count();
+    console.log(`done — ${count} templates total in DB`);
+}
+
+main().then(() => process.exit(0)).catch(e => { console.error(e); process.exit(1); });

--- a/scripts/verify-template-roundtrip.ts
+++ b/scripts/verify-template-roundtrip.ts
@@ -1,0 +1,56 @@
+// E2E check for the template-first flow: templateToPhases -> createEstimateFromPhases
+// against a real lead, verify structure, then delete (cascade).
+import { prisma } from "../src/lib/prisma";
+import { templateToPhases, createEstimateFromPhases } from "../src/lib/gpt-estimate";
+
+async function main() {
+    const tpl = await templateToPhases("Kitchen Remodel");
+    if (!tpl.ok) throw new Error(tpl.error);
+    console.log(`template: ${tpl.name} — ${tpl.phases.length} phases, ${tpl.phases.reduce((s, p) => s + p.items.length, 0)} items`);
+
+    const badName = await templateToPhases("Not A Real Template");
+    if (badName.ok) throw new Error("expected miss on unknown template name");
+
+    const legacy = await templateToPhases("Mobilization"); // flat template, no Section rows
+    if (!legacy.ok) throw new Error(legacy.error);
+
+    const lead = await prisma.lead.findFirst({ select: { id: true } });
+    if (!lead) throw new Error("no lead to test against");
+
+    const created = await createEstimateFromPhases({
+        title: "TEMPLATE ROUNDTRIP — DELETE ME",
+        leadId: lead.id,
+        phases: tpl.phases,
+        paymentMilestones: [{ name: "Deposit", percentage: 30 }, { name: "Rough-in Complete", percentage: 40 }, { name: "Completion", percentage: 30 }],
+    });
+    if (!created.ok) throw new Error(created.error);
+
+    const est = await prisma.estimate.findUnique({
+        where: { id: created.estimateId },
+        include: { items: { include: { costCode: true } }, paymentSchedules: true },
+    });
+    if (!est) throw new Error("estimate missing after create");
+
+    const sections = est.items.filter(i => i.type === "Section");
+    const children = est.items.filter(i => i.parentId);
+    const uncoded = children.filter(i => !i.costCodeId);
+    const checks: [string, boolean][] = [
+        ["phase count survives round-trip", sections.length === tpl.phases.length],
+        ["all children parented", children.length === est.items.length - sections.length],
+        ["every line item cost-coded", uncoded.length === 0],
+        ["no warnings from template codes", created.warnings.length === 0],
+        ["cabinet allowance labeled Allowance", est.items.find(i => i.name === "Cabinet Allowance")?.type === "Allowance"],
+        ["cabinetry coded 11-CABINET", est.items.find(i => i.name === "Cabinet Allowance")?.costCode?.code === "11-CABINET"],
+        ["milestones sum to total", Math.abs(est.paymentSchedules.reduce((s, m) => s + Number(m.amount), 0) - Number(est.totalAmount)) < 0.005],
+    ];
+
+    let failed = 0;
+    for (const [label, ok] of checks) { console.log(`${ok ? "PASS" : "FAIL"}  ${label}`); if (!ok) failed++; }
+
+    await prisma.estimate.delete({ where: { id: created.estimateId } });
+    console.log("cleanup: deleted", created.estimateId);
+    if (failed) throw new Error(`${failed} checks failed`);
+    console.log("ALL CHECKS PASSED");
+}
+
+main().then(() => process.exit(0)).catch(e => { console.error(e); process.exit(1); });

--- a/src/app/api/ai-estimate/route.ts
+++ b/src/app/api/ai-estimate/route.ts
@@ -31,7 +31,7 @@ AVAILABLE PHASES (use the code field exactly as shown):
 ${phasesList || "Use standard construction phases"}
 
 AVAILABLE COST TYPES (use exactly as shown):
-${typesList || "Labor, Material, Subcontractor, Equipment, Unit, Allowance, Other"}
+${typesList || "Labor, Material, Allowance, Subcontractor, Equipment, Other"}
 
 INSTRUCTIONS:
 - Organize the estimate into 6-12 phases that apply to this project
@@ -72,7 +72,7 @@ Return ONLY a valid JSON object with this exact structure:
         {
           "name": string,
           "description": string,
-          "costType": string (exactly one of: ${typesList || "Labor, Material, Subcontractor, Equipment, Unit, Allowance, Other"}),
+          "costType": string (exactly one of: ${typesList || "Labor, Material, Allowance, Subcontractor, Equipment, Other"}),
           "quantity": number,
           "unit": string (e.g. "sq ft", "hr", "each", "job", "linear ft"),
           "unitCost": number

--- a/src/app/api/ai-estimate/suggest/route.ts
+++ b/src/app/api/ai-estimate/suggest/route.ts
@@ -64,7 +64,7 @@ Parent Item: "${itemName}"
 ${projectName ? `Project: "${projectName}"` : ""}
 ${existingNames ? `Already exists in estimate: ${existingNames}` : ""}
 
-Return ONLY a JSON array of objects with "name", "description", and "costType" (one of: Labor, Material, Subcontractor, Equipment, Unit, Allowance, Other).
+Return ONLY a JSON array of objects with "name", "description", and "costType" (one of: Labor, Material, Allowance, Subcontractor, Equipment, Other).
 
 Example for "Bathroom Tile":
 [

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -2,7 +2,7 @@ import { createHash, timingSafeEqual } from "crypto";
 import { createMcpHandler } from "mcp-handler";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
-import { createEstimateFromPhases, CLOSED_PROJECT_STATUSES, CLOSED_LEAD_STAGES } from "@/lib/gpt-estimate";
+import { createEstimateFromPhases, templateToPhases, CLOSED_PROJECT_STATUSES, CLOSED_LEAD_STAGES } from "@/lib/gpt-estimate";
 
 // MCP connector for ChatGPT (streamable HTTP at POST /api/mcp/mcp).
 //
@@ -87,16 +87,59 @@ const handler = createMcpHandler(
         server.registerTool(
             "get_estimating_codes",
             {
-                title: "Get ProBuild cost codes and cost types",
-                description: "Returns the active cost codes and cost types. ALWAYS call this before create_estimate and put a valid costCode + costType on every line item.",
+                title: "Get ProBuild cost codes and line-item type labels",
+                description: "Returns the active cost codes (REQUIRED on every line item) and the valid costType labels. costType is just a line label — Labor, Material, Allowance, Subcontractor, Equipment, Other — matching how GTR estimates (allowances + lump-sum labor).",
                 inputSchema: {},
             },
             async () => {
-                const [costCodes, costTypes] = await Promise.all([
-                    prisma.costCode.findMany({ where: { isActive: true }, orderBy: { code: "asc" }, select: { code: true, name: true, description: true } }),
-                    prisma.costType.findMany({ where: { isActive: true }, orderBy: { name: "asc" }, select: { name: true } }),
-                ]);
-                return textResult({ costCodes, costTypes: costTypes.map(t => t.name) });
+                const costCodes = await prisma.costCode.findMany({ where: { isActive: true }, orderBy: { code: "asc" }, select: { code: true, name: true, description: true } });
+                // Static labels, not the CostType table — cost types belong to expenses;
+                // estimate lines use these labels only, matching the editor's picker.
+                return textResult({ costCodes, costTypes: ["Labor", "Material", "Allowance", "Subcontractor", "Equipment", "Other"] });
+            },
+        );
+
+        server.registerTool(
+            "list_templates",
+            {
+                title: "List GTR estimate templates",
+                description:
+                    "Catalog of GTR's standard estimate templates. Room templates (Kitchen Remodel, Single Room Remodel, Whole House Remodel, Bathroom Remodel) are full production sequences; " +
+                    "'Chunk — …' templates are reusable procedure blocks (site services, permits, demo, MEP rough/finish, closeout) for composing custom scopes. " +
+                    "ALWAYS start an estimate from these instead of drafting freehand.",
+                inputSchema: {},
+            },
+            async () => {
+                const templates = await prisma.estimateTemplate.findMany({
+                    take: 100,
+                    orderBy: { name: "asc" },
+                    include: { items: { where: { type: "Section" }, orderBy: { order: "asc" }, select: { name: true } } },
+                });
+                const counts = await prisma.estimateTemplateItem.groupBy({ by: ["templateId"], _count: { id: true } });
+                const countMap = new Map(counts.map(c => [c.templateId, c._count.id]));
+                return textResult(templates.map(t => ({
+                    name: t.name,
+                    itemCount: countMap.get(t.id) ?? 0,
+                    phases: t.items.map(i => i.name),
+                })));
+            },
+        );
+
+        server.registerTool(
+            "get_template",
+            {
+                title: "Get a GTR estimate template",
+                description:
+                    "Returns a template's full phases + line items (with cost codes, quantities and starting unit costs) in the exact shape create_estimate accepts. " +
+                    "Pull it, scale quantities/allowances to the actual job with the user, add or drop phases, then create_estimate.",
+                inputSchema: {
+                    name: z.string().min(1).max(300).describe("Template name from list_templates (case-insensitive)"),
+                },
+            },
+            async ({ name }) => {
+                const result = await templateToPhases(name);
+                if (!result.ok) return { ...textResult({ error: result.error }), isError: true };
+                return textResult(result);
             },
         );
 
@@ -127,12 +170,15 @@ const handler = createMcpHandler(
         );
     },
     {
-        serverInfo: { name: "probuild", version: "1.0.0" },
+        serverInfo: { name: "probuild", version: "1.1.0" },
         capabilities: { tools: {} },
         instructions:
             "ProBuild is Golden Touch Remodeling's construction management system. " +
-            "To build an estimate: call get_estimating_codes, draft phases with line items using those cost codes and cost types, " +
-            "confirm the target project or lead with the user (list_projects / list_leads), then create_estimate. " +
+            "TEMPLATE-FIRST workflow for estimates: 1) list_templates, 2) get_template for the closest room template (or compose from 'Chunk — …' blocks), " +
+            "3) scale quantities, allowances and prices to the actual job with the user — template numbers are starting points, " +
+            "4) confirm the target with list_projects / list_leads, 5) create_estimate. " +
+            "Every line item needs a costCode from get_estimating_codes. costType is just a line label (Labor / Material / Allowance / Subcontractor / Equipment / Other) — " +
+            "the user estimates with allowances and lump-sum labor, so keep those labels accurate. " +
             "All prices are USD sell prices. Estimates arrive as private drafts for review in ProBuild.",
     },
     { basePath: "/api/mcp", maxDuration: 60 },

--- a/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
@@ -94,7 +94,7 @@ const CHATGPT_ESTIMATE_PROMPT = `You are a residential remodeling estimator. Pro
       "phaseName": "string (e.g. Demolition)",
       "phaseCode": "string (optional)",
       "items": [
-        { "name": "string", "description": "string", "costType": "Labor | Material | Subcontractor | Equipment | Unit | Allowance | Other", "quantity": number, "unit": "string e.g. sq ft, hr, each, job, linear ft", "unitCost": number }
+        { "name": "string", "description": "string", "costType": "Labor | Material | Allowance | Subcontractor | Equipment | Other", "quantity": number, "unit": "string e.g. sq ft, hr, each, job, linear ft", "unitCost": number }
       ]
     }
   ],
@@ -130,7 +130,8 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
     const [activeTab, setActiveTab] = useState("builder"); // builder | expenses
     const [showSendModal, setShowSendModal] = useState(false);
     const [costCodes, setCostCodes] = useState<any[]>([]);
-    const [costTypes, setCostTypes] = useState<any[]>([]);
+    // Cost types are an expense concept; estimate lines carry a plain type label instead.
+    const ITEM_TYPE_LABELS = ["Labor", "Material", "Allowance", "Subcontractor", "Equipment", "Other"];
     const [showAiModal, setShowAiModal] = useState(false);
     const [aiPrompt, setAiPrompt] = useState("");
     const [isGenerating, setIsGenerating] = useState(false);
@@ -232,6 +233,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                 parentId: item.parentId || null,
                 name: item.name || "",
                 description: item.description || "",
+                type: item.type || "Material",
                 quantity: String(item.quantity || "0"),
                 unitCost: String(item.unitCost || "0"),
                 costCodeId: item.costCodeId || null,
@@ -311,7 +313,6 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
         setAiSuggestingDesc(item.id);
         try {
             const parent = item.parentId ? items.find((i: any) => i.id === item.parentId) : null;
-            const costType = costTypes.find((ct: any) => ct.id === item.costTypeId);
             const res = await fetch("/api/ai-estimate/suggest", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
@@ -320,7 +321,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                     itemName: item.name,
                     parentName: parent?.name,
                     projectName: context.name,
-                    costType: costType?.name || item.type,
+                    costType: item.type,
                 }),
             });
             if (res.ok) {
@@ -379,8 +380,6 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
     }
 
     function acceptSubitemSuggestions(parentId: string, suggestions: any[]) {
-        const typeMap: Record<string, string> = {};
-        for (const ct of costTypes) typeMap[ct.name] = ct.id;
         const newItems = suggestions.map((s: any) => ({
             id: generateId(),
             name: s.name,
@@ -393,7 +392,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
             total: 0,
             parentId,
             costCodeId: null,
-            costTypeId: typeMap[s.costType] || null,
+            costTypeId: null,
         }));
         setItems([...items, ...newItems]);
         setShowSubitemSuggestions(null);
@@ -507,21 +506,49 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
 
     function handleInsertAssembly(assembly: any) {
         const newItems = [...items];
-        const sectionId = generateId();
-        newItems.push({
-            id: sectionId, name: assembly.name, description: "", type: "Section",
-            quantity: 1, baseCost: 0, markupPercent: 0, unitCost: 0, total: 0,
-            parentId: null, costCodeId: null, costTypeId: null, isSection: true,
-        });
-        for (const tItem of assembly.items) {
+        const tItems: any[] = assembly.items || [];
+        const hasSections = tItems.some((t: any) => t.type === "Section");
+
+        if (hasSections) {
+            // Multi-phase template: keep its Section grouping. Grouping is rebuilt by
+            // walking items in order (a Section row starts a group; the CHILD rows after
+            // it belong to it). Stored parentId values reference rows of whatever
+            // estimate the template was saved from and can't be trusted — but
+            // null-vs-set still marks a row as top-level vs child.
+            let currentSectionId: string | null = null;
+            for (const tItem of tItems) {
+                const isSection = tItem.type === "Section";
+                const newId = generateId();
+                newItems.push({
+                    id: newId, name: tItem.name, description: tItem.description || "",
+                    type: tItem.type, quantity: tItem.quantity,
+                    baseCost: Number(tItem.baseCost) || 0, markupPercent: tItem.markupPercent,
+                    unitCost: Number(tItem.unitCost) || 0,
+                    total: (tItem.quantity || 0) * (Number(tItem.unitCost) || 0),
+                    parentId: isSection || tItem.parentId == null ? null : currentSectionId,
+                    costCodeId: tItem.costCodeId, costTypeId: tItem.costTypeId,
+                    ...(isSection ? { isSection: true } : {}),
+                });
+                if (isSection) currentSectionId = newId;
+            }
+        } else {
+            // Flat template: wrap its items in a new section named after the template.
+            const sectionId = generateId();
             newItems.push({
-                id: generateId(), name: tItem.name, description: tItem.description || "",
-                type: tItem.type, quantity: tItem.quantity,
-                baseCost: Number(tItem.baseCost) || 0, markupPercent: tItem.markupPercent,
-                unitCost: Number(tItem.unitCost) || 0,
-                total: (tItem.quantity || 0) * (Number(tItem.unitCost) || 0),
-                parentId: sectionId, costCodeId: tItem.costCodeId, costTypeId: tItem.costTypeId,
+                id: sectionId, name: assembly.name, description: "", type: "Section",
+                quantity: 1, baseCost: 0, markupPercent: 0, unitCost: 0, total: 0,
+                parentId: null, costCodeId: null, costTypeId: null, isSection: true,
             });
+            for (const tItem of tItems) {
+                newItems.push({
+                    id: generateId(), name: tItem.name, description: tItem.description || "",
+                    type: tItem.type, quantity: tItem.quantity,
+                    baseCost: Number(tItem.baseCost) || 0, markupPercent: tItem.markupPercent,
+                    unitCost: Number(tItem.unitCost) || 0,
+                    total: (tItem.quantity || 0) * (Number(tItem.unitCost) || 0),
+                    parentId: sectionId, costCodeId: tItem.costCodeId, costTypeId: tItem.costTypeId,
+                });
+            }
         }
         setItems(newItems);
         setShowAssemblyDropdown(false);
@@ -627,10 +654,6 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
             .then(res => res.json())
             .then(data => { if (Array.isArray(data)) setCostCodes(data); })
             .catch((err) => console.error("[EstimateEditor] Failed to load cost codes:", err));
-        fetch('/api/cost-types?active=true')
-            .then(res => res.json())
-            .then(data => { if (Array.isArray(data)) setCostTypes(data); })
-            .catch((err) => console.error("[EstimateEditor] Failed to load cost types:", err));
     }, []);
 
     // Subtotal from leaf items only (sections would double-count)
@@ -917,7 +940,6 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                     description: aiPrompt,
                     location: context.location || 'Vancouver, WA',
                     costCodes,
-                    costTypes,
                 }),
             });
 
@@ -1020,6 +1042,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                     parentId: item.parentId || null,
                     name: item.name || "",
                     description: item.description || "",
+                    type: item.type || "Material",
                     quantity: String(item.quantity || "0"),
                     unitCost: String(item.unitCost || "0"),
                     costCodeId: item.costCodeId || null,
@@ -1075,7 +1098,6 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                     phases: parsed.phases,
                     paymentMilestones: parsed.paymentMilestones,
                     costCodes,
-                    costTypes,
                 }),
             });
             if (!res.ok) {
@@ -2184,21 +2206,22 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                                                                             ))}
                                                                         </select>
                                                                         <select
-                                                                            value={item.costTypeId || ""}
+                                                                            value={ITEM_TYPE_LABELS.includes(item.type) ? item.type : ""}
                                                                             onChange={e => {
-                                                                                updateItem(index, "costTypeId", e.target.value || null);
-                                                                                const ct = costTypes.find(c => c.id === e.target.value);
-                                                                                if (ct) updateItem(index, "type", ct.name);
+                                                                                const label = e.target.value;
+                                                                                if (!label) return;
+                                                                                // One atomic update: set the label and drop any stale CostType link.
+                                                                                setItems(prev => prev.map((it, i) => i === index ? { ...it, type: label, costTypeId: null } : it));
                                                                             }}
                                                                             className={`hover:bg-slate-200 focus:bg-white focus:ring-1 ring-hui-border text-[11px] rounded-full px-2.5 py-0.5 border-0 focus:outline-none cursor-pointer transition ${
-                                                                                costTypes.find(c => c.id === item.costTypeId)?.name === 'Allowance'
+                                                                                item.type === 'Allowance'
                                                                                     ? 'bg-amber-100 text-amber-700 font-semibold'
                                                                                     : 'bg-slate-100 text-hui-textMuted'
                                                                             }`}
                                                                         >
                                                                             <option value="">Type</option>
-                                                                            {costTypes.map(ct => (
-                                                                                <option key={ct.id} value={ct.id}>{ct.name}</option>
+                                                                            {ITEM_TYPE_LABELS.map(label => (
+                                                                                <option key={label} value={label}>{label}</option>
                                                                             ))}
                                                                         </select>
                                                                         <span className="w-px h-3 bg-slate-200"></span>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -4778,14 +4778,14 @@ export async function saveEstimateAsTemplate(estimateId: string, templateName: s
 export async function getEstimateTemplates() {
     return await prisma.estimateTemplate.findMany({
         orderBy: { createdAt: "desc" },
-        include: { items: { orderBy: { order: "asc" } } },
+        include: { items: { orderBy: [{ order: "asc" }, { id: "asc" }] } },
     });
 }
 
 export async function createEstimateFromTemplate(projectId: string, templateId: string) {
     const template = await prisma.estimateTemplate.findUnique({
         where: { id: templateId },
-        include: { items: { orderBy: { order: "asc" } } },
+        include: { items: { orderBy: [{ order: "asc" }, { id: "asc" }] } },
     });
     if (!template) throw new Error("Template not found");
 
@@ -4804,9 +4804,18 @@ export async function createEstimateFromTemplate(projectId: string, templateId: 
     const templateCode = `EST-${String(estimate.number).padStart(5, "0")}`;
     await prisma.estimate.update({ where: { id: estimate.id }, data: { code: templateCode } });
 
+    // Rebuild grouping by walking items in order: a Section row starts a group and
+    // the child rows after it belong to that group. Stored template parentId VALUES
+    // can't be copied — they reference rows in whatever estimate the template was
+    // saved from, and EstimateItem.parentId is a self-FK, so a raw copy fails or
+    // dangles — but null-vs-set still reliably marks a row as top-level vs child.
+    let currentSectionId: string | null = null;
     for (const item of template.items) {
+        const isSection = item.type === "Section";
+        const newId = crypto.randomUUID();
         await prisma.estimateItem.create({
             data: {
+                id: newId,
                 estimateId: estimate.id,
                 name: item.name,
                 description: item.description || "",
@@ -4817,11 +4826,12 @@ export async function createEstimateFromTemplate(projectId: string, templateId: 
                 unitCost: item.unitCost,
                 total: toNum(item.quantity) * toNum(item.unitCost),
                 order: item.order,
-                parentId: item.parentId,
+                parentId: isSection || item.parentId == null ? null : currentSectionId,
                 costCodeId: item.costCodeId,
                 costTypeId: item.costTypeId,
             },
         });
+        if (isSection) currentSectionId = newId;
     }
 
     revalidatePath(`/projects/${projectId}/estimates`);

--- a/src/lib/gpt-estimate.ts
+++ b/src/lib/gpt-estimate.ts
@@ -39,6 +39,66 @@ export type CreateEstimateResult =
 // Validation failures raised inside the transaction; mapped to { ok: false }.
 class EstimateInputError extends Error {}
 
+/**
+ * Converts a stored EstimateTemplate's flat item rows (Section rows + parentId
+ * children) back into the phases[] shape create_estimate accepts, so ChatGPT can
+ * pull a template, adjust it with the user, and push it back unchanged in form.
+ */
+export async function templateToPhases(templateName: string): Promise<
+    | { ok: true; name: string; phases: { phaseName: string; phaseCode?: string; items: { name: string; description?: string; costCode?: string; costType?: string; quantity: number; unitCost: number }[] }[] }
+    | { ok: false; error: string }
+> {
+    // Template names aren't unique — resolve case-insensitively but prefer an exact
+    // match, and refuse ambiguity rather than answering non-deterministically.
+    const matches = await prisma.estimateTemplate.findMany({
+        where: { name: { equals: templateName, mode: "insensitive" } },
+        include: { items: { orderBy: [{ order: "asc" }, { id: "asc" }] } },
+    });
+    if (matches.length === 0) return { ok: false, error: `No template named "${templateName}". Call list_templates for the catalog.` };
+    const template = matches.find(t => t.name === templateName) ?? (matches.length === 1 ? matches[0] : null);
+    if (!template) return { ok: false, error: `Multiple templates match "${templateName}" (${matches.map(t => `"${t.name}"`).join(", ")}). Use the exact name.` };
+
+    // EstimateTemplateItem.costCodeId is a bare string (no relation) — map to codes manually.
+    const costCodes = await prisma.costCode.findMany({ select: { id: true, code: true } });
+    const codeById = new Map(costCodes.map(c => [c.id, c.code]));
+
+    // Grouping is rebuilt by walking items in order (a Section row starts a phase;
+    // the CHILD rows after it belong to that phase). Stored parentId values reference
+    // rows of whatever estimate the template was saved from and can't be trusted,
+    // but null-vs-set still marks top-level vs child. Genuinely top-level items
+    // (and flat legacy templates) collect in an implicit phase.
+    type Phase = { phaseName: string; phaseCode?: string; items: { name: string; description?: string; costCode?: string; costType?: string; quantity: number; unitCost: number }[] };
+    const phases: Phase[] = [];
+    let currentSection: Phase | null = null;
+    let flat: Phase | null = null;
+
+    for (const item of template.items) {
+        if (item.type === "Section") {
+            currentSection = { phaseName: item.name, phaseCode: (item.costCodeId && codeById.get(item.costCodeId)) || undefined, items: [] };
+            phases.push(currentSection);
+            continue;
+        }
+        let current = item.parentId != null ? currentSection : null;
+        if (!current) {
+            if (!flat) {
+                flat = { phaseName: template.name, items: [] };
+                phases.push(flat);
+            }
+            current = flat;
+        }
+        current.items.push({
+            name: item.name,
+            description: item.description ?? undefined,
+            costCode: (item.costCodeId && codeById.get(item.costCodeId)) || undefined,
+            costType: item.type,
+            quantity: item.quantity,
+            unitCost: Number(item.unitCost),
+        });
+    }
+
+    return { ok: true, name: template.name, phases: phases.filter(p => p.items.length > 0) };
+}
+
 export async function createEstimateFromPhases(input: CreateEstimateInput): Promise<CreateEstimateResult> {
     const { title, projectId, leadId, phases, paymentMilestones } = input;
 


### PR DESCRIPTION
Seeds 9 standard estimate templates (room templates + reusable chunk blocks) in Project Book production order with cost-coded items; adds MCP tools list_templates/get_template for template-first ChatGPT estimating; decouples cost types from the estimate form (plain Labor/Material/Allowance labels); fixes pre-existing createEstimateFromTemplate dangling-parentId bug and type-edits-not-saving bug; editor template insertion now preserves multi-phase grouping.

Two Codex review rounds — all blockers and real issues fixed. Verification: npm run build clean; verify-template-roundtrip 7/7; verify-gpt-estimate 16/16; seeder idempotent (run twice against prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)