### PR TITLE
feat(estimates): template curation — provenance, management page, overwrite-on-save

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1037,6 +1037,7 @@ model TakeoffFile {
 model EstimateTemplate {
   id        String                 @id @default(cuid())
   name      String
+  source    String                 @default("custom") // "standard" (seeded GTR library) | "custom" (saved in-app)
   items     EstimateTemplateItem[]
   createdAt DateTime               @default(now())
   updatedAt DateTime               @updatedAt

--- a/scripts/seed-estimate-templates.ts
+++ b/scripts/seed-estimate-templates.ts
@@ -37,7 +37,7 @@ async function main() {
                 await tx.estimateTemplate.deleteMany({ where: { id: { in: existing.map(e => e.id) } } });
             }
 
-            const template = await tx.estimateTemplate.create({ data: { name: seed.name } });
+            const template = await tx.estimateTemplate.create({ data: { name: seed.name, source: "standard" } });
 
             let order = 0;
             const rows: Parameters<typeof tx.estimateTemplateItem.createMany>[0]["data"] = [];

--- a/src/app/api/estimate-templates/route.ts
+++ b/src/app/api/estimate-templates/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+
+// Management surface for the estimate template library (settings/templates).
+// Session-authenticated via middleware like the rest of /api.
+
+export async function GET() {
+    const templates = await prisma.estimateTemplate.findMany({
+        orderBy: [{ source: "desc" }, { name: "asc" }], // standard first, then A-Z
+        include: { items: { orderBy: [{ order: "asc" }, { id: "asc" }], select: { type: true, name: true } } },
+    });
+    return NextResponse.json(templates.map(t => ({
+        id: t.id,
+        name: t.name,
+        source: t.source,
+        itemCount: t.items.length,
+        phases: t.items.filter(i => i.type === "Section").map(i => i.name),
+        createdAt: t.createdAt,
+        updatedAt: t.updatedAt,
+        // updatedAt is set on create too; >2s drift means it was actually modified
+        modified: t.updatedAt.getTime() - t.createdAt.getTime() > 2000,
+    })));
+}
+
+export async function PATCH(req: NextRequest) {
+    let body: { id?: string; name?: string };
+    try {
+        body = await req.json();
+    } catch {
+        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+    const { id, name } = body;
+    if (!id || !name?.trim()) return NextResponse.json({ error: "id and name are required" }, { status: 400 });
+
+    const clash = await prisma.estimateTemplate.findFirst({
+        where: { name: { equals: name.trim(), mode: "insensitive" }, id: { not: id } },
+        select: { name: true },
+    });
+    if (clash) return NextResponse.json({ error: `A template named "${clash.name}" already exists` }, { status: 409 });
+
+    const template = await prisma.estimateTemplate.update({ where: { id }, data: { name: name.trim() } });
+    return NextResponse.json({ id: template.id, name: template.name });
+}
+
+export async function DELETE(req: NextRequest) {
+    const id = new URL(req.url).searchParams.get("id");
+    if (!id) return NextResponse.json({ error: "id is required" }, { status: 400 });
+    await prisma.estimateTemplate.delete({ where: { id } }); // items cascade
+    return NextResponse.json({ ok: true });
+}

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -112,14 +112,16 @@ const handler = createMcpHandler(
             async () => {
                 const templates = await prisma.estimateTemplate.findMany({
                     take: 100,
-                    orderBy: { name: "asc" },
+                    orderBy: [{ source: "desc" }, { name: "asc" }], // standard library first
                     include: { items: { where: { type: "Section" }, orderBy: { order: "asc" }, select: { name: true } } },
                 });
                 const counts = await prisma.estimateTemplateItem.groupBy({ by: ["templateId"], _count: { id: true } });
                 const countMap = new Map(counts.map(c => [c.templateId, c._count.id]));
                 return textResult(templates.map(t => ({
                     name: t.name,
+                    source: t.source, // "standard" = curated GTR library, "custom" = saved in-app
                     itemCount: countMap.get(t.id) ?? 0,
+                    updatedAt: t.updatedAt.toISOString().slice(0, 10),
                     phases: t.items.map(i => i.name),
                 })));
             },

--- a/src/app/settings/layout.tsx
+++ b/src/app/settings/layout.tsx
@@ -53,6 +53,7 @@ export default function SettingsLayout({ children }: { children: React.ReactNode
                         <ul className="space-y-0.5">
                             {navLink("/settings/contacts", "Contacts")}
                             {navLink("/settings/cost-codes", "Cost Codes")}
+                            {navLink("/settings/templates", "Estimate Templates")}
                             {navLink("/settings/catalog", "Design Catalog")}
                         </ul>
                     </div>

--- a/src/app/settings/templates/page.tsx
+++ b/src/app/settings/templates/page.tsx
@@ -1,0 +1,160 @@
+"use client";
+export const dynamic = "force-dynamic";
+
+import { useState, useEffect } from "react";
+import { toast } from "sonner";
+
+type TemplateRow = {
+    id: string;
+    name: string;
+    source: string; // "standard" | "custom"
+    itemCount: number;
+    phases: string[];
+    createdAt: string;
+    updatedAt: string;
+    modified: boolean;
+};
+
+function fmtDate(iso: string) {
+    return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}
+
+export default function EstimateTemplatesPage() {
+    const [templates, setTemplates] = useState<TemplateRow[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [expanded, setExpanded] = useState<string | null>(null);
+    const [renaming, setRenaming] = useState<TemplateRow | null>(null);
+    const [renameValue, setRenameValue] = useState("");
+
+    useEffect(() => { void fetchTemplates(); }, []);
+
+    async function fetchTemplates() {
+        const res = await fetch("/api/estimate-templates");
+        if (res.ok) setTemplates(await res.json());
+        else toast.error("Failed to load templates");
+        setLoading(false);
+    }
+
+    async function handleRename(e: React.FormEvent) {
+        e.preventDefault();
+        if (!renaming || !renameValue.trim()) return;
+        const res = await fetch("/api/estimate-templates", {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ id: renaming.id, name: renameValue.trim() }),
+        });
+        if (res.ok) {
+            toast.success("Template renamed");
+            setRenaming(null);
+            void fetchTemplates();
+        } else {
+            const d = await res.json().catch(() => ({}));
+            toast.error(d.error || "Rename failed");
+        }
+    }
+
+    async function handleDelete(t: TemplateRow) {
+        const warning = t.source === "standard"
+            ? `"${t.name}" is a GTR standard template. Deleting it removes it for ChatGPT too (the seeder can restore it). Delete?`
+            : `Delete "${t.name}"? This can't be undone.`;
+        if (!confirm(warning)) return;
+        const res = await fetch(`/api/estimate-templates?id=${t.id}`, { method: "DELETE" });
+        if (res.ok) {
+            toast.success("Template deleted");
+            void fetchTemplates();
+        } else toast.error("Delete failed");
+    }
+
+    return (
+        <div>
+            <div className="flex justify-between items-start mb-4">
+                <div>
+                    <h1 className="text-xl font-bold text-hui-textMain">Estimate Templates</h1>
+                    <p className="text-sm text-hui-textMuted mt-1">
+                        The template library ChatGPT and the estimate editor pull from.
+                        <span className="font-medium"> Standard</span> = seeded GTR library; <span className="font-medium">Custom</span> = saved in ProBuild.
+                    </p>
+                </div>
+            </div>
+
+            <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 text-xs text-blue-800 mb-4">
+                <strong>To edit a template's contents:</strong> insert it into any estimate (Insert Assembly), adjust the items,
+                select them and save as a template <em>with the same name</em> — it replaces the existing one instead of creating a duplicate.
+            </div>
+
+            {loading ? (
+                <p className="text-sm text-hui-textMuted">Loading…</p>
+            ) : (
+                <div className="bg-white border border-hui-border rounded-lg overflow-hidden">
+                    <table className="w-full text-sm">
+                        <thead>
+                            <tr className="bg-slate-50 text-[11px] uppercase tracking-wider text-hui-textMuted">
+                                <th className="text-left px-4 py-2.5">Template</th>
+                                <th className="text-left px-3 py-2.5">Source</th>
+                                <th className="text-right px-3 py-2.5">Items</th>
+                                <th className="text-left px-3 py-2.5">Created</th>
+                                <th className="text-left px-3 py-2.5">Modified</th>
+                                <th className="px-3 py-2.5"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {templates.map(t => (
+                                <>
+                                    <tr key={t.id} className="border-t border-hui-border hover:bg-slate-50">
+                                        <td className="px-4 py-2.5">
+                                            <button onClick={() => setExpanded(expanded === t.id ? null : t.id)} className="font-medium text-hui-textMain hover:text-hui-primary text-left">
+                                                {t.name}
+                                            </button>
+                                        </td>
+                                        <td className="px-3 py-2.5">
+                                            <span className={`text-[10px] font-semibold uppercase tracking-wide rounded-full px-2 py-0.5 ${t.source === "standard" ? "bg-violet-100 text-violet-700" : "bg-slate-100 text-slate-600"}`}>
+                                                {t.source}
+                                            </span>
+                                        </td>
+                                        <td className="px-3 py-2.5 text-right text-hui-textMuted">{t.itemCount}</td>
+                                        <td className="px-3 py-2.5 text-hui-textMuted">{fmtDate(t.createdAt)}</td>
+                                        <td className="px-3 py-2.5 text-hui-textMuted">{t.modified ? fmtDate(t.updatedAt) : "—"}</td>
+                                        <td className="px-3 py-2.5 text-right whitespace-nowrap">
+                                            <button onClick={() => { setRenaming(t); setRenameValue(t.name); }} className="text-xs text-hui-primary hover:underline mr-3">Rename</button>
+                                            <button onClick={() => handleDelete(t)} className="text-xs text-red-600 hover:underline">Delete</button>
+                                        </td>
+                                    </tr>
+                                    {expanded === t.id && (
+                                        <tr key={`${t.id}-phases`} className="border-t border-hui-border bg-slate-50">
+                                            <td colSpan={6} className="px-6 py-2.5 text-xs text-hui-textMuted">
+                                                {t.phases.length > 0
+                                                    ? <><span className="font-semibold text-hui-textMain">Phases:</span> {t.phases.join(" → ")}</>
+                                                    : "No phase sections (flat item list)."}
+                                            </td>
+                                        </tr>
+                                    )}
+                                </>
+                            ))}
+                            {templates.length === 0 && (
+                                <tr><td colSpan={6} className="px-4 py-6 text-center text-hui-textMuted">No templates yet.</td></tr>
+                            )}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+
+            {renaming && (
+                <div className="fixed inset-0 bg-slate-900/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+                    <form onSubmit={handleRename} className="bg-white rounded-xl shadow-2xl max-w-md w-full p-6">
+                        <h2 className="text-lg font-bold text-hui-textMain mb-3">Rename template</h2>
+                        <input
+                            value={renameValue}
+                            onChange={e => setRenameValue(e.target.value)}
+                            className="hui-input w-full mb-4"
+                            autoFocus
+                        />
+                        <div className="flex justify-end gap-3">
+                            <button type="button" onClick={() => setRenaming(null)} className="hui-btn hui-btn-secondary">Cancel</button>
+                            <button type="submit" className="hui-btn hui-btn-primary">Save</button>
+                        </div>
+                    </form>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -4751,28 +4751,42 @@ export async function saveEstimateAsTemplate(estimateId: string, templateName: s
     });
     if (!estimate) throw new Error("Estimate not found");
 
+    const itemRows = estimate.items.map((item) => ({
+        name: item.name,
+        description: item.description || "",
+        type: item.type,
+        quantity: item.quantity,
+        baseCost: item.baseCost,
+        markupPercent: item.markupPercent,
+        unitCost: item.unitCost,
+        order: item.order,
+        parentId: item.parentId,
+        costCodeId: item.costCodeId,
+        costTypeId: item.costTypeId,
+    }));
+
+    // Saving under an existing name replaces that template's contents (keeping its
+    // id/source and bumping updatedAt) instead of piling up same-name duplicates.
+    const existing = await prisma.estimateTemplate.findFirst({
+        where: { name: { equals: templateName, mode: "insensitive" } },
+        select: { id: true },
+    });
+    if (existing) {
+        const template = await prisma.$transaction(async tx => {
+            await tx.estimateTemplateItem.deleteMany({ where: { templateId: existing.id } });
+            return tx.estimateTemplate.update({
+                where: { id: existing.id },
+                data: { name: templateName, items: { create: itemRows } },
+            });
+        });
+        return { id: template.id, name: template.name, updated: true };
+    }
+
     const template = await prisma.estimateTemplate.create({
-        data: {
-            name: templateName,
-            items: {
-                create: estimate.items.map((item) => ({
-                    name: item.name,
-                    description: item.description || "",
-                    type: item.type,
-                    quantity: item.quantity,
-                    baseCost: item.baseCost,
-                    markupPercent: item.markupPercent,
-                    unitCost: item.unitCost,
-                    order: item.order,
-                    parentId: item.parentId,
-                    costCodeId: item.costCodeId,
-                    costTypeId: item.costTypeId,
-                })),
-            },
-        },
+        data: { name: templateName, items: { create: itemRows } },
     });
 
-    return { id: template.id, name: template.name };
+    return { id: template.id, name: template.name, updated: false };
 }
 
 export async function getEstimateTemplates() {
@@ -4843,28 +4857,43 @@ export async function createEstimateFromTemplate(projectId: string, templateId: 
 // =============================================
 
 export async function saveItemsAsAssembly(name: string, items: { name: string; description?: string; type: string; quantity: number; baseCost: number; markupPercent: number; unitCost: number; order: number; parentId?: string | null; costCodeId?: string | null; costTypeId?: string | null; isSection?: boolean }[]) {
+    const itemRows = items.map((item, idx) => ({
+        name: item.name,
+        description: item.description || "",
+        type: item.type,
+        quantity: item.quantity,
+        baseCost: item.baseCost || 0,
+        markupPercent: item.markupPercent,
+        unitCost: item.unitCost || 0,
+        order: idx,
+        parentId: item.parentId || null,
+        costCodeId: item.costCodeId || null,
+        costTypeId: item.costTypeId || null,
+    }));
+
+    // Same-name save replaces the existing template (keeps id/source, bumps
+    // updatedAt) so the library doesn't accumulate duplicates.
+    const existing = await prisma.estimateTemplate.findFirst({
+        where: { name: { equals: name, mode: "insensitive" } },
+        select: { id: true },
+    });
+    if (existing) {
+        const template = await prisma.$transaction(async tx => {
+            await tx.estimateTemplateItem.deleteMany({ where: { templateId: existing.id } });
+            return tx.estimateTemplate.update({
+                where: { id: existing.id },
+                data: { name, items: { create: itemRows } },
+                include: { items: true },
+            });
+        });
+        return { id: template.id, name: template.name, itemCount: template.items.length, updated: true };
+    }
+
     const template = await prisma.estimateTemplate.create({
-        data: {
-            name,
-            items: {
-                create: items.map((item, idx) => ({
-                    name: item.name,
-                    description: item.description || "",
-                    type: item.type,
-                    quantity: item.quantity,
-                    baseCost: item.baseCost || 0,
-                    markupPercent: item.markupPercent,
-                    unitCost: item.unitCost || 0,
-                    order: idx,
-                    parentId: item.parentId || null,
-                    costCodeId: item.costCodeId || null,
-                    costTypeId: item.costTypeId || null,
-                })),
-            },
-        },
+        data: { name, items: { create: itemRows } },
         include: { items: true },
     });
-    return { id: template.id, name: template.name, itemCount: template.items.length };
+    return { id: template.id, name: template.name, itemCount: template.items.length, updated: false };
 }
 
 export async function deleteAssembly(templateId: string) {


### PR DESCRIPTION
- EstimateTemplate.source column (standard/custom) — already migrated on prod, 10 standard + 2 custom stamped
- Settings → Estimate Templates management page: provenance badge, created/modified dates, phase preview, rename/delete
- Save-as-template with an existing name replaces contents instead of duplicating (bumps updatedAt) — doubles as the manual edit path
- MCP list_templates returns source + updatedAt, standard library first

Verification: typecheck + full build clean; verify-template-roundtrip 7/7 after changes; reseed idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)