### PR TITLE
feat(connector): send_estimate, invoice-from-estimate, AR view + weekly digest, create_lead

### DIFF
--- a/scripts/verify-billing-tools.ts
+++ b/scripts/verify-billing-tools.ts
@@ -2,7 +2,8 @@
 // change-order draft round-trip (create -> verify -> delete), and error paths of
 // the send cores. Deliberately never triggers a customer email or QB send.
 import { prisma } from "../src/lib/prisma";
-import { getProjectBilling, createChangeOrderDraft, sendMilestoneInvoicesCore, resendInvoiceCore, billChangeOrderCore, sendChangeOrderToClientCore, handleChangeOrderApproved } from "../src/lib/billing-core";
+import { getProjectBilling, createChangeOrderDraft, sendMilestoneInvoicesCore, resendInvoiceCore, billChangeOrderCore, sendChangeOrderToClientCore, handleChangeOrderApproved, listReceivables, createInvoiceFromEstimateGuarded } from "../src/lib/billing-core";
+import { createLead } from "../src/lib/actions";
 
 async function main() {
     const checks: [string, boolean][] = [];
@@ -134,6 +135,48 @@ async function main() {
     checks.push(["milestone send: bad invoice errors cleanly", badSend.success === false && badSend.error === "Invoice not found"]);
     const badResend = await resendInvoiceCore("not-a-real-invoice");
     checks.push(["resend: bad invoice errors cleanly", badResend.success === false]);
+
+    // 5. Accounts receivable (read-only)
+    const ar = await listReceivables();
+    checks.push(["AR returns summary", typeof ar.totalOutstanding === "number" && Array.isArray(ar.invoices)]);
+    checks.push(["AR totals = sum of balances", Math.abs(ar.totalOutstanding - ar.invoices.reduce((s, r) => s + r.balanceDue, 0)) < 0.01]);
+    checks.push(["AR overdue ⊆ total", ar.overdueOutstanding <= ar.totalOutstanding + 0.01]);
+    checks.push(["AR excludes drafts/zero-balance", ar.invoices.every(r => r.status !== "Draft" && r.balanceDue > 0)]);
+
+    // 6. Invoice-from-estimate guard: an estimate that ALREADY has an invoice must
+    // return it, not create a duplicate.
+    const invoiced = await prisma.invoice.findFirst({ where: { estimateId: { not: null } }, select: { id: true, estimateId: true } });
+    if (invoiced?.estimateId) {
+        const before = await prisma.invoice.count({ where: { estimateId: invoiced.estimateId } });
+        const guard = await createInvoiceFromEstimateGuarded(invoiced.estimateId);
+        const after = await prisma.invoice.count({ where: { estimateId: invoiced.estimateId } });
+        checks.push(["invoice guard returns existing", guard.ok && guard.alreadyExisted === true && guard.invoiceId === invoiced.id]);
+        checks.push(["invoice guard creates nothing", before === after]);
+    }
+    const badInv = await createInvoiceFromEstimateGuarded("not-a-real-estimate");
+    checks.push(["invoice guard: bad id errors cleanly", !badInv.ok]);
+
+    // 7. Lead round-trip (create → verify dedup → delete; client cleanup if created).
+    // createLead ends with revalidatePath, which throws outside a request context
+    // (fine in the MCP route) — swallow it here and verify via lookup.
+    const clientBefore = await prisma.client.findFirst({ where: { name: "LEAD VERIFY DELETE ME" }, select: { id: true } });
+    const tolerantCreateLead = async (data: Parameters<typeof createLead>[0]) => {
+        try { return await createLead(data); } catch (e: any) {
+            if (!String(e?.message).includes("static generation store")) throw e;
+            const found = await prisma.lead.findFirst({ where: { name: data.name, client: { name: data.clientName } }, orderBy: { createdAt: "desc" }, select: { id: true } });
+            if (!found) throw e;
+            return { id: found.id };
+        }
+    };
+    const lead1 = await tolerantCreateLead({ name: "Verify lead — delete me", clientName: "LEAD VERIFY DELETE ME", clientEmail: "lead-verify@example.invalid", projectType: "Kitchen Remodeling" });
+    const lead2 = await tolerantCreateLead({ name: "Verify lead — delete me", clientName: "LEAD VERIFY DELETE ME" });
+    checks.push(["lead created", !!lead1.id]);
+    checks.push(["24h dedup returns same lead", lead2.id === lead1.id]);
+    const leadRow = await prisma.lead.findUnique({ where: { id: lead1.id }, select: { clientId: true, projectType: true } });
+    checks.push(["lead carries projectType", leadRow?.projectType === "Kitchen Remodeling"]);
+    await prisma.lead.delete({ where: { id: lead1.id } });
+    if (!clientBefore && leadRow?.clientId) await prisma.client.delete({ where: { id: leadRow.clientId } });
+    console.log("lead cleanup done");
 
     let failed = 0;
     for (const [label, ok] of checks) { console.log(`${ok ? "PASS" : "FAIL"}  ${label}`); if (!ok) failed++; }

--- a/src/app/api/cron/ar-digest/route.ts
+++ b/src/app/api/cron/ar-digest/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { sendArDigest } from "@/lib/billing-core";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+/**
+ * Weekly accounts-receivable digest to the team (System Notification Email):
+ * every invoice with a balance due, overdue ones flagged. Skips the email when
+ * nothing is outstanding.
+ */
+export async function GET(request: Request) {
+    // Any deployed environment (production or preview) requires the cron secret,
+    // and fails closed if CRON_SECRET is unset. Only local dev skips the check.
+    const authHeader = request.headers.get("authorization");
+    if (process.env.VERCEL_ENV && (!process.env.CRON_SECRET || authHeader !== `Bearer ${process.env.CRON_SECRET}`)) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const result = await sendArDigest();
+    console.log("[cron/ar-digest]", JSON.stringify({ sent: result.sent, invoices: result.invoiceCount, outstanding: result.totalOutstanding }));
+    return NextResponse.json(result);
+}

--- a/src/app/api/cron/co-billing-sweep/route.ts
+++ b/src/app/api/cron/co-billing-sweep/route.ts
@@ -16,8 +16,10 @@ export const maxDuration = 120;
  * after() automation, which fires within seconds of signing.
  */
 export async function GET(request: Request) {
+    // Any deployed environment (production or preview) requires the cron secret,
+    // and fails closed if CRON_SECRET is unset. Only local dev skips the check.
     const authHeader = request.headers.get("authorization");
-    if (process.env.VERCEL_ENV === "production" && authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    if (process.env.VERCEL_ENV && (!process.env.CRON_SECRET || authHeader !== `Bearer ${process.env.CRON_SECRET}`)) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -3,7 +3,7 @@ import { createMcpHandler } from "mcp-handler";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { createEstimateFromPhases, templateToPhases, CLOSED_PROJECT_STATUSES, CLOSED_LEAD_STAGES } from "@/lib/gpt-estimate";
-import { getProjectBilling, sendMilestoneInvoicesCore, resendInvoiceCore, createChangeOrderDraft, billChangeOrderCore, sendChangeOrderToClientCore } from "@/lib/billing-core";
+import { getProjectBilling, sendMilestoneInvoicesCore, resendInvoiceCore, createChangeOrderDraft, billChangeOrderCore, sendChangeOrderToClientCore, listReceivables, createInvoiceFromEstimateGuarded } from "@/lib/billing-core";
 import { coTaxRate, coTaxLabel } from "@/lib/co-tax";
 
 // MCP connector for ChatGPT (streamable HTTP at POST /api/mcp/mcp).
@@ -406,6 +406,189 @@ const handler = createMcpHandler(
         );
 
         server.registerTool(
+            "send_estimate",
+            {
+                title: "Send an estimate to the customer",
+                annotations: { readOnlyHint: false },
+                description:
+                    "Emails the customer their estimate with a portal link to review and sign it (signing auto-creates the invoice). Works for project AND lead estimates. " +
+                    "TWO-STEP: call without confirmToken for a preview + token; show the user the recipient and total, then echo the confirmToken after they approve. " +
+                    "Milestones must sum to the estimate balance or the send is refused with the exact mismatch.",
+                inputSchema: {
+                    estimateId: z.string().max(50).describe("Estimate id from list_project_billing (or the id create_estimate returned)"),
+                    overrideEmail: z.string().email().optional().describe("Only to send to a different address than the client on file"),
+                    customMessage: z.string().max(2000).optional().describe("Optional personal note included in the email"),
+                    confirmToken: z.string().max(40).optional().describe("Token from the preview response; supplying it executes the send"),
+                },
+            },
+            async ({ estimateId, overrideEmail, customMessage, confirmToken }) => {
+                const estimate = await prisma.estimate.findUnique({
+                    where: { id: estimateId },
+                    select: {
+                        code: true, title: true, status: true, totalAmount: true, taxExempt: true,
+                        memo: true, termsAndConditions: true, taxRatePercent: true, taxRateName: true,
+                        items: { orderBy: { order: "asc" }, select: { id: true, name: true, description: true, quantity: true, unitCost: true, total: true, parentId: true } },
+                        paymentSchedules: { orderBy: { order: "asc" }, select: { id: true, name: true, amount: true, percentage: true, dueDate: true, status: true } },
+                        project: { select: { name: true, client: { select: { name: true, email: true } } } },
+                        lead: { select: { name: true, client: { select: { name: true, email: true } } } },
+                    },
+                });
+                if (!estimate) return { ...textResult({ error: "Estimate not found" }), isError: true };
+                const client = estimate.project?.client ?? estimate.lead?.client;
+                const recipient = (overrideEmail || client?.email || "").trim();
+                if (!recipient) return { ...textResult({ error: "The client has no email on file — add one in ProBuild first, or pass overrideEmail." }), isError: true };
+
+                // sendEstimateToClient auto-repairs the LAST unpaid milestone to make the
+                // schedule sum to the balance due. Compute that repair here so the preview
+                // discloses it and the token binds it — no silent adjustment on confirm.
+                const rc = (n: number) => Math.round((n + Number.EPSILON) * 100) / 100;
+                const schedules = estimate.paymentSchedules;
+                const paidSum = schedules.filter(s => s.status === "Paid").reduce((s, m) => s + Number(m.amount), 0);
+                const unpaid = schedules.filter(s => s.status !== "Paid");
+                const balanceDue = rc(Number(estimate.totalAmount) - paidSum);
+                let milestoneRepair: { milestone: string; from: number; to: number } | null = null;
+                if (unpaid.length > 0) {
+                    const otherUnpaid = unpaid.slice(0, -1).reduce((s, m) => s + Number(m.amount), 0);
+                    const last = unpaid[unpaid.length - 1];
+                    const correctLast = rc(balanceDue - otherUnpaid);
+                    if (correctLast < 0) {
+                        // Unrepairable: the other milestones alone already exceed the balance
+                        // due. Refuse now with the exact mismatch instead of minting a token
+                        // for a send that would fail after the user approves.
+                        return {
+                            ...textResult({
+                                error: `Milestones don't fit the estimate: the unpaid milestones before "${last.name}" already total $${otherUnpaid.toFixed(2)}, but the balance due is $${balanceDue.toFixed(2)}. Fix the milestone amounts in ProBuild before sending.`,
+                            }),
+                            isError: true,
+                        };
+                    }
+                    if (Math.abs(correctLast - Number(last.amount)) > 0.001) {
+                        milestoneRepair = { milestone: last.name, from: Number(last.amount), to: correctLast };
+                    }
+                }
+
+                // Fingerprint the full customer-visible content (items, milestones,
+                // memo/terms, tax, message, pending repair) so ANY edit between preview
+                // and confirm invalidates the token — total alone can't mask a change.
+                const fingerprint = createHash("sha256").update(JSON.stringify({
+                    items: estimate.items.map(i => [i.id, i.name, i.description, i.quantity, Number(i.unitCost), Number(i.total), i.parentId]),
+                    schedules: schedules.map(s => [s.id, s.name, Number(s.amount), s.percentage, s.dueDate?.toISOString() ?? null, s.status]),
+                    memo: estimate.memo, terms: estimate.termsAndConditions,
+                    taxExempt: estimate.taxExempt,
+                    taxRatePercent: estimate.taxRatePercent != null ? Number(estimate.taxRatePercent) : null,
+                    taxRateName: estimate.taxRateName,
+                    customMessage: customMessage ?? null,
+                    milestoneRepair,
+                })).digest("hex").slice(0, 24);
+                const payload = JSON.stringify({ estimateId, recipient, code: estimate.code, total: Number(estimate.totalAmount), status: estimate.status, fingerprint });
+
+                if (!verifyPreviewToken(confirmToken, payload)) {
+                    return textResult({
+                        preview: true,
+                        estimate: { code: estimate.code, title: estimate.title, status: estimate.status, total: Number(estimate.totalAmount), taxExempt: estimate.taxExempt, balanceDue },
+                        target: estimate.project?.name ?? estimate.lead?.name,
+                        recipient,
+                        clientName: client?.name,
+                        ...(milestoneRepair ? {
+                            milestoneAdjustmentOnSend: `Sending will adjust milestone "${milestoneRepair.milestone}" from $${milestoneRepair.from.toFixed(2)} to $${milestoneRepair.to.toFixed(2)} so the schedule matches the balance due — tell the user.`,
+                        } : {}),
+                        confirmToken: mintPreviewToken(payload),
+                        instruction: "Show this to the user (including any milestone adjustment). Call again with this confirmToken ONLY after they explicitly approve.",
+                    });
+                }
+                const { sendEstimateToClient } = await import("@/lib/actions");
+                const result = await sendEstimateToClient(estimateId, undefined, overrideEmail, undefined, customMessage);
+                if (!result.success) return { ...textResult({ error: result.error }), isError: true };
+                return textResult({ ...result, note: "The customer reviews and signs via the portal link; signing auto-creates the invoice in ProBuild." });
+            },
+        );
+
+        server.registerTool(
+            "create_invoice_from_estimate",
+            {
+                title: "Create the project invoice from an estimate",
+                annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+                description:
+                    "Creates the invoice (with its payment milestones) from a project estimate — the prerequisite for billing milestones or change orders on a project that has no invoice yet. " +
+                    "Idempotent: if the estimate already has an invoice, that one is returned. Nothing is emailed.",
+                inputSchema: {
+                    estimateId: z.string().max(50).describe("Estimate id from list_project_billing"),
+                },
+            },
+            async ({ estimateId }) => {
+                const result = await createInvoiceFromEstimateGuarded(estimateId);
+                if (!result.ok) return { ...textResult({ error: result.error }), isError: true };
+                return textResult(result);
+            },
+        );
+
+        server.registerTool(
+            "list_receivables",
+            {
+                title: "Who owes us money (all projects)",
+                annotations: { readOnlyHint: true },
+                description:
+                    "Accounts receivable across ALL projects: every invoice with a balance due, its unpaid milestones, age in days, and overdue flags (past due date or 30+ days old). " +
+                    "Use for 'who owes us money?', 'what's overdue?', 'total outstanding?'.",
+                inputSchema: {},
+            },
+            async () => textResult(await listReceivables()),
+        );
+
+        server.registerTool(
+            "create_lead",
+            {
+                title: "Create a lead",
+                annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
+                description:
+                    "Captures a new lead in ProBuild (finds or creates the client; duplicate leads within 24h are deduped). Use when the user meets a prospect in the field. " +
+                    "The prospect is NOT emailed; an internal new-lead alert may go to the team.",
+                inputSchema: {
+                    name: z.string().min(1).max(200).describe("Lead name, e.g. 'Smith kitchen remodel'"),
+                    clientName: z.string().min(1).max(200).describe("The prospect's name"),
+                    clientEmail: z.string().email().optional(),
+                    clientPhone: z.string().max(30).optional(),
+                    location: z.string().max(300).optional().describe("City or address"),
+                    projectType: z.string().max(100).optional().describe("e.g. Kitchen Remodeling, Bathroom, ADU"),
+                    message: z.string().max(2000).optional().describe("Notes about the job"),
+                },
+            },
+            async args => {
+                const { createLead } = await import("@/lib/actions");
+                const lead = await createLead(args);
+                // Client matching is by exact name — if the caller supplied contact info
+                // that differs from what's on the matched client, surface it so a
+                // same-name collision doesn't silently attach to the wrong person.
+                const created = await prisma.lead.findUnique({
+                    where: { id: lead.id },
+                    select: { client: { select: { name: true, email: true, primaryPhone: true } } },
+                });
+                const warnings: string[] = [];
+                if (args.clientEmail) {
+                    if (!created?.client?.email) {
+                        warnings.push(`Matched existing client "${created?.client?.name}" who has NO email on file — the provided email (${args.clientEmail}) was NOT saved. Add it on the client record in ProBuild if it's them.`);
+                    } else if (created.client.email.toLowerCase() !== args.clientEmail.toLowerCase()) {
+                        warnings.push(`Attached to existing client "${created.client.name}" whose email on file is ${created.client.email}, not ${args.clientEmail} — verify it's the same person (the provided email was NOT saved).`);
+                    }
+                }
+                if (args.clientPhone) {
+                    const digits = (s: string) => s.replace(/\D/g, "").slice(-10);
+                    if (!created?.client?.primaryPhone) {
+                        warnings.push(`Matched client has no phone on file — the provided phone was NOT saved; add it in ProBuild if it's them.`);
+                    } else if (digits(created.client.primaryPhone) !== digits(args.clientPhone)) {
+                        warnings.push(`Existing client's phone on file (${created.client.primaryPhone}) differs from the one provided — verify it's the same person.`);
+                    }
+                }
+                return textResult({
+                    leadId: lead.id,
+                    url: `https://probuild.goldentouchremodeling.com/leads/${lead.id}`,
+                    warnings,
+                    note: "Lead created (or matched to an identical lead from the last 24h).",
+                });
+            },
+        );
+
+        server.registerTool(
             "bill_change_order",
             {
                 title: "Bill an approved change order",
@@ -426,7 +609,7 @@ const handler = createMcpHandler(
         );
     },
     {
-        serverInfo: { name: "probuild", version: "1.3.0" },
+        serverInfo: { name: "probuild", version: "1.4.0" },
         capabilities: { tools: {} },
         instructions:
             "ProBuild is Golden Touch Remodeling's construction management system. " +
@@ -436,8 +619,11 @@ const handler = createMcpHandler(
             "Every line item needs a costCode from get_estimating_codes. costType is just a line label (Labor / Material / Allowance / Subcontractor / Equipment / Other) — " +
             "the user estimates with allowances and lump-sum labor, so keep those labels accurate. " +
             "All prices are USD sell prices. Estimates arrive as private drafts for review in ProBuild. " +
-            "BILLING: list_project_billing shows a project's invoices/milestones/estimates. send_milestone_invoice and resend_invoice EMAIL THE CUSTOMER — " +
-            "always run the preview step, show the user exactly what will be sent and to whom, and only pass confirm: true after their explicit approval. Never self-confirm. " +
+            "ESTIMATE lifecycle: create_estimate (draft) → send_estimate (preview + user approval; customer signs via portal, which auto-creates the invoice). " +
+            "If a project needs an invoice without a signed estimate, create_invoice_from_estimate. list_receivables answers 'who owes us money?' across all projects. " +
+            "create_lead captures field prospects. " +
+            "BILLING: list_project_billing shows a project's invoices/milestones/estimates. send_milestone_invoice, resend_invoice and send_estimate EMAIL THE CUSTOMER — " +
+            "always run the preview step, show the user exactly what will be sent and to whom, and only echo back the preview's confirmToken after their explicit approval. Never self-confirm. " +
             "Change-order lifecycle: create_change_order (draft) → send_change_order (preview + user approval; customer signs via portal) → " +
             "once Approved, bill_change_order puts it on the invoice → send_milestone_invoice emails the payment link. " +
             "QuickBooks is handled server-side; never ask the user for QuickBooks credentials.",

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -112,6 +112,178 @@ export async function getProjectBilling(projectId: string) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Accounts receivable: every invoice still owed money, across all projects.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function listReceivables() {
+    const now = Date.now();
+    const invoices = await prisma.invoice.findMany({
+        where: { balanceDue: { gt: 0 }, status: { notIn: ["Draft"] } },
+        orderBy: { issueDate: "asc" },
+        select: {
+            id: true, code: true, status: true, totalAmount: true, balanceDue: true,
+            issueDate: true, sentAt: true, createdAt: true,
+            project: { select: { id: true, name: true } },
+            client: { select: { name: true, email: true } },
+            payments: {
+                where: { status: "Pending" },
+                orderBy: { createdAt: "asc" },
+                select: { id: true, name: true, amount: true, dueDate: true, qbInvoiceSentAt: true, qbSyncError: true },
+            },
+        },
+    });
+
+    const rows = invoices.map(inv => {
+        const anchor = inv.issueDate ?? inv.sentAt ?? inv.createdAt;
+        const ageDays = Math.floor((now - anchor.getTime()) / 86_400_000);
+        // Due dates are business dates: a milestone isn't "past due" until the
+        // whole due day has elapsed (24h grace covers timezone-of-storage skew).
+        const pastDue = inv.payments.some(p => p.dueDate && p.dueDate.getTime() + 86_400_000 < now);
+        return {
+            invoiceId: inv.id,
+            code: inv.code,
+            status: inv.status,
+            project: inv.project?.name ?? null,
+            projectId: inv.project?.id ?? null,
+            client: inv.client?.name ?? null,
+            balanceDue: Number(inv.balanceDue),
+            total: Number(inv.totalAmount),
+            ageDays,
+            overdue: pastDue || ageDays > 30,
+            unpaidMilestones: inv.payments.map(p => ({
+                id: p.id, name: p.name, amount: Number(p.amount), dueDate: p.dueDate,
+                lastEmailedAt: p.qbInvoiceSentAt, paymentLinkStale: !!p.qbSyncError,
+            })),
+        };
+    });
+
+    return {
+        totalOutstanding: Math.round(rows.reduce((s, r) => s + r.balanceDue, 0) * 100) / 100,
+        overdueOutstanding: Math.round(rows.filter(r => r.overdue).reduce((s, r) => s + r.balanceDue, 0) * 100) / 100,
+        invoiceCount: rows.length,
+        invoices: rows,
+    };
+}
+
+/**
+ * Weekly AR digest to the team (System Notification Email). Returns the summary
+ * so the cron response is inspectable; sends nothing when nothing is owed.
+ */
+export async function sendArDigest() {
+    const ar = await listReceivables();
+    if (ar.invoiceCount === 0) return { sent: false, reason: "nothing outstanding", ...ar };
+
+    const settings = await prisma.companySettings.findUnique({ where: { id: "singleton" }, select: { notificationEmail: true, email: true, companyName: true } });
+    const to = settings?.notificationEmail?.trim() || settings?.email?.trim();
+    if (!to) return { sent: false, reason: "no notification email configured", ...ar };
+
+    const esc = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    const row = (r: (typeof ar.invoices)[number]) => `
+        <tr style="${r.overdue ? "background:#fef2f2;" : ""}">
+            <td style="padding:6px 10px;border-bottom:1px solid #eee;">${esc(r.code)}${r.overdue ? " ⚠️" : ""}</td>
+            <td style="padding:6px 10px;border-bottom:1px solid #eee;">${esc(r.project ?? "—")}</td>
+            <td style="padding:6px 10px;border-bottom:1px solid #eee;">${esc(r.client ?? "—")}</td>
+            <td style="padding:6px 10px;border-bottom:1px solid #eee;text-align:right;">${formatCurrency(r.balanceDue)}</td>
+            <td style="padding:6px 10px;border-bottom:1px solid #eee;text-align:right;">${r.ageDays}d</td>
+        </tr>`;
+
+    const sendResult = await sendNotification(
+        to,
+        `AR digest — ${formatCurrency(ar.totalOutstanding)} outstanding across ${ar.invoiceCount} invoice${ar.invoiceCount === 1 ? "" : "s"}${ar.overdueOutstanding > 0 ? ` (${formatCurrency(ar.overdueOutstanding)} overdue)` : ""}`,
+        `<div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 640px; margin: 0 auto; padding: 24px; color: #333;">
+            <h2 style="font-size:18px;">Accounts receivable</h2>
+            <p><strong>${formatCurrency(ar.totalOutstanding)}</strong> outstanding · <strong style="color:#b91c1c;">${formatCurrency(ar.overdueOutstanding)}</strong> overdue (30+ days or past due date)</p>
+            <table style="border-collapse:collapse;width:100%;font-size:13px;">
+                <tr style="text-align:left;color:#64748b;"><th style="padding:6px 10px;">Invoice</th><th style="padding:6px 10px;">Project</th><th style="padding:6px 10px;">Client</th><th style="padding:6px 10px;text-align:right;">Balance</th><th style="padding:6px 10px;text-align:right;">Age</th></tr>
+                ${ar.invoices.map(row).join("")}
+            </table>
+            <p style="color:#64748b;font-size:12px;margin-top:16px;">Ask ChatGPT "who owes us money?" for the live view, or "resend the invoice on [project]" to nudge with a fresh payment link.</p>
+        </div>`,
+        undefined,
+        { fromName: settings?.companyName || "ProBuild" },
+    );
+    if (!sendResult.success) return { sent: false, reason: "email send failed", ...ar };
+    return { sent: true, ...ar };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Invoice creation from a signed estimate, with the duplicate guard the raw
+// action lacks (it's also called by the customer signing flow, so it must stay
+// ungated and unmodified — the guard lives here).
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function createInvoiceFromEstimateGuarded(estimateId: string) {
+    const estimate = await prisma.estimate.findUnique({
+        where: { id: estimateId },
+        select: { id: true, code: true, title: true, projectId: true, totalAmount: true },
+    });
+    if (!estimate) return { ok: false as const, error: "Estimate not found" };
+    if (!estimate.projectId) return { ok: false as const, error: `Estimate ${estimate.code} is attached to a lead, not a project — convert the lead to a project first.` };
+
+    const existing = await prisma.invoice.findFirst({
+        where: { estimateId },
+        orderBy: [{ createdAt: "asc" }, { id: "asc" }], // same tie-break as the post-create branch
+        select: { id: true, code: true, status: true, balanceDue: true },
+    });
+    if (existing) {
+        return {
+            ok: true as const,
+            alreadyExisted: true,
+            invoiceId: existing.id,
+            invoiceCode: existing.code,
+            status: existing.status,
+            balanceDue: Number(existing.balanceDue),
+            note: "This estimate already has an invoice — no new one created.",
+        };
+    }
+
+    // Invoice.estimateId has no unique constraint (prod carries one legacy
+    // duplicate, so one can't be added yet) — compensate instead of lock: if a
+    // concurrent call created an invoice first, delete ours (untouched, seconds
+    // old, milestones cascade) and return the winner. Deterministic: earliest
+    // createdAt wins, id breaks ties.
+    const { createInvoiceFromEstimate } = await import("./actions");
+    const created = await createInvoiceFromEstimate(estimateId);
+
+    const all = await prisma.invoice.findMany({
+        where: { estimateId },
+        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+        select: { id: true, code: true, status: true, balanceDue: true },
+    });
+    const winner = all[0];
+    if (winner && winner.id !== created.id) {
+        // Conditional delete: only remove OUR seconds-old invoice if it's still an
+        // untouched draft. If anything already interacted with it, keep both and
+        // let the duplicate surface for human review rather than destroy state.
+        const removed = await prisma.invoice.deleteMany({
+            where: { id: created.id, estimateId, status: "Draft", sentAt: null },
+        });
+        if (removed.count === 1) {
+            return {
+                ok: true as const,
+                alreadyExisted: true,
+                invoiceId: winner.id,
+                invoiceCode: winner.code,
+                status: winner.status,
+                balanceDue: Number(winner.balanceDue),
+                note: "A concurrent request created this estimate's invoice first — returning that one.",
+            };
+        }
+    }
+
+    const invoice = await prisma.invoice.findUnique({ where: { id: created.id }, select: { code: true, status: true, balanceDue: true } });
+    return {
+        ok: true as const,
+        alreadyExisted: false,
+        invoiceId: created.id,
+        invoiceCode: invoice?.code ?? "",
+        status: invoice?.status ?? "Draft",
+        balanceDue: Number(invoice?.balanceDue ?? 0),
+        note: `Invoice ${invoice?.code} created from estimate ${estimate.code} with its payment milestones. Use send_milestone_invoice or resend_invoice to send it.`,
+    };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Invoice email (ProBuild-native portal link). Moved verbatim from actions.ts.
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/vercel.json
+++ b/vercel.json
@@ -17,6 +17,10 @@
       "schedule": "30 * * * *"
     },
     {
+      "path": "/api/cron/ar-digest",
+      "schedule": "0 15 * * 1"
+    },
+    {
       "path": "/api/cron/drive-receipts",
       "schedule": "0 13 * * *"
     }


### PR DESCRIPTION
Four connector tools completing the estimate loop, plus a Monday AR digest cron. Preview-token gate on the estimate send binds a full content fingerprint with disclosed milestone auto-repair; invoice creation is duplicate-guarded with a deterministic compensating strategy; lead capture surfaces client-collision warnings; crons fail closed without CRON_SECRET.

Two Codex rounds; all fixable findings addressed. Deferred (documented in commit): DB unique on Invoice.estimateId pending Mesplay INV-00170 cleanup; ungated legacy server actions flagged for follow-up.

Verification: tsc + build clean; verify-billing-tools 32/32 against prod DB, zero customer emails fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)