### PR TITLE
feat(estimates): Project Overview + Notes & Assumptions sections

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -385,6 +385,16 @@ model Estimate {
   // Phase 9: Terms & Sending
   termsAndConditions String? // Snapshot of T&C HTML at time of sending
   sentAt             DateTime? // When the estimate was emailed to the client
+
+  // Project Overview / Vision cover section (client-facing, no pricing) + Notes & Assumptions
+  overviewEnabled Boolean @default(false)
+  overviewTitle   String? // UI default "Project Overview"
+  overviewBody    String? // sanitized rich-text HTML
+  notesEnabled    Boolean @default(false)
+  notesTitle      String? // UI default "Estimate Notes & Assumptions"
+  notesBody       String? // sanitized rich-text HTML
+  notesPlacement  String  @default("after") // "before" | "after" line items
+
   changeOrders       ChangeOrder[]
   files              EstimateFile[]
 

--- a/src/app/portal/estimates/[id]/PortalEstimateClient.tsx
+++ b/src/app/portal/estimates/[id]/PortalEstimateClient.tsx
@@ -455,6 +455,28 @@ export default function PortalEstimateClient({ initialEstimate, companySettings 
                         </div>
                     )}
 
+                    {/* Project Overview / Vision — after the header/client info, before pricing */}
+                    {initialEstimate.overviewEnabled && initialEstimate.overviewBody && (
+                        <>
+                            <PortalRichSection
+                                variant="overview"
+                                title={initialEstimate.overviewTitle || "Project Overview"}
+                                html={initialEstimate.overviewBody}
+                            />
+                            {/* Force the priced line items onto a fresh PDF page */}
+                            <div data-pdf-break aria-hidden="true" className="h-0" />
+                        </>
+                    )}
+
+                    {/* Notes & Assumptions — before the line items */}
+                    {initialEstimate.notesEnabled && initialEstimate.notesBody && initialEstimate.notesPlacement === "before" && (
+                        <PortalRichSection
+                            variant="notes"
+                            title={initialEstimate.notesTitle || "Estimate Notes & Assumptions"}
+                            html={initialEstimate.notesBody}
+                        />
+                    )}
+
                     {/* Line Items — editor-matched layout */}
                     <div className="bg-white">
                         {/* Column headers */}
@@ -531,6 +553,15 @@ export default function PortalEstimateClient({ initialEstimate, companySettings 
                             </div>
                         </div>
                     </div>
+
+                    {/* Notes & Assumptions — after the line items */}
+                    {initialEstimate.notesEnabled && initialEstimate.notesBody && initialEstimate.notesPlacement !== "before" && (
+                        <PortalRichSection
+                            variant="notes"
+                            title={initialEstimate.notesTitle || "Estimate Notes & Assumptions"}
+                            html={initialEstimate.notesBody}
+                        />
+                    )}
 
                     {/* Pay in Full — hidden in capture mode */}
                     {showPayInFull && !isCapture && (
@@ -769,6 +800,55 @@ function TermsAndConditions({ html }: { html: string }) {
                 />
             ) : (
                 /* Legacy plain-text path — rendered as JSX to avoid markup injection */
+                <div data-pdf-row="true" className={contentClassName}>
+                    <p className="whitespace-pre-wrap">{html}</p>
+                </div>
+            )}
+        </div>
+    );
+}
+
+/**
+ * Client-facing rich-text section for the estimate Project Overview and Notes &
+ * Assumptions. Mirrors the TermsAndConditions rich-HTML path: detect editor HTML,
+ * sanitize, and tag each top-level block with data-pdf-row so the screenshot PDF
+ * paginator can break between paragraphs instead of splitting one.
+ * "overview" renders a prominent proposal-style title; "notes" a compact heading.
+ */
+function PortalRichSection({ title, html, variant }: { title: string; html: string; variant: "overview" | "notes" }) {
+    const ref = useRef<HTMLDivElement>(null);
+
+    const trimmed = (html || "").trimStart();
+    const isRichHtml =
+        trimmed.startsWith("<p") ||
+        trimmed.startsWith("<h") ||
+        trimmed.startsWith("<ul") ||
+        trimmed.startsWith("<ol") ||
+        trimmed.startsWith("<div");
+
+    const sanitized = isRichHtml ? DOMPurify.sanitize(html) : "";
+
+    useEffect(() => {
+        if (!ref.current || !isRichHtml) return;
+        Array.from(ref.current.children).forEach(child => {
+            (child as HTMLElement).setAttribute("data-pdf-row", "true");
+        });
+    }, [sanitized, isRichHtml]);
+
+    const contentClassName = "prose prose-sm max-w-none text-slate-600 prose-headings:text-slate-800 prose-headings:font-semibold prose-headings:mt-4 prose-headings:mb-2 prose-strong:text-slate-700 prose-p:leading-relaxed prose-p:text-[13px] prose-p:my-1.5 prose-li:text-[13px] prose-li:my-0.5 prose-ol:pl-4 prose-ul:pl-4 prose-ol:my-2 prose-ul:my-2";
+
+    return (
+        <div className="px-10 pt-8 pb-8 border-t border-slate-100">
+            <div data-pdf-row="true" className="mb-4">
+                {variant === "overview" ? (
+                    <h2 className="text-xl font-bold text-slate-800 tracking-tight">{title}</h2>
+                ) : (
+                    <h2 className="text-xs font-semibold text-slate-500 uppercase tracking-wider">{title}</h2>
+                )}
+            </div>
+            {isRichHtml ? (
+                <div ref={ref} className={contentClassName} dangerouslySetInnerHTML={{ __html: sanitized }} />
+            ) : (
                 <div data-pdf-row="true" className={contentClassName}>
                     <p className="whitespace-pre-wrap">{html}</p>
                 </div>

--- a/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
@@ -42,7 +42,8 @@ function recalcMilestoneAmounts(schedules: any[], total: number): any[] {
 
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import dynamic from "next/dynamic";
-import { saveEstimate, createInvoiceFromEstimate, deleteEstimate, duplicateEstimate, saveEstimateAsTemplate, uploadEstimateFile, deleteEstimateFile, getEstimateFiles, saveItemsAsAssembly, getEstimateTemplates, deleteAssembly, updateItemApproval, bulkUpdateItemApproval, linkPOToEstimateItem, unlinkPOFromEstimateItem, getProjectPurchaseOrdersForLinking, recordEstimatePayment, sendEstimatePaymentReceipt, unrecordEstimatePayment, getDocumentTemplates } from "@/lib/actions";
+import { saveEstimate, createInvoiceFromEstimate, deleteEstimate, duplicateEstimate, saveEstimateAsTemplate, uploadEstimateFile, deleteEstimateFile, getEstimateFiles, saveItemsAsAssembly, getEstimateTemplates, deleteAssembly, updateItemApproval, bulkUpdateItemApproval, linkPOToEstimateItem, unlinkPOFromEstimateItem, getProjectPurchaseOrdersForLinking, recordEstimatePayment, sendEstimatePaymentReceipt, unrecordEstimatePayment, getDocumentTemplates, createDocumentTemplate } from "@/lib/actions";
+import RichTextEditor from "@/components/RichTextEditor";
 import { useRouter } from "next/navigation";
 import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
 import ExpensesTab from "./ExpensesTab";
@@ -183,6 +184,21 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
     const [showTerms, setShowTerms] = useState(false);
     const [termsTemplates, setTermsTemplates] = useState<{id: string; name: string; body: string; isDefault: boolean}[]>([]);
     const [memo, setMemo] = useState<string>(initialEstimate.memo || "");
+    // Project Overview / Vision (client-facing cover section, no pricing)
+    const [overviewEnabled, setOverviewEnabled] = useState<boolean>(initialEstimate.overviewEnabled ?? false);
+    const [overviewTitle, setOverviewTitle] = useState<string>(initialEstimate.overviewTitle || "");
+    const [overviewBody, setOverviewBody] = useState<string>(initialEstimate.overviewBody || "");
+    const [showOverview, setShowOverview] = useState<boolean>(!!initialEstimate.overviewEnabled);
+    const [overviewTemplates, setOverviewTemplates] = useState<{ id: string; name: string; body: string; isDefault: boolean }[]>([]);
+    // Estimate Notes & Assumptions (client-facing, placed before/after line items)
+    const [notesEnabled, setNotesEnabled] = useState<boolean>(initialEstimate.notesEnabled ?? false);
+    const [notesTitle, setNotesTitle] = useState<string>(initialEstimate.notesTitle || "");
+    const [notesBody, setNotesBody] = useState<string>(initialEstimate.notesBody || "");
+    const [notesPlacement, setNotesPlacement] = useState<"before" | "after">(initialEstimate.notesPlacement === "before" ? "before" : "after");
+    const [showNotes, setShowNotes] = useState<boolean>(!!initialEstimate.notesEnabled);
+    const [notesTemplates, setNotesTemplates] = useState<{ id: string; name: string; body: string; isDefault: boolean }[]>([]);
+    const [isSavingOverviewTpl, setIsSavingOverviewTpl] = useState(false);
+    const [isSavingNotesTpl, setIsSavingNotesTpl] = useState(false);
     const [estimateFiles, setEstimateFiles] = useState<any[]>(initialEstimate.files || []);
     const [isUploadingFile, setIsUploadingFile] = useState(false);
     const [signatureUrl, setSignatureUrl] = useState<string | null>(initialEstimate.signatureUrl || null);
@@ -267,6 +283,13 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
             expirationDate: expirationDate ? new Date(expirationDate).toISOString().split("T")[0] : null,
             memo: memo || null,
             termsAndConditions: termsAndConditions || null,
+            overviewEnabled: !!overviewEnabled,
+            overviewTitle: overviewTitle || null,
+            overviewBody: overviewBody || null,
+            notesEnabled: !!notesEnabled,
+            notesTitle: notesTitle || null,
+            notesBody: notesBody || null,
+            notesPlacement,
             signatureUrl: signatureUrl || null,
             targetMarginPercent: parseFloat(targetMargin) || 25,
             taxExempt: !!taxExempt,
@@ -277,7 +300,9 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
         };
     }, [
         title, code, status, processingFeeMarkup, hideProcessingFee, expirationDate,
-        memo, termsAndConditions, signatureUrl, targetMargin, taxExempt, selectedTaxName,
+        memo, termsAndConditions, overviewEnabled, overviewTitle, overviewBody,
+        notesEnabled, notesTitle, notesBody, notesPlacement,
+        signatureUrl, targetMargin, taxExempt, selectedTaxName,
         taxOptions, defaultTaxRate, items, paymentSchedules
     ]);
 
@@ -414,6 +439,36 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
             }
         }).catch((err) => console.error("[EstimateEditor] Failed to load T&C templates:", err));
     }, []);
+
+    useEffect(() => {
+        getDocumentTemplates("overview").then((data: any[]) => setOverviewTemplates(data))
+            .catch((err) => console.error("[EstimateEditor] Failed to load overview templates:", err));
+        getDocumentTemplates("notes").then((data: any[]) => setNotesTemplates(data))
+            .catch((err) => console.error("[EstimateEditor] Failed to load notes templates:", err));
+    }, []);
+
+    async function handleSaveDocTemplate(type: "overview" | "notes", body: string) {
+        const label = type === "overview" ? "Project Overview" : "Notes & Assumptions";
+        if (!body || !body.trim()) {
+            toast.error(`Add some ${label} content before saving a template.`);
+            return;
+        }
+        const name = window.prompt(`Save this ${label} as a reusable template. Template name:`)?.trim();
+        if (!name) return;
+        const setBusy = type === "overview" ? setIsSavingOverviewTpl : setIsSavingNotesTpl;
+        setBusy(true);
+        try {
+            await createDocumentTemplate({ name, type, body });
+            const refreshed = await getDocumentTemplates(type);
+            if (type === "overview") setOverviewTemplates(refreshed as any);
+            else setNotesTemplates(refreshed as any);
+            toast.success(`Saved "${name}" template.`);
+        } catch (e: any) {
+            toast.error(e?.message || "Failed to save template.");
+        } finally {
+            setBusy(false);
+        }
+    }
 
     async function handleFileUpload(e: React.ChangeEvent<HTMLInputElement>) {
         const file = e.target.files?.[0];
@@ -742,6 +797,13 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                 expirationDate: expirationDate ? new Date(expirationDate).toISOString() : null,
                 memo: memo || null,
                 termsAndConditions: termsAndConditions || null,
+                overviewEnabled,
+                overviewTitle: overviewTitle || null,
+                overviewBody: overviewBody || null,
+                notesEnabled,
+                notesTitle: notesTitle || null,
+                notesBody: notesBody || null,
+                notesPlacement,
                 signatureUrl: signatureUrl || null,
                 targetMarginPercent: parseFloat(targetMargin) || 25,
                 taxExempt,
@@ -1032,6 +1094,13 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                 expirationDate: expirationDate ? new Date(expirationDate).toISOString().split("T")[0] : null,
                 memo: memo || null,
                 termsAndConditions: termsAndConditions || null,
+                overviewEnabled,
+                overviewTitle: overviewTitle || null,
+                overviewBody: overviewBody || null,
+                notesEnabled,
+                notesTitle: notesTitle || null,
+                notesBody: notesBody || null,
+                notesPlacement,
                 signatureUrl: signatureUrl || null,
                 targetMarginPercent: parseFloat(targetMargin) || 25,
                 taxExempt: !!taxExempt,
@@ -2730,6 +2799,113 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                                 <button onClick={addPaymentSchedule} className="hui-btn hui-btn-secondary text-indigo-700 border-indigo-200 hover:bg-indigo-100 bg-white transition shadow-sm text-xs py-1.5 px-3">
                                     + Add milestone
                                 </button>
+                            </div>
+                        </div>
+
+                        {/* Project Overview / Vision Section */}
+                        <div className="mt-8 mx-2">
+                            <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
+                                <button
+                                    onClick={() => setShowOverview(!showOverview)}
+                                    className="w-full flex items-center justify-between px-6 py-4 hover:bg-slate-50 transition"
+                                >
+                                    <div className="flex items-center gap-2">
+                                        <svg className="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" /></svg>
+                                        <span className="text-sm font-semibold text-slate-800">Project Overview</span>
+                                        {overviewEnabled && <span className="text-[10px] bg-green-100 text-green-700 px-1.5 py-0.5 rounded-full font-medium">On</span>}
+                                    </div>
+                                    <svg className={`w-4 h-4 text-slate-400 transition-transform ${showOverview ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" /></svg>
+                                </button>
+                                {showOverview && (
+                                    <div className="px-6 pb-5 border-t border-slate-100 space-y-3">
+                                        <label className="flex items-start gap-2 mt-3 cursor-pointer">
+                                            <input type="checkbox" checked={overviewEnabled} onChange={e => setOverviewEnabled(e.target.checked)} className="mt-0.5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500" />
+                                            <span className="text-sm text-slate-600">Include a Project Overview page (shown after the header/client info, before pricing, with a page break so the line items begin on the next page).</span>
+                                        </label>
+                                        <div>
+                                            <label className="text-xs font-medium text-slate-500 mb-1 block">Page title</label>
+                                            <input value={overviewTitle} onChange={e => setOverviewTitle(e.target.value)} placeholder="Project Overview" className="hui-input w-full text-sm" />
+                                        </div>
+                                        {overviewTemplates.length > 0 && (
+                                            <select
+                                                className="hui-input w-full text-sm"
+                                                value=""
+                                                onChange={e => { const t = overviewTemplates.find(t => t.id === e.target.value); if (t) setOverviewBody(t.body); }}
+                                            >
+                                                <option value="" disabled>Load a saved overview template...</option>
+                                                {overviewTemplates.map(t => <option key={t.id} value={t.id}>{t.name}{t.isDefault ? " (Default)" : ""}</option>)}
+                                            </select>
+                                        )}
+                                        <RichTextEditor
+                                            value={overviewBody}
+                                            onChange={setOverviewBody}
+                                            placeholder="Describe the overall project vision, the major areas of work, and how the scopes fit together. No pricing here."
+                                        />
+                                        <div className="flex justify-end">
+                                            <button type="button" onClick={() => handleSaveDocTemplate("overview", overviewBody)} disabled={isSavingOverviewTpl} className="text-xs font-medium text-indigo-600 hover:text-indigo-800 disabled:opacity-50">
+                                                {isSavingOverviewTpl ? "Saving…" : "Save as template"}
+                                            </button>
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+
+                        {/* Estimate Notes & Assumptions Section */}
+                        <div className="mt-8 mx-2">
+                            <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
+                                <button
+                                    onClick={() => setShowNotes(!showNotes)}
+                                    className="w-full flex items-center justify-between px-6 py-4 hover:bg-slate-50 transition"
+                                >
+                                    <div className="flex items-center gap-2">
+                                        <svg className="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" /></svg>
+                                        <span className="text-sm font-semibold text-slate-800">Notes &amp; Assumptions</span>
+                                        {notesEnabled && <span className="text-[10px] bg-green-100 text-green-700 px-1.5 py-0.5 rounded-full font-medium">On</span>}
+                                    </div>
+                                    <svg className={`w-4 h-4 text-slate-400 transition-transform ${showNotes ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" /></svg>
+                                </button>
+                                {showNotes && (
+                                    <div className="px-6 pb-5 border-t border-slate-100 space-y-3">
+                                        <label className="flex items-start gap-2 mt-3 cursor-pointer">
+                                            <input type="checkbox" checked={notesEnabled} onChange={e => setNotesEnabled(e.target.checked)} className="mt-0.5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500" />
+                                            <span className="text-sm text-slate-600">Include a Notes &amp; Assumptions section for exclusions, allowances, and estimating assumptions.</span>
+                                        </label>
+                                        <div className="grid grid-cols-2 gap-3">
+                                            <div>
+                                                <label className="text-xs font-medium text-slate-500 mb-1 block">Section title</label>
+                                                <input value={notesTitle} onChange={e => setNotesTitle(e.target.value)} placeholder="Estimate Notes & Assumptions" className="hui-input w-full text-sm" />
+                                            </div>
+                                            <div>
+                                                <label className="text-xs font-medium text-slate-500 mb-1 block">Placement</label>
+                                                <select value={notesPlacement} onChange={e => setNotesPlacement(e.target.value === "before" ? "before" : "after")} className="hui-input w-full text-sm">
+                                                    <option value="before">Before the line items</option>
+                                                    <option value="after">After the line items</option>
+                                                </select>
+                                            </div>
+                                        </div>
+                                        {notesTemplates.length > 0 && (
+                                            <select
+                                                className="hui-input w-full text-sm"
+                                                value=""
+                                                onChange={e => { const t = notesTemplates.find(t => t.id === e.target.value); if (t) setNotesBody(t.body); }}
+                                            >
+                                                <option value="" disabled>Load a saved notes template...</option>
+                                                {notesTemplates.map(t => <option key={t.id} value={t.id}>{t.name}{t.isDefault ? " (Default)" : ""}</option>)}
+                                            </select>
+                                        )}
+                                        <RichTextEditor
+                                            value={notesBody}
+                                            onChange={setNotesBody}
+                                            placeholder="Exclusions, allowances, and assumptions behind this estimate..."
+                                        />
+                                        <div className="flex justify-end">
+                                            <button type="button" onClick={() => handleSaveDocTemplate("notes", notesBody)} disabled={isSavingNotesTpl} className="text-xs font-medium text-indigo-600 hover:text-indigo-800 disabled:opacity-50">
+                                                {isSavingNotesTpl ? "Saving…" : "Save as template"}
+                                            </button>
+                                        </div>
+                                    </div>
+                                )}
                             </div>
                         </div>
 

--- a/src/components/RichTextEditor.tsx
+++ b/src/components/RichTextEditor.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEditor, EditorContent, type Editor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import DOMPurify from "dompurify";
+import { useEffect } from "react";
+
+/**
+ * Controlled rich-text editor built on TipTap. Emits sanitized HTML via onChange.
+ * Used for the estimate Project Overview and Notes & Assumptions sections — the same
+ * HTML shape (headings / paragraphs / bullet + numbered lists / bold / italic) that
+ * the portal, portal-download PDF, and emailed pdf-lib PDF all know how to render.
+ *
+ * SSR note: immediatelyRender:false is required under the Next.js App Router so the
+ * editor mounts on the client only and never produces a hydration mismatch.
+ */
+
+const ALLOWED_TAGS = ["p", "h1", "h2", "h3", "ul", "ol", "li", "strong", "em", "b", "i", "br", "a"];
+const ALLOWED_ATTR = ["href", "target", "rel"];
+
+export function sanitizeRichHtml(html: string): string {
+    return DOMPurify.sanitize(html || "", { ALLOWED_TAGS, ALLOWED_ATTR });
+}
+
+function ToolbarButton({
+    active,
+    disabled,
+    onClick,
+    label,
+    children,
+}: {
+    active?: boolean;
+    disabled?: boolean;
+    onClick: () => void;
+    label: string;
+    children: React.ReactNode;
+}) {
+    return (
+        <button
+            type="button"
+            aria-label={label}
+            title={label}
+            aria-pressed={!!active}
+            disabled={disabled}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={onClick}
+            className={`h-8 min-w-8 px-2 rounded text-sm font-medium transition ${
+                active
+                    ? "bg-indigo-600 text-white"
+                    : "bg-white text-slate-600 hover:bg-slate-100 border border-slate-200"
+            } disabled:opacity-40 disabled:pointer-events-none`}
+        >
+            {children}
+        </button>
+    );
+}
+
+function Toolbar({ editor }: { editor: Editor }) {
+    return (
+        <div className="flex flex-wrap items-center gap-1 border-b border-slate-200 bg-slate-50 px-2 py-1.5">
+            <ToolbarButton label="Heading 1" active={editor.isActive("heading", { level: 1 })} onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}>
+                H1
+            </ToolbarButton>
+            <ToolbarButton label="Heading 2" active={editor.isActive("heading", { level: 2 })} onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}>
+                H2
+            </ToolbarButton>
+            <span className="mx-1 h-5 w-px bg-slate-200" />
+            <ToolbarButton label="Bold" active={editor.isActive("bold")} onClick={() => editor.chain().focus().toggleBold().run()}>
+                <span className="font-bold">B</span>
+            </ToolbarButton>
+            <ToolbarButton label="Italic" active={editor.isActive("italic")} onClick={() => editor.chain().focus().toggleItalic().run()}>
+                <span className="italic">I</span>
+            </ToolbarButton>
+            <span className="mx-1 h-5 w-px bg-slate-200" />
+            <ToolbarButton label="Bullet list" active={editor.isActive("bulletList")} onClick={() => editor.chain().focus().toggleBulletList().run()}>
+                • List
+            </ToolbarButton>
+            <ToolbarButton label="Numbered list" active={editor.isActive("orderedList")} onClick={() => editor.chain().focus().toggleOrderedList().run()}>
+                1. List
+            </ToolbarButton>
+        </div>
+    );
+}
+
+export default function RichTextEditor({
+    value,
+    onChange,
+    placeholder,
+}: {
+    value: string;
+    onChange: (html: string) => void;
+    placeholder?: string;
+}) {
+    const editor = useEditor({
+        immediatelyRender: false,
+        // StarterKit (v3) already bundles Link, ListKeymap, Underline, etc. — configure it
+        // in place rather than re-adding a second Link extension (which throws a duplicate).
+        extensions: [
+            StarterKit.configure({
+                heading: { levels: [1, 2, 3] },
+                link: { openOnClick: false, autolink: true },
+            }),
+        ],
+        content: value || "",
+        editorProps: {
+            attributes: {
+                class: "prose prose-sm max-w-none min-h-[140px] px-4 py-3 focus:outline-none prose-headings:font-semibold prose-p:my-1.5 prose-ul:my-2 prose-ol:my-2 prose-li:my-0.5",
+                ...(placeholder ? { "data-placeholder": placeholder } : {}),
+            },
+        },
+        onUpdate: ({ editor }) => {
+            // Emit the raw editor HTML (not sanitized) so the controlled-sync effect below
+            // compares raw-to-raw and never calls setContent mid-keystroke (which would jump
+            // the cursor). TipTap's schema only produces whitelisted nodes, and every render
+            // path sanitizes again: the portal via DOMPurify, the pdf-lib path by drawing only
+            // whitelisted tags — same defense-in-depth as the existing Terms & Conditions field.
+            const html = editor.getHTML();
+            // TipTap emits "<p></p>" for an empty doc — normalize to "" so an untouched
+            // section is treated as absent by the renderers.
+            onChange(html === "<p></p>" ? "" : html);
+        },
+    });
+
+    // Sync external value changes (e.g. loading a saved template) into the editor
+    // without clobbering the user's cursor while they type.
+    useEffect(() => {
+        if (!editor) return;
+        const current = editor.getHTML();
+        const next = value || "";
+        const normalizedCurrent = current === "<p></p>" ? "" : current;
+        if (next !== normalizedCurrent && next !== current) {
+            editor.commands.setContent(next, { emitUpdate: false });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [value, editor]);
+
+    if (!editor) {
+        return <div className="min-h-[180px] rounded-lg border border-slate-200 bg-slate-50 animate-pulse" />;
+    }
+
+    return (
+        <div className="rounded-lg border border-slate-200 overflow-hidden focus-within:ring-2 focus-within:ring-indigo-500/40 focus-within:border-indigo-300">
+            <Toolbar editor={editor} />
+            <EditorContent editor={editor} />
+        </div>
+    );
+}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -2788,6 +2788,13 @@ export async function saveEstimate(estimateId: string, contextId: string, contex
                     ...(data.expirationDate !== undefined && { expirationDate: data.expirationDate }),
                     ...(data.memo !== undefined && { memo: data.memo }),
                     ...(data.termsAndConditions !== undefined && { termsAndConditions: data.termsAndConditions }),
+                    ...(data.overviewEnabled !== undefined && { overviewEnabled: !!data.overviewEnabled }),
+                    ...(data.overviewTitle !== undefined && { overviewTitle: data.overviewTitle }),
+                    ...(data.overviewBody !== undefined && { overviewBody: data.overviewBody }),
+                    ...(data.notesEnabled !== undefined && { notesEnabled: !!data.notesEnabled }),
+                    ...(data.notesTitle !== undefined && { notesTitle: data.notesTitle }),
+                    ...(data.notesBody !== undefined && { notesBody: data.notesBody }),
+                    ...(data.notesPlacement !== undefined && { notesPlacement: data.notesPlacement === "before" ? "before" : "after" }),
                 },
             });
         } catch {

--- a/src/lib/build-pdf.ts
+++ b/src/lib/build-pdf.ts
@@ -30,6 +30,27 @@ export async function buildPdf(
     const cssToMm = pageW / element.offsetWidth;
     const totalHeightMm = element.offsetHeight * cssToMm;
 
+    // Degenerate measurement guard: a detached/hidden element has offsetWidth 0, which
+    // makes cssToMm/totalHeightMm Infinity and the pagination loop below never terminate.
+    // Render a single fitted page instead of hanging.
+    if (!(element.offsetWidth > 0) || !isFinite(cssToMm) || !isFinite(totalHeightMm) || totalHeightMm <= 0) {
+        const imgDataSingle = await toJpeg(element, {
+            quality,
+            pixelRatio,
+            filter: (node: HTMLElement) =>
+                !(node.nodeType === 1 && node.hasAttribute && node.hasAttribute("data-pdf-skip")),
+        });
+        const imgSingle = new Image();
+        imgSingle.src = imgDataSingle;
+        await new Promise<void>((resolve, reject) => {
+            imgSingle.onload = () => resolve();
+            imgSingle.onerror = () => reject(new Error("img load failed"));
+        });
+        const fittedH = imgSingle.width > 0 ? Math.min((imgSingle.height / imgSingle.width) * pageW, usableH) : usableH;
+        pdf.addImage(imgDataSingle, "JPEG", 0, 0, pageW, fittedH);
+        return pdf;
+    }
+
     const allRowEls = Array.from(element.querySelectorAll("[data-pdf-row]")) as HTMLElement[];
     const rowEls = allRowEls.filter(el => {
         if (el.closest("[data-pdf-skip]")) return false;
@@ -48,11 +69,28 @@ export async function buildPdf(
         };
     });
 
+    // Mandatory breaks: content at/after a [data-pdf-break] marker MUST begin a new
+    // page (e.g. the estimate line items start fresh after the Project Overview).
+    const forcedBreaksMm = (Array.from(element.querySelectorAll("[data-pdf-break]")) as HTMLElement[])
+        .map(el => (el.getBoundingClientRect().top + window.scrollY - elTop) * cssToMm)
+        .filter(mm => mm > 0.5 && mm < totalHeightMm)
+        .sort((a, b) => a - b);
+
     // Step 2: Find safe page-break points (always between rows)
     const breaks: number[] = [0];
     let cursor = 0;
     while (cursor < totalHeightMm) {
         const limit = cursor + effectiveH;
+        if (limit >= totalHeightMm && forcedBreaksMm.every(f => f <= cursor + 0.5)) break;
+
+        // A forced break within this page window wins — advance exactly to it so the
+        // following content (line items) lands at the top of the next page.
+        const forced = forcedBreaksMm.find(f => f > cursor + 0.5 && f <= limit);
+        if (forced !== undefined) {
+            breaks.push(forced);
+            cursor = forced;
+            continue;
+        }
         if (limit >= totalHeightMm) break;
 
         let safeBreak = limit;

--- a/src/lib/pdf-richtext.ts
+++ b/src/lib/pdf-richtext.ts
@@ -1,0 +1,278 @@
+import { PDFDocument, PDFPage, PDFFont, type RGB } from "pdf-lib";
+
+/**
+ * Minimal HTML-subset renderer for pdf-lib. Draws the exact tag set the estimate
+ * rich-text editor (TipTap) produces — h1/h2/h3, p, ul/ol/li (including nested lists),
+ * strong/b, em/i, br, a — as wrapped, styled text on a pdf-lib document. Used so the
+ * Project Overview and Notes & Assumptions sections render with real formatting in the
+ * emailed/attached estimate PDF, matching the online portal and portal-download PDF.
+ *
+ * The input is sanitized editor HTML; this renderer additionally ignores any tag outside
+ * the whitelist (keeping its text) and strips characters the standard PDF fonts cannot
+ * encode (CJK, emoji, ...) so unusual content degrades gracefully instead of aborting the
+ * whole PDF.
+ */
+
+export interface RichTextFonts {
+    regular: PDFFont;
+    bold: PDFFont;
+    italic: PDFFont;
+    boldItalic: PDFFont;
+}
+
+export interface RichTextLayout {
+    pageWidth: number;
+    pageHeight: number;
+    margin: number;
+    contentWidth: number;
+}
+
+export interface RichTextCtx {
+    doc: PDFDocument;
+    page: PDFPage;
+    y: number;
+    fonts: RichTextFonts;
+    layout: RichTextLayout;
+    color: RGB;
+    mutedColor: RGB;
+}
+
+interface Run { text: string; bold: boolean; italic: boolean; }
+type Token = { type: "run"; run: Run } | { type: "br" };
+
+// WinAnsi (cp1252) Unicode extras beyond ASCII + Latin-1 that the standard PDF fonts can encode.
+const WINANSI_EXTRA = "€‚ƒ„…†‡ˆ‰Š‹ŒŽ‘’“”•–—˜™š›œžŸ";
+
+/** Drop characters the standard (WinAnsi) fonts can't encode — pdf-lib throws on them. */
+function stripUnencodable(text: string): string {
+    let out = "";
+    for (const ch of text) {
+        const c = ch.codePointAt(0)!;
+        if (c === 9 || c === 10 || c === 13 || (c >= 0x20 && c <= 0x7e) || (c >= 0xa0 && c <= 0xff) || WINANSI_EXTRA.includes(ch)) {
+            out += ch;
+        }
+    }
+    return out;
+}
+
+function decodeEntities(s: string): string {
+    return s
+        .replace(/&#(\d+);/g, (_, d: string) => { const n = parseInt(d, 10); return Number.isFinite(n) && n > 0 ? String.fromCodePoint(n) : ""; })
+        .replace(/&#x([0-9a-f]+);/gi, (_, h: string) => { const n = parseInt(h, 16); return Number.isFinite(n) && n > 0 ? String.fromCodePoint(n) : ""; })
+        .replace(/&nbsp;/g, " ")
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">")
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;|&apos;/g, "'")
+        .replace(/&mdash;/g, "—")
+        .replace(/&ndash;/g, "–")
+        .replace(/&amp;/g, "&"); // decode &amp; last to avoid double-decoding
+}
+
+function fontFor(fonts: RichTextFonts, bold: boolean, italic: boolean): PDFFont {
+    if (bold && italic) return fonts.boldItalic;
+    if (bold) return fonts.bold;
+    if (italic) return fonts.italic;
+    return fonts.regular;
+}
+
+/** Parse an inline HTML fragment into styled runs + explicit line breaks. */
+function parseInline(html: string, forceBold = false): Token[] {
+    const tokens: Token[] = [];
+    let bold = 0;
+    let italic = 0;
+    const re = /<\/?([a-z0-9]+)\b[^>]*>|[^<]+/gi;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(html)) !== null) {
+        const chunk = m[0];
+        if (chunk[0] === "<") {
+            const tag = (m[1] || "").toLowerCase();
+            const closing = chunk[1] === "/";
+            if (tag === "strong" || tag === "b") bold += closing ? -1 : 1;
+            else if (tag === "em" || tag === "i") italic += closing ? -1 : 1;
+            else if (tag === "br") tokens.push({ type: "br" });
+            // a / span / anything else: ignored styling, text is kept
+            if (bold < 0) bold = 0;
+            if (italic < 0) italic = 0;
+        } else {
+            const text = stripUnencodable(decodeEntities(chunk));
+            if (text) tokens.push({ type: "run", run: { text, bold: forceBold || bold > 0, italic: italic > 0 } });
+        }
+    }
+    return tokens;
+}
+
+interface Block {
+    type: "heading" | "paragraph" | "listitem";
+    level?: number;
+    ordered?: boolean;
+    index?: number;
+    depth?: number;
+    inline: string;
+}
+
+/**
+ * Tag-aware block parser. Unlike a flat regex it correctly handles nested <ul>/<ol>
+ * (no dropped items) and multiple <p> inside one <li> (joined with a line break).
+ */
+function parseBlocks(html: string): Block[] {
+    const blocks: Block[] = [];
+    const listStack: { ordered: boolean; counter: number }[] = [];
+    let cur: Block | null = null;
+    let curHasText = false;
+
+    const flush = () => {
+        if (cur) { blocks.push(cur); cur = null; curHasText = false; }
+    };
+
+    const re = /<(\/?)([a-z0-9]+)\b[^>]*>|([^<]+)/gi;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(html)) !== null) {
+        const text = m[3];
+        if (text !== undefined) {
+            if (cur) { cur.inline += text; if (text.trim()) curHasText = true; }
+            continue;
+        }
+        const tag = (m[2] || "").toLowerCase();
+        const closing = m[1] === "/";
+
+        if (tag === "h1" || tag === "h2" || tag === "h3") {
+            if (!closing) { flush(); cur = { type: "heading", level: parseInt(tag[1], 10), inline: "" }; }
+            else flush();
+        } else if (tag === "p") {
+            if (!closing) {
+                if (cur && cur.type === "listitem") { if (curHasText) cur.inline += "<br>"; }
+                else { flush(); cur = { type: "paragraph", inline: "" }; }
+            } else if (cur && cur.type !== "listitem") {
+                flush();
+            }
+        } else if (tag === "ul" || tag === "ol") {
+            if (!closing) { flush(); listStack.push({ ordered: tag === "ol", counter: 0 }); }
+            else listStack.pop();
+        } else if (tag === "li") {
+            if (!closing) {
+                flush();
+                const top = listStack[listStack.length - 1];
+                if (top) top.counter++;
+                cur = { type: "listitem", ordered: top ? top.ordered : false, index: top ? top.counter : 1, depth: Math.max(0, listStack.length - 1), inline: "" };
+            } else {
+                flush();
+            }
+        } else if (tag === "br") {
+            if (cur) cur.inline += "<br>";
+        } else if (cur) {
+            // inline formatting tag (strong/em/b/i/a/span/...) — keep verbatim for parseInline
+            cur.inline += m[0];
+        }
+    }
+    flush();
+    return blocks;
+}
+
+function newPage(ctx: RichTextCtx) {
+    ctx.page = ctx.doc.addPage([ctx.layout.pageWidth, ctx.layout.pageHeight]);
+    ctx.y = ctx.layout.pageHeight - ctx.layout.margin;
+}
+
+/** Flow styled tokens with word wrapping (and hard-breaking of over-long words), breaking to a new page when out of room. */
+function drawTokens(
+    ctx: RichTextCtx,
+    tokens: Token[],
+    opts: { x: number; maxWidth: number; size: number; color: RGB; lineHeight: number },
+) {
+    const { x, maxWidth, size, color, lineHeight } = opts;
+    let curX = x;
+    let drewAnythingOnLine = false;
+
+    const ensureRoom = () => {
+        if (ctx.y < ctx.layout.margin + lineHeight) newPage(ctx);
+    };
+    const newline = () => {
+        ctx.y -= lineHeight;
+        curX = x;
+        drewAnythingOnLine = false;
+        ensureRoom();
+    };
+    ensureRoom();
+
+    for (const tok of tokens) {
+        if (tok.type === "br") { newline(); continue; }
+        const font = fontFor(ctx.fonts, tok.run.bold, tok.run.italic);
+        const spaceW = font.widthOfTextAtSize(" ", size);
+        const parts = tok.run.text.split(/(\s+)/);
+        for (const part of parts) {
+            if (part === "") continue;
+            if (/^\s+$/.test(part)) {
+                if (drewAnythingOnLine) curX += spaceW;
+                continue;
+            }
+            const wordW = font.widthOfTextAtSize(part, size);
+            if (wordW <= maxWidth) {
+                if (drewAnythingOnLine && curX + wordW > x + maxWidth) newline();
+                ctx.page.drawText(part, { x: curX, y: ctx.y, size, font, color });
+                curX += wordW;
+                drewAnythingOnLine = true;
+            } else {
+                // Word wider than the column (e.g. a long URL): hard-break by characters.
+                if (drewAnythingOnLine) newline();
+                let chunk = "";
+                for (const ch of part) {
+                    if (chunk && font.widthOfTextAtSize(chunk + ch, size) > maxWidth) {
+                        ctx.page.drawText(chunk, { x, y: ctx.y, size, font, color });
+                        newline();
+                        chunk = ch;
+                    } else {
+                        chunk += ch;
+                    }
+                }
+                if (chunk) {
+                    ctx.page.drawText(chunk, { x, y: ctx.y, size, font, color });
+                    curX = x + font.widthOfTextAtSize(chunk, size);
+                    drewAnythingOnLine = true;
+                }
+            }
+        }
+    }
+    ctx.y -= lineHeight;
+}
+
+/**
+ * Render a sanitized HTML fragment onto the pdf-lib context, mutating ctx.page/ctx.y
+ * as it flows and paginates. Returns the final { page, y } so the caller can continue.
+ */
+export function drawRichHtml(html: string, ctx: RichTextCtx): { page: PDFPage; y: number } {
+    const { margin, contentWidth } = ctx.layout;
+    const src = (html || "").trim();
+    if (!src) return { page: ctx.page, y: ctx.y };
+
+    const blocks = parseBlocks(src);
+    // No recognized block tags — treat the whole thing as one paragraph of inline text.
+    if (blocks.length === 0) {
+        drawTokens(ctx, parseInline(src), { x: margin, maxWidth: contentWidth, size: 10, color: ctx.mutedColor, lineHeight: 14 });
+        return { page: ctx.page, y: ctx.y };
+    }
+
+    for (const block of blocks) {
+        if (block.type === "heading") {
+            const size = block.level === 1 ? 15 : block.level === 2 ? 12.5 : 11;
+            ctx.y -= 6;
+            if (ctx.y < margin + size * 1.4) newPage(ctx);
+            drawTokens(ctx, parseInline(block.inline, true), { x: margin, maxWidth: contentWidth, size, color: ctx.color, lineHeight: size * 1.35 });
+            ctx.y -= 2;
+        } else if (block.type === "listitem") {
+            const depth = block.depth ?? 0;
+            const indent = depth * 14;
+            const bulletX = margin + 6 + indent;
+            const textX = margin + 20 + indent;
+            if (ctx.y < margin + 14) newPage(ctx);
+            const marker = block.ordered ? `${block.index}.` : "•";
+            ctx.page.drawText(marker, { x: bulletX, y: ctx.y, size: 10, font: ctx.fonts.regular, color: ctx.mutedColor });
+            drawTokens(ctx, parseInline(block.inline), { x: textX, maxWidth: margin + contentWidth - textX, size: 10, color: ctx.mutedColor, lineHeight: 14 });
+        } else {
+            drawTokens(ctx, parseInline(block.inline), { x: margin, maxWidth: contentWidth, size: 10, color: ctx.mutedColor, lineHeight: 14 });
+            ctx.y -= 4;
+        }
+    }
+
+    return { page: ctx.page, y: ctx.y };
+}

--- a/src/lib/pdf.ts
+++ b/src/lib/pdf.ts
@@ -4,6 +4,7 @@ import { toNum } from './prisma-helpers';
 import { buildLetterheadConfig, type LetterheadConfig } from './letterhead';
 import { isOwnSignatureStorageUrl } from './signature-storage';
 import { coTaxRate, coTaxLabel } from './co-tax';
+import { drawRichHtml, type RichTextCtx } from './pdf-richtext';
 
 /**
  * Embed a signature image from either a legacy inline data-URL or a migrated http(s)
@@ -250,6 +251,8 @@ export async function generateEstimatePdf(estimateId: string): Promise<Buffer> {
     const doc = await PDFDocument.create();
     const helvetica = await doc.embedFont(StandardFonts.Helvetica);
     const helveticaBold = await doc.embedFont(StandardFonts.HelveticaBold);
+    const helveticaOblique = await doc.embedFont(StandardFonts.HelveticaOblique);
+    const helveticaBoldOblique = await doc.embedFont(StandardFonts.HelveticaBoldOblique);
 
     const pageWidth = 612; // Letter width in points
     const pageHeight = 792; // Letter height in points
@@ -264,6 +267,23 @@ export async function generateEstimatePdf(estimateId: string): Promise<Buffer> {
             page = doc.addPage([pageWidth, pageHeight]);
             y = pageHeight - margin;
         }
+    }
+
+    // Render a titled rich-text section (Project Overview / Notes & Assumptions) using
+    // the shared HTML-subset renderer, keeping the closure's page/y cursor in sync.
+    const richFonts = { regular: helvetica, bold: helveticaBold, italic: helveticaOblique, boldItalic: helveticaBoldOblique };
+    function drawRichSection(title: string, body: string, titleSize: number) {
+        checkNewPage(140);
+        page.drawText(title, { x: margin, y, size: titleSize, font: helveticaBold, color: colors.textMain });
+        y -= titleSize + 10;
+        const ctx: RichTextCtx = {
+            doc, page, y, fonts: richFonts,
+            layout: { pageWidth, pageHeight, margin, contentWidth },
+            color: colors.textMain, mutedColor: colors.textMuted,
+        };
+        const res = drawRichHtml(body, ctx);
+        page = res.page;
+        y = res.y;
     }
 
     // --- Letterhead ---
@@ -327,6 +347,21 @@ export async function generateEstimatePdf(estimateId: string): Promise<Buffer> {
     });
     y -= 20;
 
+    // --- Project Overview / Vision (client-facing, no pricing) ---
+    // Rendered after the header/client block, then the estimate details are forced
+    // onto a fresh page so pricing begins on the following page.
+    if (estimate.overviewEnabled && estimate.overviewBody) {
+        drawRichSection(estimate.overviewTitle || 'Project Overview', estimate.overviewBody, 15);
+        page = doc.addPage([pageWidth, pageHeight]);
+        y = pageHeight - margin;
+    }
+
+    // --- Estimate Notes & Assumptions (placed before the line items) ---
+    if (estimate.notesEnabled && estimate.notesBody && estimate.notesPlacement === 'before') {
+        drawRichSection(estimate.notesTitle || 'Estimate Notes & Assumptions', estimate.notesBody, 12);
+        y -= 12;
+    }
+
     // --- Table Header ---
     const cols = {
         name: margin,
@@ -363,6 +398,9 @@ export async function generateEstimatePdf(estimateId: string): Promise<Buffer> {
         y -= 14;
     }
 
+    // Guard against a before-placement Notes section leaving no room: keep the table
+    // header with at least the first row instead of stranding it at the page bottom.
+    checkNewPage(120);
     drawTableHeader();
 
     // --- Table Rows ---
@@ -505,6 +543,12 @@ export async function generateEstimatePdf(estimateId: string): Promise<Buffer> {
     page.drawText(totalStr2, {
         x: cols.total - totalWidth2, y: y - 8, size: 14, font: helveticaBold, color: colors.primary,
     });
+
+    // --- Estimate Notes & Assumptions (placed immediately after the line items/totals) ---
+    if (estimate.notesEnabled && estimate.notesBody && estimate.notesPlacement !== 'before') {
+        y -= 30;
+        drawRichSection(estimate.notesTitle || 'Estimate Notes & Assumptions', estimate.notesBody, 12);
+    }
 
     // --- Payment Schedule ---
     if (estimate.paymentSchedules.length > 0) {


### PR DESCRIPTION
## What

Adds two optional, client-facing rich-text sections to estimates so a large estimate reads like a professional proposal without attaching a separate cover document.

- **Project Overview / Vision** — rich-text page placed after the estimate header/client info and **before pricing**, with an automatic page break so line items begin on the next page. Shows no pricing. Custom title (e.g. "Project Vision", "Scope of Work").
- **Notes & Assumptions** — rich-text section placed **before or after** the line items (per-estimate toggle) for exclusions, allowances, and estimating assumptions.

Both render with full formatting in all three client-facing surfaces: the online portal estimate, the portal-download PDF, and the emailed/attached PDF.

## How

- **Schema:** 7 additive columns on `Estimate` (`overviewEnabled/Title/Body`, `notesEnabled/Title/Body`, `notesPlacement`). Already applied to the DB (schema-first).
- **Editor:** two collapsible cards — include toggle, custom title, TipTap rich-text editor (H1/H2, bold, italic, bullet/numbered lists), notes placement selector, and load/save reusable templates (reuses `DocumentTemplate` with new `overview`/`notes` types — no new model).
- **Portal:** reuses the existing sanitize + per-block `data-pdf-row` mechanism; new invisible `data-pdf-break` marker forces line items onto a fresh PDF page.
- **Emailed PDF:** new `src/lib/pdf-richtext.ts` — a small HTML-subset → pdf-lib renderer (headings, paragraphs, nested lists, bold/italic) so the programmatic PDF matches the online view.

## Verification

- `tsc --noEmit` clean; `npm run build` passes.
- pdf-lib renderer verified with instrumented assertions: correct fonts for bold/italic/nested, list markers, entity decoding (incl. numeric), nested-list content preserved, long-word hard-break stays in column, CJK/emoji don't crash, clean multi-page pagination.
- Codex peer review run; all real findings addressed (dirty-check snapshot omission, nested-list content loss, WinAnsi crash, infinite-loop guard, table-header strand guard, duplicate TipTap Link).

## Notes

- HTML is stored raw and sanitized on render (DOMPurify in portal; pdf-lib draws whitelisted tags only) — matches the existing `termsAndConditions` convention.
- A pre-existing, unrelated issue (saveEstimate not actually transactional) was found during this work and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)