### PR TITLE
fix(change-orders): persist item edits, stop double-taxing billed amounts

### DIFF
--- a/src/app/portal/change-orders/[id]/PortalChangeOrderClient.tsx
+++ b/src/app/portal/change-orders/[id]/PortalChangeOrderClient.tsx
@@ -6,7 +6,7 @@ import SignaturePad from "@/components/SignaturePad";
 import Link from "next/link";
 import { toast } from "sonner";
 import { formatCurrency } from "@/lib/utils";
-import { coTaxRate, coTaxLabel } from "@/lib/co-tax";
+import { coTaxRate, coTaxLabel, coLineCents, coItemsSubtotal } from "@/lib/co-tax";
 
 export default function PortalChangeOrderClient({ initialData, companySettings }: { initialData: any, companySettings?: any }) {
     const [isApproving, setIsApproving] = useState(false);
@@ -47,11 +47,13 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
     const companyAddress = companySettings?.address || "";
 
     const items = initialData.items || [];
-    const subtotal = items.reduce((acc: number, item: any) => acc + (Number(item.quantity || 0) * Number(item.unitCost || 0)), 0);
-    // Tax follows the estimate's treatment (tax-exempt customers pay none) — the
-    // amount shown here is what the customer signs AND what billing charges.
-    const tax = subtotal * coTaxRate(initialData.estimate);
-    const total = subtotal + tax;
+    // Same integer-cents math as the editor, updateChangeOrder's item sync, and
+    // billChangeOrderCore. Tax follows the estimate's treatment (tax-exempt
+    // customers pay none) — the amount shown here is what the customer signs
+    // AND what billing charges, to the cent.
+    const subtotal = coItemsSubtotal(items);
+    const tax = Math.round(subtotal * coTaxRate(initialData.estimate) * 100) / 100;
+    const total = Math.round((subtotal + tax) * 100) / 100;
     const taxLabel = coTaxLabel(initialData.estimate);
 
     return (
@@ -202,7 +204,7 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
                             </thead>
                             <tbody className="divide-y divide-slate-100">
                                 {items.map((item: any) => {
-                                    const itemTotal = Number(item.quantity || 0) * Number(item.unitCost || 0);
+                                    const itemTotal = coLineCents(Number(item.quantity || 0), Number(item.unitCost || 0)) / 100;
                                     return (
                                         <tr key={item.id}>
                                             <td className="py-3">

--- a/src/app/projects/[id]/change-orders/[coId]/ChangeOrderEditor.tsx
+++ b/src/app/projects/[id]/change-orders/[coId]/ChangeOrderEditor.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import Link from "next/link";
 import { formatCurrency } from "@/lib/utils";
-import { coTaxRate, coTaxLabel } from "@/lib/co-tax";
+import { coTaxRate, coTaxLabel, coLineCents, coItemsSubtotal } from "@/lib/co-tax";
 
 export default function ChangeOrderEditor({ context, initialData }: { context: any, initialData: any }) {
     const router = useRouter();
@@ -23,11 +23,17 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
     const [isSigning, setIsSigning] = useState(false);
     const [isSending, setIsSending] = useState(false);
 
-    const subtotal = items.reduce((acc, item) => acc + ((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0)), 0);
+    // A signed CO is a contract: its items are locked (the server rejects item
+    // writes on Approved COs; only title/description remain editable).
+    const isApproved = initialData.status === "Approved";
+
+    // Same integer-cents math as the server's item sync and billChangeOrderCore,
+    // so the Revised Amount shown here is exactly what billing will charge.
     // Tax follows the estimate's treatment (tax-exempt customers pay none) — kept
     // in sync with the portal signature page and billChangeOrderCore via lib/co-tax.
-    const tax = subtotal * coTaxRate(initialData.estimate);
-    const total = subtotal + tax;
+    const subtotal = coItemsSubtotal(items);
+    const tax = Math.round(subtotal * coTaxRate(initialData.estimate) * 100) / 100;
+    const total = Math.round((subtotal + tax) * 100) / 100;
     const taxLabel = coTaxLabel(initialData.estimate);
 
     async function handleSign() {
@@ -47,32 +53,43 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
         }
     }
 
-    async function handleSave() {
-        if (isDeleting) return; // Prevent saving if we are in the middle of deleting
+    // Returns whether the save persisted — the send flow must not email the client
+    // a signature request when the save failed (they'd sign the stale amounts).
+    async function handleSave(): Promise<boolean> {
+        if (isDeleting) return false; // Prevent saving if we are in the middle of deleting
         setIsSaving(true);
         const mappedItems = items.map((item, index) => ({
-            ...item,
+            id: item.id,
+            name: item.name,
+            description: item.description || null,
+            type: item.type,
+            quantity: parseFloat(item.quantity) || 0,
+            unitCost: parseFloat(item.unitCost) || 0,
             order: index,
-            total: (parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0)
+            costCodeId: item.costCodeId || null,
+            costTypeId: item.costTypeId || null,
         }));
-        
-        // Use standard update behavior (just save the primitive fields for now, items sync require robust backend diff logic similar to estimates)
-        // Since our backend `updateChangeOrder` primarily saves primitive fields, we will adapt it.
-        // For line items, ideally we sync them. But for simplicity let's assume they were created correctly and we just update amounts/names.
+
         try {
+            // The server syncs the items and recomputes totalAmount from them as the
+            // PRE-TAX subtotal (billing adds the estimate's tax on top) — sending a
+            // tax-inclusive total here is what inflated billed amounts before.
+            // Status is never sent: sendChangeOrderToClientCore owns Draft -> Sent,
+            // and Approved/Declined belong to the signature flows.
             await updateChangeOrder(initialData.id, {
                 title,
                 description,
-                status,
-                totalAmount: total,
-                balanceDue: total // simplistic approach
+                ...(isApproved ? {} : { items: mappedItems }),
             });
             toast.success("Change Order saved");
             router.refresh();
-        } catch(e) {
-            toast.error("Failed to save CO");
+            return true;
+        } catch (e: any) {
+            toast.error(e?.message || "Failed to save CO");
+            return false;
+        } finally {
+            setIsSaving(false);
         }
-        setIsSaving(false);
     }
 
     async function handleDelete() {
@@ -179,11 +196,16 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
                             if (!confirm("Save and send this change order to the client for approval?")) return;
                             setIsSending(true);
                             try {
-                                // Save first, then send email
-                                setStatus("Sent");
-                                await handleSave();
+                                // Save first, then send email. A failed save must
+                                // abort the send — otherwise the client is asked to
+                                // sign amounts that never persisted. The Sent status
+                                // is owned by sendChangeOrderToClientCore; the local
+                                // badge only updates after a confirmed send.
+                                const saved = await handleSave();
+                                if (!saved) return;
                                 const result = await sendChangeOrderToClient(initialData.id);
                                 if (result.success) {
+                                    setStatus("Sent");
                                     toast.success(`Change order sent to ${result.sentTo}`);
                                     router.refresh();
                                 } else {
@@ -252,13 +274,14 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
 
                                 <div className="divide-y divide-slate-100">
                                     {items.map((item, index) => {
-                                        const itemTotal = (parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0);
+                                        const itemTotal = coLineCents(parseFloat(item.quantity) || 0, parseFloat(item.unitCost) || 0) / 100;
                                         return (
                                             <div key={item.id} className="flex items-center px-8 py-3 bg-white group hover:bg-slate-50 transition border-transparent border-l-2">
                                                 <div className="flex-1">
                                                     <input
                                                         type="text"
                                                         value={item.name}
+                                                        disabled={isApproved}
                                                         onChange={e => updateItem(index, "name", e.target.value)}
                                                         className="w-full bg-transparent focus:outline-none focus:bg-white focus:ring-1 ring-hui-border rounded px-2 py-1 -ml-2 transition text-sm font-medium text-hui-textMain"
                                                     />
@@ -267,6 +290,7 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
                                                     <input
                                                         type="number"
                                                         value={item.quantity}
+                                                        disabled={isApproved}
                                                         onChange={e => updateItem(index, "quantity", e.target.value)}
                                                         className="w-full bg-transparent focus:outline-none focus:bg-white focus:ring-1 ring-slate-200 rounded px-2 py-1 text-right hover:bg-slate-50 transition text-sm font-medium text-slate-700"
                                                     />
@@ -276,6 +300,7 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
                                                     <input
                                                         type="number"
                                                         value={item.unitCost}
+                                                        disabled={isApproved}
                                                         onChange={e => updateItem(index, "unitCost", e.target.value)}
                                                         className="w-full bg-transparent focus:outline-none focus:bg-white focus:ring-1 ring-slate-200 rounded px-2 py-1 pl-6 text-right hover:bg-slate-50 transition text-sm font-medium text-slate-700"
                                                     />
@@ -284,9 +309,11 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
                                                     {formatCurrency(itemTotal)}
                                                 </div>
                                                 <div className="w-10 pt-1.5 flex justify-end">
-                                                    <button onClick={() => removeItem(index)} className="text-slate-300 hover:text-red-500 hover:bg-red-50 rounded p-1.5 transition opacity-0 group-hover:opacity-100">
-                                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6 6 18M6 6l12 12" /></svg>
-                                                    </button>
+                                                    {!isApproved && (
+                                                        <button onClick={() => removeItem(index)} className="text-slate-300 hover:text-red-500 hover:bg-red-50 rounded p-1.5 transition opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto">
+                                                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6 6 18M6 6l12 12" /></svg>
+                                                        </button>
+                                                    )}
                                                 </div>
                                             </div>
                                         );
@@ -296,14 +323,16 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
                                     )}
                                 </div>
 
-                                <div className="p-4 px-8 border-t border-slate-100 bg-white hover:bg-slate-50 transition-colors flex items-center gap-4 cursor-pointer group" onClick={addItem}>
-                                    <button className="text-sm font-semibold text-amber-600 group-hover:text-amber-700 flex items-center gap-2 transition">
-                                        <span className="bg-amber-50 text-amber-600 group-hover:bg-amber-100 rounded p-1">
-                                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 5v14M5 12h14"/></svg>
-                                        </span>
-                                        Add New Item
-                                    </button>
-                                </div>
+                                {!isApproved && (
+                                    <div className="p-4 px-8 border-t border-slate-100 bg-white hover:bg-slate-50 transition-colors flex items-center gap-4 cursor-pointer group" onClick={addItem}>
+                                        <button className="text-sm font-semibold text-amber-600 group-hover:text-amber-700 flex items-center gap-2 transition">
+                                            <span className="bg-amber-50 text-amber-600 group-hover:bg-amber-100 rounded p-1">
+                                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 5v14M5 12h14"/></svg>
+                                            </span>
+                                            Add New Item
+                                        </button>
+                                    </div>
+                                )}
                             </div>
 
                             <div className="bg-slate-50 p-10 flex justify-end border-t border-slate-200">

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -13,6 +13,7 @@ import { createHmac, timingSafeEqual } from "crypto";
 import { resolveSessionClientId } from "./portal-auth";
 import { persistSignature } from "./signature-storage";
 import { getCurrentUserWithPermissions, hasPermission } from "./permissions";
+import { coLineCents } from "./co-tax";
 import { emptyDoc } from "@/lib/studio/doc";
 import type { RoomType } from "@/lib/studio/templates";
 import { normalizeE164 } from "./phone";
@@ -7232,10 +7233,97 @@ export async function getChangeOrderForPortal(id: string) {
 
 export async function updateChangeOrder(id: string, data: any) {
     "use server";
-    const co = await prisma.changeOrder.update({
-        where: { id },
-        data
-    });
+    // Money-path: this is a remotely invokable server action — gate it like
+    // sendChangeOrderToClient and whitelist fields so callers can't write
+    // approval/signature/audit columns or arbitrary amounts.
+    const user = await getCurrentUserWithPermissions();
+    if (!user) throw new Error("Unauthorized");
+    if (!hasPermission(user, "changeOrders")) throw new Error("Forbidden");
+
+    const items: any[] | undefined = Array.isArray(data.items) ? data.items : undefined;
+
+    const co = await prisma.$transaction(async (tx) => {
+        // Row lock (same style as billChangeOrderCore): a concurrent approval or
+        // billing run serializes on this row, so we can't read a stale status and
+        // re-price a CO that gets approved mid-save — approve/bill writers block
+        // until this transaction commits, and vice versa.
+        const locked = await tx.$queryRaw<Array<{ status: string; totalAmount: unknown }>>`
+            SELECT "status", "totalAmount" FROM "ChangeOrder" WHERE "id" = ${id} FOR UPDATE`;
+        const current = locked[0];
+        if (!current) throw new Error("Change order not found");
+
+        const scalarData: Record<string, unknown> = {};
+        if (data.title !== undefined) scalarData.title = data.title;
+        if (data.description !== undefined) scalarData.description = data.description;
+        if (data.status !== undefined && data.status !== current.status) {
+            // The editor only moves Draft <-> Sent. Approved/Declined are owned by
+            // the signature/decline flows (approveChangeOrder drives billing) — a
+            // raw status write in either direction would bypass them.
+            if (!["Draft", "Sent"].includes(data.status) || !["Draft", "Sent"].includes(current.status)) {
+                throw new Error(`Status can only move between Draft and Sent here — "${current.status}" is owned by the signature flow.`);
+            }
+            scalarData.status = data.status;
+        }
+
+        if (items) {
+            // Integer-cents line math (mirrors createChangeOrderDraft) so float dust
+            // can't mis-round a line. totalAmount is the PRE-TAX subtotal — billing
+            // (billChangeOrderCore) adds the estimate's tax on top when invoicing —
+            // and is recomputed here from the items, never trusted from the client.
+            let totalCents = 0;
+            const rows = items.map((item: any, idx: number) => {
+                const quantity = parseFloat(item.quantity) || 0;
+                const unitCost = parseFloat(item.unitCost) || 0;
+                const unitCents = Math.round(unitCost * 100);
+                const lineCents = coLineCents(quantity, unitCost);
+                totalCents += lineCents;
+                return {
+                    id: item.id || undefined,
+                    name: item.name || "",
+                    description: item.description || null,
+                    ...(item.type ? { type: item.type } : {}),
+                    quantity,
+                    unitCost: unitCents / 100,
+                    total: lineCents / 100,
+                    order: item.order ?? idx,
+                    costCodeId: item.costCodeId || null,
+                    costTypeId: item.costTypeId || null,
+                };
+            });
+
+            // An Approved CO's items are what the customer signed and what billing
+            // put on the invoice — any item write here (amounts, quantities, cost
+            // codes) would desync the signed document from the billed milestone.
+            // Title/description edits stay allowed via the scalar path.
+            if (current.status === "Approved") {
+                throw new Error("This change order is approved and billed — its items are locked. Create a new change order for additional work.");
+            }
+
+            // Differential item sync (same pattern as saveEstimate): delete rows the
+            // editor removed, update surviving rows, create new ones.
+            const existing = await tx.changeOrderItem.findMany({ where: { changeOrderId: id }, select: { id: true } });
+            const existingIds = new Set(existing.map(i => i.id));
+            const incomingIds = new Set(rows.map(r => r.id).filter(Boolean));
+            const toDelete = existing.filter(i => !incomingIds.has(i.id)).map(i => i.id);
+            if (toDelete.length > 0) {
+                await tx.changeOrderItem.deleteMany({ where: { id: { in: toDelete }, changeOrderId: id } });
+            }
+            for (const row of rows) {
+                const { id: itemId, ...itemData } = row;
+                if (itemId && existingIds.has(itemId)) {
+                    await tx.changeOrderItem.update({ where: { id: itemId }, data: itemData });
+                } else {
+                    await tx.changeOrderItem.create({ data: { ...itemData, ...(itemId ? { id: itemId } : {}), changeOrderId: id } });
+                }
+            }
+
+            scalarData.totalAmount = totalCents / 100;
+            scalarData.balanceDue = totalCents / 100;
+        }
+
+        return tx.changeOrder.update({ where: { id }, data: scalarData });
+    }, { timeout: 15_000 });
+
     revalidatePath(`/projects/${co.projectId}/change-orders/${id}`);
     revalidatePath(`/projects/${co.projectId}/change-orders`);
     return co;

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -929,11 +929,19 @@ export async function sendChangeOrderToClientCore(changeOrderId: string): Promis
         where: { id: changeOrderId },
         include: {
             project: { include: { client: true } },
+            estimate: { select: { taxExempt: true, taxRatePercent: true, taxRateName: true } },
             items: { orderBy: { order: "asc" } },
         }
     });
 
     if (!co) return { success: false, error: "Change order not found" };
+
+    // co.totalAmount is the PRE-TAX subtotal (same semantic as billChangeOrderCore).
+    // The email must show the tax-inclusive Revised Amount — the number on the
+    // signature page and the number billing will actually charge.
+    const coSubtotal = Math.round(Number(co.totalAmount) * 100) / 100;
+    const coTaxAmount = Math.round(coSubtotal * coTaxRate(co.estimate) * 100) / 100;
+    const coRevisedAmount = Math.round((coSubtotal + coTaxAmount) * 100) / 100;
     const client = co.project?.client;
     if (!client?.email) return { success: false, error: "Client has no email address" };
 
@@ -969,7 +977,8 @@ export async function sendChangeOrderToClientCore(changeOrderId: string): Promis
                 </p>
                 <div style="background: #f9fafb; border-radius: 8px; padding: 16px; text-align: center; margin: 24px 0;">
                     <div style="color: #666; font-size: 13px; margin-bottom: 4px;">Change Order Amount</div>
-                    <div style="font-size: 24px; font-weight: 700; color: #111;">${formatCurrency(co.totalAmount)}</div>
+                    <div style="font-size: 24px; font-weight: 700; color: #111;">${formatCurrency(coRevisedAmount)}</div>
+                    ${coTaxAmount > 0 ? `<div style="color: #999; font-size: 12px; margin-top: 4px;">${formatCurrency(coSubtotal)} + ${formatCurrency(coTaxAmount)} ${coTaxLabel(co.estimate)}</div>` : ""}
                 </div>
                 <div style="text-align: center; margin: 32px 0;">
                     <a href="${portalUrl}" style="display: inline-block; background: #059669; color: #fff; text-decoration: none; padding: 14px 32px; border-radius: 8px; font-weight: 600; font-size: 15px;">

--- a/src/lib/co-tax.ts
+++ b/src/lib/co-tax.ts
@@ -20,6 +20,22 @@ export function coTaxRate(estimate: EstimateTaxInfo): number {
     return Number.isFinite(pct) ? pct / 100 : DEFAULT_CO_TAX_RATE;
 }
 
+// Integer-cents line math shared by the CO editor, the portal signature page,
+// and the item sync in updateChangeOrder, so the amount the customer sees is
+// bit-identical to the amount persisted and billed. toPrecision strips float
+// dust before rounding (0.29 * 5000 = 14.499999999999998 must round as 14.5).
+export function coLineCents(quantity: number, unitCost: number): number {
+    const unitCents = Math.round((unitCost || 0) * 100);
+    return Math.round(Number(((quantity || 0) * unitCents).toPrecision(12)));
+}
+
+export function coItemsSubtotal(items: Array<{ quantity?: number | string | null; unitCost?: number | string | null }>): number {
+    return items.reduce((cents, item) => cents + coLineCents(
+        parseFloat(String(item.quantity)) || 0,
+        parseFloat(String(item.unitCost)) || 0,
+    ), 0) / 100;
+}
+
 export function coTaxLabel(estimate: EstimateTaxInfo): string {
     if (estimate?.taxExempt) return "Tax Exempt";
     const pctDisplay = (coTaxRate(estimate) * 100).toFixed(1).replace(/\.0$/, "");

--- a/src/lib/pdf.ts
+++ b/src/lib/pdf.ts
@@ -3,6 +3,7 @@ import { prisma } from './prisma';
 import { toNum } from './prisma-helpers';
 import { buildLetterheadConfig, type LetterheadConfig } from './letterhead';
 import { isOwnSignatureStorageUrl } from './signature-storage';
+import { coTaxRate, coTaxLabel } from './co-tax';
 
 /**
  * Embed a signature image from either a legacy inline data-URL or a migrated http(s)
@@ -1090,12 +1091,25 @@ export async function generateChangeOrderPdf(coId: string): Promise<Buffer> {
     y -= 25;
 
     const coLabelX = coCols.unitCost - 60;
-    const coTotal = Number(co.totalAmount) || 0;
+    // co.totalAmount is the PRE-TAX subtotal (billChangeOrderCore semantic); show
+    // the same Subtotal / Tax / Revised Amount breakdown the customer signs on the
+    // portal page so the PDF and signature page never disagree.
+    const coSubtotal = Math.round((Number(co.totalAmount) || 0) * 100) / 100;
+    const coTax = Math.round(coSubtotal * coTaxRate(co.estimate) * 100) / 100;
+    const coTotal = Math.round((coSubtotal + coTax) * 100) / 100;
 
-    page.drawText('Change Order Total', { x: coLabelX, y, size: 14, font: helveticaBold, color: colors.primary });
-    const coTotalStr = formatCurrency(coTotal);
-    const coTotalW = helveticaBold.widthOfTextAtSize(coTotalStr, 14);
-    page.drawText(coTotalStr, { x: coCols.total - coTotalW, y, size: 14, font: helveticaBold, color: colors.primary });
+    const drawCoTotalRow = (label: string, value: string, size: number, font: PDFFont, color: ReturnType<typeof rgb>) => {
+        page.drawText(label, { x: coLabelX, y, size, font, color });
+        const vw = font.widthOfTextAtSize(value, size);
+        page.drawText(value, { x: coCols.total - vw, y, size, font, color });
+    };
+
+    drawCoTotalRow('Subtotal', formatCurrency(coSubtotal), 10, helvetica, colors.textMain);
+    y -= 18;
+    drawCoTotalRow(coTaxLabel(co.estimate), formatCurrency(coTax), 10, helvetica, colors.textMain);
+    y -= 22;
+    checkNewPage(60);
+    drawCoTotalRow('Revised Amount', formatCurrency(coTotal), 14, helveticaBold, colors.primary);
 
     // Signatures — client approval and company countersignature are independent blocks.
     if (co.status === 'Approved' && co.approvedBy) {


### PR DESCRIPTION
## Summary
Fixes the two change-order editor money bugs behind the CO-00007 "Berg ADU" incident (2026-07-09, client emailed $5,400 for a $5,000-incl-tax CO):

- **Item edits never persisted** — `handleSave` built `mappedItems` but never sent them; `updateChangeOrder` only wrote scalars, so line-item edits silently reverted and CO amounts were uneditable. `updateChangeOrder` now syncs `ChangeOrderItem` rows differentially (saveEstimate pattern) in one transaction.
- **Double taxation** — the editor saved `totalAmount = subtotal + tax`, but `billChangeOrderCore` treats `totalAmount` as the PRE-TAX subtotal and adds the estimate's tax on top. `totalAmount` is now canonically pre-tax and **recomputed server-side from the synced items** (integer-cents math; the client's total is never trusted).

## Alignment end to end
The amount the customer signs is now identical, to the cent, at every hop: editor / portal signature page / PDF / send email → milestone from `billChangeOrderCore` → QBO invoice (`pushMilestoneToQuickBooks` back-splits the same total; Drift Guard blocks sends on mismatch) → payment. New shared `coLineCents`/`coItemsSubtotal` in `lib/co-tax.ts` are used by all display + persistence paths. The send email and CO PDF now show the tax-inclusive **Revised Amount** (the email previously showed the pre-tax number).

## Hardening (from Codex review, 2 rounds)
- `updateChangeOrder` was an unauthenticated remotely-invokable server action passing raw `data` to Prisma. Now: `changeOrders` permission gate, scalar whitelist, `FOR UPDATE` row lock against concurrent approval/billing, status writes limited to Draft ↔ Sent (both directions checked), and item writes rejected on Approved COs — the editor also disables the builder UI once signed.
- Send-for-approval aborts if the save failed (no signature requests for amounts that never persisted); the Sent badge updates only after a confirmed send; `sendChangeOrderToClientCore` owns the Draft→Sent flip.
- Hover-hidden remove-item button got the mandatory `[@media(hover:none)]` classes.

## Testing
- `tsc --noEmit`: zero new errors vs a clean-main baseline (worktree shares a stale generated Prisma client, so absolute-zero isn't reachable locally — CI is authoritative).
- `e2e/money-pipeline.spec.ts` has no change-order coverage and the estimate→invoice chain it guards is untouched; CI run on this PR confirms.
- Codex peer review: round 1 (2 blockers, 2 real issues) and round 2 (2 real issues) — all addressed; one nit defended (client temp ids as item PKs, matching the existing saveEstimate pattern).

Note for `feat/undo-milestone-warnings`: on rebase, its older `ChangeOrderEditor.tsx` and hardcoded-8.8% `PortalChangeOrderClient.tsx` should take this branch's versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)