### PR TITLE
feat(mcp): zero-quantity option lines + upload_file connector tool

### DIFF
--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/prisma";
 import { getSupabase, STORAGE_BUCKET } from "@/lib/supabase";
 import { hasPermission } from "@/lib/permissions";
 import { authorizeFileScope, isAncestorFinancial } from "@/lib/file-auth";
+import { ALLOWED_FILE_EXTENSIONS } from "@/lib/project-files";
 
 export const maxDuration = 60;
 export const dynamic = "force-dynamic";
@@ -143,14 +144,9 @@ export async function POST(req: NextRequest) {
             return NextResponse.json({ error: "No files selected" }, { status: 400 });
         }
 
-        const ALLOWED_EXTENSIONS = new Set([
-            ".pdf", ".doc", ".docx", ".xls", ".xlsx", ".csv",
-            ".jpg", ".jpeg", ".png", ".gif", ".webp", ".heic",
-            ".txt", ".rtf", ".dwg", ".dxf",
-        ]);
         for (const file of files) {
             const ext = file.name.includes(".") ? `.${file.name.split(".").pop()!.toLowerCase()}` : "";
-            if (!ALLOWED_EXTENSIONS.has(ext)) {
+            if (!ALLOWED_FILE_EXTENSIONS.has(ext)) {
                 return NextResponse.json({ error: `File type not allowed: ${ext || "(no extension)"}. Allowed: PDF, Word, Excel, images.` }, { status: 400 });
             }
         }

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -748,12 +748,24 @@ const handler = createMcpHandler(
                 }
                 // Closed/won jobs are accepted on purpose — find_job surfaces them and
                 // parking documents on a finished job is a normal filing action.
-                if (projectId) {
-                    const project = await prisma.project.findUnique({ where: { id: projectId }, select: { id: true } });
-                    if (!project) return { ...textResult({ error: `No project with id ${projectId}. Use find_job or list_projects.` }), isError: true };
+                let targetProjectId: string | null = projectId ?? null;
+                let targetLeadId: string | null = leadId ?? null;
+                let movedToProjectNote: string | null = null;
+                if (targetProjectId) {
+                    const project = await prisma.project.findUnique({ where: { id: targetProjectId }, select: { id: true } });
+                    if (!project) return { ...textResult({ error: `No project with id ${targetProjectId}. Use find_job or list_projects.` }), isError: true };
                 } else {
-                    const lead = await prisma.lead.findUnique({ where: { id: leadId! }, select: { id: true } });
-                    if (!lead) return { ...textResult({ error: `No lead with id ${leadId}. Use find_job or list_leads.` }), isError: true };
+                    const lead = await prisma.lead.findUnique({ where: { id: targetLeadId! }, select: { id: true } });
+                    if (!lead) return { ...textResult({ error: `No lead with id ${targetLeadId}. Use find_job or list_leads.` }), isError: true };
+                    // A won lead becomes a project, and the customer portal only reads
+                    // project-owned folders — a "shared" folder filed on the lead would
+                    // be unreachable. Normalize converted leads to their project.
+                    const linkedProject = await prisma.project.findFirst({ where: { leadId: targetLeadId! }, select: { id: true, name: true } });
+                    if (linkedProject) {
+                        movedToProjectNote = `This lead was already converted to project "${linkedProject.name}" — the file was filed on the project.`;
+                        targetProjectId = linkedProject.id;
+                        targetLeadId = null;
+                    }
                 }
 
                 const b64 = contentBase64.replace(/\s+/g, "");
@@ -777,7 +789,7 @@ const handler = createMcpHandler(
                 let folderId: string | null = null;
                 const folderName = folder?.trim();
                 if (folderName) {
-                    const scope = { projectId: projectId ?? null, leadId: leadId ?? null, parentId: null };
+                    const scope = { projectId: targetProjectId, leadId: targetLeadId, parentId: null };
                     const existing = await prisma.fileFolder.findFirst({
                         where: { ...scope, name: { equals: folderName, mode: "insensitive" } },
                         select: { id: true, name: true, visibility: true },
@@ -800,16 +812,16 @@ const handler = createMcpHandler(
                     buffer,
                     fileName,
                     mimeType: mimeTypeForFileName(fileName),
-                    projectId: projectId ?? null,
-                    leadId: leadId ?? null,
+                    projectId: targetProjectId,
+                    leadId: targetLeadId,
                     folderId,
                     visibility: fileVisibility,
                 });
                 if (!saved.ok) return { ...textResult({ error: saved.error }), isError: true };
 
-                const filesUrl = projectId
-                    ? `https://probuild.goldentouchremodeling.com/projects/${projectId}/files`
-                    : `https://probuild.goldentouchremodeling.com/leads/${leadId}/files`;
+                const filesUrl = targetProjectId
+                    ? `https://probuild.goldentouchremodeling.com/projects/${targetProjectId}/files`
+                    : `https://probuild.goldentouchremodeling.com/leads/${targetLeadId}/files`;
                 return textResult({
                     fileId: saved.file.id,
                     name: saved.file.name,
@@ -817,6 +829,7 @@ const handler = createMcpHandler(
                     folder: folderName ?? null,
                     visibility: fileVisibility,
                     url: filesUrl,
+                    ...(movedToProjectNote ? { movedToProject: movedToProjectNote } : {}),
                     note: fileVisibility === "shared"
                         ? "This file IS visible to the customer (in the client portal, once the job has a project with the portal's Files section enabled)."
                         : "Internal file — the customer cannot see it.",

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/prisma";
 import { createEstimateFromPhases, updateEstimateFromPhases, templateToPhases, estimateToPhases, CLOSED_PROJECT_STATUSES, CLOSED_LEAD_STAGES } from "@/lib/gpt-estimate";
 import { getProjectBilling, sendMilestoneInvoicesCore, resendInvoiceCore, createChangeOrderDraft, billChangeOrderCore, sendChangeOrderToClientCore, listReceivables, createInvoiceFromEstimateGuarded } from "@/lib/billing-core";
 import { coTaxRate, coTaxLabel } from "@/lib/co-tax";
+import { ALLOWED_FILE_EXTENSIONS, fileExtension, mimeTypeForFileName, saveProjectFile } from "@/lib/project-files";
 
 // MCP connector for ChatGPT (streamable HTTP at POST /api/mcp/mcp).
 //
@@ -53,7 +54,7 @@ const phaseItemSchema = z.object({
     description: z.string().max(2000).optional(),
     costCode: z.string().max(50).optional().describe("ProBuild cost code (the 'code' value from get_estimating_codes, e.g. '01-DEMO'). Set on every item."),
     costType: z.string().max(50).optional().describe("ProBuild cost type name from get_estimating_codes, e.g. 'Labor' or 'Material'."),
-    quantity: z.number().positive().max(1_000_000).describe("Quantity in the given unit"),
+    quantity: z.number().min(0).max(1_000_000).describe("Quantity in the given unit. 0 is allowed and marks an optional/alternate line shown at $0 — it adds nothing to the estimate total."),
     unit: z.string().max(30).optional().describe("e.g. 'sq ft', 'hours', 'job'"),
     unitCost: z.number().min(0).max(10_000_000).describe("Sell price per unit in USD"),
 });
@@ -717,9 +718,101 @@ const handler = createMcpHandler(
                 return textResult(result);
             },
         );
+
+        server.registerTool(
+            "upload_file",
+            {
+                title: "Upload a document to a job's Files tab",
+                annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+                description:
+                    "Parks a document (RFQ, RFI, spec sheet, spreadsheet, photo) on a project's or lead's Files tab in ProBuild. " +
+                    "Send the file's raw bytes base64-encoded — max ~3 MB per file; larger files must be uploaded in ProBuild directly. " +
+                    "Files are INTERNAL by default; visibility 'shared' makes the file visible to the CUSTOMER in their portal — only use it when the user explicitly asks. " +
+                    "Optionally group files into a named top-level folder (created if it doesn't exist, e.g. 'RFQs').",
+                inputSchema: {
+                    projectId: z.string().max(50).optional().describe("Target project id from list_projects / find_job (omit if using leadId)"),
+                    leadId: z.string().max(50).optional().describe("Target lead id from list_leads / find_job (omit if using projectId)"),
+                    fileName: z.string().min(1).max(200).describe("File name WITH extension, e.g. 'RFQ-plumbing-sub.pdf'. Allowed: pdf, doc/docx, xls/xlsx, csv, jpg/png/gif/webp/heic, txt, rtf, dwg, dxf"),
+                    contentBase64: z.string().min(1).max(4_400_000).describe("The file's raw bytes, standard base64-encoded (no data: URL prefix). Max ~3 MB decoded."),
+                    folder: z.string().max(120).optional().describe("Optional top-level folder name on the job's Files tab, e.g. 'RFQs' — found case-insensitively or created"),
+                    visibility: z.enum(["team", "shared"]).optional().describe("'team' = internal only (default); 'shared' = the customer sees it in their portal"),
+                },
+            },
+            async ({ projectId, leadId, fileName, contentBase64, folder, visibility }) => {
+                if ((projectId ? 1 : 0) + (leadId ? 1 : 0) !== 1) {
+                    return { ...textResult({ error: "Provide exactly one of projectId or leadId (use find_job / list_projects / list_leads to resolve the target)." }), isError: true };
+                }
+                const ext = fileExtension(fileName);
+                if (!ALLOWED_FILE_EXTENSIONS.has(ext)) {
+                    return { ...textResult({ error: `File type "${ext || "(no extension)"}" not allowed. Allowed: ${[...ALLOWED_FILE_EXTENSIONS].join(", ")}.` }), isError: true };
+                }
+                // Closed/won jobs are accepted on purpose — find_job surfaces them and
+                // parking documents on a finished job is a normal filing action.
+                if (projectId) {
+                    const project = await prisma.project.findUnique({ where: { id: projectId }, select: { id: true } });
+                    if (!project) return { ...textResult({ error: `No project with id ${projectId}. Use find_job or list_projects.` }), isError: true };
+                } else {
+                    const lead = await prisma.lead.findUnique({ where: { id: leadId! }, select: { id: true } });
+                    if (!lead) return { ...textResult({ error: `No lead with id ${leadId}. Use find_job or list_leads.` }), isError: true };
+                }
+
+                const b64 = contentBase64.replace(/\s+/g, "");
+                if (b64.length % 4 !== 0 || !/^[A-Za-z0-9+/]*={0,2}$/.test(b64)) {
+                    return { ...textResult({ error: "contentBase64 is not valid base64 — send the file's raw bytes standard-base64-encoded, without a data: URL prefix." }), isError: true };
+                }
+                const buffer = Buffer.from(b64, "base64");
+                if (buffer.length === 0) {
+                    return { ...textResult({ error: "contentBase64 decoded to 0 bytes." }), isError: true };
+                }
+                const MAX_UPLOAD_BYTES = 3_300_000; // stays under Vercel's 4.5 MB request cap after base64 expansion
+                if (buffer.length > MAX_UPLOAD_BYTES) {
+                    return { ...textResult({ error: `File is ${(buffer.length / 1_000_000).toFixed(1)} MB — the connector accepts up to ~3 MB. Upload larger files in ProBuild directly.` }), isError: true };
+                }
+
+                let folderId: string | null = null;
+                const folderName = folder?.trim();
+                if (folderName) {
+                    const scope = { projectId: projectId ?? null, leadId: leadId ?? null, parentId: null };
+                    const existing = await prisma.fileFolder.findFirst({
+                        where: { ...scope, name: { equals: folderName, mode: "insensitive" } },
+                        select: { id: true },
+                    });
+                    folderId = existing
+                        ? existing.id
+                        : (await prisma.fileFolder.create({ data: { name: folderName, ...scope }, select: { id: true } })).id;
+                }
+
+                const saved = await saveProjectFile({
+                    buffer,
+                    fileName,
+                    mimeType: mimeTypeForFileName(fileName),
+                    projectId: projectId ?? null,
+                    leadId: leadId ?? null,
+                    folderId,
+                    // null = inherit the folder's visibility (default "team"), same as the app.
+                    visibility: visibility ?? null,
+                });
+                if (!saved.ok) return { ...textResult({ error: saved.error }), isError: true };
+
+                const filesUrl = projectId
+                    ? `https://probuild.goldentouchremodeling.com/projects/${projectId}/files`
+                    : `https://probuild.goldentouchremodeling.com/leads/${leadId}/files`;
+                return textResult({
+                    fileId: saved.file.id,
+                    name: saved.file.name,
+                    sizeBytes: saved.file.size,
+                    folder: folderName ?? null,
+                    visibility: visibility ?? "team (inherited)",
+                    url: filesUrl,
+                    note: visibility === "shared"
+                        ? "This file IS visible to the customer in their portal."
+                        : "Internal file — the customer cannot see it.",
+                });
+            },
+        );
     },
     {
-        serverInfo: { name: "probuild", version: "1.5.0" },
+        serverInfo: { name: "probuild", version: "1.6.0" },
         capabilities: { tools: {} },
         instructions:
             "ProBuild is Golden Touch Remodeling's construction management system. " +
@@ -728,6 +821,7 @@ const handler = createMcpHandler(
             "4) confirm the target with list_projects / list_leads, 5) create_estimate. " +
             "Every line item needs a costCode from get_estimating_codes. costType is just a line label (Labor / Material / Allowance / Subcontractor / Equipment / Other) — " +
             "the user estimates with allowances and lump-sum labor, so keep those labels accurate. " +
+            "Quantity 0 is valid and is how the user presents OPTIONAL/alternate scope: the line shows at $0 and adds nothing to the total — preserve such lines when revising an estimate. " +
             "All prices are USD sell prices. Estimates arrive as private drafts for review in ProBuild. " +
             "ESTIMATE lifecycle: create_estimate (draft) → [get_estimate to read, update_estimate to revise in place while still Draft/Sent] → send_estimate (preview + user approval; customer signs via portal, which auto-creates the invoice). "
             + "update_estimate edits an existing unsigned estimate (line items, tax jurisdiction/rate, title, terms); once signed or invoiced, revisions go through a change order. " +
@@ -738,6 +832,8 @@ const handler = createMcpHandler(
             "always run the preview step, show the user exactly what will be sent and to whom, and only echo back the preview's confirmToken after their explicit approval. Never self-confirm. " +
             "Change-order lifecycle: create_change_order (draft) → send_change_order (preview + user approval; customer signs via portal) → " +
             "once Approved, bill_change_order puts it on the invoice → send_milestone_invoice emails the payment link. " +
+            "FILES: upload_file parks documents (RFQs, RFIs, spec sheets, generated spreadsheets) on a project's or lead's Files tab — base64 content, ~3 MB max, optional folder. " +
+            "Uploads default to internal visibility; only pass visibility 'shared' (customer-visible in the portal) when the user explicitly asks. " +
             "QuickBooks is handled server-side; never ask the user for QuickBooks credentials.",
     },
     { basePath: "/api/mcp", maxDuration: 60 },

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -769,17 +769,31 @@ const handler = createMcpHandler(
                     return { ...textResult({ error: `File is ${(buffer.length / 1_000_000).toFixed(1)} MB — the connector accepts up to ~3 MB. Upload larger files in ProBuild directly.` }), isError: true };
                 }
 
+                // Always store an EXPLICIT visibility (never null/inherit): the portal
+                // shows null-visibility files inside shared folders, so inheriting
+                // could silently expose a file this tool just reported as internal.
+                const fileVisibility = visibility ?? "team";
+
                 let folderId: string | null = null;
                 const folderName = folder?.trim();
                 if (folderName) {
                     const scope = { projectId: projectId ?? null, leadId: leadId ?? null, parentId: null };
                     const existing = await prisma.fileFolder.findFirst({
                         where: { ...scope, name: { equals: folderName, mode: "insensitive" } },
-                        select: { id: true },
+                        select: { id: true, name: true, visibility: true },
                     });
+                    // The portal only traverses SHARED folders — a shared file inside a
+                    // team folder would be unreachable by the customer. Refuse the
+                    // combination rather than silently flipping an existing folder to
+                    // shared (that would expose everything already in it).
+                    if (existing && fileVisibility === "shared" && existing.visibility !== "shared") {
+                        return { ...textResult({ error: `Folder "${existing.name}" is not a shared folder, so the customer could never see a shared file inside it. Upload the shared file without a folder, use a folder that is already shared, or drop visibility to keep it internal.` }), isError: true };
+                    }
                     folderId = existing
                         ? existing.id
-                        : (await prisma.fileFolder.create({ data: { name: folderName, ...scope }, select: { id: true } })).id;
+                        // A folder created for a shared upload is created shared (it
+                        // contains only what this tool puts in it); otherwise team.
+                        : (await prisma.fileFolder.create({ data: { name: folderName, ...scope, visibility: fileVisibility === "shared" ? "shared" : "team" }, select: { id: true } })).id;
                 }
 
                 const saved = await saveProjectFile({
@@ -789,8 +803,7 @@ const handler = createMcpHandler(
                     projectId: projectId ?? null,
                     leadId: leadId ?? null,
                     folderId,
-                    // null = inherit the folder's visibility (default "team"), same as the app.
-                    visibility: visibility ?? null,
+                    visibility: fileVisibility,
                 });
                 if (!saved.ok) return { ...textResult({ error: saved.error }), isError: true };
 
@@ -802,10 +815,10 @@ const handler = createMcpHandler(
                     name: saved.file.name,
                     sizeBytes: saved.file.size,
                     folder: folderName ?? null,
-                    visibility: visibility ?? "team (inherited)",
+                    visibility: fileVisibility,
                     url: filesUrl,
-                    note: visibility === "shared"
-                        ? "This file IS visible to the customer in their portal."
+                    note: fileVisibility === "shared"
+                        ? "This file IS visible to the customer (in the client portal, once the job has a project with the portal's Files section enabled)."
                         : "Internal file — the customer cannot see it.",
                 });
             },

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -7892,15 +7892,22 @@ export async function createPurchaseOrderFromEstimate(projectId: string, estimat
             memos: "",
             terms: "Standard Subcontractor/Vendor terms apply unless overridden.",
             items: {
-                create: selectedItems.map((item: any, idx: number) => ({
-                    description: item.name + (item.description ? ` - ${item.description}` : ""),
-                    quantity: parseFloat(item.quantity) || 1,
-                    unitCost: parseFloat(item.unitCost) || 0,
-                    total: (parseFloat(item.quantity) || 1) * (parseFloat(item.unitCost) || 0),
-                    order: idx,
-                    costCodeId: item.costCodeId,
-                    costTypeId: item.costTypeId
-                }))
+                create: selectedItems.map((item: any, idx: number) => {
+                    // Preserve an explicit zero quantity (optional/alternate estimate
+                    // lines are shown at $0) — only a missing/unparseable quantity
+                    // falls back to 1. `|| 1` would reprice a $0 option into the PO.
+                    const parsedQty = parseFloat(item.quantity);
+                    const qty = Number.isFinite(parsedQty) ? parsedQty : 1;
+                    return {
+                        description: item.name + (item.description ? ` - ${item.description}` : ""),
+                        quantity: qty,
+                        unitCost: parseFloat(item.unitCost) || 0,
+                        total: qty * (parseFloat(item.unitCost) || 0),
+                        order: idx,
+                        costCodeId: item.costCodeId,
+                        costTypeId: item.costTypeId
+                    };
+                })
             }
         }
     });

--- a/src/lib/ai-estimate-transform.ts
+++ b/src/lib/ai-estimate-transform.ts
@@ -87,7 +87,13 @@ export function transformPhasesToItems(
         const children: ReturnType<typeof makeItem>[] = [];
         for (let ii = 0; ii < phaseItems.length; ii++) {
             const item = phaseItems[ii];
-            const qty = toNum(item.quantity) || 1;
+            // An explicit zero quantity is meaningful — it's how estimators show
+            // optional/alternate lines at $0 without pricing them into the total —
+            // so only a missing or unparseable quantity defaults to 1.
+            const rawQty = toNum(item.quantity);
+            const explicitZero = rawQty === 0
+                && (typeof item.quantity === "number" || (typeof item.quantity === "string" && /\d/.test(item.quantity)));
+            const qty = rawQty || (explicitZero ? 0 : 1);
             const uc = toCents(toNum(item.unitCost));
             children.push(makeItem({
                 id: `imp_${ts}_p${pi}_i${ii}`,

--- a/src/lib/gpt-estimate.ts
+++ b/src/lib/gpt-estimate.ts
@@ -351,6 +351,9 @@ export async function updateEstimateFromPhases(input: UpdateEstimateInput): Prom
         // paymentMilestones is ignored here — milestone math is done by
         // recomputeMilestones below so items and tax share one total path.
         transformed = transformPhasesToItems({ phases }, costCodes, costTypes);
+        if (transformed.totalEstimate === 0) {
+            warnings.push("Estimate total is $0 — every line item is quantity 0 (all optional). Give at least one line a real quantity unless a $0 estimate is intentional; milestones on a $0 total are all $0.");
+        }
         idMap = new Map<string, string>();
         for (const item of transformed.items) idMap.set(item.id, randomUUID());
     }
@@ -579,6 +582,9 @@ export async function createEstimateFromPhases(input: CreateEstimateInput): Prom
         costCodes,
         costTypes,
     );
+    if (transformed.totalEstimate === 0) {
+        warnings.push("Estimate total is $0 — every line item is quantity 0 (all optional). Give at least one line a real quantity unless a $0 estimate is intentional; milestones on a $0 total are all $0.");
+    }
 
     // The transform emits placeholder ids (imp_<ts>_p0, ...) with parentId references;
     // remap them to fresh ids so they can be persisted with real parent links.

--- a/src/lib/gpt-estimate.ts
+++ b/src/lib/gpt-estimate.ts
@@ -352,7 +352,7 @@ export async function updateEstimateFromPhases(input: UpdateEstimateInput): Prom
         // recomputeMilestones below so items and tax share one total path.
         transformed = transformPhasesToItems({ phases }, costCodes, costTypes);
         if (transformed.totalEstimate === 0) {
-            warnings.push("Estimate total is $0 — every line item is quantity 0 (all optional). Give at least one line a real quantity unless a $0 estimate is intentional; milestones on a $0 total are all $0.");
+            warnings.push("Estimate total is $0. Verify line-item quantities and unit costs unless a $0 estimate is intentional; milestones on a $0 total are all $0.");
         }
         idMap = new Map<string, string>();
         for (const item of transformed.items) idMap.set(item.id, randomUUID());
@@ -583,7 +583,7 @@ export async function createEstimateFromPhases(input: CreateEstimateInput): Prom
         costTypes,
     );
     if (transformed.totalEstimate === 0) {
-        warnings.push("Estimate total is $0 — every line item is quantity 0 (all optional). Give at least one line a real quantity unless a $0 estimate is intentional; milestones on a $0 total are all $0.");
+        warnings.push("Estimate total is $0. Verify line-item quantities and unit costs unless a $0 estimate is intentional; milestones on a $0 total are all $0.");
     }
 
     // The transform emits placeholder ids (imp_<ts>_p0, ...) with parentId references;

--- a/src/lib/project-files.ts
+++ b/src/lib/project-files.ts
@@ -1,0 +1,94 @@
+import { prisma } from "@/lib/prisma";
+import { getSupabase, STORAGE_BUCKET } from "@/lib/supabase";
+
+// Single source of truth for which file types may enter project/lead storage —
+// shared by the browser upload route (/api/files) and the MCP connector's
+// upload_file tool so the two allowlists can't drift.
+export const ALLOWED_FILE_EXTENSIONS = new Set([
+    ".pdf", ".doc", ".docx", ".xls", ".xlsx", ".csv",
+    ".jpg", ".jpeg", ".png", ".gif", ".webp", ".heic",
+    ".txt", ".rtf", ".dwg", ".dxf",
+]);
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+    ".pdf": "application/pdf",
+    ".doc": "application/msword",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".xls": "application/vnd.ms-excel",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".csv": "text/csv",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".heic": "image/heic",
+    ".txt": "text/plain",
+    ".rtf": "application/rtf",
+    ".dwg": "image/vnd.dwg",
+    ".dxf": "image/vnd.dxf",
+};
+
+export function fileExtension(fileName: string): string {
+    return fileName.includes(".") ? `.${fileName.split(".").pop()!.toLowerCase()}` : "";
+}
+
+export function mimeTypeForFileName(fileName: string): string {
+    return MIME_BY_EXTENSION[fileExtension(fileName)] ?? "application/octet-stream";
+}
+
+export type SaveProjectFileInput = {
+    buffer: Buffer;
+    fileName: string;
+    mimeType: string;
+    projectId?: string | null;
+    leadId?: string | null;
+    folderId?: string | null;
+    // null = inherit from the folder (default "team"), matching /api/files.
+    visibility?: string | null;
+    uploadedById?: string | null;
+};
+
+export type SaveProjectFileResult =
+    | { ok: true; file: { id: string; name: string; size: number; url: string } }
+    | { ok: false; error: string };
+
+/**
+ * Stores a file in Supabase Storage and records it as a ProjectFile, using the
+ * same storage-path scheme as /api/files so both surfaces list identically.
+ * Callers are responsible for authorization and extension validation.
+ */
+export async function saveProjectFile(input: SaveProjectFileInput): Promise<SaveProjectFileResult> {
+    const supabase = getSupabase();
+    if (!supabase) {
+        return { ok: false, error: "Storage not configured (SUPABASE_URL / SUPABASE_SERVICE_KEY missing)." };
+    }
+
+    const prefix = input.projectId ? `projects/${input.projectId}` : `leads/${input.leadId}`;
+    const safeName = input.fileName.replace(/[^a-zA-Z0-9._-]/g, "_");
+    const storagePath = `${prefix}/${Date.now()}_${safeName}`;
+
+    const { error: uploadError } = await supabase.storage
+        .from(STORAGE_BUCKET)
+        .upload(storagePath, input.buffer, { contentType: input.mimeType, upsert: false });
+    if (uploadError) {
+        return { ok: false, error: `Storage upload failed: ${uploadError.message}` };
+    }
+
+    const { data: urlData } = supabase.storage.from(STORAGE_BUCKET).getPublicUrl(storagePath);
+    const record = await prisma.projectFile.create({
+        data: {
+            name: input.fileName,
+            url: urlData?.publicUrl || storagePath,
+            size: input.buffer.length,
+            mimeType: input.mimeType,
+            ...(input.visibility && { visibility: input.visibility }),
+            ...(input.projectId && { projectId: input.projectId }),
+            ...(input.leadId && { leadId: input.leadId }),
+            ...(input.folderId && { folderId: input.folderId }),
+            uploadedById: input.uploadedById ?? null,
+        },
+        select: { id: true, name: true, size: true, url: true },
+    });
+    return { ok: true, file: record };
+}

--- a/src/lib/project-files.ts
+++ b/src/lib/project-files.ts
@@ -76,19 +76,26 @@ export async function saveProjectFile(input: SaveProjectFileInput): Promise<Save
     }
 
     const { data: urlData } = supabase.storage.from(STORAGE_BUCKET).getPublicUrl(storagePath);
-    const record = await prisma.projectFile.create({
-        data: {
-            name: input.fileName,
-            url: urlData?.publicUrl || storagePath,
-            size: input.buffer.length,
-            mimeType: input.mimeType,
-            ...(input.visibility && { visibility: input.visibility }),
-            ...(input.projectId && { projectId: input.projectId }),
-            ...(input.leadId && { leadId: input.leadId }),
-            ...(input.folderId && { folderId: input.folderId }),
-            uploadedById: input.uploadedById ?? null,
-        },
-        select: { id: true, name: true, size: true, url: true },
-    });
-    return { ok: true, file: record };
+    try {
+        const record = await prisma.projectFile.create({
+            data: {
+                name: input.fileName,
+                url: urlData?.publicUrl || storagePath,
+                size: input.buffer.length,
+                mimeType: input.mimeType,
+                ...(input.visibility && { visibility: input.visibility }),
+                ...(input.projectId && { projectId: input.projectId }),
+                ...(input.leadId && { leadId: input.leadId }),
+                ...(input.folderId && { folderId: input.folderId }),
+                uploadedById: input.uploadedById ?? null,
+            },
+            select: { id: true, name: true, size: true, url: true },
+        });
+        return { ok: true, file: record };
+    } catch (err: any) {
+        // The object is already in storage; without the DB row it would be
+        // orphaned and invisible everywhere — best-effort delete before failing.
+        await supabase.storage.from(STORAGE_BUCKET).remove([storagePath]).catch(() => {});
+        return { ok: false, error: `File record creation failed: ${err?.message ?? "unknown error"}` };
+    }
 }


### PR DESCRIPTION
## What

Two connector improvements from Richard's Christensen estimate session:

**1. Zero-quantity line items (options/alternates)**
Richard uses quantity 0 to present optional/alternate scope at $0. The connector's `create_estimate` / `update_estimate` rejected any qty <= 0, which blocked revising EST-00321 (its "Composite Decking Upgrade" alternate is qty 0).
- `phaseItemSchema.quantity`: `.positive()` -> `.min(0)`; `create_change_order` intentionally still requires > 0
- **Money-math fix**: `transformPhasesToItems` did `toNum(quantity) || 1`, silently coercing an explicit 0 to 1 and pricing the $0 option INTO the estimate total. Explicit 0 now stays 0; missing/blank/unparseable quantity still defaults to 1 (AI-generation and paste-import paths unchanged otherwise).
- Warns (does not refuse) when a rewrite produces a $0 total (every line qty 0)

**2. `upload_file` MCP tool**
Parks RFQ/RFI documents and generated spreadsheets on a project's or lead's Files tab.
- Base64 content, ~3 MB cap (Vercel 4.5 MB request limit), same Supabase Storage path scheme + ProjectFile rows as /api/files
- Shared extension allowlist extracted to `src/lib/project-files.ts` (imported by both /api/files and the connector so they can't drift)
- Optional top-level folder find-or-create (e.g. "RFQs"); visibility team (default, internal) or shared (client portal) — tool result states customer visibility explicitly

## Review

Codex peer review, 2 rounds: no blockers. Round 1 flagged the $0-total case (fixed with warning); folder find-or-create race accepted (cosmetic, same race exists in the app UI). Verified: no divide-by-quantity downstream, /api/files allowlist refactor behavior-identical, base64 validation + path traversal checks sound.

`npm run build` green (typecheck + compile, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
