### PR TITLE
feat(billing): change-order lifecycle tools (send for signature + bill to invoice)

### DIFF
--- a/scripts/verify-billing-tools.ts
+++ b/scripts/verify-billing-tools.ts
@@ -2,7 +2,7 @@
 // change-order draft round-trip (create -> verify -> delete), and error paths of
 // the send cores. Deliberately never triggers a customer email or QB send.
 import { prisma } from "../src/lib/prisma";
-import { getProjectBilling, createChangeOrderDraft, sendMilestoneInvoicesCore, resendInvoiceCore } from "../src/lib/billing-core";
+import { getProjectBilling, createChangeOrderDraft, sendMilestoneInvoicesCore, resendInvoiceCore, billChangeOrderCore, sendChangeOrderToClientCore } from "../src/lib/billing-core";
 
 async function main() {
     const checks: [string, boolean][] = [];
@@ -49,7 +49,81 @@ async function main() {
         checks.push(["CO rejects cross-project estimate", !bad.ok]);
     }
 
-    // 3. Send cores: error paths only (never send for real)
+    // 3. Bill-change-order round-trip on a project that HAS an invoice
+    const invProject = await prisma.invoice.findFirst({ select: { id: true, projectId: true, estimateId: true, status: true, totalAmount: true, balanceDue: true } });
+    if (!invProject) throw new Error("no invoice for bill-CO test");
+    const estForCo = invProject.estimateId
+        ? { id: invProject.estimateId }
+        : await prisma.estimate.findFirst({ where: { projectId: invProject.projectId }, select: { id: true } });
+    if (!estForCo) throw new Error("no estimate on invoice project for bill-CO test");
+    const coBill = await createChangeOrderDraft({
+        projectId: invProject.projectId,
+        estimateId: estForCo.id,
+        title: "BILL CO VERIFY — DELETE ME",
+        items: [{ name: "Extra outlet", costCode: "04-ELEC", costType: "Subcontractor", quantity: 2, unitCost: 105 }],
+    });
+    if (!coBill.ok) throw new Error(`bill-CO create failed: ${coBill.error}`);
+
+    // Cleanup in finally so a mid-test failure can't leave a CO/milestone/bumped
+    // totals behind. Statuses of ALL the project's invoices are snapshotted so
+    // whichever invoice billing targets gets its status restored (billing a Paid
+    // invoice flips it to Partially Paid).
+    const statusSnapshot = new Map(
+        (await prisma.invoice.findMany({ where: { projectId: invProject.projectId }, select: { id: true, status: true } }))
+            .map(i => [i.id, i.status]),
+    );
+    let billedMilestoneId: string | null = null;
+    let billedInvoiceId: string | null = null;
+    let billedAmount = 0;
+    try {
+        const notApproved = await billChangeOrderCore(coBill.changeOrderId);
+        checks.push(["billing a Draft CO refuses", !notApproved.ok]);
+
+        await prisma.changeOrder.update({ where: { id: coBill.changeOrderId }, data: { status: "Approved", approvedAt: new Date(), approvedBy: "verify-script" } });
+        const billed = await billChangeOrderCore(coBill.changeOrderId);
+        if (!billed.ok) throw new Error(`bill failed: ${billed.error}`);
+        billedMilestoneId = billed.milestoneId;
+        billedInvoiceId = billed.invoiceId;
+        billedAmount = billed.amount;
+        checks.push(["billed CO creates Pending milestone", billed.alreadyBilled === false && billed.milestoneStatus === "Pending"]);
+        checks.push(["milestone amount = CO total", Math.abs(billed.amount - 210) < 0.005]);
+
+        const again = await billChangeOrderCore(coBill.changeOrderId);
+        checks.push(["second bill is idempotent", again.ok && again.alreadyBilled === true && again.milestoneId === billed.milestoneId]);
+    } finally {
+        // Belt & braces: if the bill result was lost mid-test, find the milestone
+        // by its CO-code prefix so cleanup still removes it.
+        if (!billedMilestoneId) {
+            const coRow = await prisma.changeOrder.findUnique({ where: { id: coBill.changeOrderId }, select: { code: true } });
+            if (coRow) {
+                const stray = await prisma.paymentSchedule.findFirst({
+                    where: { name: { startsWith: `${coRow.code} — ` }, invoice: { projectId: invProject.projectId } },
+                    select: { id: true, amount: true, invoiceId: true },
+                });
+                if (stray) { billedMilestoneId = stray.id; billedInvoiceId = stray.invoiceId; billedAmount = Number(stray.amount); }
+            }
+        }
+        const originalStatus = billedInvoiceId ? statusSnapshot.get(billedInvoiceId) : undefined;
+        await prisma.$transaction([
+            ...(billedMilestoneId ? [prisma.paymentSchedule.delete({ where: { id: billedMilestoneId } })] : []),
+            ...(billedInvoiceId ? [prisma.invoice.update({
+                where: { id: billedInvoiceId },
+                data: {
+                    totalAmount: { decrement: billedAmount },
+                    balanceDue: { decrement: billedAmount },
+                    ...(originalStatus ? { status: originalStatus } : {}),
+                },
+            })] : []),
+            prisma.changeOrder.delete({ where: { id: coBill.changeOrderId } }),
+        ]);
+        console.log("bill-CO cleanup done (finally)");
+    }
+
+    // 3b. Change-order send: error path only (never emails)
+    const badCoSend = await sendChangeOrderToClientCore("not-a-real-co");
+    checks.push(["CO send: bad id errors cleanly", badCoSend.success === false]);
+
+    // 4. Send cores: error paths only (never send for real)
     const badSend = await sendMilestoneInvoicesCore("not-a-real-invoice", ["x"], undefined, undefined, "test");
     checks.push(["milestone send: bad invoice errors cleanly", badSend.success === false && badSend.error === "Invoice not found"]);
     const badResend = await resendInvoiceCore("not-a-real-invoice");

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -3,7 +3,7 @@ import { createMcpHandler } from "mcp-handler";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { createEstimateFromPhases, templateToPhases, CLOSED_PROJECT_STATUSES, CLOSED_LEAD_STAGES } from "@/lib/gpt-estimate";
-import { getProjectBilling, sendMilestoneInvoicesCore, resendInvoiceCore, createChangeOrderDraft } from "@/lib/billing-core";
+import { getProjectBilling, sendMilestoneInvoicesCore, resendInvoiceCore, createChangeOrderDraft, billChangeOrderCore, sendChangeOrderToClientCore } from "@/lib/billing-core";
 
 // MCP connector for ChatGPT (streamable HTTP at POST /api/mcp/mcp).
 //
@@ -337,9 +337,74 @@ const handler = createMcpHandler(
                 return textResult(result);
             },
         );
+
+        server.registerTool(
+            "send_change_order",
+            {
+                title: "Send a change order to the customer for signature",
+                description:
+                    "Emails the customer a portal link to review and SIGN a Draft (or re-sends a Sent) change order — they approve or decline on their phone. " +
+                    "TWO-STEP: call without confirmToken for a preview + token, show the user what will be sent and to whom, then echo the confirmToken after they approve. " +
+                    "Once the customer signs (status Approved), bill_change_order puts it on the invoice.",
+                inputSchema: {
+                    changeOrderId: z.string().max(50).describe("Change order id from list_project_billing"),
+                    confirmToken: z.string().max(40).optional().describe("Token from the preview response; supplying it executes the send"),
+                },
+            },
+            async ({ changeOrderId, confirmToken }) => {
+                const co = await prisma.changeOrder.findUnique({
+                    where: { id: changeOrderId },
+                    select: { code: true, title: true, status: true, totalAmount: true, updatedAt: true, project: { select: { name: true, client: { select: { name: true, email: true } } } } },
+                });
+                if (!co) return { ...textResult({ error: "Change order not found" }), isError: true };
+                if (co.status !== "Draft" && co.status !== "Sent") {
+                    return { ...textResult({ error: `Change order ${co.code} is "${co.status}" — only Draft or Sent change orders can be (re)sent for signature.` }), isError: true };
+                }
+                const recipient = co.project?.client?.email ?? "";
+                if (!recipient) {
+                    return { ...textResult({ error: "The client has no email on file — add one in ProBuild first." }), isError: true };
+                }
+
+                // updatedAt in the payload means any edit to the CO between preview
+                // and confirm (title, items, totals) invalidates the token.
+                const payload = JSON.stringify({ changeOrderId, recipient, code: co.code, title: co.title, total: Number(co.totalAmount), status: co.status, updatedAt: co.updatedAt.toISOString() });
+                if (!verifyPreviewToken(confirmToken, payload)) {
+                    return textResult({
+                        preview: true,
+                        changeOrder: { code: co.code, title: co.title, status: co.status, total: Number(co.totalAmount) },
+                        project: co.project?.name,
+                        recipient,
+                        confirmToken: mintPreviewToken(payload),
+                        instruction: "Show this to the user. Call again with this confirmToken ONLY after they explicitly approve.",
+                    });
+                }
+                const result = await sendChangeOrderToClientCore(changeOrderId);
+                if (!result.success) return { ...textResult({ error: result.error }), isError: true };
+                return textResult({ ...result, note: "Customer will sign via the portal link. Once status shows Approved in list_project_billing, use bill_change_order." });
+            },
+        );
+
+        server.registerTool(
+            "bill_change_order",
+            {
+                title: "Bill an approved change order",
+                description:
+                    "Adds an APPROVED change order to the project's invoice as a new payment milestone (idempotent — a CO can only be billed once). " +
+                    "Nothing is emailed by this tool; it returns the milestone id so you can then run send_milestone_invoice (preview → user approval → confirm) " +
+                    "to email the customer the QuickBooks payment link. Find change order ids and statuses via list_project_billing.",
+                inputSchema: {
+                    changeOrderId: z.string().max(50).describe("Change order id from list_project_billing (status must be Approved)"),
+                },
+            },
+            async ({ changeOrderId }) => {
+                const result = await billChangeOrderCore(changeOrderId);
+                if (!result.ok) return { ...textResult({ error: result.error }), isError: true };
+                return textResult(result);
+            },
+        );
     },
     {
-        serverInfo: { name: "probuild", version: "1.2.0" },
+        serverInfo: { name: "probuild", version: "1.3.0" },
         capabilities: { tools: {} },
         instructions:
             "ProBuild is Golden Touch Remodeling's construction management system. " +
@@ -351,7 +416,9 @@ const handler = createMcpHandler(
             "All prices are USD sell prices. Estimates arrive as private drafts for review in ProBuild. " +
             "BILLING: list_project_billing shows a project's invoices/milestones/estimates. send_milestone_invoice and resend_invoice EMAIL THE CUSTOMER — " +
             "always run the preview step, show the user exactly what will be sent and to whom, and only pass confirm: true after their explicit approval. Never self-confirm. " +
-            "create_change_order captures field changes as drafts only. QuickBooks is handled server-side; never ask the user for QuickBooks credentials.",
+            "Change-order lifecycle: create_change_order (draft) → send_change_order (preview + user approval; customer signs via portal) → " +
+            "once Approved, bill_change_order puts it on the invoice → send_milestone_invoice emails the payment link. " +
+            "QuickBooks is handled server-side; never ask the user for QuickBooks credentials.",
     },
     { basePath: "/api/mcp", maxDuration: 60 },
 );

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -7341,79 +7341,14 @@ export async function countersignChangeOrderAsCompany(id: string, signerName: st
 
 export async function sendChangeOrderToClient(changeOrderId: string): Promise<{ success: true; sentTo: string } | { success: false; error: string }> {
     "use server";
-    const co = await prisma.changeOrder.findUnique({
-        where: { id: changeOrderId },
-        include: {
-            project: { include: { client: true } },
-            items: { orderBy: { order: "asc" } },
-        }
-    });
-
-    if (!co) return { success: false, error: "Change order not found" };
-    const client = co.project?.client;
-    if (!client?.email) return { success: false, error: "Client has no email address" };
-
-    // Update status to Sent (only if still in Draft or Sent state)
-    await prisma.changeOrder.updateMany({
-        where: { id: changeOrderId, status: { in: ["Draft", "Sent"] } },
-        data: { status: "Sent", sentAt: new Date() }
-    });
-
-    const { buildClientPortalUrl } = await import("./client-portal-auth");
-    const portalUrl = await buildClientPortalUrl(client.id, client.email, `/portal/change-orders/${changeOrderId}`);
-    const settings = await prisma.companySettings.findUnique({ where: { id: "singleton" } });
-    const companyName = settings?.companyName || "Your Contractor";
-
-    const changeOrderCc = buildCc(client.email, (client as any).additionalEmail);
-    await sendNotification(
-        client.email,
-        `${companyName} sent you a change order to review`,
-        `<!DOCTYPE html>
-        <html>
-        <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 40px 20px; color: #333;">
-            <div style="background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; padding: 32px;">
-                <h2 style="font-size: 20px; margin: 0 0 8px;">Change Order for Your Review</h2>
-                <p style="color: #666; margin: 0 0 24px;">Hi ${client.name},</p>
-                <p style="color: #666; line-height: 1.6;">
-                    ${companyName} has sent you a change order titled "<strong>${co.title}</strong>" for project <strong>${co.project?.name || "your project"}</strong>.
-                    Please review the scope changes and approve or decline.
-                </p>
-                <div style="background: #f9fafb; border-radius: 8px; padding: 16px; text-align: center; margin: 24px 0;">
-                    <div style="color: #666; font-size: 13px; margin-bottom: 4px;">Change Order Amount</div>
-                    <div style="font-size: 24px; font-weight: 700; color: #111;">${formatCurrency(co.totalAmount)}</div>
-                </div>
-                <div style="text-align: center; margin: 32px 0;">
-                    <a href="${portalUrl}" style="display: inline-block; background: #059669; color: #fff; text-decoration: none; padding: 14px 32px; border-radius: 8px; font-weight: 600; font-size: 15px;">
-                        Review Change Order
-                    </a>
-                </div>
-                <p style="color: #999; font-size: 13px; text-align: center;">
-                    Or copy this link: ${portalUrl}
-                </p>
-            </div>
-            <p style="text-align: center; color: #aaa; font-size: 12px; margin-top: 32px;">
-                Sent via ProBuild &bull; ${companyName}
-            </p>
-        </body>
-        </html>`,
-        undefined,
-        { fromName: companyName, replyTo: settings?.email || undefined, cc: changeOrderCc, copyToInternal: true }
-    );
-
-    // Log activity
-    await logActivity({
-        projectId: co.projectId,
-        actorType: "TEAM",
-        actorName: companyName,
-        action: "sent_change_order",
-        entityType: "change_order",
-        entityId: changeOrderId,
-        entityName: `Change Order ${co.code || co.title}`,
-    });
-
-    revalidatePath(`/projects/${co.projectId}/change-orders/${changeOrderId}`);
-    revalidatePath(`/projects/${co.projectId}/change-orders`);
-    return { success: true, sentTo: client.email };
+    // Customer-facing send from the UI — require the changeOrders permission
+    // (this export is a remotely invokable server action). Core logic lives in
+    // billing-core.ts so the shared-secret-gated MCP connector can reuse it.
+    const user = await getCurrentUserWithPermissions();
+    if (!user) return { success: false, error: "Unauthorized" };
+    if (!hasPermission(user, "changeOrders")) return { success: false, error: "Forbidden" };
+    const { sendChangeOrderToClientCore } = await import("./billing-core");
+    return sendChangeOrderToClientCore(changeOrderId);
 }
 
 export async function uploadSubcontractorCOI(subcontractorId: string, formData: FormData) {

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -86,6 +86,14 @@ export async function getProjectBilling(projectId: string) {
         estimates: project.estimates.map(e => ({
             id: e.id, code: e.code, title: e.title, status: e.status, total: Number(e.totalAmount),
         })),
+        changeOrders: (await prisma.changeOrder.findMany({
+            where: { projectId },
+            orderBy: { createdAt: "desc" },
+            select: { id: true, code: true, title: true, status: true, totalAmount: true, approvedAt: true, sentAt: true },
+        })).map(co => ({
+            id: co.id, code: co.code, title: co.title, status: co.status,
+            total: Number(co.totalAmount), approvedAt: co.approvedAt, sentAt: co.sentAt,
+        })),
         invoices: project.invoices.map(inv => ({
             id: inv.id, code: inv.code, status: inv.status,
             total: Number(inv.totalAmount), balanceDue: Number(inv.balanceDue),
@@ -510,6 +518,219 @@ export async function sendMilestoneInvoicesCore(
             error: globalErr?.message || "An unexpected error occurred",
         };
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bill an APPROVED change order: add it as a milestone on the project's invoice
+// (mirrors addInvoiceMilestone's totals math) so the existing QB milestone-send
+// rail can take it from there. Never bills the same CO twice.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type BillChangeOrderOutcome =
+    | { kind: "error"; error: string }
+    | { kind: "duplicate"; dup: { id: string; name: string; amount: number; status: string; invoiceId: string; invoiceCode: string } }
+    | { kind: "created"; milestoneId: string; milestoneName: string; amount: number; invoiceId: string; invoiceCode: string; projectId: string; coCode: string };
+
+export async function billChangeOrderCore(changeOrderId: string) {
+    // Everything — status check, idempotency check, invoice pick, create,
+    // totals bump — runs inside ONE transaction that takes a row lock on the
+    // CO (SELECT ... FOR UPDATE): concurrent bill calls serialize on the row,
+    // and concurrent status writers (approve/decline use plain updates) block
+    // until this transaction commits, so a just-declined CO can't be billed.
+    const outcome = await prisma.$transaction(async (tx): Promise<BillChangeOrderOutcome> => {
+        const locked = await tx.$queryRaw<Array<{ id: string; code: string; title: string; status: string; totalAmount: unknown; projectId: string; estimateId: string }>>`
+            SELECT "id", "code", "title", "status", "totalAmount", "projectId", "estimateId"
+            FROM "ChangeOrder" WHERE "id" = ${changeOrderId} FOR UPDATE`;
+        const co = locked[0];
+        if (!co) return { kind: "error", error: "Change order not found" };
+        if (co.status !== "Approved") {
+            return { kind: "error", error: `Change order ${co.code} is "${co.status}" — only Approved change orders can be billed. Send it for customer signature first.` };
+        }
+        const amount = Math.round(Number(co.totalAmount) * 100) / 100;
+        if (!(amount > 0)) return { kind: "error", error: `Change order ${co.code} has a $0 total — nothing to bill.` };
+
+        // Idempotency: a milestone named after this CO on any of the project's
+        // invoices means it's already billed (unless canceled). Name-prefix match
+        // is the only available link, so an amount mismatch is surfaced for human
+        // review instead of being silently treated as already-billed.
+        const milestoneName = `${co.code} — ${co.title}`.slice(0, 300);
+        const existing = await tx.paymentSchedule.findFirst({
+            where: {
+                name: { startsWith: `${co.code} — ` },
+                status: { not: "Canceled" },
+                invoice: { projectId: co.projectId },
+            },
+            select: { id: true, name: true, amount: true, status: true, invoiceId: true, invoice: { select: { code: true } } },
+        });
+        if (existing) {
+            if (Math.abs(Number(existing.amount) - amount) > 0.005) {
+                return {
+                    kind: "error",
+                    error: `A milestone "${existing.name}" ($${Number(existing.amount).toFixed(2)}) already exists on invoice ${existing.invoice.code} but doesn't match this change order's total ($${amount.toFixed(2)}). Review it in ProBuild before billing.`,
+                };
+            }
+            return { kind: "duplicate", dup: { id: existing.id, name: existing.name, amount: Number(existing.amount), status: existing.status, invoiceId: existing.invoiceId, invoiceCode: existing.invoice.code } };
+        }
+
+        // Target invoice: prefer the one generated from the CO's estimate, else the
+        // project's most recent. No invoice at all -> tell the user to create one
+        // (invoices are auto-created when an estimate is signed) rather than
+        // inventing financial records implicitly.
+        const invoice =
+            (await tx.invoice.findFirst({ where: { estimateId: co.estimateId }, orderBy: { createdAt: "desc" }, select: { id: true, code: true, status: true } })) ??
+            (await tx.invoice.findFirst({ where: { projectId: co.projectId }, orderBy: { createdAt: "desc" }, select: { id: true, code: true, status: true } }));
+        if (!invoice) {
+            return { kind: "error", error: "This project has no invoice yet — create the invoice from the signed estimate in ProBuild first, then bill the change order." };
+        }
+
+        const created = await tx.paymentSchedule.create({
+            data: { invoiceId: invoice.id, name: milestoneName, amount, status: "Pending" },
+        });
+        // Same totals math as addInvoiceMilestone: bump invoice totals; a fully
+        // Paid invoice becomes Partially Paid when new work lands on it.
+        const nextStatus = invoice.status === "Paid" ? "Partially Paid" : invoice.status;
+        await tx.invoice.update({
+            where: { id: invoice.id },
+            data: {
+                totalAmount: { increment: amount },
+                balanceDue: { increment: amount },
+                ...(nextStatus !== invoice.status ? { status: nextStatus } : {}),
+            },
+        });
+        return { kind: "created", milestoneId: created.id, milestoneName, amount, invoiceId: invoice.id, invoiceCode: invoice.code, projectId: co.projectId, coCode: co.code };
+    }, { timeout: 15_000 });
+
+    if (outcome.kind === "error") return { ok: false as const, error: outcome.error };
+    if (outcome.kind === "duplicate") {
+        return {
+            ok: true as const,
+            alreadyBilled: true,
+            invoiceId: outcome.dup.invoiceId,
+            invoiceCode: outcome.dup.invoiceCode,
+            milestoneId: outcome.dup.id,
+            milestoneName: outcome.dup.name,
+            amount: outcome.dup.amount,
+            milestoneStatus: outcome.dup.status,
+            note: "This change order is already on the invoice — use send_milestone_invoice if it still needs to go out.",
+        };
+    }
+
+    // Best-effort: the billing transaction is already committed — a logging
+    // hiccup must not make the caller believe the bill failed.
+    try {
+        await logActivityLazy({
+            projectId: outcome.projectId,
+            actorType: "TEAM",
+            actorName: "ChatGPT connector",
+            action: "billed_change_order",
+            entityType: "invoice",
+            entityId: outcome.invoiceId,
+            entityName: `Invoice ${outcome.invoiceCode}`,
+            metadata: { changeOrder: outcome.coCode, milestone: outcome.milestoneName, amount: outcome.amount },
+        });
+    } catch { /* activity feed only */ }
+
+    revalidatePath(`/projects/${outcome.projectId}/invoices`);
+    revalidatePath(`/projects/${outcome.projectId}/invoices/${outcome.invoiceId}`);
+    revalidatePath(`/invoices`);
+
+    return {
+        ok: true as const,
+        alreadyBilled: false,
+        invoiceId: outcome.invoiceId,
+        invoiceCode: outcome.invoiceCode,
+        milestoneId: outcome.milestoneId,
+        milestoneName: outcome.milestoneName,
+        amount: outcome.amount,
+        milestoneStatus: "Pending",
+        note: "Milestone added. Use send_milestone_invoice (preview -> user approval -> confirm) to email the customer the QuickBooks payment link.",
+    };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Change-order signature request. Moved verbatim from actions.ts's
+// sendChangeOrderToClient; emails the customer a portal link to review & sign.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function sendChangeOrderToClientCore(changeOrderId: string): Promise<{ success: true; sentTo: string } | { success: false; error: string }> {
+    const co = await prisma.changeOrder.findUnique({
+        where: { id: changeOrderId },
+        include: {
+            project: { include: { client: true } },
+            items: { orderBy: { order: "asc" } },
+        }
+    });
+
+    if (!co) return { success: false, error: "Change order not found" };
+    const client = co.project?.client;
+    if (!client?.email) return { success: false, error: "Client has no email address" };
+
+    // Update status to Sent (only if still in Draft or Sent state). A zero count
+    // means the status flipped (Approved/Declined) since the caller checked —
+    // fail instead of emailing a signature request for a CO that's past signing.
+    const gate = await prisma.changeOrder.updateMany({
+        where: { id: changeOrderId, status: { in: ["Draft", "Sent"] } },
+        data: { status: "Sent", sentAt: new Date() }
+    });
+    if (gate.count === 0) {
+        return { success: false, error: `Change order ${co.code} is no longer in a sendable state (now "${(await prisma.changeOrder.findUnique({ where: { id: changeOrderId }, select: { status: true } }))?.status}") — refresh and retry.` };
+    }
+
+    const { buildClientPortalUrl } = await import("./client-portal-auth");
+    const portalUrl = await buildClientPortalUrl(client.id, client.email, `/portal/change-orders/${changeOrderId}`);
+    const settings = await prisma.companySettings.findUnique({ where: { id: "singleton" } });
+    const companyName = settings?.companyName || "Your Contractor";
+
+    const changeOrderCc = buildCc(client.email, (client as any).additionalEmail);
+    await sendNotification(
+        client.email,
+        `${companyName} sent you a change order to review`,
+        `<!DOCTYPE html>
+        <html>
+        <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 40px 20px; color: #333;">
+            <div style="background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; padding: 32px;">
+                <h2 style="font-size: 20px; margin: 0 0 8px;">Change Order for Your Review</h2>
+                <p style="color: #666; margin: 0 0 24px;">Hi ${client.name},</p>
+                <p style="color: #666; line-height: 1.6;">
+                    ${companyName} has sent you a change order titled "<strong>${co.title}</strong>" for project <strong>${co.project?.name || "your project"}</strong>.
+                    Please review the scope changes and approve or decline.
+                </p>
+                <div style="background: #f9fafb; border-radius: 8px; padding: 16px; text-align: center; margin: 24px 0;">
+                    <div style="color: #666; font-size: 13px; margin-bottom: 4px;">Change Order Amount</div>
+                    <div style="font-size: 24px; font-weight: 700; color: #111;">${formatCurrency(co.totalAmount)}</div>
+                </div>
+                <div style="text-align: center; margin: 32px 0;">
+                    <a href="${portalUrl}" style="display: inline-block; background: #059669; color: #fff; text-decoration: none; padding: 14px 32px; border-radius: 8px; font-weight: 600; font-size: 15px;">
+                        Review Change Order
+                    </a>
+                </div>
+                <p style="color: #999; font-size: 13px; text-align: center;">
+                    Or copy this link: ${portalUrl}
+                </p>
+            </div>
+            <p style="text-align: center; color: #aaa; font-size: 12px; margin-top: 32px;">
+                Sent via ProBuild &bull; ${companyName}
+            </p>
+        </body>
+        </html>`,
+        undefined,
+        { fromName: companyName, replyTo: settings?.email || undefined, cc: changeOrderCc, copyToInternal: true }
+    );
+
+    // Log activity
+    await logActivityLazy({
+        projectId: co.projectId,
+        actorType: "TEAM",
+        actorName: companyName,
+        action: "sent_change_order",
+        entityType: "change_order",
+        entityId: changeOrderId,
+        entityName: `Change Order ${co.code || co.title}`,
+    });
+
+    revalidatePath(`/projects/${co.projectId}/change-orders/${changeOrderId}`);
+    revalidatePath(`/projects/${co.projectId}/change-orders`);
+    return { success: true, sentTo: client.email };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Completes the field change-order loop from ChatGPT: create draft → send_change_order (preview-token gated; customer signs via portal) → bill_change_order (row-locked transaction, idempotent, mirrors addInvoiceMilestone totals math) → existing send_milestone_invoice rail for payment. Missing permission gate on sendChangeOrderToClient fixed. list_project_billing now returns change orders.

Two Codex rounds — blocker (double-bill race) fixed with SELECT FOR UPDATE; all round-2 real issues addressed; deferred product decision flagged: unwind when a billed CO is later declined.

Verification: tsc + build clean; verify-billing-tools 21/21 (round-trip under lock, idempotency, error paths — no real emails fired); estimate + template suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)