### PR TITLE
feat(estimates): address-based WA sales tax defaulting on new estimates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@ NEXTAUTH_SECRET=generate_a_strong_secret_here
 GOOGLE_CLIENT_ID=your_google_client_id_here
 GOOGLE_CLIENT_SECRET=your_google_client_secret_here
 
+# Google Maps — browser key for Places autocomplete + map previews (referrer-restricted)
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_browser_maps_key_here
+# Server key for Geocoding (address normalization at save) — must NOT be referrer-restricted
+GOOGLE_MAPS_SERVER_API_KEY=your_server_maps_key_here
+
 # Supabase Storage (for file uploads)
 SUPABASE_URL=https://YOUR_PROJECT_REF.supabase.co
 SUPABASE_SERVICE_KEY=your_supabase_service_role_key_here

--- a/src/app/api/mobile/leads/route.ts
+++ b/src/app/api/mobile/leads/route.ts
@@ -6,6 +6,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { authenticateMobileOrSession } from "@/lib/mobile-auth";
 import { ensureLeadFolder, isDriveConnected } from "@/lib/lead-drive";
+import { geocodeJobSiteAddress } from "@/lib/geocode";
 
 export const dynamic = "force-dynamic";
 
@@ -71,7 +72,10 @@ export async function POST(req: NextRequest) {
         : null;
     const clientPhone = typeof body.clientPhone === "string" ? body.clientPhone.trim() || null : null;
     const projectType = typeof body.projectType === "string" ? body.projectType.trim() || null : null;
-    const location = typeof body.location === "string" ? body.location.trim() || null : null;
+    const rawLocation = typeof body.location === "string" ? body.location.trim() || null : null;
+    // Mobile intake bypasses the web form's Places autocomplete entirely —
+    // normalize server-side (fail-soft keeps the raw string).
+    const location = (await geocodeJobSiteAddress(rawLocation))?.formattedAddress ?? rawLocation;
     const note = typeof body.note === "string" ? body.note.trim() : "";
     const leadName = (typeof body.name === "string" && body.name.trim())
         || `${clientName}${projectType ? ` - ${projectType}` : ""}`;

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -22,6 +22,7 @@ import { getSupabase, STORAGE_BUCKET } from "./supabase";
 import { archiveExecutedContractPdf, sendExecutedContractEmails } from "./contract-finalize";
 import { appendContractCountersignaturePage } from "./pdf";
 import { defaultTaxForNewEstimate } from "./wa-tax";
+import { geocodeJobSiteAddress } from "./geocode";
 
 type NotificationToggleKey = "newLead" | "estimateViewed" | "estimateSigned" | "contractSigned" | "invoiceViewed" | "paymentReceived" | "messageReceived";
 
@@ -274,11 +275,15 @@ export async function createLead(data: { name: string; clientName: string; clien
     });
     if (existing) return { id: existing.id };
 
+    // Normalize the job-site address (autocomplete isn't enforced client-side,
+    // so hand-typed text reaches here); fail-soft keeps the raw string.
+    const geo = await geocodeJobSiteAddress(data.location);
+
     const lead = await prisma.lead.create({
         data: {
             name: data.name,
             clientId: client.id,
-            location: data.location || null,
+            location: geo?.formattedAddress ?? (data.location || null),
             source: data.source || null,
             projectType: data.projectType || null,
             message: data.message || null,
@@ -430,10 +435,17 @@ export async function updateLeadInfo(id: string, data: any) {
     const lead = await prisma.lead.findUnique({ where: { id }});
     if (!lead) return;
 
+    // Normalize the job-site address before the transaction (external call).
+    // EditLeadModal sends the whole form, so skip the lookup when unchanged.
+    const geo = data.location && data.location !== lead.location
+        ? await geocodeJobSiteAddress(data.location)
+        : null;
+    const location = geo?.formattedAddress ?? data.location;
+
     const updateData: any = {
         source: data.source,
         stage: data.stage,
-        location: data.location,
+        location,
         tags: data.tags,
         targetRevenue: data.targetRevenue ? parseFloat(data.targetRevenue) : null,
         expectedProfit: data.expectedProfit ? parseFloat(data.expectedProfit) : null,
@@ -453,7 +465,18 @@ export async function updateLeadInfo(id: string, data: any) {
         if (data.location !== undefined) {
             const linked = await tx.project.findUnique({ where: { leadId: id }, select: { id: true } });
             if (linked) {
-                await tx.project.update({ where: { id: linked.id }, data: { location: data.location || null } });
+                await tx.project.update({
+                    where: { id: linked.id },
+                    data: {
+                        location: location || null,
+                        // Precise geocode also refreshes the time-clock geofence;
+                        // clearing the address clears it; coarse/failed lookups
+                        // leave existing coordinates alone.
+                        ...(geo?.lat != null && geo?.lng != null
+                            ? { locationLat: geo.lat, locationLng: geo.lng }
+                            : !location ? { locationLat: null, locationLng: null } : {}),
+                    },
+                });
                 linkedProjectId = linked.id;
             }
         }
@@ -704,7 +727,11 @@ export async function updateLead(leadId: string, data: { name?: string; source?:
     const updateData: any = {};
     if (data.name !== undefined) updateData.name = data.name;
     if (data.source !== undefined) updateData.source = data.source;
-    if (data.location !== undefined) updateData.location = data.location;
+    let locationGeo: Awaited<ReturnType<typeof geocodeJobSiteAddress>> = null;
+    if (data.location !== undefined) {
+        locationGeo = await geocodeJobSiteAddress(data.location);
+        updateData.location = locationGeo?.formattedAddress ?? data.location;
+    }
     if (data.projectType !== undefined) updateData.projectType = data.projectType;
     if (data.expectedStartDate !== undefined) updateData.expectedStartDate = data.expectedStartDate ? new Date(data.expectedStartDate) : null;
     if (data.targetRevenue !== undefined) updateData.targetRevenue = data.targetRevenue;
@@ -714,13 +741,26 @@ export async function updateLead(leadId: string, data: { name?: string; source?:
         data: updateData,
     });
 
-    // Sync name to linked project when lead name changes
-    if (data.name !== undefined) {
+    // Sync name/location to linked project so they stay a single source of truth
+    if (data.name !== undefined || data.location !== undefined) {
         const linkedProject = await prisma.project.findUnique({ where: { leadId } });
         if (linkedProject) {
             await prisma.project.update({
                 where: { id: linkedProject.id },
-                data: { name: data.name },
+                data: {
+                    ...(data.name !== undefined ? { name: data.name } : {}),
+                    ...(data.location !== undefined
+                        ? {
+                            location: updateData.location || null,
+                            // Precise geocode also refreshes the time-clock geofence;
+                            // clearing the address clears it; coarse/failed lookups
+                            // leave existing coordinates alone.
+                            ...(locationGeo?.lat != null && locationGeo?.lng != null
+                                ? { locationLat: locationGeo.lat, locationLng: locationGeo.lng }
+                                : !updateData.location ? { locationLat: null, locationLng: null } : {}),
+                        }
+                        : {}),
+                },
             });
             revalidatePath(`/projects`);
             revalidatePath(`/projects/${linkedProject.id}`, 'layout');
@@ -996,13 +1036,19 @@ export async function convertLeadToProject(leadId: string) {
     const existingProject = await prisma.project.findUnique({ where: { leadId } });
     if (existingProject) return { id: existingProject.id };
 
+    // Normalize the job-site address (outside the transaction — external call).
+    // Also catches legacy leads saved before geocode-on-save existed; a precise
+    // match seeds the project's time-clock geofence coordinates.
+    const geo = await geocodeJobSiteAddress(lead.location);
+
     // Wrap entire conversion in a transaction for atomicity
     const project = await prisma.$transaction(async (tx) => {
         const project = await tx.project.create({
             data: {
                 name: lead.name,
                 clientId: lead.clientId,
-                location: lead.location,
+                location: geo?.formattedAddress ?? lead.location,
+                ...(geo?.lat != null && geo?.lng != null ? { locationLat: geo.lat, locationLng: geo.lng } : {}),
                 status: "In Progress",
                 type: lead.projectType || "Unknown",
                 managerId: lead.managerId || null,
@@ -6861,9 +6907,17 @@ export async function updateProjectLocation(projectId: string, location: string)
         ? await prisma.user.findUnique({ where: { email: session.user.email }, select: { role: true } })
         : null;
     if (!caller || !["ADMIN", "MANAGER"].includes(caller.role)) throw new Error("Forbidden");
+    const geo = await geocodeJobSiteAddress(location);
     await prisma.project.update({
         where: { id: projectId },
-        data: { location: location || null }
+        data: {
+            location: geo?.formattedAddress ?? (location || null),
+            // Precise geocode also refreshes the time-clock geofence; clearing
+            // the address clears it; coarse/failed lookups leave it alone.
+            ...(geo?.lat != null && geo?.lng != null
+                ? { locationLat: geo.lat, locationLng: geo.lng }
+                : !location ? { locationLat: null, locationLng: null } : {}),
+        }
     });
     revalidatePath(`/projects/${projectId}`, 'layout');
     return { success: true };

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -21,6 +21,7 @@ import { headers } from "next/headers";
 import { getSupabase, STORAGE_BUCKET } from "./supabase";
 import { archiveExecutedContractPdf, sendExecutedContractEmails } from "./contract-finalize";
 import { appendContractCountersignaturePage } from "./pdf";
+import { defaultTaxForNewEstimate } from "./wa-tax";
 
 type NotificationToggleKey = "newLead" | "estimateViewed" | "estimateSigned" | "contractSigned" | "invoiceViewed" | "paymentReceived" | "messageReceived";
 
@@ -1139,6 +1140,9 @@ export async function createProject(data: {
 }
 
 export async function createDraftEstimate(projectId: string) {
+    // WA is destination-based: default the rate from the job-site address,
+    // falling back to the company default (null fields) when unresolvable.
+    const taxDefault = await defaultTaxForNewEstimate({ projectId });
     const estimate = await prisma.estimate.create({
         data: {
             title: "Draft Estimate",
@@ -1148,6 +1152,7 @@ export async function createDraftEstimate(projectId: string) {
             totalAmount: 0,
             balanceDue: 0,
             privacy: "Shared",
+            ...(taxDefault ?? {}),
         },
     });
 
@@ -1160,6 +1165,7 @@ export async function createDraftEstimate(projectId: string) {
 }
 
 export async function createDraftLeadEstimate(leadId: string) {
+    const taxDefault = await defaultTaxForNewEstimate({ leadId });
     const estimate = await prisma.estimate.create({
         data: {
             title: "Draft Estimate",
@@ -1169,6 +1175,7 @@ export async function createDraftLeadEstimate(leadId: string) {
             totalAmount: 0,
             balanceDue: 0,
             privacy: "Shared",
+            ...(taxDefault ?? {}),
         },
     });
 
@@ -4476,6 +4483,7 @@ export async function createEstimateFromTemplate(projectId: string, templateId: 
     });
     if (!template) throw new Error("Template not found");
 
+    const taxDefault = await defaultTaxForNewEstimate({ projectId });
     const estimate = await prisma.estimate.create({
         data: {
             title: template.name,
@@ -4485,6 +4493,7 @@ export async function createEstimateFromTemplate(projectId: string, templateId: 
             totalAmount: 0,
             balanceDue: 0,
             privacy: "Shared",
+            ...(taxDefault ?? {}),
         },
     });
 

--- a/src/lib/geocode.ts
+++ b/src/lib/geocode.ts
@@ -1,0 +1,74 @@
+// Server-side job-site address normalization via the Google Geocoding API.
+//
+// The lead/project forms use the Places autocomplete widget, but selecting a
+// suggestion is optional (raw keystrokes save verbatim) and the mobile intake
+// API takes free text, so hand-typed strings reach the DB. Normalizing at save
+// time gives every entry path a verified formatted address — which also
+// upgrades the WA DOR tax lookup (wa-tax.ts) from zip-level to exact-address
+// matches.
+//
+// Fail-soft: any miss (no key, denied key, timeout, ambiguous/partial match)
+// returns null and callers keep the raw user string. NEXT_PUBLIC_GOOGLE_MAPS_
+// API_KEY is browser-referrer-restricted (verified live: REQUEST_DENIED from
+// a server) — server calls need GOOGLE_MAPS_SERVER_API_KEY.
+
+const GEOCODE_URL = "https://maps.googleapis.com/maps/api/geocode/json";
+const GEOCODE_TIMEOUT_MS = 3000;
+
+export type GeocodedAddress = {
+    formattedAddress: string;
+    // Set only for precise matches (ROOFTOP / RANGE_INTERPOLATED). A city-level
+    // geocode must never place a time-clock geofence at a city center, so
+    // coarse results normalize the string but leave coordinates untouched.
+    lat: number | null;
+    lng: number | null;
+};
+
+let warnedDenied = false;
+
+export async function geocodeJobSiteAddress(raw: string | null | undefined): Promise<GeocodedAddress | null> {
+    const address = raw?.trim();
+    if (!address) return null;
+    const key = process.env.GOOGLE_MAPS_SERVER_API_KEY || process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+    if (!key) return null;
+    try {
+        const params = new URLSearchParams({ address, region: "us", key });
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), GEOCODE_TIMEOUT_MS);
+        let payload: any;
+        try {
+            const res = await fetch(`${GEOCODE_URL}?${params.toString()}`, { signal: controller.signal });
+            if (!res.ok) return null;
+            payload = await res.json();
+        } finally {
+            clearTimeout(timeoutId);
+        }
+        if (payload?.status === "REQUEST_DENIED" && !warnedDenied) {
+            warnedDenied = true;
+            console.warn(
+                `[geocode] Google Geocoding request denied: ${payload.error_message ?? "(no message)"} — ` +
+                `set GOOGLE_MAPS_SERVER_API_KEY (the NEXT_PUBLIC key is referrer-restricted).`
+            );
+        }
+        // Exactly one candidate required: multiple results mean the input was
+        // ambiguous, and storing Google's first guess could change the meaning.
+        if (payload?.status !== "OK" || !Array.isArray(payload.results) || payload.results.length !== 1) return null;
+        const result = payload.results[0];
+        // partial_match means Google changed/guessed part of the input; keep the
+        // user's raw string rather than risk normalizing to a different place.
+        if (result.partial_match === true) return null;
+        const formattedAddress = typeof result.formatted_address === "string" ? result.formatted_address.trim() : "";
+        if (!formattedAddress) return null;
+        const geometry = result.geometry ?? {};
+        const precise = geometry.location_type === "ROOFTOP" || geometry.location_type === "RANGE_INTERPOLATED";
+        let lat: number | null = null;
+        let lng: number | null = null;
+        if (precise && typeof geometry.location?.lat === "number" && typeof geometry.location?.lng === "number") {
+            lat = geometry.location.lat;
+            lng = geometry.location.lng;
+        }
+        return { formattedAddress, lat, lng };
+    } catch {
+        return null;
+    }
+}

--- a/src/lib/wa-tax.ts
+++ b/src/lib/wa-tax.ts
@@ -1,0 +1,172 @@
+// Address-based sales tax defaulting for new estimates (WA-only).
+//
+// Washington is destination-based: the combined sales tax rate comes from the
+// job-site address, not a company-wide default. On estimate creation we ask
+// the WA DOR rate-lookup service for the rate at the project/lead address and
+// persist it as the estimate's taxRateName/taxRatePercent. The editor's rate
+// dropdown still lets the user override. Every miss (no usable address,
+// out-of-state, service down) returns null so creation falls back to the
+// existing company-default behavior — null must never be treated as exempt.
+//
+// Service contract (verified live 2026-07):
+//   GET https://webgis.dor.wa.gov/webapi/AddressRates.aspx?output=xml&addr=&city=&zip=
+//   - zip is required; addr+city refine the match from county-level to exact address
+//   - hit:  <response ... rate=".080" code="0"><rate name="WINLOCK" .../></response>
+//   - miss: rate="-1" (e.g. code="9" for a non-WA zip) — no <rate> element
+
+import { prisma } from "./prisma";
+
+const DOR_LOOKUP_URL = "https://webgis.dor.wa.gov/webapi/AddressRates.aspx";
+const LOOKUP_TIMEOUT_MS = 3000;
+
+type AddressQuery = { addr: string; city: string; zip: string };
+
+type ClientAddress = {
+    addressLine1: string | null;
+    city: string | null;
+    state: string | null;
+    zipCode: string | null;
+};
+
+// "204 SW Kerron St, Winlock, WA 98596" → parts the DOR service understands.
+// Null without a WA-shaped 5-digit zip (the service rejects zip-less queries).
+function parseLocationText(text: string | null | undefined): AddressQuery | null {
+    if (!text) return null;
+    // Last WA-shaped zip (980xx–994xx live in 98/99): house numbers can be five
+    // digits too, so first-match breaks "12345 NE 8th St Bellevue WA 98005".
+    const zipMatches = [...text.matchAll(/\b(9[89]\d{3})(?:-\d{4})?\b/g)];
+    const zipMatch = zipMatches[zipMatches.length - 1];
+    if (!zipMatch) return null;
+    const zip = zipMatch[1];
+    const parts = text.split(",").map(p => p.trim()).filter(Boolean);
+    if (parts.length === 1) {
+        // Comma-less free text ("709 w 32 st Vancouver Washington 98660"): the
+        // DOR geocoder tolerates trailing city text inside addr (verified live),
+        // so send everything before the zip/state as one addr string. Only the
+        // matched zip token and a TRAILING/LONE state token are stripped —
+        // "123 Washington Ave" keeps its street name.
+        const single = parts[0];
+        const zipStart = single.lastIndexOf(zipMatch[0]);
+        const withoutZip = zipStart >= 0 ? single.slice(0, zipStart) + single.slice(zipStart + zipMatch[0].length) : single;
+        const stripped = withoutZip
+            .replace(/[.,]/g, " ")
+            .replace(/(?:^|\s)(WA|Washington)\s*$/i, " ")
+            .replace(/\s+/g, " ")
+            .trim();
+        return /^\d/.test(stripped) ? { addr: stripped, city: "", zip } : { addr: "", city: stripped, zip };
+    }
+    const street = /^\d/.test(parts[0]) ? parts[0] : "";
+    let city = "";
+    for (const part of street ? parts.slice(1) : parts) {
+        const cleaned = part
+            .replace(/\b\d{5}(?:-\d{4})?\b/g, "")
+            .replace(/\b(WA|Washington)\b/gi, "")
+            .replace(/[.,]/g, "")
+            .trim();
+        if (cleaned && !/\d/.test(cleaned)) {
+            city = cleaned;
+            break;
+        }
+    }
+    return { addr: street, city, zip };
+}
+
+function titleCase(name: string): string {
+    return name
+        .toLowerCase()
+        .replace(/(^|[\s-])[a-z]/g, c => c.toUpperCase())
+        // DOR jurisdiction acronyms (e.g. "CLARK PTBA") should stay uppercase.
+        .replace(/\b(Ptba|Rta|Cez)\b/g, s => s.toUpperCase());
+}
+
+async function lookupWaTaxRate(query: AddressQuery): Promise<{ name: string; ratePercent: number } | null> {
+    const params = new URLSearchParams({ output: "xml", addr: query.addr, city: query.city, zip: query.zip });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), LOOKUP_TIMEOUT_MS);
+    let xml: string;
+    try {
+        const res = await fetch(`${DOR_LOOKUP_URL}?${params.toString()}`, { signal: controller.signal });
+        if (!res.ok) return null;
+        xml = await res.text();
+    } catch {
+        return null;
+    } finally {
+        clearTimeout(timeoutId);
+    }
+    // `rate` on <response> is the combined state+local rate as a decimal (".080").
+    // `\brate=` can't match inside `localrate=` (no word boundary mid-word).
+    const rate = Number(xml.match(/<response[^>]*\brate="([^"]+)"/)?.[1]);
+    const name = xml.match(/<rate\b[^>]*\bname="([^"]*)"/)?.[1]?.trim();
+    if (!name || !Number.isFinite(rate) || rate <= 0 || rate >= 0.25) return null;
+    // Store as a percent (8.0, 10.35) to match CompanySettings.salesTaxes rates.
+    return { name: titleCase(name), ratePercent: Math.round(rate * 10000) / 100 };
+}
+
+// Resolve the default tax fields for a new estimate from its owner's job-site
+// address: the project/lead free-text location first, then the client's
+// billing address as a proxy. Fail-soft: null means "keep current defaulting".
+export async function defaultTaxForNewEstimate(owner: {
+    projectId?: string | null;
+    leadId?: string | null;
+}): Promise<{ taxRateName: string; taxRatePercent: number } | null> {
+    try {
+        const clientSelect = { select: { addressLine1: true, city: true, state: true, zipCode: true } };
+        let location: string | null = null;
+        let client: ClientAddress | null = null;
+        if (owner.projectId) {
+            const project = await prisma.project.findUnique({
+                where: { id: owner.projectId },
+                select: { location: true, client: clientSelect },
+            });
+            location = project?.location ?? null;
+            client = project?.client ?? null;
+        } else if (owner.leadId) {
+            const lead = await prisma.lead.findUnique({
+                where: { id: owner.leadId },
+                select: { location: true, client: clientSelect },
+            });
+            location = lead?.location ?? null;
+            client = lead?.client ?? null;
+        }
+
+        const candidates: AddressQuery[] = [];
+        const fromLocation = parseLocationText(location);
+        if (fromLocation) candidates.push(fromLocation);
+
+        const clientState = client?.state?.trim().toUpperCase() ?? "";
+        const clientZip = client?.zipCode?.match(/\b(9[89]\d{3})\b/)?.[1];
+        const clientInWa = clientState === "" || clientState === "WA" || clientState === "WASHINGTON";
+        if (clientZip && clientInWa) {
+            const clientCandidate = {
+                addr: client?.addressLine1?.trim() ?? "",
+                city: client?.city?.trim() ?? "",
+                zip: clientZip,
+            };
+            if (!fromLocation) {
+                candidates.push(clientCandidate);
+            } else if (clientCandidate.zip === fromLocation.zip) {
+                // Same zip: the billing address only helps if it adds the street
+                // the free text lacked — then it refines a coarse zip-level match,
+                // so it goes first. Otherwise it would just repeat the lookup.
+                if (!fromLocation.addr && clientCandidate.addr) candidates.unshift(clientCandidate);
+            } else {
+                // Different zip: the job-site location stays first — the billing
+                // address may be a different destination, so it's only a backup.
+                candidates.push(clientCandidate);
+            }
+        }
+
+        // Fire lookups together (bounds worst-case latency to one timeout) but
+        // honor candidate priority when picking the winner. allSettled so one
+        // unexpected rejection can't discard another candidate's hit.
+        const settled = await Promise.allSettled(candidates.map(lookupWaTaxRate));
+        for (const s of settled) {
+            if (s.status === "fulfilled" && s.value) {
+                return { taxRateName: s.value.name, taxRatePercent: s.value.ratePercent };
+            }
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}


### PR DESCRIPTION
## What  New estimates (project or lead context) now default `taxRateName`/`taxRatePercent` from the **job-site address** via the WA DOR rate-lookup API, instead of always inheriting the static company-default rate. WA is destination-based — a Winlock project no longer silently gets the Kalama default.  ## How  - New `src/lib/wa-tax.ts`: parses street/city/zip from the project/lead free-text `location` (client billing address as fallback/refiner), queries `webgis.dor.wa.gov/webapi/AddressRates.aspx` (free, no key, 3s timeout, candidates concurrent), returns `{ taxRateName, taxRatePercent }` or `null`. - Wired into `createDraftEstimate`, `createDraftLeadEstimate`, `createEstimateFromTemplate`. - **Fail-soft**: any miss (no usable address, out-of-state, service down) leaves tax fields `null` → editor keeps applying the company default exactly as today. Null is never treated as exempt. - User override unchanged — the editor's existing rate dropdown shows the address-derived rate (via its orphaned-rate path) and any company rate can be picked instead. - Existing/approved estimates untouched; change orders keep inheriting the estimate's rate via `co-tax.ts`.  ## Verification  - Live-verified against real prod projects (read-only): comma-less addresses, lowercase cities, `Washington`-named streets, 5-digit house numbers, out-of-state zips, addressless e2e fixture (→ null). - `npm run build` clean. - e2e seed data has no addresses, so specs never trigger a network call; `money-pipeline.spec.ts` fixtures are created via direct Prisma with `taxExempt: true` — CI run on this PR confirms. - Codex peer review: 2 rounds. Fixed: same-zip candidate ordering, Washington-street stripping, 5-digit house-number zip confusion, sequential-lookup latency. Deliberately kept: zip-only lookups accept DOR's own zip-level fallback rate (jurisdiction name is visible on the estimate and overridable) since most real project locations lack a street address.  🤖 Generated with [Claude Code](https://claude.com/claude-code)   ---  ## Addendum: server-side geocode-on-save (commit 7b0fd1d)  Places autocomplete on the forms is advisory (raw keystrokes save verbatim; mobile intake bypasses it), so job-site addresses are now normalized server-side at save time via the Google Geocoding API in all six `location` writers. Formatted address replaces the raw string; precise (ROOFTOP/RANGE_INTERPOLATED) matches also seed/refresh `Project.locationLat/Lng` for time-clock geofencing; clearing an address clears its coordinates. Fail-soft: ambiguous/partial/denied/no-key keeps the raw string.  **Activation required**: add `GOOGLE_MAPS_SERVER_API_KEY` (non-referrer-restricted, Geocoding API enabled) to Vercel — the existing `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` is referrer-restricted and is rejected server-side (verified live). Until then every lookup fails soft and behavior is unchanged; a one-time `console.warn` flags the misconfiguration in server logs.  Codex round 2 on this addendum: fixed multi-result ambiguity guard, stale-geofence-on-clear, missing `updateLead`-to-project location sync, and skip-geocode-when-unchanged in `updateLeadInfo`. 