### PR TITLE
fix(billing): change-order tax follows the estimate's exemption and rate

### DIFF
--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -3,7 +3,8 @@ import { createMcpHandler } from "mcp-handler";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { createEstimateFromPhases, templateToPhases, CLOSED_PROJECT_STATUSES, CLOSED_LEAD_STAGES } from "@/lib/gpt-estimate";
-import { getProjectBilling, sendMilestoneInvoicesCore, resendInvoiceCore, createChangeOrderDraft, billChangeOrderCore, sendChangeOrderToClientCore, CO_TAX_RATE } from "@/lib/billing-core";
+import { getProjectBilling, sendMilestoneInvoicesCore, resendInvoiceCore, createChangeOrderDraft, billChangeOrderCore, sendChangeOrderToClientCore } from "@/lib/billing-core";
+import { coTaxRate, coTaxLabel } from "@/lib/co-tax";
 
 // MCP connector for ChatGPT (streamable HTTP at POST /api/mcp/mcp).
 //
@@ -362,7 +363,11 @@ const handler = createMcpHandler(
             async ({ changeOrderId, confirmToken }) => {
                 const co = await prisma.changeOrder.findUnique({
                     where: { id: changeOrderId },
-                    select: { code: true, title: true, status: true, totalAmount: true, updatedAt: true, project: { select: { name: true, client: { select: { name: true, email: true } } } } },
+                    select: {
+                        code: true, title: true, status: true, totalAmount: true, updatedAt: true,
+                        estimate: { select: { taxExempt: true, taxRatePercent: true, taxRateName: true } },
+                        project: { select: { name: true, client: { select: { name: true, email: true } } } },
+                    },
                 });
                 if (!co) return { ...textResult({ error: "Change order not found" }), isError: true };
                 if (co.status !== "Draft" && co.status !== "Sent") {
@@ -378,13 +383,14 @@ const handler = createMcpHandler(
                 const payload = JSON.stringify({ changeOrderId, recipient, code: co.code, title: co.title, total: Number(co.totalAmount), status: co.status, updatedAt: co.updatedAt.toISOString() });
                 if (!verifyPreviewToken(confirmToken, payload)) {
                     const subtotal = Number(co.totalAmount);
-                    const taxAmount = Math.round(subtotal * CO_TAX_RATE * 100) / 100;
+                    const taxAmount = Math.round(subtotal * coTaxRate(co.estimate) * 100) / 100;
                     return textResult({
                         preview: true,
                         changeOrder: {
                             code: co.code, title: co.title, status: co.status,
                             subtotal,
-                            estimatedTax: taxAmount,
+                            tax: taxAmount,
+                            taxTreatment: coTaxLabel(co.estimate),
                             revisedAmountCustomerSigns: Math.round((subtotal + taxAmount) * 100) / 100,
                         },
                         project: co.project?.name,

--- a/src/app/portal/change-orders/[id]/PortalChangeOrderClient.tsx
+++ b/src/app/portal/change-orders/[id]/PortalChangeOrderClient.tsx
@@ -6,6 +6,7 @@ import SignaturePad from "@/components/SignaturePad";
 import Link from "next/link";
 import { toast } from "sonner";
 import { formatCurrency } from "@/lib/utils";
+import { coTaxRate, coTaxLabel } from "@/lib/co-tax";
 
 export default function PortalChangeOrderClient({ initialData, companySettings }: { initialData: any, companySettings?: any }) {
     const [isApproving, setIsApproving] = useState(false);
@@ -47,8 +48,11 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
 
     const items = initialData.items || [];
     const subtotal = items.reduce((acc: number, item: any) => acc + (Number(item.quantity || 0) * Number(item.unitCost || 0)), 0);
-    const tax = subtotal * 0.088;
+    // Tax follows the estimate's treatment (tax-exempt customers pay none) — the
+    // amount shown here is what the customer signs AND what billing charges.
+    const tax = subtotal * coTaxRate(initialData.estimate);
     const total = subtotal + tax;
+    const taxLabel = coTaxLabel(initialData.estimate);
 
     return (
         <div className="min-h-screen bg-slate-100 font-sans">
@@ -224,7 +228,7 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
                                     <span>{formatCurrency(subtotal)}</span>
                                 </div>
                                 <div className="flex justify-between py-2 text-sm text-slate-600">
-                                    <span>Tax (8.8%)</span>
+                                    <span>{taxLabel}</span>
                                     <span>{formatCurrency(tax)}</span>
                                 </div>
                                 <div className="border-t-2 border-slate-800 mt-1 pt-2 flex justify-between text-lg font-bold text-amber-600">

--- a/src/app/projects/[id]/change-orders/[coId]/ChangeOrderEditor.tsx
+++ b/src/app/projects/[id]/change-orders/[coId]/ChangeOrderEditor.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import Link from "next/link";
 import { formatCurrency } from "@/lib/utils";
+import { coTaxRate, coTaxLabel } from "@/lib/co-tax";
 
 export default function ChangeOrderEditor({ context, initialData }: { context: any, initialData: any }) {
     const router = useRouter();
@@ -23,8 +24,11 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
     const [isSending, setIsSending] = useState(false);
 
     const subtotal = items.reduce((acc, item) => acc + ((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0)), 0);
-    const tax = subtotal * 0.088;
+    // Tax follows the estimate's treatment (tax-exempt customers pay none) — kept
+    // in sync with the portal signature page and billChangeOrderCore via lib/co-tax.
+    const tax = subtotal * coTaxRate(initialData.estimate);
     const total = subtotal + tax;
+    const taxLabel = coTaxLabel(initialData.estimate);
 
     async function handleSign() {
         if (!signName.trim()) { toast.error("Please enter a name to sign"); return; }
@@ -309,7 +313,7 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
                                         <span className="text-slate-800">{formatCurrency(subtotal)}</span>
                                     </div>
                                     <div className="flex justify-between text-slate-500 font-medium">
-                                        <span>Estimated Tax (8.8%)</span>
+                                        <span>{taxLabel}</span>
                                         <span className="text-slate-800">{formatCurrency(tax)}</span>
                                     </div>
                                     <div className="h-px w-full bg-slate-200 my-4 shadow-sm"></div>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -7195,7 +7195,7 @@ export async function getChangeOrder(id: string) {
         where: { id },
         include: {
             project: { include: { client: true } },
-            estimate: { select: { title: true, code: true } },
+            estimate: { select: { title: true, code: true, taxExempt: true, taxRatePercent: true, taxRateName: true } },
             items: { orderBy: { order: "asc" } },
             paymentSchedules: { orderBy: { order: "asc" } }
         }
@@ -7223,7 +7223,7 @@ export async function getChangeOrderForPortal(id: string) {
         },
         include: {
             project: { include: { client: true } },
-            estimate: { select: { title: true, code: true } },
+            estimate: { select: { title: true, code: true, taxExempt: true, taxRatePercent: true, taxRateName: true } },
             items: { orderBy: { order: "asc" } },
             paymentSchedules: { orderBy: { order: "asc" } }
         }

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -14,6 +14,7 @@ function revalidatePath(path: string) {
 import { prisma } from "@/lib/prisma";
 import { sendNotification } from "./email";
 import { formatCurrency } from "./utils";
+import { coTaxRate, coTaxLabel } from "./co-tax";
 
 // Session-free cores of the billing flows, shared by the permission-gated server
 // actions in actions.ts and the MCP connector (whose auth is the shared secret at
@@ -526,16 +527,10 @@ export async function sendMilestoneInvoicesCore(
 // rail can take it from there. Never bills the same CO twice.
 // ─────────────────────────────────────────────────────────────────────────────
 
-// Change orders are presented to the customer as subtotal + 8.8% tax — the same
-// hardcoded rate in ChangeOrderEditor.tsx and PortalChangeOrderClient.tsx (they
-// can't import this module client-side; keep all three in sync). The customer
-// signs the REVISED amount (gross), so that is what gets billed.
-export const CO_TAX_RATE = 0.088;
-
 type BillChangeOrderOutcome =
     | { kind: "error"; error: string }
     | { kind: "duplicate"; dup: { id: string; name: string; amount: number; status: string; invoiceId: string; invoiceCode: string } }
-    | { kind: "created"; milestoneId: string; milestoneName: string; amount: number; subtotal: number; taxAmount: number; invoiceId: string; invoiceCode: string; projectId: string; coCode: string };
+    | { kind: "created"; milestoneId: string; milestoneName: string; amount: number; subtotal: number; taxAmount: number; taxLabel: string; invoiceId: string; invoiceCode: string; projectId: string; coCode: string };
 
 export async function billChangeOrderCore(changeOrderId: string) {
     // Everything — status check, idempotency check, invoice pick, create,
@@ -552,10 +547,15 @@ export async function billChangeOrderCore(changeOrderId: string) {
         if (co.status !== "Approved") {
             return { kind: "error", error: `Change order ${co.code} is "${co.status}" — only Approved change orders can be billed. Send it for customer signature first.` };
         }
-        // Bill the amount the customer signed: subtotal + 8.8% tax ("Revised
-        // Amount" on the signature page), not the stored subtotal.
+        // Bill the amount the customer signed: subtotal + tax ("Revised Amount"
+        // on the signature page). The rate comes from the CO's estimate — a
+        // tax-exempt customer (per the estimate / their QuickBooks setup) adds no tax.
+        const estimateTax = await tx.estimate.findUnique({
+            where: { id: co.estimateId },
+            select: { taxExempt: true, taxRatePercent: true, taxRateName: true },
+        });
         const subtotal = Math.round(Number(co.totalAmount) * 100) / 100;
-        const taxAmount = Math.round(subtotal * CO_TAX_RATE * 100) / 100;
+        const taxAmount = Math.round(subtotal * coTaxRate(estimateTax) * 100) / 100;
         const amount = Math.round((subtotal + taxAmount) * 100) / 100;
         if (!(amount > 0)) return { kind: "error", error: `Change order ${co.code} has a $0 total — nothing to bill.` };
 
@@ -607,7 +607,7 @@ export async function billChangeOrderCore(changeOrderId: string) {
                 ...(nextStatus !== invoice.status ? { status: nextStatus } : {}),
             },
         });
-        return { kind: "created", milestoneId: created.id, milestoneName, amount, subtotal, taxAmount, invoiceId: invoice.id, invoiceCode: invoice.code, projectId: co.projectId, coCode: co.code };
+        return { kind: "created", milestoneId: created.id, milestoneName, amount, subtotal, taxAmount, taxLabel: coTaxLabel(estimateTax), invoiceId: invoice.id, invoiceCode: invoice.code, projectId: co.projectId, coCode: co.code };
     }, { timeout: 15_000 });
 
     if (outcome.kind === "error") return { ok: false as const, error: outcome.error };
@@ -654,9 +654,11 @@ export async function billChangeOrderCore(changeOrderId: string) {
         amount: outcome.amount,
         subtotal: outcome.subtotal,
         taxAmount: outcome.taxAmount,
-        taxRate: `${(CO_TAX_RATE * 100).toFixed(1)}%`,
+        taxLabel: outcome.taxLabel,
         milestoneStatus: "Pending",
-        note: `Milestone added for the signed Revised Amount: ${formatCurrency(outcome.subtotal)} + ${formatCurrency(outcome.taxAmount)} tax = ${formatCurrency(outcome.amount)}. Use send_milestone_invoice (preview -> user approval -> confirm) to email the customer the QuickBooks payment link.`,
+        note: outcome.taxAmount > 0
+            ? `Milestone added for the signed Revised Amount: ${formatCurrency(outcome.subtotal)} + ${formatCurrency(outcome.taxAmount)} tax (${outcome.taxLabel}) = ${formatCurrency(outcome.amount)}. Use send_milestone_invoice (preview -> user approval -> confirm) to email the customer the QuickBooks payment link.`
+            : `Milestone added for ${formatCurrency(outcome.amount)} (${outcome.taxLabel} — no tax). Use send_milestone_invoice (preview -> user approval -> confirm) to email the customer the QuickBooks payment link.`,
     };
 }
 

--- a/src/lib/co-tax.ts
+++ b/src/lib/co-tax.ts
@@ -1,0 +1,29 @@
+// Single source of the change-order tax rule, shared by billing (billing-core),
+// the MCP send preview, the staff CO editor, and the customer signature page.
+// Client-safe: no prisma, pure functions.
+//
+// Rule: the CO inherits its estimate's tax treatment (which mirrors the
+// customer's QuickBooks tax setup) — tax-exempt estimates add no tax; otherwise
+// the estimate's rate applies, falling back to the historical 8.8% default.
+
+export const DEFAULT_CO_TAX_RATE = 0.088;
+
+export type EstimateTaxInfo = {
+    taxExempt?: boolean | null;
+    taxRatePercent?: number | string | { toString(): string } | null;
+    taxRateName?: string | null;
+} | null | undefined;
+
+export function coTaxRate(estimate: EstimateTaxInfo): number {
+    if (estimate?.taxExempt) return 0;
+    const pct = estimate?.taxRatePercent != null ? Number(estimate.taxRatePercent) : NaN;
+    return Number.isFinite(pct) ? pct / 100 : DEFAULT_CO_TAX_RATE;
+}
+
+export function coTaxLabel(estimate: EstimateTaxInfo): string {
+    if (estimate?.taxExempt) return "Tax Exempt";
+    const pctDisplay = (coTaxRate(estimate) * 100).toFixed(1).replace(/\.0$/, "");
+    return estimate?.taxRateName
+        ? `${estimate.taxRateName} (${pctDisplay}%)`
+        : `Estimated Tax (${pctDisplay}%)`;
+}


### PR DESCRIPTION
Tax-exempt customers (per the estimate, mirroring their QuickBooks customer setup) were shown and would have been billed 8.8% tax on change orders — the rate was hardcoded in the editor, portal signature page, and billing. Centralized in lib/co-tax.ts and applied to all four surfaces; displayed = signed = billed in every case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)