### PR TITLE
feat(tasks): Office Tasks kanban board + AI-routine ingest endpoint

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,8 @@ model User {
   teamMessages     TeamMessage[]
   fieldUpdatesSeenAt DateTime?
   clippedImports   ClippedImport[]
+  officeTasks        OfficeTask[]      @relation("OfficeTaskAssignee")
+  createdOfficeTasks OfficeTask[]      @relation("OfficeTaskCreator")
 }
 
 model Client {
@@ -150,6 +152,25 @@ model LeadTask {
   assignee   User?     @relation(fields: [assigneeId], references: [id])
   createdAt  DateTime  @default(now())
   updatedAt  DateTime  @updatedAt
+}
+
+model OfficeTask {
+  id          String    @id @default(cuid())
+  title       String
+  notes       String?
+  status      String    @default("To Do") // To Do, In Progress, Done
+  position    Int       @default(0) // sort order within its status column
+  dueDate     DateTime?
+  assigneeId  String?
+  assignee    User?     @relation("OfficeTaskAssignee", fields: [assigneeId], references: [id])
+  aiPrompt    String?   // suggested prompt the user can copy into Claude
+  createdById String?
+  createdBy   User?     @relation("OfficeTaskCreator", fields: [createdById], references: [id])
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@index([status, position])
+  @@index([assigneeId])
 }
 
 model LeadMeeting {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -164,6 +164,7 @@ model OfficeTask {
   assigneeId  String?
   assignee    User?     @relation("OfficeTaskAssignee", fields: [assigneeId], references: [id])
   aiPrompt    String?   // suggested prompt the user can copy into Claude
+  automationGap String? // what capability gap forced this to be handed off to a human
   createdById String?
   createdBy   User?     @relation("OfficeTaskCreator", fields: [createdById], references: [id])
   createdAt   DateTime  @default(now())

--- a/src/app/api/office-tasks/ingest/route.ts
+++ b/src/app/api/office-tasks/ingest/route.ts
@@ -1,0 +1,123 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { revalidatePath } from "next/cache";
+import { parseOfficeTaskDateOnly } from "@/lib/office-task-utils";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Office Tasks ingest — lets the owner's Google Chat AI routines auto-file
+ * "needs a human" items onto the /tasks board, each carrying a ready-to-run
+ * AI prompt and a diagnosis of what capability gap forced the handoff.
+ *
+ * Auth: Authorization: Bearer ${OFFICE_TASKS_INGEST_SECRET}. Secret-authed,
+ * not session-authed — does NOT call assertOfficeTaskAccess (there is no
+ * human session here).
+ */
+
+const MAX_TITLE_LENGTH = 300;
+
+interface IngestPayload {
+    title?: string;
+    notes?: string;
+    aiPrompt?: string;
+    automationGap?: string;
+    source?: string;
+    assigneeEmail?: string;
+    dueDate?: string; // "YYYY-MM-DD"
+}
+
+export async function POST(req: Request) {
+    const secret = process.env.OFFICE_TASKS_INGEST_SECRET;
+    if (!secret) {
+        console.error("OFFICE_TASKS_INGEST_SECRET is not configured");
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const authHeader = req.headers.get("authorization");
+    if (authHeader !== `Bearer ${secret}`) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    let body: IngestPayload;
+    try {
+        body = await req.json();
+    } catch {
+        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const title = (body.title || "").trim();
+    if (!title) {
+        return NextResponse.json({ error: "title is required" }, { status: 400 });
+    }
+    if (title.length > MAX_TITLE_LENGTH) {
+        return NextResponse.json({ error: `title must be ${MAX_TITLE_LENGTH} characters or fewer` }, { status: 400 });
+    }
+
+    let dueDate: Date | null = null;
+    if (body.dueDate) {
+        try {
+            dueDate = parseOfficeTaskDateOnly(body.dueDate);
+        } catch {
+            return NextResponse.json({ error: "dueDate must be a YYYY-MM-DD string" }, { status: 400 });
+        }
+    }
+
+    // Dedupe: an already-filed, not-yet-Done task with the same title (case-
+    // insensitive) means this is a re-send of something already on the board.
+    const existing = await prisma.officeTask.findFirst({
+        where: {
+            title: { equals: title, mode: "insensitive" },
+            status: { not: "Done" },
+        },
+        select: { id: true },
+    });
+    if (existing) {
+        return NextResponse.json({ deduped: true, id: existing.id }, { status: 200 });
+    }
+
+    let assigneeId: string | null = null;
+    if (body.assigneeEmail?.trim()) {
+        const assignee = await prisma.user.findFirst({
+            where: {
+                email: { equals: body.assigneeEmail.trim(), mode: "insensitive" },
+                role: { in: ["ADMIN", "MANAGER"] },
+                status: "ACTIVATED",
+            },
+            select: { id: true },
+        });
+        assigneeId = assignee?.id ?? null; // no match → create unassigned, never error
+    }
+
+    let notes = body.notes?.trim() || null;
+    if (body.source?.trim()) {
+        const sourceLine = `Source: ${body.source.trim()}`;
+        notes = notes ? `${notes}\n${sourceLine}` : sourceLine;
+    }
+
+    const task = await prisma.$transaction(async (tx) => {
+        const last = await tx.officeTask.findFirst({
+            where: { status: "To Do" },
+            orderBy: { position: "desc" },
+            select: { position: true },
+        });
+
+        return tx.officeTask.create({
+            data: {
+                title,
+                status: "To Do",
+                position: (last?.position ?? -1) + 1,
+                notes,
+                aiPrompt: body.aiPrompt?.trim() || null,
+                automationGap: body.automationGap?.trim() || null,
+                assigneeId,
+                dueDate,
+                createdById: null,
+            },
+            select: { id: true },
+        });
+    });
+
+    revalidatePath("/tasks");
+    return NextResponse.json({ id: task.id }, { status: 201 });
+}

--- a/src/app/tasks/TasksBoardClient.tsx
+++ b/src/app/tasks/TasksBoardClient.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useMemo, useState, useTransition } from "react";
 import { DragDropContext, Droppable, Draggable, type DropResult } from "@hello-pangea/dnd";
 import { toast } from "sonner";
-import { createOfficeTask, updateOfficeTask, moveOfficeTask, deleteOfficeTask } from "@/lib/actions";
-import { formatLocalDateString } from "@/lib/report-utils";
+import { createOfficeTask, updateOfficeTask, moveOfficeTask, deleteOfficeTask, getOfficeTasksBoard } from "@/lib/actions";
+import { formatLocalDateString, parseLocalDateString } from "@/lib/report-utils";
 
 const STATUSES = ["To Do", "In Progress", "Done"] as const;
 type Status = (typeof STATUSES)[number];
@@ -66,22 +66,40 @@ function firstName(user: BoardUser): string {
     return user.email.split("@")[0];
 }
 
+// dueDate is stored as UTC midnight for the picked calendar date (see
+// parseOfficeTaskDateOnly in actions.ts). Extracting the date via toISOString()
+// recovers exactly that calendar date regardless of the viewer's local timezone —
+// using .toLocaleDateString()/local getters here would shift the date backward
+// by a day west of UTC (e.g. Pacific time).
+function dueDateToISO(dueDate: Date | string): string {
+    return new Date(dueDate).toISOString().slice(0, 10);
+}
+
+// Format a "YYYY-MM-DD" string for display without reintroducing timezone drift.
+function formatISODateForDisplay(iso: string): string {
+    const d = parseLocalDateString(iso);
+    if (!d) return iso;
+    return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
 function dueDateInfo(dueDate: Date | string | null, status: string): { label: string; className: string } | null {
     if (!dueDate) return null;
-    const d = new Date(dueDate);
-    const label = d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+    const iso = dueDateToISO(dueDate);
+    const label = formatISODateForDisplay(iso);
     if (status === "Done") return { label, className: "bg-slate-100 text-slate-600" };
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const dueMidnight = new Date(d.getFullYear(), d.getMonth(), d.getDate());
-    const diffDays = Math.round((dueMidnight.getTime() - today.getTime()) / 86400000);
-    if (diffDays < 0) return { label, className: "bg-red-100 text-red-700" };
+
+    const todayStr = formatLocalDateString(new Date());
+    if (iso < todayStr) return { label, className: "bg-red-100 text-red-700" };
+
+    const dueLocal = parseLocalDateString(iso);
+    const todayLocal = parseLocalDateString(todayStr);
+    const diffDays = dueLocal && todayLocal ? Math.round((dueLocal.getTime() - todayLocal.getTime()) / 86400000) : 999;
     if (diffDays <= 2) return { label, className: "bg-amber-100 text-amber-700" };
     return { label, className: "bg-slate-100 text-slate-600" };
 }
 
 function composePrompt(title: string, notes: string, dueDate: Date | string | null): string {
-    const dueStr = dueDate ? new Date(dueDate).toLocaleDateString() : "No due date";
+    const dueStr = dueDate ? formatISODateForDisplay(dueDateToISO(dueDate)) : "No due date";
     return `Help me complete this Golden Touch office task: ${title}. Details: ${notes || "none"}. Due: ${dueStr}. You have access to our ProBuild backend, QuickBooks, Gmail, and Google Drive — pull whatever you need and draft the pieces that require a human to review or send.`;
 }
 
@@ -141,8 +159,32 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
         return map;
     }, [visibleTasks]);
 
+    // On any server-action failure, re-fetch the authoritative board state instead
+    // of restoring a whole-board snapshot — a snapshot restore would also wipe out
+    // any other operation that succeeded concurrently. Re-syncs the open dialog's
+    // drafts from the refreshed task (or closes the dialog if it was deleted
+    // elsewhere).
+    async function refreshBoard() {
+        try {
+            const board = await getOfficeTasksBoard();
+            const freshTasks = board.tasks as unknown as Task[];
+            setTasks(freshTasks);
+            if (selectedTaskId) {
+                const fresh = freshTasks.find((t) => t.id === selectedTaskId);
+                if (fresh) {
+                    setDraftTitle(fresh.title);
+                    setDraftNotes(fresh.notes || "");
+                    setDraftAiPrompt(fresh.aiPrompt || "");
+                } else {
+                    setSelectedTaskId(null);
+                }
+            }
+        } catch {
+            toast.error("Failed to refresh board");
+        }
+    }
+
     function performMove(taskId: string, newStatus: string, newIndex: number) {
-        const prevTasks = tasks;
         const moved = tasks.find((t) => t.id === taskId);
         if (!moved) return;
 
@@ -168,7 +210,7 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
                 await moveOfficeTask(taskId, newStatus, clampedIndex);
             } catch {
                 toast.error("Failed to move task");
-                setTasks(prevTasks);
+                await refreshBoard();
             }
         });
     }
@@ -201,7 +243,6 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
         assigneeId?: string | null;
         aiPrompt?: string | null;
     }) {
-        const prevTasks = tasks;
         setTasks((prev) =>
             prev.map((t) => {
                 if (t.id !== id) return t;
@@ -222,7 +263,7 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
                 await updateOfficeTask(id, data);
             } catch {
                 toast.error("Failed to update task");
-                setTasks(prevTasks);
+                await refreshBoard();
             }
         });
     }
@@ -235,7 +276,6 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
 
     function handleDelete(id: string) {
         if (!confirm("Delete this task? This cannot be undone.")) return;
-        const prevTasks = tasks;
         setTasks((prev) => prev.filter((t) => t.id !== id));
         setSelectedTaskId(null);
         startTransition(async () => {
@@ -244,7 +284,7 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
                 toast.success("Task deleted");
             } catch {
                 toast.error("Failed to delete task");
-                setTasks(prevTasks);
+                await refreshBoard();
             }
         });
     }
@@ -256,13 +296,15 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
         handleFieldUpdate(selectedTask.id, { aiPrompt: suggested });
     }
 
-    function handleCopyForClaude() {
+    async function handleCopyForClaude() {
         if (!selectedTask) return;
         const text = draftAiPrompt.trim() || composePrompt(draftTitle, draftNotes, selectedTask.dueDate);
-        navigator.clipboard
-            .writeText(text)
-            .then(() => toast.success("Copied to clipboard"))
-            .catch(() => toast.error("Failed to copy"));
+        try {
+            await navigator.clipboard.writeText(text);
+            toast.success("Copied to clipboard");
+        } catch {
+            toast.error("Failed to copy — clipboard unavailable");
+        }
     }
 
     return (
@@ -439,7 +481,7 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
                                     <input
                                         type="date"
                                         className="hui-input mt-1 w-full"
-                                        value={selectedTask.dueDate ? formatLocalDateString(new Date(selectedTask.dueDate)) : ""}
+                                        value={selectedTask.dueDate ? dueDateToISO(selectedTask.dueDate) : ""}
                                         onChange={(e) => handleFieldUpdate(selectedTask.id, { dueDate: e.target.value || null })}
                                     />
                                 </div>

--- a/src/app/tasks/TasksBoardClient.tsx
+++ b/src/app/tasks/TasksBoardClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, useTransition } from "react";
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { DragDropContext, Droppable, Draggable, type DropResult } from "@hello-pangea/dnd";
 import { toast } from "sonner";
 import { createOfficeTask, updateOfficeTask, moveOfficeTask, deleteOfficeTask, getOfficeTasksBoard } from "@/lib/actions";
@@ -136,6 +136,15 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
 
     const selectedTask = tasks.find((t) => t.id === selectedTaskId) || null;
 
+    // Tracks the CURRENT dialog selection for async callbacks (refreshBoard)
+    // that may resolve after the user has since opened a different task's
+    // dialog — reading selectedTaskId itself there would close over whichever
+    // task was selected when the failed mutation started, not what's open now.
+    const selectedTaskIdRef = useRef<string | null>(null);
+    useEffect(() => {
+        selectedTaskIdRef.current = selectedTaskId;
+    }, [selectedTaskId]);
+
     useEffect(() => {
         if (selectedTask) {
             setDraftTitle(selectedTask.title);
@@ -169,8 +178,9 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
             const board = await getOfficeTasksBoard();
             const freshTasks = board.tasks as unknown as Task[];
             setTasks(freshTasks);
-            if (selectedTaskId) {
-                const fresh = freshTasks.find((t) => t.id === selectedTaskId);
+            const currentSelectedId = selectedTaskIdRef.current;
+            if (currentSelectedId) {
+                const fresh = freshTasks.find((t) => t.id === currentSelectedId);
                 if (fresh) {
                     setDraftTitle(fresh.title);
                     setDraftNotes(fresh.notes || "");

--- a/src/app/tasks/TasksBoardClient.tsx
+++ b/src/app/tasks/TasksBoardClient.tsx
@@ -1,0 +1,512 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { DragDropContext, Droppable, Draggable, type DropResult } from "@hello-pangea/dnd";
+import { toast } from "sonner";
+import { createOfficeTask, updateOfficeTask, moveOfficeTask, deleteOfficeTask } from "@/lib/actions";
+import { formatLocalDateString } from "@/lib/report-utils";
+
+const STATUSES = ["To Do", "In Progress", "Done"] as const;
+type Status = (typeof STATUSES)[number];
+
+type BoardUser = { id: string; name: string | null; email: string };
+
+type Task = {
+    id: string;
+    title: string;
+    notes: string | null;
+    status: string;
+    position: number;
+    dueDate: Date | string | null;
+    assigneeId: string | null;
+    assignee: BoardUser | null;
+    aiPrompt: string | null;
+    createdById: string | null;
+    createdAt: Date | string;
+    updatedAt: Date | string;
+};
+
+interface Props {
+    initialTasks: Task[];
+    users: BoardUser[];
+}
+
+const AVATAR_COLORS = [
+    "bg-blue-100 text-blue-700",
+    "bg-green-100 text-green-700",
+    "bg-amber-100 text-amber-700",
+    "bg-purple-100 text-purple-700",
+    "bg-pink-100 text-pink-700",
+    "bg-teal-100 text-teal-700",
+    "bg-indigo-100 text-indigo-700",
+    "bg-orange-100 text-orange-700",
+];
+
+function hashString(s: string): number {
+    let h = 0;
+    for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
+    return Math.abs(h);
+}
+
+function avatarColor(id: string): string {
+    return AVATAR_COLORS[hashString(id) % AVATAR_COLORS.length];
+}
+
+function getInitials(name: string | null | undefined, email: string): string {
+    if (name) {
+        const parts = name.trim().split(/\s+/);
+        if (parts.length > 1) return (parts[0][0] + parts[1][0]).toUpperCase();
+        return name.slice(0, 2).toUpperCase();
+    }
+    return email.slice(0, 2).toUpperCase();
+}
+
+function firstName(user: BoardUser): string {
+    if (user.name) return user.name.trim().split(/\s+/)[0];
+    return user.email.split("@")[0];
+}
+
+function dueDateInfo(dueDate: Date | string | null, status: string): { label: string; className: string } | null {
+    if (!dueDate) return null;
+    const d = new Date(dueDate);
+    const label = d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+    if (status === "Done") return { label, className: "bg-slate-100 text-slate-600" };
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const dueMidnight = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+    const diffDays = Math.round((dueMidnight.getTime() - today.getTime()) / 86400000);
+    if (diffDays < 0) return { label, className: "bg-red-100 text-red-700" };
+    if (diffDays <= 2) return { label, className: "bg-amber-100 text-amber-700" };
+    return { label, className: "bg-slate-100 text-slate-600" };
+}
+
+function composePrompt(title: string, notes: string, dueDate: Date | string | null): string {
+    const dueStr = dueDate ? new Date(dueDate).toLocaleDateString() : "No due date";
+    return `Help me complete this Golden Touch office task: ${title}. Details: ${notes || "none"}. Due: ${dueStr}. You have access to our ProBuild backend, QuickBooks, Gmail, and Google Drive — pull whatever you need and draft the pieces that require a human to review or send.`;
+}
+
+function chipClass(active: boolean): string {
+    return `px-3 py-1.5 rounded-full text-xs font-semibold transition whitespace-nowrap ${active ? "bg-hui-primary text-white" : "bg-slate-100 text-hui-textMuted hover:bg-slate-200"
+        }`;
+}
+
+function NoteIcon({ className }: { className?: string }) {
+    return (
+        <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+    );
+}
+
+function SparkleIcon({ className }: { className?: string }) {
+    return (
+        <svg className={className} fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 2l1.6 5.4L19 9l-5.4 1.6L12 16l-1.6-5.4L5 9l5.4-1.6L12 2zM19 14l.8 2.7L22.5 17.5l-2.7.8L19 21l-.8-2.7-2.7-.8 2.7-.8L19 14z" />
+        </svg>
+    );
+}
+
+export default function TasksBoardClient({ initialTasks, users }: Props) {
+    const [tasks, setTasks] = useState<Task[]>(initialTasks);
+    const [filterId, setFilterId] = useState<string | null>(null);
+    const [quickAdd, setQuickAdd] = useState<Record<string, string>>({});
+    const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+    const [draftTitle, setDraftTitle] = useState("");
+    const [draftNotes, setDraftNotes] = useState("");
+    const [draftAiPrompt, setDraftAiPrompt] = useState("");
+    const [, startTransition] = useTransition();
+
+    const selectedTask = tasks.find((t) => t.id === selectedTaskId) || null;
+
+    useEffect(() => {
+        if (selectedTask) {
+            setDraftTitle(selectedTask.title);
+            setDraftNotes(selectedTask.notes || "");
+            setDraftAiPrompt(selectedTask.aiPrompt || "");
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selectedTaskId]);
+
+    const visibleTasks = useMemo(() => {
+        if (!filterId) return tasks;
+        return tasks.filter((t) => t.assigneeId === filterId);
+    }, [tasks, filterId]);
+
+    const columns = useMemo(() => {
+        const map: Record<string, Task[]> = { "To Do": [], "In Progress": [], Done: [] };
+        for (const t of visibleTasks) {
+            (map[t.status] ||= []).push(t);
+        }
+        for (const s of STATUSES) map[s].sort((a, b) => a.position - b.position);
+        return map;
+    }, [visibleTasks]);
+
+    function performMove(taskId: string, newStatus: string, newIndex: number) {
+        const prevTasks = tasks;
+        const moved = tasks.find((t) => t.id === taskId);
+        if (!moved) return;
+
+        const byStatus: Record<string, Task[]> = { "To Do": [], "In Progress": [], Done: [] };
+        for (const t of tasks) {
+            if (t.id === taskId) continue;
+            (byStatus[t.status] ||= []).push(t);
+        }
+        for (const s of STATUSES) byStatus[s].sort((a, b) => a.position - b.position);
+
+        const destList = byStatus[newStatus];
+        const clampedIndex = Math.max(0, Math.min(newIndex, destList.length));
+        destList.splice(clampedIndex, 0, { ...moved, status: newStatus });
+
+        const next: Task[] = [];
+        for (const s of STATUSES) {
+            byStatus[s].forEach((t, i) => next.push({ ...t, position: i }));
+        }
+        setTasks(next);
+
+        startTransition(async () => {
+            try {
+                await moveOfficeTask(taskId, newStatus, clampedIndex);
+            } catch {
+                toast.error("Failed to move task");
+                setTasks(prevTasks);
+            }
+        });
+    }
+
+    function handleDragEnd(result: DropResult) {
+        const { source, destination, draggableId } = result;
+        if (!destination) return;
+        if (source.droppableId === destination.droppableId && source.index === destination.index) return;
+        performMove(draggableId, destination.droppableId, destination.index);
+    }
+
+    function handleQuickAdd(status: string) {
+        const title = (quickAdd[status] || "").trim();
+        if (!title) return;
+        setQuickAdd((prev) => ({ ...prev, [status]: "" }));
+        startTransition(async () => {
+            try {
+                const created = await createOfficeTask({ title, status });
+                setTasks((prev) => [...prev, created as unknown as Task]);
+            } catch {
+                toast.error("Failed to create task");
+            }
+        });
+    }
+
+    function handleFieldUpdate(id: string, data: {
+        title?: string;
+        notes?: string | null;
+        dueDate?: string | null;
+        assigneeId?: string | null;
+        aiPrompt?: string | null;
+    }) {
+        const prevTasks = tasks;
+        setTasks((prev) =>
+            prev.map((t) => {
+                if (t.id !== id) return t;
+                const updated: Task = { ...t };
+                if (data.title !== undefined) updated.title = data.title;
+                if (data.notes !== undefined) updated.notes = data.notes;
+                if (data.dueDate !== undefined) updated.dueDate = data.dueDate;
+                if (data.aiPrompt !== undefined) updated.aiPrompt = data.aiPrompt;
+                if (data.assigneeId !== undefined) {
+                    updated.assigneeId = data.assigneeId;
+                    updated.assignee = data.assigneeId ? users.find((u) => u.id === data.assigneeId) || null : null;
+                }
+                return updated;
+            })
+        );
+        startTransition(async () => {
+            try {
+                await updateOfficeTask(id, data);
+            } catch {
+                toast.error("Failed to update task");
+                setTasks(prevTasks);
+            }
+        });
+    }
+
+    function handleStatusSelect(newStatus: string) {
+        if (!selectedTask || newStatus === selectedTask.status) return;
+        const destCount = tasks.filter((t) => t.status === newStatus && t.id !== selectedTask.id).length;
+        performMove(selectedTask.id, newStatus, destCount);
+    }
+
+    function handleDelete(id: string) {
+        if (!confirm("Delete this task? This cannot be undone.")) return;
+        const prevTasks = tasks;
+        setTasks((prev) => prev.filter((t) => t.id !== id));
+        setSelectedTaskId(null);
+        startTransition(async () => {
+            try {
+                await deleteOfficeTask(id);
+                toast.success("Task deleted");
+            } catch {
+                toast.error("Failed to delete task");
+                setTasks(prevTasks);
+            }
+        });
+    }
+
+    function handleSuggestPrompt() {
+        if (!selectedTask) return;
+        const suggested = composePrompt(draftTitle, draftNotes, selectedTask.dueDate);
+        setDraftAiPrompt(suggested);
+        handleFieldUpdate(selectedTask.id, { aiPrompt: suggested });
+    }
+
+    function handleCopyForClaude() {
+        if (!selectedTask) return;
+        const text = draftAiPrompt.trim() || composePrompt(draftTitle, draftNotes, selectedTask.dueDate);
+        navigator.clipboard
+            .writeText(text)
+            .then(() => toast.success("Copied to clipboard"))
+            .catch(() => toast.error("Failed to copy"));
+    }
+
+    return (
+        <>
+            {/* Toolbar */}
+            <div className="bg-white border-b border-hui-border px-6 py-4 flex items-center justify-between gap-4 flex-wrap shrink-0">
+                <div>
+                    <h1 className="text-xl font-bold text-hui-textMain">Office Tasks</h1>
+                    <p className="text-sm text-hui-textMuted mt-0.5">{tasks.length} tasks</p>
+                </div>
+                <div className="flex items-center gap-2 flex-wrap">
+                    <button onClick={() => setFilterId(null)} className={chipClass(filterId === null)}>
+                        All
+                    </button>
+                    {users.map((u) => (
+                        <button key={u.id} onClick={() => setFilterId(u.id)} className={chipClass(filterId === u.id)}>
+                            {firstName(u)}
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            {filterId && (
+                <div className="px-6 pt-2 text-xs text-hui-textMuted shrink-0">
+                    Filtered — clear the filter to reorder cards.
+                </div>
+            )}
+
+            {/* Board */}
+            <div className="flex-1 overflow-x-auto overflow-y-hidden">
+                <DragDropContext onDragEnd={handleDragEnd}>
+                    <div className="flex gap-4 h-full px-6 py-4 min-w-max">
+                        {STATUSES.map((status) => (
+                            <Droppable droppableId={status} key={status}>
+                                {(provided, snapshot) => (
+                                    <div
+                                        ref={provided.innerRef}
+                                        {...provided.droppableProps}
+                                        className={`w-80 shrink-0 flex flex-col bg-white rounded-xl shadow-sm border border-hui-border p-3 h-full ${snapshot.isDraggingOver ? "bg-slate-50" : ""
+                                            }`}
+                                    >
+                                        <div className="flex items-center justify-between mb-2 px-1">
+                                            <h3 className="text-sm font-semibold text-hui-textMain">{status}</h3>
+                                            <span className="text-xs text-hui-textMuted">{columns[status].length}</span>
+                                        </div>
+                                        <input
+                                            className="hui-input text-sm mb-2"
+                                            placeholder="+ Add a task…"
+                                            value={quickAdd[status] || ""}
+                                            onChange={(e) => setQuickAdd((prev) => ({ ...prev, [status]: e.target.value }))}
+                                            onKeyDown={(e) => {
+                                                if (e.key === "Enter") handleQuickAdd(status);
+                                            }}
+                                        />
+                                        <div className="flex-1 overflow-y-auto space-y-2 min-h-[40px]">
+                                            {columns[status].map((task, index) => {
+                                                const due = dueDateInfo(task.dueDate, task.status);
+                                                return (
+                                                    <Draggable draggableId={task.id} index={index} key={task.id} isDragDisabled={!!filterId}>
+                                                        {(dragProvided, dragSnapshot) => (
+                                                            <div
+                                                                ref={dragProvided.innerRef}
+                                                                {...dragProvided.draggableProps}
+                                                                {...dragProvided.dragHandleProps}
+                                                                onClick={() => setSelectedTaskId(task.id)}
+                                                                className={`bg-white border border-hui-border rounded-lg p-3 cursor-pointer hover:border-hui-primary/50 transition ${dragSnapshot.isDragging ? "shadow-lg" : "shadow-sm"
+                                                                    }`}
+                                                            >
+                                                                <p className="text-sm font-medium text-hui-textMain">{task.title}</p>
+                                                                <div className="flex items-center gap-2 mt-2 flex-wrap">
+                                                                    {task.assignee && (
+                                                                        <div
+                                                                            title={task.assignee.name || task.assignee.email}
+                                                                            className={`w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold shrink-0 ${avatarColor(
+                                                                                task.assignee.id
+                                                                            )}`}
+                                                                        >
+                                                                            {getInitials(task.assignee.name, task.assignee.email)}
+                                                                        </div>
+                                                                    )}
+                                                                    {due && (
+                                                                        <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${due.className}`}>
+                                                                            {due.label}
+                                                                        </span>
+                                                                    )}
+                                                                    {task.notes && <NoteIcon className="w-3.5 h-3.5 text-hui-textMuted" />}
+                                                                    {task.aiPrompt && <SparkleIcon className="w-3.5 h-3.5 text-hui-primary" />}
+                                                                </div>
+                                                            </div>
+                                                        )}
+                                                    </Draggable>
+                                                );
+                                            })}
+                                            {provided.placeholder}
+                                        </div>
+                                    </div>
+                                )}
+                            </Droppable>
+                        ))}
+                    </div>
+                </DragDropContext>
+            </div>
+
+            {/* Edit dialog */}
+            {selectedTask && (
+                <div
+                    className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+                    onClick={() => setSelectedTaskId(null)}
+                >
+                    <div
+                        className="bg-white rounded-xl shadow-xl max-w-lg w-full max-h-[90vh] overflow-y-auto border border-hui-border"
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        <div className="px-6 py-4 border-b border-hui-border flex justify-between items-center sticky top-0 bg-white z-10">
+                            <h2 className="text-lg font-bold text-hui-textMain">Edit Task</h2>
+                            <button
+                                onClick={() => setSelectedTaskId(null)}
+                                className="text-hui-textMuted hover:text-hui-textMain transition"
+                            >
+                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                            </button>
+                        </div>
+
+                        <div className="p-6 space-y-4 text-sm">
+                            <div>
+                                <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Title</label>
+                                <input
+                                    className="hui-input mt-1 w-full"
+                                    value={draftTitle}
+                                    onChange={(e) => setDraftTitle(e.target.value)}
+                                    onBlur={() => {
+                                        if (draftTitle.trim() && draftTitle !== selectedTask.title) {
+                                            handleFieldUpdate(selectedTask.id, { title: draftTitle.trim() });
+                                        }
+                                    }}
+                                />
+                            </div>
+
+                            <div>
+                                <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Notes</label>
+                                <textarea
+                                    className="hui-input mt-1 w-full"
+                                    rows={3}
+                                    value={draftNotes}
+                                    onChange={(e) => setDraftNotes(e.target.value)}
+                                    onBlur={() => {
+                                        if (draftNotes !== (selectedTask.notes || "")) {
+                                            handleFieldUpdate(selectedTask.id, { notes: draftNotes || null });
+                                        }
+                                    }}
+                                />
+                            </div>
+
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                <div>
+                                    <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Assignee</label>
+                                    <select
+                                        className="hui-input mt-1 w-full cursor-pointer"
+                                        value={selectedTask.assigneeId || ""}
+                                        onChange={(e) => handleFieldUpdate(selectedTask.id, { assigneeId: e.target.value || null })}
+                                    >
+                                        <option value="">Unassigned</option>
+                                        {users.map((u) => (
+                                            <option key={u.id} value={u.id}>
+                                                {u.name || u.email}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+                                <div>
+                                    <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Due Date</label>
+                                    <input
+                                        type="date"
+                                        className="hui-input mt-1 w-full"
+                                        value={selectedTask.dueDate ? formatLocalDateString(new Date(selectedTask.dueDate)) : ""}
+                                        onChange={(e) => handleFieldUpdate(selectedTask.id, { dueDate: e.target.value || null })}
+                                    />
+                                </div>
+                            </div>
+
+                            <div>
+                                <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Status</label>
+                                <select
+                                    className="hui-input mt-1 w-full cursor-pointer"
+                                    value={selectedTask.status}
+                                    onChange={(e) => handleStatusSelect(e.target.value)}
+                                >
+                                    {STATUSES.map((s) => (
+                                        <option key={s} value={s}>
+                                            {s}
+                                        </option>
+                                    ))}
+                                </select>
+                            </div>
+
+                            <div className="border-t border-hui-border pt-4">
+                                <p className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider mb-2 flex items-center gap-1">
+                                    <SparkleIcon className="w-3.5 h-3.5 text-hui-primary" /> AI Assist
+                                </p>
+                                <textarea
+                                    className="hui-input w-full"
+                                    rows={4}
+                                    placeholder="What should an AI assistant do for this task?"
+                                    value={draftAiPrompt}
+                                    onChange={(e) => setDraftAiPrompt(e.target.value)}
+                                    onBlur={() => {
+                                        if (draftAiPrompt !== (selectedTask.aiPrompt || "")) {
+                                            handleFieldUpdate(selectedTask.id, { aiPrompt: draftAiPrompt || null });
+                                        }
+                                    }}
+                                />
+                                <div className="flex gap-2 mt-2">
+                                    <button
+                                        type="button"
+                                        disabled={draftAiPrompt.trim().length > 0}
+                                        onClick={handleSuggestPrompt}
+                                        className="hui-btn hui-btn-secondary text-xs disabled:opacity-50 disabled:cursor-not-allowed"
+                                    >
+                                        Suggest prompt
+                                    </button>
+                                    <button type="button" onClick={handleCopyForClaude} className="hui-btn hui-btn-secondary text-xs">
+                                        Copy for Claude
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="px-6 py-4 border-t border-hui-border flex justify-between items-center">
+                            <button
+                                type="button"
+                                onClick={() => handleDelete(selectedTask.id)}
+                                className="hui-btn text-red-600 hover:bg-red-50"
+                            >
+                                Delete
+                            </button>
+                            <button type="button" onClick={() => setSelectedTaskId(null)} className="hui-btn hui-btn-secondary">
+                                Close
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </>
+    );
+}

--- a/src/app/tasks/TasksBoardClient.tsx
+++ b/src/app/tasks/TasksBoardClient.tsx
@@ -21,6 +21,7 @@ type Task = {
     assigneeId: string | null;
     assignee: BoardUser | null;
     aiPrompt: string | null;
+    automationGap: string | null;
     createdById: string | null;
     createdAt: Date | string;
     updatedAt: Date | string;
@@ -124,6 +125,14 @@ function SparkleIcon({ className }: { className?: string }) {
     );
 }
 
+function WrenchIcon({ className }: { className?: string }) {
+    return (
+        <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.7 6.3a4 4 0 00-5.6 4.6L4 16l1.4 1.4L10.6 12.7a4 4 0 004.6-5.6l-2.1 2.1a1.5 1.5 0 01-2.1-2.1l2.1-2.1z" />
+        </svg>
+    );
+}
+
 export default function TasksBoardClient({ initialTasks, users }: Props) {
     const [tasks, setTasks] = useState<Task[]>(initialTasks);
     const [filterId, setFilterId] = useState<string | null>(null);
@@ -132,6 +141,7 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
     const [draftTitle, setDraftTitle] = useState("");
     const [draftNotes, setDraftNotes] = useState("");
     const [draftAiPrompt, setDraftAiPrompt] = useState("");
+    const [draftAutomationGap, setDraftAutomationGap] = useState("");
     const [, startTransition] = useTransition();
 
     const selectedTask = tasks.find((t) => t.id === selectedTaskId) || null;
@@ -150,6 +160,7 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
             setDraftTitle(selectedTask.title);
             setDraftNotes(selectedTask.notes || "");
             setDraftAiPrompt(selectedTask.aiPrompt || "");
+            setDraftAutomationGap(selectedTask.automationGap || "");
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedTaskId]);
@@ -185,6 +196,7 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
                     setDraftTitle(fresh.title);
                     setDraftNotes(fresh.notes || "");
                     setDraftAiPrompt(fresh.aiPrompt || "");
+                    setDraftAutomationGap(fresh.automationGap || "");
                 } else {
                     setSelectedTaskId(null);
                 }
@@ -252,6 +264,7 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
         dueDate?: string | null;
         assigneeId?: string | null;
         aiPrompt?: string | null;
+        automationGap?: string | null;
     }) {
         setTasks((prev) =>
             prev.map((t) => {
@@ -261,6 +274,7 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
                 if (data.notes !== undefined) updated.notes = data.notes;
                 if (data.dueDate !== undefined) updated.dueDate = data.dueDate;
                 if (data.aiPrompt !== undefined) updated.aiPrompt = data.aiPrompt;
+                if (data.automationGap !== undefined) updated.automationGap = data.automationGap;
                 if (data.assigneeId !== undefined) {
                     updated.assigneeId = data.assigneeId;
                     updated.assignee = data.assigneeId ? users.find((u) => u.id === data.assigneeId) || null : null;
@@ -402,6 +416,7 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
                                                                     )}
                                                                     {task.notes && <NoteIcon className="w-3.5 h-3.5 text-hui-textMuted" />}
                                                                     {task.aiPrompt && <SparkleIcon className="w-3.5 h-3.5 text-hui-primary" />}
+                                                                    {task.automationGap && <WrenchIcon className="w-3.5 h-3.5 text-amber-600" />}
                                                                 </div>
                                                             </div>
                                                         )}
@@ -541,6 +556,25 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
                                         Copy for Claude
                                     </button>
                                 </div>
+                            </div>
+
+                            <div className="border-t border-hui-border pt-4">
+                                <p className="text-xs font-semibold text-amber-700 uppercase tracking-wider mb-1 flex items-center gap-1">
+                                    <WrenchIcon className="w-3.5 h-3.5" /> Automation Gap
+                                </p>
+                                <p className="text-xs text-hui-textMuted mb-2">What would make this automatic next time?</p>
+                                <textarea
+                                    className="hui-input w-full bg-amber-50/50 border-amber-200 focus:border-amber-400 focus:ring-amber-400"
+                                    rows={3}
+                                    placeholder="e.g. we don't have API access to the vendor portal to check order status automatically"
+                                    value={draftAutomationGap}
+                                    onChange={(e) => setDraftAutomationGap(e.target.value)}
+                                    onBlur={() => {
+                                        if (draftAutomationGap !== (selectedTask.automationGap || "")) {
+                                            handleFieldUpdate(selectedTask.id, { automationGap: draftAutomationGap || null });
+                                        }
+                                    }}
+                                />
                             </div>
                         </div>
 

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -1,0 +1,28 @@
+import { getSessionOrDev } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { redirect } from "next/navigation";
+import { getOfficeTasksBoard } from "@/lib/actions";
+import TasksBoardClient from "./TasksBoardClient";
+
+export const dynamic = "force-dynamic";
+
+export default async function TasksPage() {
+    const session = await getSessionOrDev();
+    if (!session?.user?.email) redirect("/login");
+
+    const user = await prisma.user.findUnique({ where: { email: session.user.email } });
+    if (!user && process.env.NODE_ENV !== "development") redirect("/login");
+    const effectiveUser = user ?? { role: "ADMIN" };
+
+    if (effectiveUser.role !== "ADMIN" && effectiveUser.role !== "MANAGER") {
+        redirect("/projects");
+    }
+
+    const { tasks, users } = await getOfficeTasksBoard();
+
+    return (
+        <div className="flex flex-col h-[calc(100vh-64px)] -m-6 overflow-hidden bg-hui-background">
+            <TasksBoardClient initialTasks={tasks} users={users} />
+        </div>
+    );
+}

--- a/src/components/nav/navItems.tsx
+++ b/src/components/nav/navItems.tsx
@@ -31,6 +31,9 @@ const TimeClockIcon = svg(
 const CompanyIcon = svg(
   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
 );
+const TasksIcon = svg(
+  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-5 9l2 2 4-4" />
+);
 const SettingsIcon = svg(
   <>
     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
@@ -53,6 +56,7 @@ export const NAV_ITEMS: NavItem[] = [
   // Projects is always visible (the API filters by ProjectAccess).
   { key: "projects", href: "/projects", label: "Projects", Icon: ProjectsIcon, show: () => true },
   { key: "leads", href: "/leads", label: "Leads", Icon: LeadsIcon, show: (can) => can("leadAccess") },
+  { key: "tasks", href: "/tasks", label: "Tasks", Icon: TasksIcon, show: (can) => can("manageTeamMembers") },
   { key: "financials", href: "/invoices", label: "Financials", Icon: FinancialsIcon, show: (can) => can("invoices") || can("financialReports") },
   { key: "reports", href: "/reports", label: "Reports", Icon: ReportsIcon, show: (can) => can("financialReports") },
   { key: "field", href: "/manager/field-updates", label: "Field", Icon: ReportsIcon, show: (can) => can("schedules"), custom: "fieldUpdates" },

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -9381,9 +9381,32 @@ function parseOfficeTaskDateOnly(s: string): Date {
 async function assertOfficeTaskAccess() {
     const session = await getSessionOrDev();
     const sessionUserId = (session?.user as any)?.id as string | null | undefined;
+    const sessionEmail = session?.user?.email as string | null | undefined;
     const sessionRole = ((session?.user as any)?.role as string | null) ?? null;
-    if (!sessionRole || !["ADMIN", "MANAGER"].includes(sessionRole)) throw new Error("Forbidden");
-    return { id: sessionUserId ?? null, role: sessionRole };
+
+    // Dev-fallback session with no backing User row (see buildDevSession in
+    // auth.ts) — same shape getFieldUpdatesFeed trusts: no id, but a synthetic
+    // ADMIN/MANAGER role. There's no DB row to re-check in that case.
+    const isSyntheticDevAccess = !sessionUserId && (sessionRole === "ADMIN" || sessionRole === "MANAGER");
+    if (isSyntheticDevAccess) {
+        return { id: null as string | null, role: sessionRole as string };
+    }
+
+    // Otherwise, re-resolve the caller from the DB instead of trusting the
+    // session's role/id: auth.ts's jwt() callback leaves token.role/userId
+    // untouched when the DB lookup finds no user (deleted user, live token),
+    // and never encodes `status` into the token at all — so a disabled user's
+    // token would still read role: ADMIN until it expires.
+    const user = sessionUserId
+        ? await prisma.user.findUnique({ where: { id: sessionUserId }, select: { id: true, role: true, status: true } })
+        : sessionEmail
+            ? await prisma.user.findUnique({ where: { email: sessionEmail }, select: { id: true, role: true, status: true } })
+            : null;
+
+    if (!user || !["ADMIN", "MANAGER"].includes(user.role) || user.status === "DISABLED") {
+        throw new Error("Forbidden");
+    }
+    return { id: user.id, role: user.role };
 }
 
 export async function getOfficeTasksBoard() {

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -9357,4 +9357,143 @@ export async function addVoiceEstimateItem(projectId: string, name: string, quan
     return item;
 }
 
+// =============================================
+// Office Tasks (internal kanban board — ADMIN/MANAGER only)
+// =============================================
+
+async function assertOfficeTaskAccess() {
+    const session = await getServerSession(authOptions);
+    const caller = session?.user?.email
+        ? await prisma.user.findUnique({ where: { email: session.user.email }, select: { id: true, role: true } })
+        : null;
+    if (!caller || !["ADMIN", "MANAGER"].includes(caller.role)) throw new Error("Forbidden");
+    return caller;
+}
+
+export async function getOfficeTasksBoard() {
+    await assertOfficeTaskAccess();
+
+    const [tasks, users] = await Promise.all([
+        prisma.officeTask.findMany({
+            orderBy: [{ status: "asc" }, { position: "asc" }],
+            include: { assignee: { select: { id: true, name: true, email: true } } },
+        }),
+        prisma.user.findMany({
+            where: { role: { in: ["ADMIN", "MANAGER"] }, status: "ACTIVATED" },
+            select: { id: true, name: true, email: true },
+        }),
+    ]);
+
+    return { tasks, users };
+}
+
+export async function createOfficeTask(data: {
+    title: string;
+    status?: string;
+    assigneeId?: string | null;
+    dueDate?: string | null;
+}) {
+    const caller = await assertOfficeTaskAccess();
+
+    const status = data.status || "To Do";
+    const last = await prisma.officeTask.findFirst({
+        where: { status },
+        orderBy: { position: "desc" },
+        select: { position: true },
+    });
+
+    const task = await prisma.officeTask.create({
+        data: {
+            title: data.title,
+            status,
+            position: (last?.position ?? -1) + 1,
+            assigneeId: data.assigneeId || null,
+            dueDate: data.dueDate ? new Date(data.dueDate) : null,
+            createdById: caller.id,
+        },
+        include: { assignee: { select: { id: true, name: true, email: true } } },
+    });
+
+    revalidatePath("/tasks");
+    return task;
+}
+
+export async function updateOfficeTask(id: string, data: {
+    title?: string;
+    notes?: string | null;
+    dueDate?: string | null;
+    assigneeId?: string | null;
+    aiPrompt?: string | null;
+}) {
+    await assertOfficeTaskAccess();
+
+    const updateData: any = {};
+    if (data.title !== undefined) updateData.title = data.title;
+    if (data.notes !== undefined) updateData.notes = data.notes || null;
+    if (data.dueDate !== undefined) updateData.dueDate = data.dueDate ? new Date(data.dueDate) : null;
+    if (data.assigneeId !== undefined) updateData.assigneeId = data.assigneeId || null;
+    if (data.aiPrompt !== undefined) updateData.aiPrompt = data.aiPrompt || null;
+
+    const task = await prisma.officeTask.update({
+        where: { id },
+        data: updateData,
+        include: { assignee: { select: { id: true, name: true, email: true } } },
+    });
+
+    revalidatePath("/tasks");
+    return task;
+}
+
+export async function moveOfficeTask(id: string, newStatus: string, newIndex: number) {
+    await assertOfficeTaskAccess();
+
+    const task = await prisma.officeTask.findUnique({ where: { id } });
+    if (!task) throw new Error("Task not found");
+
+    const oldStatus = task.status;
+
+    await prisma.$transaction(async (tx) => {
+        const targetTasks = await tx.officeTask.findMany({
+            where: { status: newStatus, id: { not: id } },
+            orderBy: { position: "asc" },
+        });
+
+        const clampedIndex = Math.max(0, Math.min(newIndex, targetTasks.length));
+        targetTasks.splice(clampedIndex, 0, { ...task, status: newStatus } as typeof task);
+
+        for (let i = 0; i < targetTasks.length; i++) {
+            const t = targetTasks[i];
+            await tx.officeTask.update({
+                where: { id: t.id },
+                data: { position: i, status: newStatus },
+            });
+        }
+
+        if (oldStatus !== newStatus) {
+            const sourceTasks = await tx.officeTask.findMany({
+                where: { status: oldStatus, id: { not: id } },
+                orderBy: { position: "asc" },
+            });
+            for (let i = 0; i < sourceTasks.length; i++) {
+                await tx.officeTask.update({
+                    where: { id: sourceTasks[i].id },
+                    data: { position: i },
+                });
+            }
+        }
+    });
+
+    revalidatePath("/tasks");
+    return { success: true };
+}
+
+export async function deleteOfficeTask(id: string) {
+    await assertOfficeTaskAccess();
+
+    await prisma.officeTask.delete({ where: { id } });
+
+    revalidatePath("/tasks");
+    return { success: true };
+}
+
 

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -24,6 +24,7 @@ import { archiveExecutedContractPdf, sendExecutedContractEmails } from "./contra
 import { appendContractCountersignaturePage } from "./pdf";
 import { defaultTaxForNewEstimate } from "./wa-tax";
 import { geocodeJobSiteAddress } from "./geocode";
+import { assertValidOfficeTaskStatus, parseOfficeTaskDateOnly } from "./office-task-utils";
 
 type NotificationToggleKey = "newLead" | "estimateViewed" | "estimateSigned" | "contractSigned" | "invoiceViewed" | "paymentReceived" | "messageReceived";
 
@@ -9361,23 +9362,6 @@ export async function addVoiceEstimateItem(projectId: string, name: string, quan
 // Office Tasks (internal kanban board — ADMIN/MANAGER only)
 // =============================================
 
-const OFFICE_TASK_STATUSES = ["To Do", "In Progress", "Done"] as const;
-
-function assertValidOfficeTaskStatus(status: string) {
-    if (!(OFFICE_TASK_STATUSES as readonly string[]).includes(status)) {
-        throw new Error(`Invalid status: ${status}`);
-    }
-}
-
-// Parse a "YYYY-MM-DD" date-only string as UTC midnight, so the stored instant's
-// calendar date is timezone-invariant (matches what the user picked, regardless
-// of the server's or client's local timezone).
-function parseOfficeTaskDateOnly(s: string): Date {
-    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
-    if (!m) throw new Error("Invalid date");
-    return new Date(Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3])));
-}
-
 async function assertOfficeTaskAccess() {
     const session = await getSessionOrDev();
     const sessionUserId = (session?.user as any)?.id as string | null | undefined;
@@ -9467,6 +9451,7 @@ export async function updateOfficeTask(id: string, data: {
     dueDate?: string | null;
     assigneeId?: string | null;
     aiPrompt?: string | null;
+    automationGap?: string | null;
 }) {
     await assertOfficeTaskAccess();
 
@@ -9476,6 +9461,7 @@ export async function updateOfficeTask(id: string, data: {
     if (data.dueDate !== undefined) updateData.dueDate = data.dueDate ? parseOfficeTaskDateOnly(data.dueDate) : null;
     if (data.assigneeId !== undefined) updateData.assigneeId = data.assigneeId || null;
     if (data.aiPrompt !== undefined) updateData.aiPrompt = data.aiPrompt || null;
+    if (data.automationGap !== undefined) updateData.automationGap = data.automationGap || null;
 
     const task = await prisma.officeTask.update({
         where: { id },

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -9361,13 +9361,29 @@ export async function addVoiceEstimateItem(projectId: string, name: string, quan
 // Office Tasks (internal kanban board — ADMIN/MANAGER only)
 // =============================================
 
+const OFFICE_TASK_STATUSES = ["To Do", "In Progress", "Done"] as const;
+
+function assertValidOfficeTaskStatus(status: string) {
+    if (!(OFFICE_TASK_STATUSES as readonly string[]).includes(status)) {
+        throw new Error(`Invalid status: ${status}`);
+    }
+}
+
+// Parse a "YYYY-MM-DD" date-only string as UTC midnight, so the stored instant's
+// calendar date is timezone-invariant (matches what the user picked, regardless
+// of the server's or client's local timezone).
+function parseOfficeTaskDateOnly(s: string): Date {
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
+    if (!m) throw new Error("Invalid date");
+    return new Date(Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3])));
+}
+
 async function assertOfficeTaskAccess() {
-    const session = await getServerSession(authOptions);
-    const caller = session?.user?.email
-        ? await prisma.user.findUnique({ where: { email: session.user.email }, select: { id: true, role: true } })
-        : null;
-    if (!caller || !["ADMIN", "MANAGER"].includes(caller.role)) throw new Error("Forbidden");
-    return caller;
+    const session = await getSessionOrDev();
+    const sessionUserId = (session?.user as any)?.id as string | null | undefined;
+    const sessionRole = ((session?.user as any)?.role as string | null) ?? null;
+    if (!sessionRole || !["ADMIN", "MANAGER"].includes(sessionRole)) throw new Error("Forbidden");
+    return { id: sessionUserId ?? null, role: sessionRole };
 }
 
 export async function getOfficeTasksBoard() {
@@ -9396,22 +9412,26 @@ export async function createOfficeTask(data: {
     const caller = await assertOfficeTaskAccess();
 
     const status = data.status || "To Do";
-    const last = await prisma.officeTask.findFirst({
-        where: { status },
-        orderBy: { position: "desc" },
-        select: { position: true },
-    });
+    assertValidOfficeTaskStatus(status);
 
-    const task = await prisma.officeTask.create({
-        data: {
-            title: data.title,
-            status,
-            position: (last?.position ?? -1) + 1,
-            assigneeId: data.assigneeId || null,
-            dueDate: data.dueDate ? new Date(data.dueDate) : null,
-            createdById: caller.id,
-        },
-        include: { assignee: { select: { id: true, name: true, email: true } } },
+    const task = await prisma.$transaction(async (tx) => {
+        const last = await tx.officeTask.findFirst({
+            where: { status },
+            orderBy: { position: "desc" },
+            select: { position: true },
+        });
+
+        return tx.officeTask.create({
+            data: {
+                title: data.title,
+                status,
+                position: (last?.position ?? -1) + 1,
+                assigneeId: data.assigneeId || null,
+                dueDate: data.dueDate ? parseOfficeTaskDateOnly(data.dueDate) : null,
+                createdById: caller.id,
+            },
+            include: { assignee: { select: { id: true, name: true, email: true } } },
+        });
     });
 
     revalidatePath("/tasks");
@@ -9430,7 +9450,7 @@ export async function updateOfficeTask(id: string, data: {
     const updateData: any = {};
     if (data.title !== undefined) updateData.title = data.title;
     if (data.notes !== undefined) updateData.notes = data.notes || null;
-    if (data.dueDate !== undefined) updateData.dueDate = data.dueDate ? new Date(data.dueDate) : null;
+    if (data.dueDate !== undefined) updateData.dueDate = data.dueDate ? parseOfficeTaskDateOnly(data.dueDate) : null;
     if (data.assigneeId !== undefined) updateData.assigneeId = data.assigneeId || null;
     if (data.aiPrompt !== undefined) updateData.aiPrompt = data.aiPrompt || null;
 
@@ -9446,13 +9466,14 @@ export async function updateOfficeTask(id: string, data: {
 
 export async function moveOfficeTask(id: string, newStatus: string, newIndex: number) {
     await assertOfficeTaskAccess();
-
-    const task = await prisma.officeTask.findUnique({ where: { id } });
-    if (!task) throw new Error("Task not found");
-
-    const oldStatus = task.status;
+    assertValidOfficeTaskStatus(newStatus);
 
     await prisma.$transaction(async (tx) => {
+        const task = await tx.officeTask.findUnique({ where: { id } });
+        if (!task) throw new Error("Task not found");
+
+        const oldStatus = task.status;
+
         const targetTasks = await tx.officeTask.findMany({
             where: { status: newStatus, id: { not: id } },
             orderBy: { position: "asc" },

--- a/src/lib/office-task-utils.ts
+++ b/src/lib/office-task-utils.ts
@@ -1,0 +1,22 @@
+// Shared, plain (non-"use server") helpers for the Office Tasks kanban board.
+// Split out of actions.ts so the secret-authed ingest route (a regular route
+// handler, not a server action) can reuse the exact same status/date-parsing
+// logic without duplicating it — a "use server" file can only export async
+// functions, so these synchronous helpers can't live there directly.
+
+export const OFFICE_TASK_STATUSES = ["To Do", "In Progress", "Done"] as const;
+
+export function assertValidOfficeTaskStatus(status: string) {
+    if (!(OFFICE_TASK_STATUSES as readonly string[]).includes(status)) {
+        throw new Error(`Invalid status: ${status}`);
+    }
+}
+
+// Parse a "YYYY-MM-DD" date-only string as UTC midnight, so the stored instant's
+// calendar date is timezone-invariant (matches what the user picked, regardless
+// of the server's or client's local timezone).
+export function parseOfficeTaskDateOnly(s: string): Date {
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
+    if (!m) throw new Error("Invalid date");
+    return new Date(Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3])));
+}


### PR DESCRIPTION
## What

Internal **Office Tasks** kanban board at `/tasks` — a Trello replacement for office staff (Justin, Margaret, Richard), plus a secret-authed ingest endpoint so the GTR Google Chat AI routines can auto-file "needs a human" items onto the board.

### Board
- Three columns (To Do / In Progress / Done) with drag-and-drop (`@hello-pangea/dnd`, first consumer in the repo)
- Every card has an assignee (initials avatar); filter chips per person
- Due dates with overdue/soon badges (date-only UTC semantics end to end)
- Card dialog: notes, assignee, due date, status, **AI Assist** (suggested prompt + "Copy for Claude"), **Automation Gap** ("what would make this automatic next time"), confirm-gated delete
- Nav item gated like Company (`manageTeamMembers`); page + all server actions re-check ADMIN/MANAGER role and non-DISABLED status against the DB

### Ingest endpoint
- `POST /api/office-tasks/ingest`, `Authorization: Bearer $OFFICE_TASKS_INGEST_SECRET` (env var to be added to Vercel before wiring the routines)
- Accepts title/notes/aiPrompt/automationGap/source/assigneeEmail/dueDate; case-insensitive title dedupe against non-Done tasks

### Schema
- New `OfficeTask` table — already applied to the production DB (additive; this repo doesn't use prisma-migrate), columns/FKs/indexes verified via information_schema

## Verification
- `npm run build` green on every commit; independent checker agent verified spec conformance and runtime (`/tasks` renders, HTTP 200)
- Codex peer review, two rounds: fixed dev-session 500, date-only UTC bug, whole-board rollback clobbering, reads-outside-transaction, missing status validation, stale-JWT auth trust, stale-dialog refresh
- Ingest endpoint exercised live: 401 wrong secret / 201 create / 200 dedupe; test row and test secret removed
- Accepted as-is (documented): READ COMMITTED isolation for the 3-user board; refetch-failure UX; nav perm-key vs role nit

## Deploy note
**Do not auto-deploy from this branch alone.** Production currently runs work deployed from the `feat/undo-milestone-warnings` working tree; deploy from a tree containing both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
