### PR TITLE
fix(estimates): white background on portal PDF capture

### DIFF
--- a/src/lib/build-pdf.ts
+++ b/src/lib/build-pdf.ts
@@ -37,6 +37,9 @@ export async function buildPdf(
         const imgDataSingle = await toJpeg(element, {
             quality,
             pixelRatio,
+            // JPEG has no alpha channel — without a background, transparent areas (e.g. the
+            // triangles outside the document card's rounded corners) encode as black. Fill white.
+            backgroundColor: "#ffffff",
             filter: (node: HTMLElement) =>
                 !(node.nodeType === 1 && node.hasAttribute && node.hasAttribute("data-pdf-skip")),
         });
@@ -120,6 +123,9 @@ export async function buildPdf(
     const imgData = await toJpeg(element, {
         quality,
         pixelRatio,
+        // JPEG has no alpha channel — without a background, transparent areas (e.g. the
+        // triangles outside the document card's rounded corners) encode as black. Fill white.
+        backgroundColor: "#ffffff",
         filter: (node: HTMLElement) =>
             !(node.nodeType === 1 && node.hasAttribute && node.hasAttribute("data-pdf-skip")),
     });


### PR DESCRIPTION
## What

The portal **Download PDF** was showing small **black triangles at the document's rounded corners**.

## Why

`build-pdf.ts` captures the estimate DOM with html-to-image's `toJpeg`. JPEG has no alpha channel, so transparent areas — the triangles outside the card's `rounded-lg overflow-hidden` corners — encode as solid black.

## Fix

Pass `backgroundColor: "#ffffff"` to both `toJpeg` calls so transparent regions render white and match the page. The brand accent bar (purple) is unchanged — it's the same bar shown in the online portal.

Pre-existing issue, surfaced while reviewing the new Project Overview PDF output. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)