### PR TITLE
feat(connector): get_estimate — read an existing estimate's line items

### DIFF
--- a/scripts/verify-estimate-edit.ts
+++ b/scripts/verify-estimate-edit.ts
@@ -1,0 +1,26 @@
+// Verifies get_estimate (read) against a real estimate.
+import { estimateToPhases } from "../src/lib/gpt-estimate";
+
+async function main() {
+    const checks: [string, boolean][] = [];
+
+    // Commercial Siding EST-00145: 4 sections, 6 line items (incl. East/Rear wall).
+    const read = await estimateToPhases("EST-00145");
+    if (!read.ok) throw new Error(read.error);
+    const lineCount = read.phases.reduce((s, p) => s + p.items.length, 0);
+    checks.push(["reads by code", read.code === "EST-00145"]);
+    checks.push(["4 phases / 6 items", read.phases.length === 4 && lineCount === 6]);
+    checks.push(["items carry unit costs", read.phases.every(p => p.items.every(i => typeof i.unitCost === "number"))]);
+    checks.push(["case-insensitive", (await estimateToPhases("est-00145")).ok]);
+    checks.push(["reads by id", (await estimateToPhases(read.estimateId)).ok]);
+    checks.push(["unknown code errors", !(await estimateToPhases("EST-99999")).ok]);
+
+    let failed = 0;
+    for (const [label, ok] of checks) { console.log(`${ok ? "PASS" : "FAIL"}  ${label}`); if (!ok) failed++; }
+    console.log(`\nEST-00145: ${read.phases.length} phases, ${lineCount} items`);
+    for (const p of read.phases) console.log(`  ${p.phaseName}${p.phaseCode ? ` [${p.phaseCode}]` : ""}: ${p.items.map(i => i.name).join(", ")}`);
+    if (failed) throw new Error(`${failed} checks failed`);
+    console.log("ALL CHECKS PASSED");
+}
+
+main().then(() => process.exit(0)).catch(e => { console.error(e); process.exit(1); });

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -2,7 +2,7 @@ import { createHash, createHmac, timingSafeEqual } from "crypto";
 import { createMcpHandler } from "mcp-handler";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
-import { createEstimateFromPhases, templateToPhases, CLOSED_PROJECT_STATUSES, CLOSED_LEAD_STAGES } from "@/lib/gpt-estimate";
+import { createEstimateFromPhases, templateToPhases, estimateToPhases, CLOSED_PROJECT_STATUSES, CLOSED_LEAD_STAGES } from "@/lib/gpt-estimate";
 import { getProjectBilling, sendMilestoneInvoicesCore, resendInvoiceCore, createChangeOrderDraft, billChangeOrderCore, sendChangeOrderToClientCore, listReceivables, createInvoiceFromEstimateGuarded } from "@/lib/billing-core";
 import { coTaxRate, coTaxLabel } from "@/lib/co-tax";
 
@@ -172,6 +172,25 @@ const handler = createMcpHandler(
             },
             async ({ name }) => {
                 const result = await templateToPhases(name);
+                if (!result.ok) return { ...textResult({ error: result.error }), isError: true };
+                return textResult(result);
+            },
+        );
+
+        server.registerTool(
+            "get_estimate",
+            {
+                title: "Read an existing estimate's full line items",
+                annotations: { readOnlyHint: true },
+                description:
+                    "Returns an existing estimate's phases, line items (with cost codes, quantities, unit costs) and payment milestones — the editable detail list_project_billing omits. " +
+                    "Use to REVISE: read it here, then either update_estimate it in place, or create_estimate a new draft from the adjusted items.",
+                inputSchema: {
+                    estimate: z.string().min(1).max(50).describe("Estimate code (e.g. 'EST-00145') or id from list_project_billing"),
+                },
+            },
+            async ({ estimate }) => {
+                const result = await estimateToPhases(estimate);
                 if (!result.ok) return { ...textResult({ error: result.error }), isError: true };
                 return textResult(result);
             },

--- a/src/lib/gpt-estimate.ts
+++ b/src/lib/gpt-estimate.ts
@@ -99,6 +99,86 @@ export async function templateToPhases(templateName: string): Promise<
     return { ok: true, name: template.name, phases: phases.filter(p => p.items.length > 0) };
 }
 
+/**
+ * Reads an EXISTING estimate (by EST-code or id) into the same phases[] shape
+ * create_estimate accepts, so ChatGPT can revise a live estimate: read it,
+ * change/drop items, then create the revised version as a new draft. Within one
+ * estimate the parentId links are real (unlike template rows), so grouping is
+ * taken directly from them.
+ */
+export async function estimateToPhases(codeOrId: string): Promise<
+    | {
+          ok: true;
+          estimateId: string;
+          code: string;
+          title: string;
+          status: string;
+          projectId: string | null;
+          leadId: string | null;
+          totalAmount: number;
+          taxExempt: boolean;
+          phases: { phaseName: string; phaseCode?: string; items: { name: string; description?: string; costCode?: string; costType?: string; quantity: number; unitCost: number }[] }[];
+          paymentMilestones: { name: string; percentage: number; amount: number }[];
+      }
+    | { ok: false; error: string }
+> {
+    const key = codeOrId.trim();
+    const estimate = await prisma.estimate.findFirst({
+        where: { OR: [{ code: { equals: key, mode: "insensitive" } }, { id: key }] },
+        include: {
+            items: { orderBy: [{ order: "asc" }, { id: "asc" }], include: { costCode: { select: { code: true } } } },
+            paymentSchedules: { orderBy: { order: "asc" } },
+        },
+    });
+    if (!estimate) return { ok: false, error: `No estimate matching "${codeOrId}". Use list_project_billing to find the estimate id or code.` };
+
+    type Phase = { phaseName: string; phaseCode?: string; items: { name: string; description?: string; costCode?: string; costType?: string; quantity: number; unitCost: number }[] };
+    const phases: Phase[] = [];
+    const byId = new Map<string, Phase>();
+    let flat: Phase | null = null;
+
+    for (const item of estimate.items) {
+        if (item.type === "Section") {
+            const phase: Phase = { phaseName: item.name, phaseCode: item.costCode?.code ?? undefined, items: [] };
+            phases.push(phase);
+            byId.set(item.id, phase);
+            continue;
+        }
+        let phase = item.parentId ? byId.get(item.parentId) : undefined;
+        if (!phase) {
+            if (!flat) { flat = { phaseName: estimate.title || "Items", items: [] }; phases.push(flat); }
+            phase = flat;
+        }
+        phase.items.push({
+            name: item.name,
+            description: item.description ?? undefined,
+            costCode: item.costCode?.code ?? undefined,
+            costType: item.type,
+            quantity: item.quantity,
+            unitCost: Number(item.unitCost),
+        });
+    }
+
+    const total = Number(estimate.totalAmount);
+    return {
+        ok: true,
+        estimateId: estimate.id,
+        code: estimate.code,
+        title: estimate.title,
+        status: estimate.status,
+        projectId: estimate.projectId,
+        leadId: estimate.leadId,
+        totalAmount: total,
+        taxExempt: !!estimate.taxExempt,
+        phases: phases.filter(p => p.items.length > 0),
+        paymentMilestones: estimate.paymentSchedules.map(m => ({
+            name: m.name,
+            percentage: m.percentage != null ? Number(m.percentage) : 0,
+            amount: Number(m.amount),
+        })),
+    };
+}
+
 export async function createEstimateFromPhases(input: CreateEstimateInput): Promise<CreateEstimateResult> {
     const { title, projectId, leadId, phases, paymentMilestones } = input;
 


### PR DESCRIPTION
Adds the missing 'revise an existing estimate' capability: read-only get_estimate returns a live estimate's phases/items/milestones in the create_estimate shape, so ChatGPT can revise (found while Richard tried to make an east-wall-only revision of EST-00145 and could only see the total). Verified against the real estimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)