### PR TITLE
fix(estimates): make saveEstimate atomic + repair schema-drift fallback

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -2751,7 +2751,9 @@ export async function saveEstimate(estimateId: string, contextId: string, contex
     // Update estimate inside a transaction to guarantee atomicity and avoid partial write inconsistencies.
     // targetMarginPercent must live in safeData so a failure on the main payload does
     // not silently revert the AI budget target to the default.
-    const result = await (async (tx) => {
+    // safeOnly re-runs the whole transaction writing only the always-present columns — see the
+    // schema-drift fallback below the closure for why the retry has to happen at this level.
+    const runSave = (safeOnly: boolean) => prisma.$transaction(async (tx) => {
         // Preserve payment credits: subtract already-paid milestones from totalAmount
         const paidMilestones = await tx.estimatePaymentSchedule.findMany({
             where: { estimateId, status: "Paid" },
@@ -2778,7 +2780,15 @@ export async function saveEstimate(estimateId: string, contextId: string, contex
             ...(data.taxRatePercent !== undefined && { taxRatePercent: data.taxRatePercent }),
         };
 
-        try {
+        // On the safeOnly retry, write only the always-present columns. A failed update inside an
+        // interactive transaction aborts the whole transaction (Postgres 25P02), so we cannot catch
+        // a missing-column error and retry within the same tx — the retry is driven from outside.
+        // select: { id: true } keeps the UPDATE ... RETURNING clause off the optional columns, so a
+        // DB missing one of them fails only when it is actually being SET — which routes to the
+        // safeOnly retry — rather than on every write via RETURNING.
+        if (safeOnly) {
+            await tx.estimate.update({ where: { id: estimateId }, data: safeData, select: { id: true } });
+        } else {
             await tx.estimate.update({
                 where: { id: estimateId },
                 data: {
@@ -2789,9 +2799,8 @@ export async function saveEstimate(estimateId: string, contextId: string, contex
                     ...(data.memo !== undefined && { memo: data.memo }),
                     ...(data.termsAndConditions !== undefined && { termsAndConditions: data.termsAndConditions }),
                 },
+                select: { id: true },
             });
-        } catch {
-            await tx.estimate.update({ where: { id: estimateId }, data: safeData });
         }
 
         // 1. Differential Item Upsert
@@ -2985,7 +2994,28 @@ export async function saveEstimate(estimateId: string, contextId: string, contex
         }
 
         return { success: true };
-    })(prisma);
+    }, {
+        // A full estimate save fans out to ~12 + itemCount + scheduleCount sequential statements;
+        // the default 5s interactive-transaction limit is too tight for large estimates that
+        // previously committed under autocommit. Give the batch room without being unbounded.
+        maxWait: 10000,
+        timeout: 30000,
+    });
+
+    // Schema-drift fallback (preserves the original "fallback to safe fields if columns missing"
+    // behavior). If the deployed DB is missing an optional column, Prisma throws P2022 and the
+    // transaction rolls back cleanly; re-run the whole transaction writing only the safe columns.
+    // Any other error (e.g. the linked-expense guard, deadlocks) propagates unchanged.
+    let result;
+    try {
+        result = await runSave(false);
+    } catch (e: any) {
+        if (e?.code === "P2022") {
+            result = await runSave(true);
+        } else {
+            throw e;
+        }
+    }
 
     if (contextType === "project") {
         revalidatePath(`/projects/${contextId}/estimates`);


### PR DESCRIPTION
## What
`saveEstimate` (`src/lib/actions.ts`) claimed to run in a transaction but invoked its callback with the plain `prisma` client (`(async (tx) => {...})(prisma)`), so the estimate scalar update (`totalAmount`, `balanceDue`, `computedStatus`) and the `EstimateItem` / `EstimatePaymentSchedule` differential upserts/deletes were **not atomic**. A mid-write failure could leave the money fields inconsistent with the actual line items/schedules.

This wraps the whole body in a real `prisma.$transaction` so it rolls back cleanly. Pre-existing issue, unrelated to the estimate Notes feature it was found alongside.

## Wrapping surfaced (and this PR fixes)
- **Schema-drift fallback poisoning** — the old inner `try/catch` retry (write `safeData` when the deployed DB lacks an optional column) can't work inside an interactive transaction: a `P2022` aborts the whole tx (`25P02`). The fallback is now driven from **outside** the transaction — on `P2022` it rolls back and re-runs writing only the always-present columns. Other errors (linked-expense guard, deadlocks) propagate unchanged.
- **`RETURNING` referenced the missing column** — added `select: { id: true }` to both estimate updates so `UPDATE ... RETURNING` never lists the optional columns; a missing column now fails only when it is actually being `SET`.
- **Transaction timeout** — `{ maxWait: 10000, timeout: 30000 }` so large estimate saves don't hit the 5s interactive-transaction default.

## Review
- Two rounds of codex-peer-review; both blockers (fallback poisoning, RETURNING) resolved.
- `npm run build` passes with 0 errors.
- Money-path: PR CI runs `e2e/money-pipeline.spec.ts` (sign→convert→invoice chain, mirror links, exactly-once activity writers).

## Deferred (separate task)
Pre-existing concurrency hardening between `saveEstimate` and `recordEstimatePayment` (inverse lock order + stale `paidSum` snapshot) — tracked separately, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)