### PR TITLE
feat(connector): update_estimate + find_job for the ChatGPT connector

### DIFF
--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -2,7 +2,7 @@ import { createHash, createHmac, timingSafeEqual } from "crypto";
 import { createMcpHandler } from "mcp-handler";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
-import { createEstimateFromPhases, templateToPhases, estimateToPhases, CLOSED_PROJECT_STATUSES, CLOSED_LEAD_STAGES } from "@/lib/gpt-estimate";
+import { createEstimateFromPhases, updateEstimateFromPhases, templateToPhases, estimateToPhases, CLOSED_PROJECT_STATUSES, CLOSED_LEAD_STAGES } from "@/lib/gpt-estimate";
 import { getProjectBilling, sendMilestoneInvoicesCore, resendInvoiceCore, createChangeOrderDraft, billChangeOrderCore, sendChangeOrderToClientCore, listReceivables, createInvoiceFromEstimateGuarded } from "@/lib/billing-core";
 import { coTaxRate, coTaxLabel } from "@/lib/co-tax";
 
@@ -219,6 +219,38 @@ const handler = createMcpHandler(
                 if (!result.ok) {
                     return { ...textResult({ error: result.error }), isError: true };
                 }
+                return textResult(result);
+            },
+        );
+
+        server.registerTool(
+            "update_estimate",
+            {
+                title: "Edit an existing (unsigned) estimate in place",
+                annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+                description:
+                    "Revise an EXISTING estimate that the customer hasn't committed to yet — only Draft or Sent (unsigned, not-yet-invoiced) estimates. " +
+                    "Refuses once it's signed/Approved or already has an invoice (use a change order for those). " +
+                    "Workflow: get_estimate to read the current items, adjust, then call this. " +
+                    "Pass `phases` to REPLACE all line items (totals + milestone amounts recompute automatically); " +
+                    "pass tax fields (taxExempt, or taxRateName + taxRatePercent — e.g. change the tax jurisdiction from Vancouver to Camas) to reprice tax; " +
+                    "pass title / memo / termsAndConditions to edit those. Only the fields you send change. " +
+                    "paymentMilestones may only be sent together with phases. After editing, send_estimate to (re)deliver it.",
+                inputSchema: {
+                    estimate: z.string().min(1).max(50).describe("Estimate code (e.g. 'EST-00317') or id from get_estimate / list_project_billing"),
+                    title: z.string().min(1).max(300).optional(),
+                    phases: z.array(phaseSchema).min(1).max(50).optional().describe("If provided, REPLACES every line item on the estimate"),
+                    paymentMilestones: z.array(milestoneSchema).max(20).optional().describe("Only valid together with phases; percentages must sum to 100"),
+                    taxExempt: z.boolean().optional().describe("Mark the estimate tax-exempt (adds no tax) or clear it"),
+                    taxRateName: z.string().max(100).nullable().optional().describe("Tax jurisdiction label shown to the customer, e.g. 'Camas'"),
+                    taxRatePercent: z.number().min(0).max(30).nullable().optional().describe("Sales tax percent for that jurisdiction, e.g. 8.4"),
+                    memo: z.string().max(5000).optional(),
+                    termsAndConditions: z.string().max(20000).optional(),
+                },
+            },
+            async args => {
+                const result = await updateEstimateFromPhases(args);
+                if (!result.ok) return { ...textResult({ error: result.error }), isError: true };
                 return textResult(result);
             },
         );
@@ -628,7 +660,7 @@ const handler = createMcpHandler(
         );
     },
     {
-        serverInfo: { name: "probuild", version: "1.4.0" },
+        serverInfo: { name: "probuild", version: "1.5.0" },
         capabilities: { tools: {} },
         instructions:
             "ProBuild is Golden Touch Remodeling's construction management system. " +
@@ -638,7 +670,8 @@ const handler = createMcpHandler(
             "Every line item needs a costCode from get_estimating_codes. costType is just a line label (Labor / Material / Allowance / Subcontractor / Equipment / Other) — " +
             "the user estimates with allowances and lump-sum labor, so keep those labels accurate. " +
             "All prices are USD sell prices. Estimates arrive as private drafts for review in ProBuild. " +
-            "ESTIMATE lifecycle: create_estimate (draft) → send_estimate (preview + user approval; customer signs via portal, which auto-creates the invoice). " +
+            "ESTIMATE lifecycle: create_estimate (draft) → [get_estimate to read, update_estimate to revise in place while still Draft/Sent] → send_estimate (preview + user approval; customer signs via portal, which auto-creates the invoice). "
+            + "update_estimate edits an existing unsigned estimate (line items, tax jurisdiction/rate, title, terms); once signed or invoiced, revisions go through a change order. " +
             "If a project needs an invoice without a signed estimate, create_invoice_from_estimate. list_receivables answers 'who owes us money?' across all projects. " +
             "create_lead captures field prospects. " +
             "BILLING: list_project_billing shows a project's invoices/milestones/estimates. send_milestone_invoice, resend_invoice and send_estimate EMAIL THE CUSTOMER — " +

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -114,6 +114,65 @@ const handler = createMcpHandler(
         );
 
         server.registerTool(
+            "find_job",
+            {
+                title: "Find a job (lead or project) and its estimates by name",
+                annotations: { readOnlyHint: true },
+                description:
+                    "Search leads AND projects by name or client — INCLUDING closed/won ones that list_leads and list_projects omit — plus any estimate by its code (e.g. 'EST-00145'). " +
+                    "Use this when you know the job or estimate by name/number but don't know whether it's still a lead or already a project (a won lead becomes a project). " +
+                    "Each hit includes its estimates (code, title, status, total) so you can go straight to get_estimate / update_estimate / list_project_billing.",
+                inputSchema: {
+                    query: z.string().trim().min(1).max(200).describe("Job name, client name, or estimate code to search for"),
+                },
+            },
+            async ({ query }) => {
+                const like = { contains: query.trim(), mode: "insensitive" as const };
+                const estSelect = { select: { id: true, code: true, title: true, status: true, totalAmount: true }, orderBy: { createdAt: "desc" as const } };
+                const [projects, leads, estimates] = await Promise.all([
+                    prisma.project.findMany({
+                        where: { OR: [{ name: like }, { client: { name: like } }] },
+                        take: 15,
+                        orderBy: { createdAt: "desc" },
+                        select: { id: true, name: true, status: true, type: true, location: true, client: { select: { name: true } }, estimates: estSelect },
+                    }),
+                    prisma.lead.findMany({
+                        where: { OR: [{ name: like }, { client: { name: like } }] },
+                        take: 15,
+                        orderBy: { createdAt: "desc" },
+                        select: { id: true, name: true, stage: true, projectType: true, location: true, client: { select: { name: true } }, estimates: estSelect },
+                    }),
+                    prisma.estimate.findMany({
+                        where: { code: like },
+                        take: 15,
+                        orderBy: { createdAt: "desc" },
+                        select: { id: true, code: true, title: true, status: true, totalAmount: true, project: { select: { id: true, name: true } }, lead: { select: { id: true, name: true } } },
+                    }),
+                ]);
+                const mapEstimates = (es: { id: string; code: string; title: string; status: string; totalAmount: unknown }[]) =>
+                    es.map(e => ({ estimateId: e.id, code: e.code, title: e.title, status: e.status, total: Number(e.totalAmount) }));
+                return textResult({
+                    projects: projects.map(p => ({
+                        type: "project", projectId: p.id, name: p.name, client: p.client?.name ?? null,
+                        status: p.status, projectType: p.type, location: p.location, estimates: mapEstimates(p.estimates),
+                    })),
+                    leads: leads.map(l => ({
+                        type: "lead", leadId: l.id, name: l.name, client: l.client?.name ?? null,
+                        stage: l.stage, projectType: l.projectType, location: l.location, estimates: mapEstimates(l.estimates),
+                    })),
+                    estimatesByCode: estimates.map(e => ({
+                        estimateId: e.id, code: e.code, title: e.title, status: e.status, total: Number(e.totalAmount),
+                        on: e.project ? { type: "project", projectId: e.project.id, name: e.project.name }
+                            : e.lead ? { type: "lead", leadId: e.lead.id, name: e.lead.name } : null,
+                    })),
+                    note: projects.length + leads.length + estimates.length === 0
+                        ? `Nothing matched "${query}". Try a shorter or different term (client last name, or the estimate code).`
+                        : "Matches include closed/won jobs. Use projectId/leadId with the estimate tools.",
+                });
+            },
+        );
+
+        server.registerTool(
             "get_estimating_codes",
             {
                 title: "Get ProBuild cost codes and line-item type labels",
@@ -673,7 +732,8 @@ const handler = createMcpHandler(
             "ESTIMATE lifecycle: create_estimate (draft) → [get_estimate to read, update_estimate to revise in place while still Draft/Sent] → send_estimate (preview + user approval; customer signs via portal, which auto-creates the invoice). "
             + "update_estimate edits an existing unsigned estimate (line items, tax jurisdiction/rate, title, terms); once signed or invoiced, revisions go through a change order. " +
             "If a project needs an invoice without a signed estimate, create_invoice_from_estimate. list_receivables answers 'who owes us money?' across all projects. " +
-            "create_lead captures field prospects. " +
+            "create_lead captures field prospects. "
+            + "To locate a job or estimate you only know by name/number (and don't know if it's still a lead or already a project), use find_job — it searches leads AND projects including closed/won ones, plus estimates by code. " +
             "BILLING: list_project_billing shows a project's invoices/milestones/estimates. send_milestone_invoice, resend_invoice and send_estimate EMAIL THE CUSTOMER — " +
             "always run the preview step, show the user exactly what will be sent and to whom, and only echo back the preview's confirmToken after their explicit approval. Never self-confirm. " +
             "Change-order lifecycle: create_change_order (draft) → send_change_order (preview + user approval; customer signs via portal) → " +

--- a/src/lib/ai-estimate-transform.ts
+++ b/src/lib/ai-estimate-transform.ts
@@ -35,7 +35,7 @@ function toNum(v: unknown): number {
 }
 
 /** Round to cents so Decimal columns never accumulate float drift. */
-function toCents(n: number): number {
+export function toCents(n: number): number {
     return Math.round(n * 100) / 100;
 }
 

--- a/src/lib/gpt-estimate.ts
+++ b/src/lib/gpt-estimate.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "crypto";
 import { prisma } from "@/lib/prisma";
-import { transformPhasesToItems, type AiData } from "@/lib/ai-estimate-transform";
+import { transformPhasesToItems, toCents, type AiData } from "@/lib/ai-estimate-transform";
 
 // Persists a phase-grouped estimate payload (the shape ChatGPT emits via the MCP
 // connector) as a real Estimate. Reuses transformPhasesToItems so the MCP path,
@@ -177,6 +177,355 @@ export async function estimateToPhases(codeOrId: string): Promise<
             amount: Number(m.amount),
         })),
     };
+}
+
+// Only estimates the customer has not yet committed to may be edited in place.
+// "Sent" is still editable because sending does NOT sign or invoice — signing
+// flips status to Approved and auto-creates the invoice (Estimate.invoices).
+// The has-invoice / signed / approved checks below are the real gate; the status
+// list is the coarse filter.
+export const EDITABLE_ESTIMATE_STATUSES = ["Draft", "Sent"];
+
+export type UpdateEstimateInput = {
+    estimate: string; // EST-code or id
+    title?: string;
+    phases?: AiData["phases"];
+    paymentMilestones?: AiData["paymentMilestones"];
+    taxExempt?: boolean;
+    taxRateName?: string | null;
+    taxRatePercent?: number | null;
+    memo?: string;
+    termsAndConditions?: string;
+};
+
+export type UpdateEstimateResult =
+    | {
+          ok: true;
+          estimateId: string;
+          code: string;
+          title: string;
+          totalAmount: number;
+          itemCount: number;
+          url: string;
+          changed: string[];
+          warnings: string[];
+      }
+    | { ok: false; error: string };
+
+// Reuse the create/transform path's exact cent rounding (no Number.EPSILON nudge)
+// so update and create can never round a milestone or total differently.
+const round2 = toCents;
+
+// The tax model, mirrored from the app: an estimate's stored totalAmount is
+// TAX-INCLUSIVE once a rate is chosen (deriveInvoiceTaxFields extracts tax back
+// OUT of it at invoice time), and TAX-EXCLUSIVE while the rate is null (approval
+// grosses it up once by the default rate — see ensureProjectAndDepositInvoiceForEstimate).
+// So the invariant this tool must keep is: total = subtotal * (1 + effectiveRate/100),
+// with effectiveRate = 0 when exempt and null when no rate is chosen (leave the
+// subtotal untouched so the approval gross-up still fires).
+function taxedTotal(subtotal: number, effectiveRate: number | null): number {
+    if (effectiveRate == null) return round2(subtotal);
+    return round2(subtotal * (1 + effectiveRate / 100));
+}
+
+// Re-proportions a milestone split across a (possibly new) total. Percentages are
+// normalized to sum to exactly 100 so the amounts always cover the total, and the
+// last milestone absorbs the rounding residual — identical to transformPhasesToItems.
+type MilestoneSource = { name: string; percentage: number; dueDate: Date | null };
+function recomputeMilestones(total: number, source: MilestoneSource[]): { name: string; percentage: number; amount: number; dueDate: Date | null; order: number }[] {
+    if (source.length === 0) return [];
+    let pcts = source.map(m => Number(m.percentage) || 0);
+    const pctSum = round2(pcts.reduce((s, p) => s + p, 0));
+    if (pctSum <= 0) {
+        const eq = 100 / source.length;
+        pcts = source.map(() => eq);
+    } else if (Math.abs(pctSum - 100) > 0.01) {
+        pcts = pcts.map(p => (p * 100) / pctSum);
+    }
+    // Stored percentages and amounts both let the LAST milestone absorb the
+    // rounding residual, so each set sums to exactly 100 / to the total — a
+    // round-tripped result therefore re-passes the "sum to 100" validation.
+    let pctAllocated = 0;
+    let allocated = 0;
+    return source.map((m, idx) => {
+        const isLast = idx === source.length - 1;
+        const percentage = isLast ? round2(100 - pctAllocated) : round2(pcts[idx]);
+        pctAllocated = round2(pctAllocated + percentage);
+        const amount = isLast ? round2(total - allocated) : round2((percentage / 100) * total);
+        allocated = round2(allocated + amount);
+        return { name: m.name, percentage, amount, dueDate: m.dueDate ?? null, order: idx };
+    });
+}
+
+/**
+ * Edits an EXISTING estimate in place (the counterpart create_estimate lacks).
+ * Hard guarantees:
+ *   1. Math never drifts. Line items go through the SAME transformPhasesToItems
+ *      the create path uses. The stored total always satisfies the tax invariant
+ *      (see taxedTotal) whether items OR tax change, and milestone amounts are
+ *      re-proportioned to sum to the new total exactly.
+ *   2. Only uncommitted estimates are touched — refuses anything Approved,
+ *      signed, or already carrying an invoice; the estimate row is locked
+ *      FOR UPDATE and re-checked inside the transaction so a concurrent signing
+ *      can't slip through.
+ *   3. No silent data loss — refuses to rewrite line items that already have
+ *      operational links (POs, time entries, schedule tasks, expenses).
+ * `phases` replaces all line items; tax / title / memo / terms update
+ * independently. A jurisdiction change needs taxRateName + taxRatePercent
+ * together. Milestone edits require `phases`.
+ */
+export async function updateEstimateFromPhases(input: UpdateEstimateInput): Promise<UpdateEstimateResult> {
+    const { estimate: key, title, phases, paymentMilestones, taxExempt, taxRateName, taxRatePercent, memo, termsAndConditions } = input;
+
+    const wantsItems = Array.isArray(phases) && phases.length > 0;
+    const wantsMilestones = Array.isArray(paymentMilestones) && paymentMilestones.length > 0;
+    // A jurisdiction is a (name, rate) pair — accepting one without the other is
+    // how you end up showing "Camas" next to Vancouver's rate. Move them together.
+    if ((taxRateName !== undefined) !== (taxRatePercent !== undefined)) {
+        return { ok: false, error: "Provide taxRateName and taxRatePercent together — a tax jurisdiction is a name plus its rate. (Use taxExempt on its own to toggle exemption.)" };
+    }
+    // Both must carry a value (apply a jurisdiction) or both be null (clear the
+    // rate). A name with a null percent would leave the total tax-exclusive and
+    // let the approval gross-up apply the DEFAULT rate under a "Camas" label.
+    if (taxRateName !== undefined && taxRatePercent !== undefined && (taxRateName == null) !== (taxRatePercent == null)) {
+        return { ok: false, error: "taxRateName and taxRatePercent must both be set to a value (to apply a jurisdiction) or both be null (to clear the tax rate)." };
+    }
+    const wantsTax = taxExempt !== undefined || taxRatePercent !== undefined;
+    const wantsMeta = title !== undefined || memo !== undefined || termsAndConditions !== undefined;
+    if (!wantsItems && !wantsMilestones && !wantsTax && !wantsMeta) {
+        return { ok: false, error: "Nothing to update — provide phases, paymentMilestones, tax fields (taxExempt or taxRateName+taxRatePercent), title, memo, or termsAndConditions." };
+    }
+    if (wantsMilestones && !wantsItems) {
+        return { ok: false, error: "paymentMilestones can only be changed together with phases (send the full line items so amounts recompute against the new total). To re-split payments only, edit the estimate in ProBuild." };
+    }
+    if (title !== undefined && !title.trim()) return { ok: false, error: "title cannot be blank." };
+    if (wantsItems && !phases!.some(p => Array.isArray(p?.items) && p.items.length > 0)) {
+        return { ok: false, error: "No phase contains line items — each phase needs a non-empty items array." };
+    }
+    if (wantsMilestones) {
+        const pctSum = Math.round(paymentMilestones!.reduce((s, m) => s + (Number(m.percentage) || 0), 0) * 100) / 100;
+        if (Math.abs(pctSum - 100) > 0.01) {
+            return { ok: false, error: `paymentMilestones percentages must sum to 100 (got ${pctSum}).` };
+        }
+    }
+    if (taxRatePercent != null && (taxRatePercent < 0 || taxRatePercent > 30)) {
+        return { ok: false, error: `taxRatePercent must be between 0 and 30 (got ${taxRatePercent}).` };
+    }
+
+    const existing = await prisma.estimate.findFirst({
+        where: { OR: [{ code: { equals: key.trim(), mode: "insensitive" } }, { id: key.trim() }] },
+        select: {
+            id: true, code: true, status: true, title: true, projectId: true, leadId: true,
+            totalAmount: true, taxExempt: true, taxRatePercent: true, approvedAt: true, signatureUrl: true,
+            _count: { select: { invoices: true } },
+            paymentSchedules: { orderBy: { order: "asc" }, select: { name: true, percentage: true, amount: true, dueDate: true } },
+        },
+    });
+    if (!existing) return { ok: false, error: `No estimate matching "${key}". Use list_project_billing or get_estimate to find the id or code.` };
+
+    const editable = editabilityError(existing);
+    if (editable) return { ok: false, error: editable };
+
+    const oldTotal = Number(existing.totalAmount);
+
+    // Cost code/type warnings + item transform, only when items are being rewritten.
+    const warnings: string[] = [];
+    let transformed: ReturnType<typeof transformPhasesToItems> | null = null;
+    let idMap: Map<string, string> | null = null;
+    if (wantsItems) {
+        const [costCodes, costTypes] = await Promise.all([
+            prisma.costCode.findMany({ where: { isActive: true }, select: { id: true, code: true, name: true } }),
+            prisma.costType.findMany({ where: { isActive: true }, select: { id: true, name: true } }),
+        ]);
+        const knownCodes = new Set(costCodes.map(c => c.code));
+        const knownTypes = new Set(costTypes.map(t => t.name));
+        for (const phase of phases!) {
+            if (phase?.phaseCode && !knownCodes.has(phase.phaseCode)) {
+                warnings.push(`Unknown phase cost code "${phase.phaseCode}" (phase "${phase.phaseName ?? "?"}") — left uncoded.`);
+            }
+            for (const item of phase?.items ?? []) {
+                if (item?.costCode && !knownCodes.has(item.costCode)) warnings.push(`Unknown cost code "${item.costCode}" on item "${item.name ?? "?"}" — left uncoded.`);
+                if (item?.costType && !knownTypes.has(item.costType)) warnings.push(`Unknown cost type "${item.costType}" on item "${item.name ?? "?"}" — left uncoded.`);
+            }
+        }
+        // paymentMilestones is ignored here — milestone math is done by
+        // recomputeMilestones below so items and tax share one total path.
+        transformed = transformPhasesToItems({ phases }, costCodes, costTypes);
+        idMap = new Map<string, string>();
+        for (const item of transformed.items) idMap.set(item.id, randomUUID());
+    }
+
+    // --- Totals & tax (the invariant) ---------------------------------------
+    // subtotal = tax-exclusive base. From the new items if rewriting, else strip
+    // tax back out of the current stored total using its current effective rate.
+    const currentEffectiveRate: number | null = existing.taxExempt
+        ? 0
+        : (existing.taxRatePercent != null ? Number(existing.taxRatePercent) : null);
+    const subtotal = transformed
+        ? transformed.totalEstimate
+        : (currentEffectiveRate == null ? oldTotal : round2(oldTotal / (1 + currentEffectiveRate / 100)));
+
+    const newExempt = taxExempt !== undefined ? !!taxExempt : existing.taxExempt;
+    const newRatePercent: number | null = taxRatePercent !== undefined
+        ? (taxRatePercent == null ? null : Number(taxRatePercent))
+        : (existing.taxRatePercent != null ? Number(existing.taxRatePercent) : null);
+    const newEffectiveRate: number | null = newExempt ? 0 : newRatePercent;
+
+    const recomputeTotal = wantsItems || wantsTax;
+    const newTotal = recomputeTotal ? taxedTotal(subtotal, newEffectiveRate) : oldTotal;
+    const totalChanged = round2(newTotal) !== round2(oldTotal);
+
+    // --- Milestones ----------------------------------------------------------
+    // Rewrite when items change or the total moved. Source is the caller's split
+    // (with phases) or the existing split carried over (percent derived from the
+    // stored amount when absent so legacy schedules re-proportion), preserving
+    // due dates by position.
+    const milestoneSource: MilestoneSource[] = wantsMilestones
+        ? paymentMilestones!.map(m => ({ name: m.name ?? "Payment", percentage: Number(m.percentage) || 0, dueDate: null }))
+        : existing.paymentSchedules.map(s => ({
+              name: s.name,
+              percentage: s.percentage != null && Number(s.percentage) > 0
+                  ? Number(s.percentage)
+                  : (oldTotal > 0 ? (Number(s.amount) / oldTotal) * 100 : 0),
+              dueDate: s.dueDate ?? null,
+          }));
+    const rewriteMilestones = (wantsItems || totalChanged) && (milestoneSource.length > 0 || wantsItems);
+    const newMilestones = rewriteMilestones ? recomputeMilestones(newTotal, milestoneSource) : [];
+
+    const changed: string[] = [];
+    try {
+        await prisma.$transaction(async tx => {
+            // Lock the estimate row, then re-check editability against the freshest
+            // state: approveEstimate (signing → invoice) could commit between the
+            // read above and here. FOR UPDATE makes a concurrent signing block on
+            // this row (or us on theirs) instead of interleaving.
+            await tx.$queryRaw`SELECT id FROM "Estimate" WHERE id = ${existing.id} FOR UPDATE`;
+            const fresh = await tx.estimate.findUnique({
+                where: { id: existing.id },
+                select: { status: true, approvedAt: true, signatureUrl: true, _count: { select: { invoices: true } } },
+            });
+            if (!fresh) throw new EstimateInputError("Estimate no longer exists.");
+            const stillEditable = editabilityError(fresh);
+            if (stillEditable) throw new EstimateInputError(stillEditable);
+
+            if (wantsItems && transformed && idMap) {
+                // Lock this estimate's item rows, then re-check for operational
+                // links INSIDE the lock so a purchase-order/time/expense/task
+                // assignment can't attach between the check and the deleteMany —
+                // deleting a linked item would SetNull and silently orphan it.
+                await tx.$queryRaw`SELECT id FROM "EstimateItem" WHERE "estimateId" = ${existing.id} FOR UPDATE`;
+                const linked = await tx.estimateItem.count({
+                    where: {
+                        estimateId: existing.id,
+                        OR: [
+                            { purchaseOrderId: { not: null } },
+                            { timeEntries: { some: {} } },
+                            { expenses: { some: {} } },
+                            { scheduleTask: { isNot: null } },
+                        ],
+                    },
+                });
+                if (linked > 0) {
+                    throw new EstimateInputError(`Can't rewrite line items: ${linked} item(s) on this estimate already have linked purchase orders, time entries, expenses or schedule tasks. Edit the items in ProBuild so those links are preserved.`);
+                }
+                const mapParentId = (tempId: string): string => {
+                    const mapped = idMap!.get(tempId);
+                    if (!mapped) throw new Error(`transform produced item with unknown parentId "${tempId}"`);
+                    return mapped;
+                };
+                await tx.estimateItem.deleteMany({ where: { estimateId: existing.id } });
+                const parents = transformed.items.filter(i => !i.parentId);
+                const children = transformed.items.filter(i => i.parentId);
+                for (const group of [parents, children]) {
+                    if (group.length === 0) continue;
+                    await tx.estimateItem.createMany({
+                        data: group.map(i => ({
+                            id: idMap!.get(i.id)!,
+                            estimateId: existing.id,
+                            name: i.name,
+                            description: i.description || null,
+                            type: i.type,
+                            quantity: i.quantity,
+                            baseCost: i.baseCost,
+                            markupPercent: i.markupPercent,
+                            unitCost: i.unitCost,
+                            total: i.total,
+                            order: i.order,
+                            parentId: i.parentId ? mapParentId(i.parentId) : null,
+                            costCodeId: i.costCodeId,
+                            costTypeId: i.costTypeId,
+                        })),
+                    });
+                }
+                changed.push(`line items (${transformed.items.length})`);
+            }
+
+            if (rewriteMilestones) {
+                await tx.estimatePaymentSchedule.deleteMany({ where: { estimateId: existing.id } });
+                if (newMilestones.length > 0) {
+                    await tx.estimatePaymentSchedule.createMany({
+                        data: newMilestones.map(m => ({
+                            estimateId: existing.id,
+                            name: m.name,
+                            percentage: m.percentage,
+                            amount: m.amount,
+                            dueDate: m.dueDate,
+                            order: m.order,
+                        })),
+                    });
+                    changed.push(`payment milestones (${newMilestones.length})`);
+                }
+            }
+
+            const data: Record<string, unknown> = {};
+            if (title !== undefined) { data.title = title.trim(); changed.push("title"); }
+            if (memo !== undefined) { data.memo = memo; changed.push("memo"); }
+            if (termsAndConditions !== undefined) { data.termsAndConditions = termsAndConditions; changed.push("terms"); }
+            if (taxExempt !== undefined) { data.taxExempt = newExempt; changed.push("taxExempt"); }
+            if (taxRateName !== undefined) { data.taxRateName = taxRateName; }
+            if (taxRatePercent !== undefined) { data.taxRatePercent = taxRatePercent; }
+            if (taxRatePercent !== undefined || taxRateName !== undefined) changed.push("tax rate");
+            // balanceDue tracks totalAmount 1:1 here — the has-invoice/paid gate
+            // guarantees no payment has been applied, so there is nothing to net out.
+            if (recomputeTotal && totalChanged) { data.totalAmount = newTotal; data.balanceDue = newTotal; changed.push("total"); }
+            else if (recomputeTotal) { data.totalAmount = newTotal; data.balanceDue = newTotal; }
+            if (Object.keys(data).length > 0) await tx.estimate.update({ where: { id: existing.id }, data });
+        });
+    } catch (err) {
+        if (err instanceof EstimateInputError) return { ok: false, error: err.message };
+        throw err;
+    }
+
+    const url = existing.projectId
+        ? `https://probuild.goldentouchremodeling.com/projects/${existing.projectId}/estimates/${existing.id}`
+        : `https://probuild.goldentouchremodeling.com/leads/${existing.leadId}/estimates/${existing.id}`;
+
+    return {
+        ok: true,
+        estimateId: existing.id,
+        code: existing.code,
+        title: title?.trim() ?? existing.title,
+        totalAmount: recomputeTotal ? newTotal : oldTotal,
+        itemCount: transformed ? transformed.items.length : 0,
+        url,
+        changed: [...new Set(changed)],
+        warnings,
+    };
+}
+
+// Returns a human-readable refusal if the estimate is past the point where an
+// AI edit is safe (signed / approved / already invoiced), or null if editable.
+function editabilityError(e: { status: string; approvedAt: Date | null; signatureUrl: string | null; _count: { invoices: number } }): string | null {
+    if (e._count.invoices > 0) {
+        return "This estimate already has an invoice (it was signed/converted). Editing it would desync the invoice, its milestones and QuickBooks — make changes with a change order, or edit it in ProBuild.";
+    }
+    if (e.approvedAt || e.signatureUrl) {
+        return "This estimate has been signed/approved by the customer and can't be edited. Use a change order for revisions.";
+    }
+    if (!EDITABLE_ESTIMATE_STATUSES.includes(e.status)) {
+        return `Only Draft or Sent (unsigned) estimates can be edited here; this one is "${e.status}". Use a change order for revisions.`;
+    }
+    return null;
 }
 
 export async function createEstimateFromPhases(input: CreateEstimateInput): Promise<CreateEstimateResult> {


### PR DESCRIPTION
## Why
The ChatGPT/ProBuild connector could **create** estimates but not **edit** one — Richard hit this trying to (a) trim a sent estimate to "east wall only" and (b) change EST-00317's tax jurisdiction Vancouver→Camas. It also couldn't locate a job by name once a lead had converted to a project ("Commercial Siding" was missing from `list_leads`).

## What
Two new MCP connector tools (v1.5.0):

**`update_estimate`** — revise an existing estimate in place (line items, tax rate/jurisdiction, title, memo, terms).
- Only edits **Draft/Sent, unsigned, not-yet-invoiced** estimates (`editabilityError`); the estimate row is locked `FOR UPDATE` and re-checked inside the transaction so a concurrent signing can't slip through. The no-invoice gate also keeps it clear of the `PaymentSchedule.sourceScheduleId` mirror rules.
- Maintains the tax invariant `total = subtotal × (1 + effectiveRate/100)`: setting a rate re-grosses the (tax-inclusive) total so invoicing no longer under-bills tax; a null rate stays tax-exclusive for the approval gross-up. Item + tax edits share one total path.
- Milestone amounts/percentages always sum to the total/100 via one `recomputeMilestones` helper; rounding reuses the transform's `toCents` so update and create never diverge.
- Refuses to rewrite line items carrying operational links (POs, time entries, expenses, schedule tasks) rather than orphaning them.

**`find_job`** — search leads AND projects (including closed/won) plus estimates by code, returning nested estimates so the caller can chain into `get_estimate`/`update_estimate`/`list_project_billing`. Read-only.

## Verification
- `tsc` + `next build` clean.
- Standalone math checks: tax re-gross, strip-and-regross (8.8→8.4), items-only on a rated estimate, exempt toggle, residual rounding, legacy milestone coverage — all pass.
- **Two rounds of Codex review** on `update_estimate` (round 1 caught a real tax under-billing bug, fixed) + one round on `find_job` (whitespace match-all, fixed).

## Known / out of scope
Two **pre-existing** money-path sharp edges surfaced but not touched here (surgical scope): `createInvoiceFromEstimate` treats a null-rate estimate total as tax-inclusive; the approval gross-up rounds milestones independently. Tracked for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
