### PR TITLE
feat(billing): auto-bill + auto-send payment link on change-order approval

### DIFF
--- a/scripts/verify-billing-tools.ts
+++ b/scripts/verify-billing-tools.ts
@@ -2,7 +2,7 @@
 // change-order draft round-trip (create -> verify -> delete), and error paths of
 // the send cores. Deliberately never triggers a customer email or QB send.
 import { prisma } from "../src/lib/prisma";
-import { getProjectBilling, createChangeOrderDraft, sendMilestoneInvoicesCore, resendInvoiceCore, billChangeOrderCore, sendChangeOrderToClientCore } from "../src/lib/billing-core";
+import { getProjectBilling, createChangeOrderDraft, sendMilestoneInvoicesCore, resendInvoiceCore, billChangeOrderCore, sendChangeOrderToClientCore, handleChangeOrderApproved } from "../src/lib/billing-core";
 
 async function main() {
     const checks: [string, boolean][] = [];
@@ -122,6 +122,10 @@ async function main() {
     // 3b. Change-order send: error path only (never emails)
     const badCoSend = await sendChangeOrderToClientCore("not-a-real-co");
     checks.push(["CO send: bad id errors cleanly", badCoSend.success === false]);
+
+    // 3c. Approval automation: failure paths only, notifications suppressed
+    const badApprove = await handleChangeOrderApproved("not-a-real-co", { notify: false });
+    checks.push(["approval hook: bad id doesn't throw", badApprove.billed === false && badApprove.sent === false && badApprove.issues.length > 0]);
 
     // 4. Send cores: error paths only (never send for real)
     const badSend = await sendMilestoneInvoicesCore("not-a-real-invoice", ["x"], undefined, undefined, "test");

--- a/src/app/api/cron/co-billing-sweep/route.ts
+++ b/src/app/api/cron/co-billing-sweep/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { handleChangeOrderApproved } from "@/lib/billing-core";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+/**
+ * Hourly backstop for the change-order approval automation: after() gives no
+ * delivery guarantee (a cancelled function can drop both the billing and the
+ * ACTION-NEEDED alert), so this sweep re-runs the idempotent handler for any
+ * Approved CO that still has no invoice milestone.
+ *
+ * The 15min–2h approvedAt band means each CO is swept by at most two hourly
+ * runs (bounded duplicate "needs a look" alerts) and never races the inline
+ * after() automation, which fires within seconds of signing.
+ */
+export async function GET(request: Request) {
+    const authHeader = request.headers.get("authorization");
+    if (process.env.VERCEL_ENV === "production" && authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const now = Date.now();
+    const candidates = await prisma.changeOrder.findMany({
+        where: {
+            status: "Approved",
+            approvedAt: { lte: new Date(now - 15 * 60_000), gte: new Date(now - 2 * 60 * 60_000) },
+        },
+        select: { id: true, code: true, projectId: true },
+        take: 10,
+    });
+
+    const results: Array<{ code: string; action: string }> = [];
+    for (const co of candidates) {
+        const billedAlready = await prisma.paymentSchedule.findFirst({
+            where: {
+                name: { startsWith: `${co.code} — ` },
+                status: { not: "Canceled" },
+                invoice: { projectId: co.projectId },
+            },
+            select: { id: true },
+        });
+        if (billedAlready) {
+            results.push({ code: co.code, action: "skipped (already billed)" });
+            continue;
+        }
+        const outcome = await handleChangeOrderApproved(co.id);
+        results.push({ code: co.code, action: outcome.sent ? "billed + sent" : `alerted: ${outcome.issues.join("; ")}` });
+    }
+
+    if (results.some(r => !r.action.startsWith("skipped"))) {
+        console.log("[cron/co-billing-sweep]", JSON.stringify(results));
+    }
+    return NextResponse.json({ checked: candidates.length, results });
+}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -3,6 +3,7 @@
 import { getServerSession } from "next-auth";
 import { prisma } from "./prisma";
 import { revalidatePath, revalidateTag, unstable_cache } from "next/cache";
+import { after } from "next/server";
 import { cache } from "react";
 import { authOptions, getSessionOrDev } from "./auth";
 import { sendNotification } from "./email";
@@ -7248,15 +7249,10 @@ export async function deleteChangeOrder(id: string) {
     revalidatePath(`/projects/${co.projectId}/change-orders`);
 }
 
-export async function updateChangeOrderStatus(id: string, status: string, projectId: string) {
-    "use server";
-    await prisma.changeOrder.update({
-        where: { id },
-        data: { status }
-    });
-    revalidatePath(`/projects/${projectId}/change-orders/${id}`);
-    revalidatePath(`/projects/${projectId}/change-orders`);
-}
+// updateChangeOrderStatus was removed: it had no callers and, as an unauthenticated
+// remotely-invokable server action, let anyone flip CO statuses — bypassing both the
+// signature flow and the approval automation. Rebuild with auth + the approval hook
+// if a raw status setter is ever actually needed.
 
 export async function approveChangeOrder(id: string, signatureName: string, userAgent: string, signatureDataUrl?: string) {
     "use server";
@@ -7284,9 +7280,12 @@ export async function approveChangeOrder(id: string, signatureName: string, user
     // error on large data-URLs); falls back to the data-URL when Storage isn't configured.
     const clientSignatureUrl = await persistSignature(signatureDataUrl, `change-orders/${id}/client`);
 
+    // Atomic transition: only the FIRST approval flips the status (a concurrent
+    // or repeated signing matches zero rows), which also preserves the original
+    // signer's audit trail instead of overwriting it.
     const approvedAt = new Date();
-    const co = await prisma.changeOrder.update({
-        where: { id },
+    const transition = await prisma.changeOrder.updateMany({
+        where: { id, status: { not: "Approved" } },
         data: {
             status: "Approved",
             approvedBy: signatureName,
@@ -7294,7 +7293,30 @@ export async function approveChangeOrder(id: string, signatureName: string, user
             clientSignatureUrl,
         },
     });
-    
+    const co = await prisma.changeOrder.findUnique({ where: { id } });
+    if (!co) return null;
+
+    // Exactly-once post-approval automation: bill the CO onto the invoice and send
+    // the payment link (the signature on the exact amount is the approval), with a
+    // team notification either way. Scheduled AFTER the response so the customer's
+    // signing screen never waits on QuickBooks; falls back to inline best-effort
+    // outside a request context.
+    if (transition.count === 1) {
+        const runAutomation = async () => {
+            try {
+                const { handleChangeOrderApproved } = await import("./billing-core");
+                await handleChangeOrderApproved(id);
+            } catch (err) {
+                console.error("[approveChangeOrder] post-approval automation failed:", err);
+            }
+        };
+        try {
+            after(runAutomation);
+        } catch {
+            await runAutomation();
+        }
+    }
+
     revalidatePath(`/projects/${co.projectId}/change-orders/${id}`);
     revalidatePath(`/projects/${co.projectId}/change-orders`);
     return co;

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -648,6 +648,85 @@ export async function billChangeOrderCore(changeOrderId: string) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Post-approval automation: when the customer signs a change order, bill it onto
+// the invoice and send them the payment link immediately — their signature on
+// the exact amount IS the approval. The team is notified either way; any hiccup
+// (no invoice yet, QuickBooks down) turns into an ACTION-NEEDED alert instead of
+// a silent stall. Never throws: the customer's approval must stand regardless.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function handleChangeOrderApproved(changeOrderId: string, opts?: { notify?: boolean }): Promise<{ billed: boolean; sent: boolean; issues: string[] }> {
+    const summary = { billed: false, sent: false, issues: [] as string[] };
+    let coLabel = changeOrderId;
+    let amountLabel = "";
+    let projectName = "";
+    let sentTo = "";
+
+    try {
+        const co = await prisma.changeOrder.findUnique({
+            where: { id: changeOrderId },
+            select: { code: true, title: true, totalAmount: true, approvedBy: true, project: { select: { name: true } } },
+        });
+        if (co) {
+            coLabel = `${co.code} — ${co.title}`;
+            amountLabel = formatCurrency(co.totalAmount);
+            projectName = co.project?.name ?? "";
+        }
+
+        const bill = await billChangeOrderCore(changeOrderId);
+        if (!bill.ok) {
+            summary.issues.push(bill.error);
+        } else if (bill.alreadyBilled) {
+            // Only the call that FRESHLY billed the CO may auto-send — this makes a
+            // concurrent/replayed approval a no-op instead of a duplicate payment
+            // email (billChangeOrderCore's row lock guarantees exactly one fresh bill).
+            summary.billed = true;
+            summary.issues.push(`Already on invoice ${bill.invoiceCode} as "${bill.milestoneName}" — no new payment email sent (it may have gone out earlier; check before resending).`);
+        } else {
+            summary.billed = true;
+            const send = await sendMilestoneInvoicesCore(bill.invoiceId, [bill.milestoneId], undefined, undefined, "Auto (change-order approval)");
+            const resultIssues = send.results.map(r => r.error).filter((e): e is string => !!e);
+            summary.sent = send.results.some(r => !!r.sentTo);
+            if (resultIssues.length) summary.issues.push(...resultIssues);
+            if (!summary.sent && !resultIssues.length) summary.issues.push(send.error || "QuickBooks send failed");
+            sentTo = send.results.find(r => r.sentTo)?.sentTo ?? "";
+        }
+    } catch (err: any) {
+        summary.issues.push(err?.message || "Unexpected error during auto-billing");
+    }
+
+    // Team notification (System Notification Email in Settings → Company).
+    if (opts?.notify === false) return summary;
+    try {
+        const esc = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+        const settings = await prisma.companySettings.findUnique({ where: { id: "singleton" }, select: { notificationEmail: true, companyName: true, email: true } });
+        const to = settings?.notificationEmail?.trim() || settings?.email?.trim();
+        if (to) {
+            const ok = summary.sent;
+            const subject = ok
+                ? `✅ Change order approved & payment link sent — ${coLabel} (${amountLabel})`
+                : `⚠️ Change order approved — needs a look — ${coLabel} (${amountLabel})`;
+            const detail = ok
+                ? `<p>The customer signed and the QuickBooks payment link for <strong>${esc(amountLabel)}</strong> was emailed to <strong>${esc(sentTo)}</strong> automatically.</p>`
+                : `<p>The customer signed, but no payment email went out automatically:</p><ul>${summary.issues.map(i => `<li>${esc(i)}</li>`).join("")}</ul><p>Review in ProBuild or ChatGPT (list_project_billing shows the state; send_milestone_invoice sends when appropriate).</p>`;
+            await sendNotification(
+                to,
+                subject,
+                `<div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 24px; color: #333;">
+                    <h2 style="font-size:18px;">Change order approved${projectName ? ` — ${esc(projectName)}` : ""}</h2>
+                    <p><strong>${esc(coLabel)}</strong> (${esc(amountLabel)})</p>
+                    ${detail}
+                </div>`,
+                undefined,
+                { fromName: settings?.companyName || "ProBuild" },
+            );
+        }
+    } catch { /* notification is best-effort */ }
+
+    return summary;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Change-order signature request. Moved verbatim from actions.ts's
 // sendChangeOrderToClient; emails the customer a portal link to review & sign.
 // ─────────────────────────────────────────────────────────────────────────────

--- a/vercel.json
+++ b/vercel.json
@@ -13,6 +13,10 @@
       "schedule": "0 * * * *"
     },
     {
+      "path": "/api/cron/co-billing-sweep",
+      "schedule": "30 * * * *"
+    },
+    {
       "path": "/api/cron/drive-receipts",
       "schedule": "0 13 * * *"
     }


### PR DESCRIPTION
Customer signs → CO billed onto invoice → QuickBooks payment link emailed → team notified (✅ sent / ⚠️ needs a look). Exactly-once via atomic status transition + freshly-billed send gate; runs post-response via after() with an hourly cron sweep backstop; removes an unauthenticated dead status-mutator action.

Two Codex rounds — duplicate-email and serverless-latency blockers fixed and confirmed; residual after()-cancellation risk covered by the cron sweep.

Verification: tsc + build clean; billing suite 22/22 (no real emails in tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)