### PR TITLE
fix(portal): staff preview for change-order portal pages

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -7203,14 +7203,22 @@ export async function getChangeOrder(id: string) {
 
 export async function getChangeOrderForPortal(id: string) {
     "use server";
-    // IDOR-4 fix: gate by portal session's clientId
-    const sessionClientId = await resolveSessionClientId();
-    if (!sessionClientId) return null;
+    // Staff (ADMIN/MANAGER) may preview any change order — mirrors getInvoiceForPortal.
+    const staffSession = await getServerSession(authOptions);
+    const isStaff = ["ADMIN", "MANAGER"].includes((staffSession?.user as any)?.role);
+
+    // IDOR-4 fix: portal clients are gated by their session's clientId
+    let clientFilter = {};
+    if (!isStaff) {
+        const sessionClientId = await resolveSessionClientId();
+        if (!sessionClientId) return null;
+        clientFilter = { project: { clientId: sessionClientId } };
+    }
 
     return await prisma.changeOrder.findFirst({
         where: {
             id,
-            project: { clientId: sessionClientId },
+            ...clientFilter,
         },
         include: {
             project: { include: { client: true } },


### PR DESCRIPTION
Staff (ADMIN/MANAGER) hitting a change-order portal link got a 404 because getChangeOrderForPortal only accepted portal-client sessions. Mirrors getInvoiceForPortal's staff-preview branch; client gating (IDOR-4) unchanged. Found live while testing the Shop project's CO signature email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)