### PR TITLE
feat(tasks): board v2 — custom columns, archive/restore, gaps rollup

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -158,8 +158,11 @@ model OfficeTask {
   id          String    @id @default(cuid())
   title       String
   notes       String?
-  status      String    @default("To Do") // To Do, In Progress, Done
-  position    Int       @default(0) // sort order within its status column
+  status      String    @default("To Do") // LEGACY — kept in sync with column.name on create/move for prod rollback safety until v2 deploys; reads should use columnId
+  columnId    String?
+  column      OfficeBoardColumn? @relation(fields: [columnId], references: [id], onDelete: SetNull)
+  position    Int       @default(0) // sort order within its column
+  archivedAt  DateTime?
   dueDate     DateTime?
   assigneeId  String?
   assignee    User?     @relation("OfficeTaskAssignee", fields: [assigneeId], references: [id])
@@ -172,6 +175,16 @@ model OfficeTask {
 
   @@index([status, position])
   @@index([assigneeId])
+  @@index([columnId])
+}
+
+model OfficeBoardColumn {
+  id           String       @id @default(cuid())
+  name         String
+  position     Int
+  isDoneColumn Boolean      @default(false)
+  createdAt    DateTime     @default(now())
+  tasks        OfficeTask[]
 }
 
 model LeadMeeting {

--- a/src/app/api/office-tasks/ingest/route.ts
+++ b/src/app/api/office-tasks/ingest/route.ts
@@ -25,6 +25,8 @@ interface IngestPayload {
     source?: string;
     assigneeEmail?: string;
     dueDate?: string; // "YYYY-MM-DD"
+    column?: string; // board column name, case-insensitive; falls back to the first column
+    status?: string; // legacy alias for `column`
 }
 
 export async function POST(req: Request) {
@@ -63,18 +65,37 @@ export async function POST(req: Request) {
         }
     }
 
-    // Dedupe: an already-filed, not-yet-Done task with the same title (case-
-    // insensitive) means this is a re-send of something already on the board.
+    // Dedupe: an already-filed, not-archived task with the same title (case-
+    // insensitive) that isn't sitting in a "Done"-style column means this is a
+    // re-send of something already on the board.
     const existing = await prisma.officeTask.findFirst({
         where: {
             title: { equals: title, mode: "insensitive" },
-            status: { not: "Done" },
+            archivedAt: null,
+            OR: [{ columnId: null }, { column: { isDoneColumn: false } }],
         },
         select: { id: true },
     });
     if (existing) {
         return NextResponse.json({ deduped: true, id: existing.id }, { status: 200 });
     }
+
+    // Resolve the target column by name (case-insensitive), falling back to the
+    // first-position column when unspecified or unmatched.
+    const columnNameInput = (body.column || body.status || "").trim();
+    let column = columnNameInput
+        ? await prisma.officeBoardColumn.findFirst({
+            where: { name: { equals: columnNameInput, mode: "insensitive" } },
+        })
+        : null;
+    if (!column) {
+        column = await prisma.officeBoardColumn.findFirst({ orderBy: { position: "asc" } });
+    }
+    if (!column) {
+        console.error("No OfficeBoardColumn configured — cannot ingest task");
+        return NextResponse.json({ error: "No board column configured" }, { status: 500 });
+    }
+    const targetColumn = column;
 
     let assigneeId: string | null = null;
     if (body.assigneeEmail?.trim()) {
@@ -97,7 +118,7 @@ export async function POST(req: Request) {
 
     const task = await prisma.$transaction(async (tx) => {
         const last = await tx.officeTask.findFirst({
-            where: { status: "To Do" },
+            where: { columnId: targetColumn.id, archivedAt: null },
             orderBy: { position: "desc" },
             select: { position: true },
         });
@@ -105,7 +126,8 @@ export async function POST(req: Request) {
         return tx.officeTask.create({
             data: {
                 title,
-                status: "To Do",
+                columnId: targetColumn.id,
+                status: targetColumn.name, // TRANSITIONAL COMPAT — see OfficeTask.status
                 position: (last?.position ?? -1) + 1,
                 notes,
                 aiPrompt: body.aiPrompt?.trim() || null,

--- a/src/app/api/office-tasks/ingest/route.ts
+++ b/src/app/api/office-tasks/ingest/route.ts
@@ -89,7 +89,7 @@ export async function POST(req: Request) {
         })
         : null;
     if (!column) {
-        column = await prisma.officeBoardColumn.findFirst({ orderBy: { position: "asc" } });
+        column = await prisma.officeBoardColumn.findFirst({ orderBy: [{ position: "asc" }, { createdAt: "asc" }] });
     }
     if (!column) {
         console.error("No OfficeBoardColumn configured — cannot ingest task");
@@ -119,7 +119,7 @@ export async function POST(req: Request) {
     const task = await prisma.$transaction(async (tx) => {
         const last = await tx.officeTask.findFirst({
             where: { columnId: targetColumn.id, archivedAt: null },
-            orderBy: { position: "desc" },
+            orderBy: [{ position: "desc" }, { createdAt: "desc" }, { id: "desc" }],
             select: { position: true },
         });
 

--- a/src/app/tasks/TasksBoardClient.tsx
+++ b/src/app/tasks/TasksBoardClient.tsx
@@ -3,20 +3,39 @@
 import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { DragDropContext, Droppable, Draggable, type DropResult } from "@hello-pangea/dnd";
 import { toast } from "sonner";
-import { createOfficeTask, updateOfficeTask, moveOfficeTask, deleteOfficeTask, getOfficeTasksBoard } from "@/lib/actions";
+import {
+    createOfficeTask,
+    updateOfficeTask,
+    moveOfficeTask,
+    deleteOfficeTask,
+    archiveOfficeTask,
+    restoreOfficeTask,
+    createBoardColumn,
+    renameBoardColumn,
+    reorderBoardColumn,
+    deleteBoardColumn,
+    getOfficeTasksBoard,
+} from "@/lib/actions";
 import { formatLocalDateString, parseLocalDateString } from "@/lib/report-utils";
 
-const STATUSES = ["To Do", "In Progress", "Done"] as const;
-type Status = (typeof STATUSES)[number];
-
 type BoardUser = { id: string; name: string | null; email: string };
+
+type BoardColumn = {
+    id: string;
+    name: string;
+    position: number;
+    isDoneColumn: boolean;
+    createdAt: Date | string;
+};
 
 type Task = {
     id: string;
     title: string;
     notes: string | null;
     status: string;
+    columnId: string | null;
     position: number;
+    archivedAt: Date | string | null;
     dueDate: Date | string | null;
     assigneeId: string | null;
     assignee: BoardUser | null;
@@ -28,7 +47,9 @@ type Task = {
 };
 
 interface Props {
+    initialColumns: BoardColumn[];
     initialTasks: Task[];
+    initialArchived: Task[];
     users: BoardUser[];
 }
 
@@ -83,11 +104,11 @@ function formatISODateForDisplay(iso: string): string {
     return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
 
-function dueDateInfo(dueDate: Date | string | null, status: string): { label: string; className: string } | null {
+function dueDateInfo(dueDate: Date | string | null, isDoneColumn: boolean): { label: string; className: string } | null {
     if (!dueDate) return null;
     const iso = dueDateToISO(dueDate);
     const label = formatISODateForDisplay(iso);
-    if (status === "Done") return { label, className: "bg-slate-100 text-slate-600" };
+    if (isDoneColumn) return { label, className: "bg-slate-100 text-slate-600" };
 
     const todayStr = formatLocalDateString(new Date());
     if (iso < todayStr) return { label, className: "bg-red-100 text-red-700" };
@@ -102,6 +123,10 @@ function dueDateInfo(dueDate: Date | string | null, status: string): { label: st
 function composePrompt(title: string, notes: string, dueDate: Date | string | null): string {
     const dueStr = dueDate ? formatISODateForDisplay(dueDateToISO(dueDate)) : "No due date";
     return `Help me complete this Golden Touch office task: ${title}. Details: ${notes || "none"}. Due: ${dueStr}. You have access to our ProBuild backend, QuickBooks, Gmail, and Google Drive — pull whatever you need and draft the pieces that require a human to review or send.`;
+}
+
+function normalizeGapKey(s: string): string {
+    return s.trim().toLowerCase().replace(/\s+/g, " ");
 }
 
 function chipClass(active: boolean): string {
@@ -133,8 +158,28 @@ function WrenchIcon({ className }: { className?: string }) {
     );
 }
 
-export default function TasksBoardClient({ initialTasks, users }: Props) {
+function ChevronIcon({ className, open }: { className?: string; open: boolean }) {
+    return (
+        <svg className={`${className} transition-transform ${open ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+    );
+}
+
+function DotsIcon({ className }: { className?: string }) {
+    return (
+        <svg className={className} fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="12" cy="5" r="1.5" />
+            <circle cx="12" cy="12" r="1.5" />
+            <circle cx="12" cy="19" r="1.5" />
+        </svg>
+    );
+}
+
+export default function TasksBoardClient({ initialColumns, initialTasks, initialArchived, users }: Props) {
+    const [columns, setColumns] = useState<BoardColumn[]>(initialColumns);
     const [tasks, setTasks] = useState<Task[]>(initialTasks);
+    const [archived, setArchived] = useState<Task[]>(initialArchived);
     const [filterId, setFilterId] = useState<string | null>(null);
     const [quickAdd, setQuickAdd] = useState<Record<string, string>>({});
     const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
@@ -142,6 +187,15 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
     const [draftNotes, setDraftNotes] = useState("");
     const [draftAiPrompt, setDraftAiPrompt] = useState("");
     const [draftAutomationGap, setDraftAutomationGap] = useState("");
+    const [addingColumn, setAddingColumn] = useState(false);
+    const [newColumnName, setNewColumnName] = useState("");
+    const [openColumnMenuId, setOpenColumnMenuId] = useState<string | null>(null);
+    const [renamingColumnId, setRenamingColumnId] = useState<string | null>(null);
+    const [renameDraftName, setRenameDraftName] = useState("");
+    const [renameDraftIsDone, setRenameDraftIsDone] = useState(false);
+    const [archivedOpen, setArchivedOpen] = useState(false);
+    const [gapsOpen, setGapsOpen] = useState(false);
+    const [expandedGapKey, setExpandedGapKey] = useState<string | null>(null);
     const [, startTransition] = useTransition();
 
     const selectedTask = tasks.find((t) => t.id === selectedTaskId) || null;
@@ -165,19 +219,60 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedTaskId]);
 
+    const columnsSorted = useMemo(() => [...columns].sort((a, b) => a.position - b.position), [columns]);
+    const firstColumnId = columnsSorted[0]?.id ?? null;
+
+    const columnById = useMemo(() => {
+        const map: Record<string, BoardColumn> = {};
+        for (const c of columns) map[c.id] = c;
+        return map;
+    }, [columns]);
+
+    // Tasks with no columnId (shouldn't exist after backfill, but a column could
+    // be deleted out from under an archived task and later restored) render in
+    // the first column.
+    function effectiveColumnId(task: Task): string | null {
+        if (task.columnId && columnById[task.columnId]) return task.columnId;
+        return firstColumnId;
+    }
+
     const visibleTasks = useMemo(() => {
         if (!filterId) return tasks;
         return tasks.filter((t) => t.assigneeId === filterId);
     }, [tasks, filterId]);
 
-    const columns = useMemo(() => {
-        const map: Record<string, Task[]> = { "To Do": [], "In Progress": [], Done: [] };
+    const tasksByColumn = useMemo(() => {
+        const map: Record<string, Task[]> = {};
+        for (const c of columnsSorted) map[c.id] = [];
         for (const t of visibleTasks) {
-            (map[t.status] ||= []).push(t);
+            const key = effectiveColumnId(t);
+            if (key) (map[key] ||= []).push(t);
         }
-        for (const s of STATUSES) map[s].sort((a, b) => a.position - b.position);
+        for (const key of Object.keys(map)) map[key].sort((a, b) => a.position - b.position);
         return map;
-    }, [visibleTasks]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [visibleTasks, columnsSorted, firstColumnId]);
+
+    // Purely client-side rollup of open (non-archived) tasks with a non-empty
+    // automationGap, grouped by normalized text.
+    const automationGapGroups = useMemo(() => {
+        const map = new Map<string, { count: number; original: string; tasks: { id: string; title: string }[] }>();
+        for (const t of tasks) {
+            const raw = (t.automationGap || "").trim();
+            if (!raw) continue;
+            const key = normalizeGapKey(raw);
+            const existing = map.get(key);
+            if (existing) {
+                existing.count++;
+                existing.tasks.push({ id: t.id, title: t.title });
+            } else {
+                map.set(key, { count: 1, original: raw, tasks: [{ id: t.id, title: t.title }] });
+            }
+        }
+        return Array.from(map.entries())
+            .map(([key, v]) => ({ key, ...v }))
+            .sort((a, b) => b.count - a.count);
+    }, [tasks]);
 
     // On any server-action failure, re-fetch the authoritative board state instead
     // of restoring a whole-board snapshot — a snapshot restore would also wipe out
@@ -187,8 +282,10 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
     async function refreshBoard() {
         try {
             const board = await getOfficeTasksBoard();
+            setColumns(board.columns as unknown as BoardColumn[]);
             const freshTasks = board.tasks as unknown as Task[];
             setTasks(freshTasks);
+            setArchived(board.archived as unknown as Task[]);
             const currentSelectedId = selectedTaskIdRef.current;
             if (currentSelectedId) {
                 const fresh = freshTasks.find((t) => t.id === currentSelectedId);
@@ -206,30 +303,32 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
         }
     }
 
-    function performMove(taskId: string, newStatus: string, newIndex: number) {
+    function performMove(taskId: string, newColumnId: string, newIndex: number) {
         const moved = tasks.find((t) => t.id === taskId);
         if (!moved) return;
 
-        const byStatus: Record<string, Task[]> = { "To Do": [], "In Progress": [], Done: [] };
+        const byColumn: Record<string, Task[]> = {};
+        for (const c of columns) byColumn[c.id] = [];
         for (const t of tasks) {
             if (t.id === taskId) continue;
-            (byStatus[t.status] ||= []).push(t);
+            const key = effectiveColumnId(t);
+            if (key) (byColumn[key] ||= []).push(t);
         }
-        for (const s of STATUSES) byStatus[s].sort((a, b) => a.position - b.position);
+        for (const key of Object.keys(byColumn)) byColumn[key].sort((a, b) => a.position - b.position);
 
-        const destList = byStatus[newStatus];
+        const destList = byColumn[newColumnId] || (byColumn[newColumnId] = []);
         const clampedIndex = Math.max(0, Math.min(newIndex, destList.length));
-        destList.splice(clampedIndex, 0, { ...moved, status: newStatus });
+        destList.splice(clampedIndex, 0, { ...moved, columnId: newColumnId });
 
         const next: Task[] = [];
-        for (const s of STATUSES) {
-            byStatus[s].forEach((t, i) => next.push({ ...t, position: i }));
+        for (const key of Object.keys(byColumn)) {
+            byColumn[key].forEach((t, i) => next.push({ ...t, position: i }));
         }
         setTasks(next);
 
         startTransition(async () => {
             try {
-                await moveOfficeTask(taskId, newStatus, clampedIndex);
+                await moveOfficeTask(taskId, newColumnId, clampedIndex);
             } catch {
                 toast.error("Failed to move task");
                 await refreshBoard();
@@ -244,13 +343,13 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
         performMove(draggableId, destination.droppableId, destination.index);
     }
 
-    function handleQuickAdd(status: string) {
-        const title = (quickAdd[status] || "").trim();
+    function handleQuickAdd(columnId: string) {
+        const title = (quickAdd[columnId] || "").trim();
         if (!title) return;
-        setQuickAdd((prev) => ({ ...prev, [status]: "" }));
+        setQuickAdd((prev) => ({ ...prev, [columnId]: "" }));
         startTransition(async () => {
             try {
-                const created = await createOfficeTask({ title, status });
+                const created = await createOfficeTask({ title, columnId });
                 setTasks((prev) => [...prev, created as unknown as Task]);
             } catch {
                 toast.error("Failed to create task");
@@ -292,15 +391,18 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
         });
     }
 
-    function handleStatusSelect(newStatus: string) {
-        if (!selectedTask || newStatus === selectedTask.status) return;
-        const destCount = tasks.filter((t) => t.status === newStatus && t.id !== selectedTask.id).length;
-        performMove(selectedTask.id, newStatus, destCount);
+    function handleColumnSelect(newColumnId: string) {
+        if (!selectedTask) return;
+        const currentColumnId = effectiveColumnId(selectedTask);
+        if (newColumnId === currentColumnId) return;
+        const destCount = (tasksByColumn[newColumnId] || []).length;
+        performMove(selectedTask.id, newColumnId, destCount);
     }
 
     function handleDelete(id: string) {
         if (!confirm("Delete this task? This cannot be undone.")) return;
         setTasks((prev) => prev.filter((t) => t.id !== id));
+        setArchived((prev) => prev.filter((t) => t.id !== id));
         setSelectedTaskId(null);
         startTransition(async () => {
             try {
@@ -308,6 +410,37 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
                 toast.success("Task deleted");
             } catch {
                 toast.error("Failed to delete task");
+                await refreshBoard();
+            }
+        });
+    }
+
+    function handleArchive(id: string) {
+        const task = tasks.find((t) => t.id === id);
+        if (!task) return;
+        setTasks((prev) => prev.filter((t) => t.id !== id));
+        setArchived((prev) => [{ ...task, archivedAt: new Date().toISOString() }, ...prev]);
+        setSelectedTaskId(null);
+        startTransition(async () => {
+            try {
+                await archiveOfficeTask(id);
+                toast.success("Task archived");
+            } catch {
+                toast.error("Failed to archive task");
+                await refreshBoard();
+            }
+        });
+    }
+
+    function handleRestore(id: string) {
+        setArchived((prev) => prev.filter((t) => t.id !== id));
+        startTransition(async () => {
+            try {
+                const restored = await restoreOfficeTask(id);
+                setTasks((prev) => [...prev, restored as unknown as Task]);
+                toast.success("Task restored");
+            } catch {
+                toast.error("Failed to restore task");
                 await refreshBoard();
             }
         });
@@ -329,6 +462,93 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
         } catch {
             toast.error("Failed to copy — clipboard unavailable");
         }
+    }
+
+    function handleAddColumn() {
+        const name = newColumnName.trim();
+        if (!name) return;
+        setNewColumnName("");
+        setAddingColumn(false);
+        startTransition(async () => {
+            try {
+                const created = await createBoardColumn(name);
+                setColumns((prev) => [...prev, created as unknown as BoardColumn]);
+            } catch (e: any) {
+                toast.error(e?.message || "Failed to create column");
+            }
+        });
+    }
+
+    function openRenameDialog(column: BoardColumn) {
+        setRenamingColumnId(column.id);
+        setRenameDraftName(column.name);
+        setRenameDraftIsDone(column.isDoneColumn);
+        setOpenColumnMenuId(null);
+    }
+
+    function handleRenameSubmit() {
+        if (!renamingColumnId) return;
+        const trimmed = renameDraftName.trim();
+        if (!trimmed) {
+            toast.error("Column name is required");
+            return;
+        }
+        const id = renamingColumnId;
+        setColumns((prev) => prev.map((c) => (c.id === id ? { ...c, name: trimmed, isDoneColumn: renameDraftIsDone } : c)));
+        setRenamingColumnId(null);
+        startTransition(async () => {
+            try {
+                await renameBoardColumn(id, trimmed, renameDraftIsDone);
+            } catch (e: any) {
+                toast.error(e?.message || "Failed to rename column");
+                await refreshBoard();
+            }
+        });
+    }
+
+    function handleColumnReorder(columnId: string, direction: -1 | 1) {
+        setOpenColumnMenuId(null);
+        const idx = columnsSorted.findIndex((c) => c.id === columnId);
+        if (idx === -1) return;
+        const newIndex = idx + direction;
+        if (newIndex < 0 || newIndex >= columnsSorted.length) return;
+
+        const reordered = [...columnsSorted];
+        const [moved] = reordered.splice(idx, 1);
+        reordered.splice(newIndex, 0, moved);
+        setColumns(reordered.map((c, i) => ({ ...c, position: i })));
+
+        startTransition(async () => {
+            try {
+                await reorderBoardColumn(columnId, newIndex);
+            } catch {
+                toast.error("Failed to reorder column");
+                await refreshBoard();
+            }
+        });
+    }
+
+    function handleDeleteColumn(columnId: string) {
+        setOpenColumnMenuId(null);
+        const columnTasks = tasksByColumn[columnId] || [];
+        if (columnTasks.length > 0) {
+            toast.error("Move or archive all tasks out of this column before deleting it");
+            return;
+        }
+        if (columns.length <= 1) {
+            toast.error("The board must have at least one column");
+            return;
+        }
+        if (!confirm("Delete this column?")) return;
+        setColumns((prev) => prev.filter((c) => c.id !== columnId));
+        startTransition(async () => {
+            try {
+                await deleteBoardColumn(columnId);
+            } catch (e: any) {
+                toast.error(e?.message || "Failed to delete column");
+                await refreshBoard();
+            }
+        });
     }
 
     return (
@@ -357,12 +577,64 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
                 </div>
             )}
 
+            {/* Automation gaps rollup — hidden entirely when there are no gaps */}
+            {automationGapGroups.length > 0 && (
+                <div className="px-6 pt-3 shrink-0">
+                    <div className="hui-card">
+                        <button
+                            type="button"
+                            onClick={() => setGapsOpen((o) => !o)}
+                            className="w-full flex items-center justify-between px-4 py-2.5"
+                        >
+                            <span className="text-sm font-semibold text-hui-textMain flex items-center gap-1.5">
+                                <WrenchIcon className="w-4 h-4 text-amber-600" />
+                                Automation gaps ({automationGapGroups.length})
+                            </span>
+                            <ChevronIcon className="w-4 h-4 text-hui-textMuted" open={gapsOpen} />
+                        </button>
+                        {gapsOpen && (
+                            <div className="border-t border-hui-border divide-y divide-slate-100">
+                                {automationGapGroups.map((g) => (
+                                    <div key={g.key}>
+                                        <button
+                                            type="button"
+                                            onClick={() => setExpandedGapKey((k) => (k === g.key ? null : g.key))}
+                                            className="w-full flex items-center gap-2 px-4 py-2 text-left hover:bg-slate-50 transition"
+                                        >
+                                            <span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 shrink-0">
+                                                {g.count}
+                                            </span>
+                                            <span className="text-sm text-hui-textMain flex-1">{g.original}</span>
+                                            <ChevronIcon className="w-3.5 h-3.5 text-hui-textMuted shrink-0" open={expandedGapKey === g.key} />
+                                        </button>
+                                        {expandedGapKey === g.key && (
+                                            <div className="px-4 pb-2 pl-9 space-y-1">
+                                                {g.tasks.map((t) => (
+                                                    <button
+                                                        key={t.id}
+                                                        type="button"
+                                                        onClick={() => setSelectedTaskId(t.id)}
+                                                        className="block text-xs text-hui-primary hover:underline text-left"
+                                                    >
+                                                        {t.title}
+                                                    </button>
+                                                ))}
+                                            </div>
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                </div>
+            )}
+
             {/* Board */}
             <div className="flex-1 overflow-x-auto overflow-y-hidden">
                 <DragDropContext onDragEnd={handleDragEnd}>
                     <div className="flex gap-4 h-full px-6 py-4 min-w-max">
-                        {STATUSES.map((status) => (
-                            <Droppable droppableId={status} key={status}>
+                        {columnsSorted.map((column) => (
+                            <Droppable droppableId={column.id} key={column.id}>
                                 {(provided, snapshot) => (
                                     <div
                                         ref={provided.innerRef}
@@ -370,22 +642,77 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
                                         className={`w-80 shrink-0 flex flex-col bg-white rounded-xl shadow-sm border border-hui-border p-3 h-full ${snapshot.isDraggingOver ? "bg-slate-50" : ""
                                             }`}
                                     >
-                                        <div className="flex items-center justify-between mb-2 px-1">
-                                            <h3 className="text-sm font-semibold text-hui-textMain">{status}</h3>
-                                            <span className="text-xs text-hui-textMuted">{columns[status].length}</span>
+                                        <div className="flex items-center justify-between mb-2 px-1 relative">
+                                            <h3 className="text-sm font-semibold text-hui-textMain flex items-center gap-1.5">
+                                                {column.name}
+                                                {column.isDoneColumn && (
+                                                    <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-green-100 text-green-700">
+                                                        Done
+                                                    </span>
+                                                )}
+                                            </h3>
+                                            <div className="flex items-center gap-1.5">
+                                                <span className="text-xs text-hui-textMuted">{(tasksByColumn[column.id] || []).length}</span>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => setOpenColumnMenuId((id) => (id === column.id ? null : column.id))}
+                                                    className="text-hui-textMuted hover:text-hui-textMain transition p-0.5"
+                                                >
+                                                    <DotsIcon className="w-4 h-4" />
+                                                </button>
+                                            </div>
+
+                                            {openColumnMenuId === column.id && (
+                                                <div
+                                                    className="absolute right-0 top-6 z-20 bg-white border border-hui-border rounded-lg shadow-lg py-1 w-44"
+                                                    onMouseLeave={() => setOpenColumnMenuId(null)}
+                                                >
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => openRenameDialog(column)}
+                                                        className="w-full text-left px-3 py-1.5 text-sm text-hui-textMain hover:bg-slate-50"
+                                                    >
+                                                        Rename
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => handleColumnReorder(column.id, -1)}
+                                                        disabled={columnsSorted.findIndex((c) => c.id === column.id) === 0}
+                                                        className="w-full text-left px-3 py-1.5 text-sm text-hui-textMain hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed"
+                                                    >
+                                                        ← Move left
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => handleColumnReorder(column.id, 1)}
+                                                        disabled={columnsSorted.findIndex((c) => c.id === column.id) === columnsSorted.length - 1}
+                                                        className="w-full text-left px-3 py-1.5 text-sm text-hui-textMain hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed"
+                                                    >
+                                                        Move right →
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => handleDeleteColumn(column.id)}
+                                                        className="w-full text-left px-3 py-1.5 text-sm text-red-600 hover:bg-red-50"
+                                                    >
+                                                        Delete
+                                                    </button>
+                                                </div>
+                                            )}
                                         </div>
+
                                         <input
                                             className="hui-input text-sm mb-2"
                                             placeholder="+ Add a task…"
-                                            value={quickAdd[status] || ""}
-                                            onChange={(e) => setQuickAdd((prev) => ({ ...prev, [status]: e.target.value }))}
+                                            value={quickAdd[column.id] || ""}
+                                            onChange={(e) => setQuickAdd((prev) => ({ ...prev, [column.id]: e.target.value }))}
                                             onKeyDown={(e) => {
-                                                if (e.key === "Enter") handleQuickAdd(status);
+                                                if (e.key === "Enter") handleQuickAdd(column.id);
                                             }}
                                         />
                                         <div className="flex-1 overflow-y-auto space-y-2 min-h-[40px]">
-                                            {columns[status].map((task, index) => {
-                                                const due = dueDateInfo(task.dueDate, task.status);
+                                            {(tasksByColumn[column.id] || []).map((task, index) => {
+                                                const due = dueDateInfo(task.dueDate, column.isDoneColumn);
                                                 return (
                                                     <Draggable draggableId={task.id} index={index} key={task.id} isDragDisabled={!!filterId}>
                                                         {(dragProvided, dragSnapshot) => (
@@ -429,9 +756,148 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
                                 )}
                             </Droppable>
                         ))}
+
+                        {/* + Add column */}
+                        <div className="w-64 shrink-0 h-full">
+                            {addingColumn ? (
+                                <div className="bg-white rounded-xl shadow-sm border border-hui-border p-3">
+                                    <input
+                                        autoFocus
+                                        className="hui-input text-sm mb-2"
+                                        placeholder="Column name…"
+                                        value={newColumnName}
+                                        onChange={(e) => setNewColumnName(e.target.value)}
+                                        onKeyDown={(e) => {
+                                            if (e.key === "Enter") handleAddColumn();
+                                            if (e.key === "Escape") {
+                                                setAddingColumn(false);
+                                                setNewColumnName("");
+                                            }
+                                        }}
+                                    />
+                                    <div className="flex gap-2">
+                                        <button type="button" onClick={handleAddColumn} className="hui-btn hui-btn-green text-xs">
+                                            Add
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => {
+                                                setAddingColumn(false);
+                                                setNewColumnName("");
+                                            }}
+                                            className="hui-btn hui-btn-secondary text-xs"
+                                        >
+                                            Cancel
+                                        </button>
+                                    </div>
+                                </div>
+                            ) : (
+                                <button
+                                    type="button"
+                                    onClick={() => setAddingColumn(true)}
+                                    className="w-full h-11 rounded-xl border border-dashed border-hui-border text-sm text-hui-textMuted hover:border-hui-primary hover:text-hui-primary transition bg-white/50"
+                                >
+                                    + Add column
+                                </button>
+                            )}
+                        </div>
                     </div>
                 </DragDropContext>
             </div>
+
+            {/* Archived drawer */}
+            <div className="px-6 pb-4 shrink-0">
+                <div className="hui-card">
+                    <button
+                        type="button"
+                        onClick={() => setArchivedOpen((o) => !o)}
+                        className="w-full flex items-center justify-between px-4 py-2.5"
+                    >
+                        <span className="text-sm font-semibold text-hui-textMain">Archived ({archived.length})</span>
+                        <ChevronIcon className="w-4 h-4 text-hui-textMuted" open={archivedOpen} />
+                    </button>
+                    {archivedOpen && (
+                        <div className="border-t border-hui-border max-h-64 overflow-y-auto">
+                            {archived.length === 0 ? (
+                                <p className="px-4 py-3 text-xs text-hui-textMuted">No archived tasks.</p>
+                            ) : (
+                                <table className="w-full text-sm">
+                                    <tbody className="divide-y divide-slate-100">
+                                        {archived.map((task) => (
+                                            <tr key={task.id}>
+                                                <td className="px-4 py-2 text-hui-textMain">{task.title}</td>
+                                                <td className="px-4 py-2 text-hui-textMuted text-xs">
+                                                    {task.assignee ? task.assignee.name || task.assignee.email : "Unassigned"}
+                                                </td>
+                                                <td className="px-4 py-2 text-hui-textMuted text-xs whitespace-nowrap">
+                                                    {task.archivedAt ? formatISODateForDisplay(dueDateToISO(task.archivedAt)) : ""}
+                                                </td>
+                                                <td className="px-4 py-2 text-right whitespace-nowrap">
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => handleRestore(task.id)}
+                                                        className="hui-btn hui-btn-secondary text-xs mr-2"
+                                                    >
+                                                        Restore
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => handleDelete(task.id)}
+                                                        className="hui-btn text-xs text-red-600 hover:bg-red-50"
+                                                    >
+                                                        Delete
+                                                    </button>
+                                                </td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            )}
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            {/* Rename column dialog */}
+            {renamingColumnId && (
+                <div
+                    className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+                    onClick={() => setRenamingColumnId(null)}
+                >
+                    <div
+                        className="bg-white rounded-xl shadow-xl max-w-sm w-full border border-hui-border p-6"
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        <h2 className="text-base font-bold text-hui-textMain mb-4">Rename Column</h2>
+                        <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Name</label>
+                        <input
+                            autoFocus
+                            className="hui-input mt-1 w-full mb-4"
+                            value={renameDraftName}
+                            onChange={(e) => setRenameDraftName(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter") handleRenameSubmit();
+                            }}
+                        />
+                        <label className="flex items-center gap-2 text-sm text-hui-textMain mb-4 cursor-pointer">
+                            <input
+                                type="checkbox"
+                                checked={renameDraftIsDone}
+                                onChange={(e) => setRenameDraftIsDone(e.target.checked)}
+                            />
+                            This is a &quot;Done&quot; column (overdue badges are suppressed here)
+                        </label>
+                        <div className="flex justify-end gap-2">
+                            <button type="button" onClick={() => setRenamingColumnId(null)} className="hui-btn hui-btn-secondary">
+                                Cancel
+                            </button>
+                            <button type="button" onClick={handleRenameSubmit} className="hui-btn hui-btn-green">
+                                Save
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
 
             {/* Edit dialog */}
             {selectedTask && (
@@ -513,15 +979,15 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
                             </div>
 
                             <div>
-                                <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Status</label>
+                                <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Column</label>
                                 <select
                                     className="hui-input mt-1 w-full cursor-pointer"
-                                    value={selectedTask.status}
-                                    onChange={(e) => handleStatusSelect(e.target.value)}
+                                    value={effectiveColumnId(selectedTask) || ""}
+                                    onChange={(e) => handleColumnSelect(e.target.value)}
                                 >
-                                    {STATUSES.map((s) => (
-                                        <option key={s} value={s}>
-                                            {s}
+                                    {columnsSorted.map((c) => (
+                                        <option key={c.id} value={c.id}>
+                                            {c.name}
                                         </option>
                                     ))}
                                 </select>
@@ -579,13 +1045,22 @@ export default function TasksBoardClient({ initialTasks, users }: Props) {
                         </div>
 
                         <div className="px-6 py-4 border-t border-hui-border flex justify-between items-center">
-                            <button
-                                type="button"
-                                onClick={() => handleDelete(selectedTask.id)}
-                                className="hui-btn text-red-600 hover:bg-red-50"
-                            >
-                                Delete
-                            </button>
+                            <div className="flex gap-2">
+                                <button
+                                    type="button"
+                                    onClick={() => handleDelete(selectedTask.id)}
+                                    className="hui-btn text-red-600 hover:bg-red-50"
+                                >
+                                    Delete
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => handleArchive(selectedTask.id)}
+                                    className="hui-btn hui-btn-secondary"
+                                >
+                                    Archive
+                                </button>
+                            </div>
                             <button type="button" onClick={() => setSelectedTaskId(null)} className="hui-btn hui-btn-secondary">
                                 Close
                             </button>

--- a/src/app/tasks/TasksBoardClient.tsx
+++ b/src/app/tasks/TasksBoardClient.tsx
@@ -253,6 +253,23 @@ export default function TasksBoardClient({ initialColumns, initialTasks, initial
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [visibleTasks, columnsSorted, firstColumnId]);
 
+    // Unfiltered version of tasksByColumn — the assignee chips only affect what's
+    // rendered, so any logic that needs the REAL count/order of a column (append
+    // index for a dialog move, the empty-column precheck before deleting a
+    // column) must read this instead of tasksByColumn, or it'll compute against
+    // a partial list when a filter is active.
+    const tasksByColumnAll = useMemo(() => {
+        const map: Record<string, Task[]> = {};
+        for (const c of columnsSorted) map[c.id] = [];
+        for (const t of tasks) {
+            const key = effectiveColumnId(t);
+            if (key) (map[key] ||= []).push(t);
+        }
+        for (const key of Object.keys(map)) map[key].sort((a, b) => a.position - b.position);
+        return map;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [tasks, columnsSorted, firstColumnId]);
+
     // Purely client-side rollup of open (non-archived) tasks with a non-empty
     // automationGap, grouped by normalized text.
     const automationGapGroups = useMemo(() => {
@@ -395,7 +412,10 @@ export default function TasksBoardClient({ initialColumns, initialTasks, initial
         if (!selectedTask) return;
         const currentColumnId = effectiveColumnId(selectedTask);
         if (newColumnId === currentColumnId) return;
-        const destCount = (tasksByColumn[newColumnId] || []).length;
+        // Use the unfiltered count — tasksByColumn is scoped to the assignee
+        // chip filter, which would append before hidden tasks while a filter
+        // is active.
+        const destCount = (tasksByColumnAll[newColumnId] || []).length;
         performMove(selectedTask.id, newColumnId, destCount);
     }
 
@@ -530,7 +550,10 @@ export default function TasksBoardClient({ initialColumns, initialTasks, initial
 
     function handleDeleteColumn(columnId: string) {
         setOpenColumnMenuId(null);
-        const columnTasks = tasksByColumn[columnId] || [];
+        // Unfiltered precheck — with an assignee filter active, tasksByColumn
+        // would hide tasks and let this optimistically clear a non-empty
+        // column (the server still rejects it, but the UI would flash).
+        const columnTasks = tasksByColumnAll[columnId] || [];
         if (columnTasks.length > 0) {
             toast.error("Move or archive all tasks out of this column before deleting it");
             return;

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -18,11 +18,11 @@ export default async function TasksPage() {
         redirect("/projects");
     }
 
-    const { tasks, users } = await getOfficeTasksBoard();
+    const { columns, tasks, archived, users } = await getOfficeTasksBoard();
 
     return (
         <div className="flex flex-col h-[calc(100vh-64px)] -m-6 overflow-hidden bg-hui-background">
-            <TasksBoardClient initialTasks={tasks} users={users} />
+            <TasksBoardClient initialColumns={columns} initialTasks={tasks} initialArchived={archived} users={users} />
         </div>
     );
 }

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -24,7 +24,7 @@ import { archiveExecutedContractPdf, sendExecutedContractEmails } from "./contra
 import { appendContractCountersignaturePage } from "./pdf";
 import { defaultTaxForNewEstimate } from "./wa-tax";
 import { geocodeJobSiteAddress } from "./geocode";
-import { assertValidOfficeTaskStatus, parseOfficeTaskDateOnly } from "./office-task-utils";
+import { assertColumnExists, parseOfficeTaskDateOnly } from "./office-task-utils";
 
 type NotificationToggleKey = "newLead" | "estimateViewed" | "estimateSigned" | "contractSigned" | "invoiceViewed" | "paymentReceived" | "messageReceived";
 
@@ -9396,9 +9396,17 @@ async function assertOfficeTaskAccess() {
 export async function getOfficeTasksBoard() {
     await assertOfficeTaskAccess();
 
-    const [tasks, users] = await Promise.all([
+    const [columns, tasks, archived, users] = await Promise.all([
+        prisma.officeBoardColumn.findMany({ orderBy: { position: "asc" } }),
         prisma.officeTask.findMany({
-            orderBy: [{ status: "asc" }, { position: "asc" }],
+            where: { archivedAt: null },
+            orderBy: [{ columnId: "asc" }, { position: "asc" }],
+            include: { assignee: { select: { id: true, name: true, email: true } } },
+        }),
+        prisma.officeTask.findMany({
+            where: { archivedAt: { not: null } },
+            orderBy: { archivedAt: "desc" },
+            take: 100,
             include: { assignee: { select: { id: true, name: true, email: true } } },
         }),
         prisma.user.findMany({
@@ -9407,23 +9415,113 @@ export async function getOfficeTasksBoard() {
         }),
     ]);
 
-    return { tasks, users };
+    return { columns, tasks, archived, users };
+}
+
+export async function createBoardColumn(name: string) {
+    await assertOfficeTaskAccess();
+
+    const trimmed = name.trim();
+    if (!trimmed) throw new Error("Column name is required");
+
+    const column = await prisma.$transaction(async (tx) => {
+        const dup = await tx.officeBoardColumn.findFirst({
+            where: { name: { equals: trimmed, mode: "insensitive" } },
+            select: { id: true },
+        });
+        if (dup) throw new Error("A column with that name already exists");
+
+        const last = await tx.officeBoardColumn.findFirst({
+            orderBy: { position: "desc" },
+            select: { position: true },
+        });
+
+        return tx.officeBoardColumn.create({
+            data: { name: trimmed, position: (last?.position ?? -1) + 1 },
+        });
+    });
+
+    revalidatePath("/tasks");
+    return column;
+}
+
+// isDoneColumn is optional here rather than a separate action — a rename
+// dialog checkbox for it is trivial to wire alongside the name field.
+export async function renameBoardColumn(id: string, name: string, isDoneColumn?: boolean) {
+    await assertOfficeTaskAccess();
+
+    const trimmed = name.trim();
+    if (!trimmed) throw new Error("Column name is required");
+
+    const dup = await prisma.officeBoardColumn.findFirst({
+        where: { name: { equals: trimmed, mode: "insensitive" }, id: { not: id } },
+        select: { id: true },
+    });
+    if (dup) throw new Error("A column with that name already exists");
+
+    const data: { name: string; isDoneColumn?: boolean } = { name: trimmed };
+    if (isDoneColumn !== undefined) data.isDoneColumn = isDoneColumn;
+
+    const column = await prisma.officeBoardColumn.update({ where: { id }, data });
+
+    revalidatePath("/tasks");
+    return column;
+}
+
+export async function reorderBoardColumn(id: string, newIndex: number) {
+    await assertOfficeTaskAccess();
+
+    await prisma.$transaction(async (tx) => {
+        const columns = await tx.officeBoardColumn.findMany({ orderBy: { position: "asc" } });
+        const idx = columns.findIndex((c) => c.id === id);
+        if (idx === -1) throw new Error("Column not found");
+
+        const [moved] = columns.splice(idx, 1);
+        const clampedIndex = Math.max(0, Math.min(newIndex, columns.length));
+        columns.splice(clampedIndex, 0, moved);
+
+        for (let i = 0; i < columns.length; i++) {
+            await tx.officeBoardColumn.update({ where: { id: columns[i].id }, data: { position: i } });
+        }
+    });
+
+    revalidatePath("/tasks");
+    return { success: true };
+}
+
+export async function deleteBoardColumn(id: string) {
+    await assertOfficeTaskAccess();
+
+    const [taskCount, columnCount] = await Promise.all([
+        prisma.officeTask.count({ where: { columnId: id, archivedAt: null } }),
+        prisma.officeBoardColumn.count(),
+    ]);
+
+    if (taskCount > 0) throw new Error("Move or archive all tasks out of this column before deleting it");
+    if (columnCount <= 1) throw new Error("The board must have at least one column");
+
+    await prisma.officeBoardColumn.delete({ where: { id } });
+
+    revalidatePath("/tasks");
+    return { success: true };
 }
 
 export async function createOfficeTask(data: {
     title: string;
-    status?: string;
+    columnId?: string;
     assigneeId?: string | null;
     dueDate?: string | null;
 }) {
     const caller = await assertOfficeTaskAccess();
 
-    const status = data.status || "To Do";
-    assertValidOfficeTaskStatus(status);
-
     const task = await prisma.$transaction(async (tx) => {
+        const column = data.columnId
+            ? await tx.officeBoardColumn.findUnique({ where: { id: data.columnId } })
+            : await tx.officeBoardColumn.findFirst({ orderBy: { position: "asc" } });
+        if (!column) throw new Error("No board column available");
+
         const last = await tx.officeTask.findFirst({
-            where: { status },
+            where: { columnId: column.id, archivedAt: null },
             orderBy: { position: "desc" },
             select: { position: true },
         });
@@ -9431,7 +9529,8 @@ export async function createOfficeTask(data: {
         return tx.officeTask.create({
             data: {
                 title: data.title,
-                status,
+                columnId: column.id,
+                status: column.name, // TRANSITIONAL COMPAT — see OfficeTask.status
                 position: (last?.position ?? -1) + 1,
                 assigneeId: data.assigneeId || null,
                 dueDate: data.dueDate ? parseOfficeTaskDateOnly(data.dueDate) : null,
@@ -9473,35 +9572,38 @@ export async function updateOfficeTask(id: string, data: {
     return task;
 }
 
-export async function moveOfficeTask(id: string, newStatus: string, newIndex: number) {
+export async function moveOfficeTask(id: string, columnId: string, newIndex: number) {
     await assertOfficeTaskAccess();
-    assertValidOfficeTaskStatus(newStatus);
+    await assertColumnExists(columnId);
 
     await prisma.$transaction(async (tx) => {
         const task = await tx.officeTask.findUnique({ where: { id } });
         if (!task) throw new Error("Task not found");
 
-        const oldStatus = task.status;
+        const column = await tx.officeBoardColumn.findUnique({ where: { id: columnId }, select: { name: true } });
+        if (!column) throw new Error("Invalid column");
+
+        const oldColumnId = task.columnId;
 
         const targetTasks = await tx.officeTask.findMany({
-            where: { status: newStatus, id: { not: id } },
+            where: { columnId, archivedAt: null, id: { not: id } },
             orderBy: { position: "asc" },
         });
 
         const clampedIndex = Math.max(0, Math.min(newIndex, targetTasks.length));
-        targetTasks.splice(clampedIndex, 0, { ...task, status: newStatus } as typeof task);
+        targetTasks.splice(clampedIndex, 0, { ...task, columnId } as typeof task);
 
         for (let i = 0; i < targetTasks.length; i++) {
             const t = targetTasks[i];
             await tx.officeTask.update({
                 where: { id: t.id },
-                data: { position: i, status: newStatus },
+                data: { position: i, columnId, status: column.name }, // TRANSITIONAL COMPAT — see OfficeTask.status
             });
         }
 
-        if (oldStatus !== newStatus) {
+        if (oldColumnId && oldColumnId !== columnId) {
             const sourceTasks = await tx.officeTask.findMany({
-                where: { status: oldStatus, id: { not: id } },
+                where: { columnId: oldColumnId, archivedAt: null, id: { not: id } },
                 orderBy: { position: "asc" },
             });
             for (let i = 0; i < sourceTasks.length; i++) {
@@ -9524,6 +9626,39 @@ export async function deleteOfficeTask(id: string) {
 
     revalidatePath("/tasks");
     return { success: true };
+}
+
+export async function archiveOfficeTask(id: string) {
+    await assertOfficeTaskAccess();
+
+    await prisma.officeTask.update({ where: { id }, data: { archivedAt: new Date() } });
+
+    revalidatePath("/tasks");
+    return { success: true };
+}
+
+export async function restoreOfficeTask(id: string) {
+    await assertOfficeTaskAccess();
+
+    const task = await prisma.$transaction(async (tx) => {
+        const existing = await tx.officeTask.findUnique({ where: { id } });
+        if (!existing) throw new Error("Task not found");
+
+        const last = await tx.officeTask.findFirst({
+            where: { columnId: existing.columnId, archivedAt: null, id: { not: id } },
+            orderBy: { position: "desc" },
+            select: { position: true },
+        });
+
+        return tx.officeTask.update({
+            where: { id },
+            data: { archivedAt: null, position: (last?.position ?? -1) + 1 },
+            include: { assignee: { select: { id: true, name: true, email: true } } },
+        });
+    });
+
+    revalidatePath("/tasks");
+    return task;
 }
 
 

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -9397,10 +9397,10 @@ export async function getOfficeTasksBoard() {
     await assertOfficeTaskAccess();
 
     const [columns, tasks, archived, users] = await Promise.all([
-        prisma.officeBoardColumn.findMany({ orderBy: { position: "asc" } }),
+        prisma.officeBoardColumn.findMany({ orderBy: [{ position: "asc" }, { createdAt: "asc" }] }),
         prisma.officeTask.findMany({
             where: { archivedAt: null },
-            orderBy: [{ columnId: "asc" }, { position: "asc" }],
+            orderBy: [{ columnId: "asc" }, { position: "asc" }, { createdAt: "asc" }, { id: "asc" }],
             include: { assignee: { select: { id: true, name: true, email: true } } },
         }),
         prisma.officeTask.findMany({
@@ -9432,7 +9432,7 @@ export async function createBoardColumn(name: string) {
         if (dup) throw new Error("A column with that name already exists");
 
         const last = await tx.officeBoardColumn.findFirst({
-            orderBy: { position: "desc" },
+            orderBy: [{ position: "desc" }, { createdAt: "desc" }],
             select: { position: true },
         });
 
@@ -9453,16 +9453,18 @@ export async function renameBoardColumn(id: string, name: string, isDoneColumn?:
     const trimmed = name.trim();
     if (!trimmed) throw new Error("Column name is required");
 
-    const dup = await prisma.officeBoardColumn.findFirst({
-        where: { name: { equals: trimmed, mode: "insensitive" }, id: { not: id } },
-        select: { id: true },
+    const column = await prisma.$transaction(async (tx) => {
+        const dup = await tx.officeBoardColumn.findFirst({
+            where: { name: { equals: trimmed, mode: "insensitive" }, id: { not: id } },
+            select: { id: true },
+        });
+        if (dup) throw new Error("A column with that name already exists");
+
+        const data: { name: string; isDoneColumn?: boolean } = { name: trimmed };
+        if (isDoneColumn !== undefined) data.isDoneColumn = isDoneColumn;
+
+        return tx.officeBoardColumn.update({ where: { id }, data });
     });
-    if (dup) throw new Error("A column with that name already exists");
-
-    const data: { name: string; isDoneColumn?: boolean } = { name: trimmed };
-    if (isDoneColumn !== undefined) data.isDoneColumn = isDoneColumn;
-
-    const column = await prisma.officeBoardColumn.update({ where: { id }, data });
 
     revalidatePath("/tasks");
     return column;
@@ -9472,7 +9474,7 @@ export async function reorderBoardColumn(id: string, newIndex: number) {
     await assertOfficeTaskAccess();
 
     await prisma.$transaction(async (tx) => {
-        const columns = await tx.officeBoardColumn.findMany({ orderBy: { position: "asc" } });
+        const columns = await tx.officeBoardColumn.findMany({ orderBy: [{ position: "asc" }, { createdAt: "asc" }] });
         const idx = columns.findIndex((c) => c.id === id);
         if (idx === -1) throw new Error("Column not found");
 
@@ -9492,15 +9494,21 @@ export async function reorderBoardColumn(id: string, newIndex: number) {
 export async function deleteBoardColumn(id: string) {
     await assertOfficeTaskAccess();
 
-    const [taskCount, columnCount] = await Promise.all([
-        prisma.officeTask.count({ where: { columnId: id, archivedAt: null } }),
-        prisma.officeBoardColumn.count(),
-    ]);
+    // Checks and the delete run inside one transaction, with counts re-read
+    // inside it, so a concurrent create/move can't slip a task into this
+    // column between the check and the delete (which would otherwise orphan
+    // it to columnId NULL via the FK's ON DELETE SET NULL).
+    await prisma.$transaction(async (tx) => {
+        const [taskCount, columnCount] = await Promise.all([
+            tx.officeTask.count({ where: { columnId: id, archivedAt: null } }),
+            tx.officeBoardColumn.count(),
+        ]);
 
-    if (taskCount > 0) throw new Error("Move or archive all tasks out of this column before deleting it");
-    if (columnCount <= 1) throw new Error("The board must have at least one column");
+        if (taskCount > 0) throw new Error("Move or archive all tasks out of this column before deleting it");
+        if (columnCount <= 1) throw new Error("The board must have at least one column");
 
-    await prisma.officeBoardColumn.delete({ where: { id } });
+        await tx.officeBoardColumn.delete({ where: { id } });
+    });
 
     revalidatePath("/tasks");
     return { success: true };
@@ -9517,12 +9525,12 @@ export async function createOfficeTask(data: {
     const task = await prisma.$transaction(async (tx) => {
         const column = data.columnId
             ? await tx.officeBoardColumn.findUnique({ where: { id: data.columnId } })
-            : await tx.officeBoardColumn.findFirst({ orderBy: { position: "asc" } });
+            : await tx.officeBoardColumn.findFirst({ orderBy: [{ position: "asc" }, { createdAt: "asc" }] });
         if (!column) throw new Error("No board column available");
 
         const last = await tx.officeTask.findFirst({
             where: { columnId: column.id, archivedAt: null },
-            orderBy: { position: "desc" },
+            orderBy: [{ position: "desc" }, { createdAt: "desc" }, { id: "desc" }],
             select: { position: true },
         });
 
@@ -9587,24 +9595,34 @@ export async function moveOfficeTask(id: string, columnId: string, newIndex: num
 
         const targetTasks = await tx.officeTask.findMany({
             where: { columnId, archivedAt: null, id: { not: id } },
-            orderBy: { position: "asc" },
+            orderBy: [{ position: "asc" }, { createdAt: "asc" }, { id: "asc" }],
         });
 
         const clampedIndex = Math.max(0, Math.min(newIndex, targetTasks.length));
         targetTasks.splice(clampedIndex, 0, { ...task, columnId } as typeof task);
 
+        // Renumbering must touch position only — status is legacy-compat and
+        // should only be rewritten for the task that actually moved, not for
+        // unrelated tasks that were already sitting in the target column.
         for (let i = 0; i < targetTasks.length; i++) {
             const t = targetTasks[i];
-            await tx.officeTask.update({
-                where: { id: t.id },
-                data: { position: i, columnId, status: column.name }, // TRANSITIONAL COMPAT — see OfficeTask.status
-            });
+            if (t.id === id) {
+                await tx.officeTask.update({
+                    where: { id: t.id },
+                    data: { position: i, columnId, status: column.name }, // TRANSITIONAL COMPAT — see OfficeTask.status
+                });
+            } else {
+                await tx.officeTask.update({
+                    where: { id: t.id },
+                    data: { position: i },
+                });
+            }
         }
 
         if (oldColumnId && oldColumnId !== columnId) {
             const sourceTasks = await tx.officeTask.findMany({
                 where: { columnId: oldColumnId, archivedAt: null, id: { not: id } },
-                orderBy: { position: "asc" },
+                orderBy: [{ position: "asc" }, { createdAt: "asc" }, { id: "asc" }],
             });
             for (let i = 0; i < sourceTasks.length; i++) {
                 await tx.officeTask.update({
@@ -9644,15 +9662,32 @@ export async function restoreOfficeTask(id: string) {
         const existing = await tx.officeTask.findUnique({ where: { id } });
         if (!existing) throw new Error("Task not found");
 
+        // The task's column may have been deleted while it was archived (FK
+        // ON DELETE SET NULL), or it may never have had one — in either case
+        // fall back to the first-position column rather than restoring into
+        // a NULL columnId.
+        let column = existing.columnId
+            ? await tx.officeBoardColumn.findUnique({ where: { id: existing.columnId } })
+            : null;
+        if (!column) {
+            column = await tx.officeBoardColumn.findFirst({ orderBy: [{ position: "asc" }, { createdAt: "asc" }] });
+        }
+        if (!column) throw new Error("No board column available");
+
         const last = await tx.officeTask.findFirst({
-            where: { columnId: existing.columnId, archivedAt: null, id: { not: id } },
-            orderBy: { position: "desc" },
+            where: { columnId: column.id, archivedAt: null, id: { not: id } },
+            orderBy: [{ position: "desc" }, { createdAt: "desc" }, { id: "desc" }],
             select: { position: true },
         });
 
         return tx.officeTask.update({
             where: { id },
-            data: { archivedAt: null, position: (last?.position ?? -1) + 1 },
+            data: {
+                archivedAt: null,
+                columnId: column.id,
+                status: column.name, // TRANSITIONAL COMPAT — see OfficeTask.status
+                position: (last?.position ?? -1) + 1,
+            },
             include: { assignee: { select: { id: true, name: true, email: true } } },
         });
     });

--- a/src/lib/office-task-utils.ts
+++ b/src/lib/office-task-utils.ts
@@ -1,16 +1,10 @@
 // Shared, plain (non-"use server") helpers for the Office Tasks kanban board.
 // Split out of actions.ts so the secret-authed ingest route (a regular route
-// handler, not a server action) can reuse the exact same status/date-parsing
-// logic without duplicating it — a "use server" file can only export async
-// functions, so these synchronous helpers can't live there directly.
+// handler, not a server action) can reuse the exact same column-lookup/date-
+// parsing logic without duplicating it — a "use server" file can only export
+// async functions, so these helpers can't live there directly.
 
-export const OFFICE_TASK_STATUSES = ["To Do", "In Progress", "Done"] as const;
-
-export function assertValidOfficeTaskStatus(status: string) {
-    if (!(OFFICE_TASK_STATUSES as readonly string[]).includes(status)) {
-        throw new Error(`Invalid status: ${status}`);
-    }
-}
+import { prisma } from "./prisma";
 
 // Parse a "YYYY-MM-DD" date-only string as UTC midnight, so the stored instant's
 // calendar date is timezone-invariant (matches what the user picked, regardless
@@ -19,4 +13,12 @@ export function parseOfficeTaskDateOnly(s: string): Date {
     const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
     if (!m) throw new Error("Invalid date");
     return new Date(Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3])));
+}
+
+// Columns are now user-defined (OfficeBoardColumn) instead of a fixed
+// To Do/In Progress/Done string enum, so validation is existence-based instead
+// of a fixed-set check.
+export async function assertColumnExists(columnId: string) {
+    const column = await prisma.officeBoardColumn.findUnique({ where: { id: columnId }, select: { id: true } });
+    if (!column) throw new Error(`Invalid column: ${columnId}`);
 }


### PR DESCRIPTION
## What

Board v2 for the Office Tasks kanban (`/tasks`):

- **Custom columns** — add, rename (incl. done-column toggle), reorder (left/right), and delete-if-empty from the board UI. Tasks are now keyed by `columnId` (new `OfficeBoardColumn` table); the legacy `status` string is still written on create/move for transition compat.
- **Archive & restore** — `archivedAt` soft-delete, Archive button in the card dialog, collapsible "Archived (N)" drawer with restore + confirm-gated permanent delete. Restore resolves a real fallback column if the original was deleted. Ingest dedupe now ignores archived and done-column tasks so recurring issues can re-file.
- **Automation-gaps rollup** — collapsible panel above the board grouping open cards by gap text with counts, click-through to the card. Hidden when empty.
- Ingest route accepts an optional `column` name (case-insensitive, `status` kept as alias), falls back to the first column.

## Schema

Additive only, already applied + verified on the production DB (this repo doesn't use prisma-migrate): `OfficeBoardColumn` table seeded with the three v1 columns, `OfficeTask.columnId` (FK, backfilled from `status`) + `archivedAt`. The `status` column is untouched — live v1 prod keeps working until this deploys.

## Verification

- Independent checker: PASS on all items (scope, auth gating, transactions, UI wiring, build, runtime 200)
- Codex peer review: fixed status-rewrite scope on move, transactional delete/rename/create for columns, restore fallback for deleted columns, deterministic position tiebreakers, and two filter-active index bugs in the client
- Accepted as-is: ingest dedupe atomicity (posting routines are sequential), gap-text normalization depth, no DB unique constraints
- `npm run build` exit 0; dev-server runtime check 200 with all columns

## Deploy note

Deploy from a tree that also contains the `feat/undo-milestone-warnings` work (same coordination as PR #184).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
