### PR TITLE
chore(estimates): rename Chunk templates to Packages

### DIFF
--- a/scripts/estimate-template-seeds.ts
+++ b/scripts/estimate-template-seeds.ts
@@ -316,14 +316,27 @@ const WHOLE_HOUSE_REMODEL: SeedPhase[] = [
     ...CLOSEOUT_CHUNK,
 ];
 
+// "Package" = reusable scope block (matches how GTR already names estimate
+// sections: "Millwork Package", "Appliance Package"...). Room templates are
+// full project blueprints composed of the same phases.
 export const SEED_TEMPLATES: SeedTemplate[] = [
-    { name: "Chunk — Project Support & Site Services", phases: SUPPORT_CHUNK },
-    { name: "Chunk — Permits & Design", phases: PERMITS_CHUNK },
-    { name: "Chunk — Demolition", phases: DEMO_CHUNK },
-    { name: "Chunk — MEP Rough-In", phases: MEP_ROUGH_CHUNK },
-    { name: "Chunk — MEP Finish", phases: MEP_FINISH_CHUNK },
-    { name: "Chunk — Closeout & Punch List", phases: CLOSEOUT_CHUNK },
+    { name: "Site Services Package", phases: SUPPORT_CHUNK },
+    { name: "Permits & Design Package", phases: PERMITS_CHUNK },
+    { name: "Demolition Package", phases: DEMO_CHUNK },
+    { name: "MEP Rough-In Package", phases: MEP_ROUGH_CHUNK },
+    { name: "MEP Finish Package", phases: MEP_FINISH_CHUNK },
+    { name: "Closeout & Punch List Package", phases: CLOSEOUT_CHUNK },
     { name: "Kitchen Remodel", phases: KITCHEN_REMODEL },
     { name: "Single Room Remodel", phases: SINGLE_ROOM_REMODEL },
     { name: "Whole House Remodel", phases: WHOLE_HOUSE_REMODEL },
+];
+
+// Superseded names cleaned up by the seeder so renames don't leave duplicates.
+export const RETIRED_TEMPLATE_NAMES: string[] = [
+    "Chunk — Project Support & Site Services",
+    "Chunk — Permits & Design",
+    "Chunk — Demolition",
+    "Chunk — MEP Rough-In",
+    "Chunk — MEP Finish",
+    "Chunk — Closeout & Punch List",
 ];

--- a/scripts/seed-estimate-templates.ts
+++ b/scripts/seed-estimate-templates.ts
@@ -6,7 +6,7 @@
 // Run: npx tsx --env-file=.env.local scripts/seed-estimate-templates.ts
 import { randomUUID } from "crypto";
 import { prisma } from "../src/lib/prisma";
-import { SEED_TEMPLATES } from "./estimate-template-seeds";
+import { SEED_TEMPLATES, RETIRED_TEMPLATE_NAMES } from "./estimate-template-seeds";
 
 async function main() {
     const costCodes = await prisma.costCode.findMany({ select: { id: true, code: true } });
@@ -21,6 +21,9 @@ async function main() {
         }
     }
     if (missing.size > 0) throw new Error(`Unknown cost codes in seed data: ${[...missing].join(", ")}`);
+
+    const retired = await prisma.estimateTemplate.deleteMany({ where: { name: { in: RETIRED_TEMPLATE_NAMES, mode: "insensitive" } } });
+    if (retired.count > 0) console.log(`removed ${retired.count} retired template(s)`);
 
     for (const seed of SEED_TEMPLATES) {
         await prisma.$transaction(async tx => {

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -105,7 +105,7 @@ const handler = createMcpHandler(
                 title: "List GTR estimate templates",
                 description:
                     "Catalog of GTR's standard estimate templates. Room templates (Kitchen Remodel, Single Room Remodel, Whole House Remodel, Bathroom Remodel) are full production sequences; " +
-                    "'Chunk — …' templates are reusable procedure blocks (site services, permits, demo, MEP rough/finish, closeout) for composing custom scopes. " +
+                    "'… Package' templates are reusable scope blocks (site services, permits, demolition, MEP rough/finish, closeout) for composing custom scopes. " +
                     "ALWAYS start an estimate from these instead of drafting freehand.",
                 inputSchema: {},
             },
@@ -174,7 +174,7 @@ const handler = createMcpHandler(
         capabilities: { tools: {} },
         instructions:
             "ProBuild is Golden Touch Remodeling's construction management system. " +
-            "TEMPLATE-FIRST workflow for estimates: 1) list_templates, 2) get_template for the closest room template (or compose from 'Chunk — …' blocks), " +
+            "TEMPLATE-FIRST workflow for estimates: 1) list_templates, 2) get_template for the closest room template (or compose from the '… Package' scope blocks), " +
             "3) scale quantities, allowances and prices to the actual job with the user — template numbers are starting points, " +
             "4) confirm the target with list_projects / list_leads, 5) create_estimate. " +
             "Every line item needs a costCode from get_estimating_codes. costType is just a line label (Labor / Material / Allowance / Subcontractor / Equipment / Other) — " +


### PR DESCRIPTION
Renames the six reusable scope-block templates from 'Chunk — X' to construction-standard 'X Package' naming (matches GTR's own estimate section names). Seeder retires old names (already run against prod — 12 templates, no duplicates); MCP tool descriptions updated. Rename only, no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)