### PR TITLE
feat(studio): auto-stack floor items onto deck platforms

### DIFF
--- a/e2e/deck-stacking.spec.ts
+++ b/e2e/deck-stacking.spec.ts
@@ -1,0 +1,70 @@
+// Room Studio deck auto-stacking - pure unit coverage of lib/studio/stacking
+// (no page, no data; runs in-process). Guards the rotated-footprint math and
+// the commit-time restack rules that keep floor items on top of decks.
+
+import { test, expect } from "@playwright/test";
+import { deckTopYAt, restackFloorItems } from "@/lib/studio/stacking";
+import type { PlacedItem } from "@/lib/studio/doc";
+
+const IN = (n: number) => n * 0.0254;
+
+// Unrotated deck, default catalog size 144x96in, h=6in, at origin.
+const deck: PlacedItem = { id: "d1", defId: "deck-platform", x: 0, z: 0, rotation: 0 };
+// Resized deck 1.5x1.5m rotated 45deg.
+const rotated: PlacedItem = {
+  id: "d2", defId: "deck-platform", x: 1.562, z: -0.197, rotation: Math.PI / 4, w: 1.5, d: 1.5,
+};
+
+test.describe("deckTopYAt", () => {
+  test("axis-aligned footprint", () => {
+    expect(deckTopYAt([deck], { x: 0, z: 0 })).toBeCloseTo(IN(6), 10);
+    expect(deckTopYAt([deck], { x: IN(71), z: 0 })).toBeCloseTo(IN(6), 10);
+    expect(deckTopYAt([deck], { x: IN(73), z: 0 })).toBeUndefined();
+    expect(deckTopYAt([deck], { x: 0, z: IN(49) })).toBeUndefined();
+  });
+
+  test("rotated footprint uses the deck's local frame", () => {
+    expect(deckTopYAt([rotated], { x: 1.562, z: -0.197 })).toBeCloseTo(IN(6), 10);
+    // 1.0m along -x: outside the 0.75 half-extent AABB but inside the rotated
+    // square (vertex reach along world axes = 0.75 * sqrt(2) ~ 1.06).
+    expect(deckTopYAt([rotated], { x: 0.562, z: -0.197 })).toBeCloseTo(IN(6), 10);
+    // (+0.6, +0.6): |dx+dz|/sqrt(2) = 0.849 > 0.75 - inside the AABB but
+    // outside the rotated square.
+    expect(deckTopYAt([rotated], { x: 2.162, z: 0.403 })).toBeUndefined();
+    expect(deckTopYAt([rotated], { x: 0.962, z: -0.797 })).toBeUndefined();
+  });
+
+  test("deck h override and overlapping decks", () => {
+    const tall: PlacedItem = { id: "d3", defId: "deck-platform", x: 0, z: 0, rotation: 0, h: IN(18) };
+    expect(deckTopYAt([tall], { x: 0, z: 0 })).toBeCloseTo(IN(18), 10);
+    // overlapping decks yield the highest surface
+    expect(deckTopYAt([deck, tall], { x: 0, z: 0 })).toBeCloseTo(IN(18), 10);
+  });
+
+  test("excludes the dragged deck itself and ignores non-decks", () => {
+    expect(deckTopYAt([deck], { x: 0, z: 0 }, "d1")).toBeUndefined();
+    const sofa: PlacedItem = { id: "s1", defId: "outdoor-sofa", x: 0, z: 0, rotation: 0 };
+    expect(deckTopYAt([sofa], { x: 0, z: 0 })).toBeUndefined();
+  });
+});
+
+test.describe("restackFloorItems", () => {
+  test("re-derives floor elevations, leaves other mounts alone", () => {
+    const chairOn: PlacedItem = { id: "c1", defId: "patio-chair", x: 0.5, z: 0, rotation: 0 };
+    const chairOff: PlacedItem = { id: "c2", defId: "patio-chair", x: 10, z: 10, rotation: 0, y: IN(6) };
+    const sconce: PlacedItem = { id: "w1", defId: "sconce", x: 0.5, z: 0, rotation: 0, y: IN(60) };
+    const out = restackFloorItems([deck, chairOn, chairOff, sconce]);
+    expect(out.find((i) => i.id === "c1")?.y).toBeCloseTo(IN(6), 10);
+    expect(out.find((i) => i.id === "c2")?.y).toBeUndefined();
+    expect(out.find((i) => i.id === "w1")?.y).toBeCloseTo(IN(60), 10);
+    expect(out.find((i) => i.id === "d1")?.y).toBeUndefined();
+  });
+
+  test("returns the same array when nothing moves", () => {
+    const settled: PlacedItem[] = [
+      deck,
+      { id: "c1", defId: "patio-chair", x: 0.5, z: 0, rotation: 0, y: IN(6) },
+    ];
+    expect(restackFloorItems(settled)).toBe(settled);
+  });
+});

--- a/src/components/studio/canvas/Items.tsx
+++ b/src/components/studio/canvas/Items.tsx
@@ -49,6 +49,37 @@ export function resolveItem(item: PlacedItem): ResolvedItem | null {
   };
 }
 
+/**
+ * Deck platforms act as raised floors: return the top-surface Y of the deck
+ * under `p`, or undefined when `p` is over the plain floor. Floor-mounted
+ * items commit this as their `y` so they sit on the deck instead of
+ * intersecting it (drops back to undefined when dragged off).
+ */
+export function deckTopYAt(
+  items: PlacedItem[],
+  p: { x: number; z: number },
+  excludeId?: string,
+): number | undefined {
+  let top: number | undefined;
+  for (const it of items) {
+    if (it.defId !== "deck-platform" || it.id === excludeId) continue;
+    const r = resolveItem(it);
+    if (!r) continue;
+    // Express p in the deck's local frame (inverse of the three.js Y rotation)
+    // and test against the half-extents of its footprint.
+    const dx = p.x - it.x;
+    const dz = p.z - it.z;
+    const cos = Math.cos(it.rotation);
+    const sin = Math.sin(it.rotation);
+    const lx = dx * cos - dz * sin;
+    const lz = dx * sin + dz * cos;
+    if (Math.abs(lx) > r.w / 2 || Math.abs(lz) > r.d / 2) continue;
+    const t = r.y + r.h;
+    if (top === undefined || t > top) top = t;
+  }
+  return top;
+}
+
 interface DragState {
   pointerId: number;
   moved: boolean;
@@ -293,11 +324,18 @@ function ItemNode({
         Math.abs(drag.cur.z - item.z) > 1e-6 ||
         Math.abs(drag.cur.rotation - item.rotation) > 1e-6;
       if (changed) {
-        useStudio.getState().updateItem(item.id, {
+        const patch: Partial<PlacedItem> = {
           x: drag.cur.x,
           z: drag.cur.z,
           rotation: drag.cur.rotation,
-        });
+        };
+        // Deck auto-stack: floor items ride on top of a deck platform they
+        // land on and drop back to the floor when dragged off. Wall/ceiling/
+        // counter mounts and the decks themselves keep their own y.
+        if (def.mount === "floor" && def.id !== "deck-platform") {
+          patch.y = deckTopYAt(allItems, { x: drag.cur.x, z: drag.cur.z }, item.id);
+        }
+        useStudio.getState().updateItem(item.id, patch);
       } else {
         // restore the transient three.js pose to the committed one
         const g = groupRef.current;

--- a/src/components/studio/canvas/Items.tsx
+++ b/src/components/studio/canvas/Items.tsx
@@ -15,6 +15,7 @@ import {
   pointInPolygon, roomHeightAt, type WallSeg, type OBB, type RoomShellInfo,
 } from "@/lib/studio/geometry";
 import { inches, formatFtIn } from "@/lib/studio/units";
+import { deckTopYAt, isDeckPlatform } from "@/lib/studio/stacking";
 import { useStudio } from "../store";
 import { useLibrary } from "../useLibrary";
 import { BUILDERS } from "./builders";
@@ -49,36 +50,6 @@ export function resolveItem(item: PlacedItem): ResolvedItem | null {
   };
 }
 
-/**
- * Deck platforms act as raised floors: return the top-surface Y of the deck
- * under `p`, or undefined when `p` is over the plain floor. Floor-mounted
- * items commit this as their `y` so they sit on the deck instead of
- * intersecting it (drops back to undefined when dragged off).
- */
-export function deckTopYAt(
-  items: PlacedItem[],
-  p: { x: number; z: number },
-  excludeId?: string,
-): number | undefined {
-  let top: number | undefined;
-  for (const it of items) {
-    if (it.defId !== "deck-platform" || it.id === excludeId) continue;
-    const r = resolveItem(it);
-    if (!r) continue;
-    // Express p in the deck's local frame (inverse of the three.js Y rotation)
-    // and test against the half-extents of its footprint.
-    const dx = p.x - it.x;
-    const dz = p.z - it.z;
-    const cos = Math.cos(it.rotation);
-    const sin = Math.sin(it.rotation);
-    const lx = dx * cos - dz * sin;
-    const lz = dx * sin + dz * cos;
-    if (Math.abs(lx) > r.w / 2 || Math.abs(lz) > r.d / 2) continue;
-    const t = r.y + r.h;
-    if (top === undefined || t > top) top = t;
-  }
-  return top;
-}
 
 interface DragState {
   pointerId: number;
@@ -332,7 +303,7 @@ function ItemNode({
         // Deck auto-stack: floor items ride on top of a deck platform they
         // land on and drop back to the floor when dragged off. Wall/ceiling/
         // counter mounts and the decks themselves keep their own y.
-        if (def.mount === "floor" && def.id !== "deck-platform") {
+        if (def.mount === "floor" && !isDeckPlatform(def.id)) {
           patch.y = deckTopYAt(allItems, { x: drag.cur.x, z: drag.cur.z }, item.id);
         }
         useStudio.getState().updateItem(item.id, patch);

--- a/src/components/studio/canvas/Placement.tsx
+++ b/src/components/studio/canvas/Placement.tsx
@@ -15,7 +15,7 @@ import {
 import { inches } from "@/lib/studio/units";
 import { useStudio } from "../store";
 import { BUILDERS } from "./builders";
-import { resolveItem } from "./Items";
+import { resolveItem, deckTopYAt } from "./Items";
 
 const GRID = inches(1);
 
@@ -118,11 +118,16 @@ function PlacementInner({ doc, placing }: { doc: DesignDoc; placing: CatalogItem
     e.stopPropagation();
     const p = poseRef.current;
     if (!p) return;
+    // Deck auto-stack: floor items dropped on a deck platform start on its
+    // top surface (decks themselves and wall/ceiling mounts are unaffected).
+    const deckY = placing.mount === "floor" && placing.id !== "deck-platform"
+      ? deckTopYAt(doc.items, p)
+      : undefined;
     addItem(placing.id, {
       x: p.x,
       z: p.z,
       rotation: p.rotation,
-      y: placing.mount === "wall" && placing.elevation ? placing.elevation : undefined,
+      y: placing.mount === "wall" && placing.elevation ? placing.elevation : deckY,
     });
     // Hold Shift to keep placing more of the same item.
     if (!e.shiftKey) setPlacing(null);

--- a/src/components/studio/canvas/Placement.tsx
+++ b/src/components/studio/canvas/Placement.tsx
@@ -15,7 +15,8 @@ import {
 import { inches } from "@/lib/studio/units";
 import { useStudio } from "../store";
 import { BUILDERS } from "./builders";
-import { resolveItem, deckTopYAt } from "./Items";
+import { deckTopYAt, isDeckPlatform } from "@/lib/studio/stacking";
+import { resolveItem } from "./Items";
 
 const GRID = inches(1);
 
@@ -120,7 +121,7 @@ function PlacementInner({ doc, placing }: { doc: DesignDoc; placing: CatalogItem
     if (!p) return;
     // Deck auto-stack: floor items dropped on a deck platform start on its
     // top surface (decks themselves and wall/ceiling mounts are unaffected).
-    const deckY = placing.mount === "floor" && placing.id !== "deck-platform"
+    const deckY = placing.mount === "floor" && !isDeckPlatform(placing.id)
       ? deckTopYAt(doc.items, p)
       : undefined;
     addItem(placing.id, {

--- a/src/components/studio/store.ts
+++ b/src/components/studio/store.ts
@@ -10,6 +10,7 @@ import { create } from "zustand";
 import type { DesignDoc, PlacedItem } from "@/lib/studio/doc";
 import { emptyDoc, newItemId } from "@/lib/studio/doc";
 import { getItemDef, type CatalogItem } from "@/lib/studio/catalog";
+import { deckTopYAt, isDeckPlatform, restackFloorItems } from "@/lib/studio/stacking";
 
 export type ViewMode = "plan" | "orbit" | "walk";
 export type SaveState = "saved" | "unsaved" | "saving" | "error";
@@ -138,20 +139,29 @@ export const useStudio = create<StudioState>((set, get) => ({
       rotation: pos.rotation ?? 0,
     };
     const s = get();
-    s.commitDoc({ ...s.doc, items: [...s.doc.items, item] });
+    let items = [...s.doc.items, item];
+    // A freshly dropped deck lifts any floor items already standing on it.
+    if (isDeckPlatform(def.id)) items = restackFloorItems(items);
+    s.commitDoc({ ...s.doc, items });
     set({ selectedId: id });
     return id;
   },
 
   updateItem: (id, patch) => {
     const s = get();
-    const items = s.doc.items.map((it) => (it.id === id ? { ...it, ...patch } : it));
+    let items = s.doc.items.map((it) => (it.id === id ? { ...it, ...patch } : it));
+    // Moving/rotating/resizing a deck re-derives the elevation of its riders.
+    const target = items.find((it) => it.id === id);
+    if (target && isDeckPlatform(target.defId)) items = restackFloorItems(items);
     s.commitDoc({ ...s.doc, items });
   },
 
   removeItem: (id) => {
     const s = get();
-    s.commitDoc({ ...s.doc, items: s.doc.items.filter((it) => it.id !== id) });
+    const removed = s.doc.items.find((it) => it.id === id);
+    let items = s.doc.items.filter((it) => it.id !== id);
+    if (removed && isDeckPlatform(removed.defId)) items = restackFloorItems(items);
+    s.commitDoc({ ...s.doc, items });
     if (s.selectedId === id) set({ selectedId: null });
   },
 
@@ -168,7 +178,13 @@ export const useStudio = create<StudioState>((set, get) => ({
       x: src.x + Math.cos(src.rotation) * offset,
       z: src.z - Math.sin(src.rotation) * offset,
     };
-    s.commitDoc({ ...s.doc, items: [...s.doc.items, copy] });
+    // The copy lands at a new spot - its deck elevation can differ from the source's.
+    if (def?.mount === "floor" && !isDeckPlatform(copy.defId)) {
+      copy.y = deckTopYAt(s.doc.items, { x: copy.x, z: copy.z });
+    }
+    let items = [...s.doc.items, copy];
+    if (isDeckPlatform(copy.defId)) items = restackFloorItems(items);
+    s.commitDoc({ ...s.doc, items });
     set({ selectedId: nid });
     return nid;
   },

--- a/src/lib/studio/stacking.ts
+++ b/src/lib/studio/stacking.ts
@@ -1,0 +1,66 @@
+// Room Studio - deck auto-stacking. Floor-mounted items ride on top of deck
+// platforms: their `y` is derived from whichever deck their center sits on
+// (undefined = plain floor). Recomputed on commit only - never per frame.
+
+import type { PlacedItem } from "./doc";
+import { getItemDef } from "./catalog";
+
+const DECK_DEF_ID = "deck-platform";
+
+export function isDeckPlatform(defId: string): boolean {
+  return defId === DECK_DEF_ID;
+}
+
+/**
+ * Top-surface Y of the deck platform under `p`, or undefined when `p` is
+ * over the plain floor. Overlapping decks yield the highest surface.
+ */
+export function deckTopYAt(
+  items: PlacedItem[],
+  p: { x: number; z: number },
+  excludeId?: string,
+): number | undefined {
+  let top: number | undefined;
+  for (const it of items) {
+    if (it.defId !== DECK_DEF_ID || it.id === excludeId) continue;
+    const def = getItemDef(it.defId);
+    if (!def) continue;
+    const w = it.w ?? def.w;
+    const d = it.d ?? def.d;
+    const h = it.h ?? def.h;
+    const base = it.y ?? def.elevation ?? 0;
+    // Express p in the deck's local frame (inverse of the three.js Y rotation)
+    // and test against the half-extents of its footprint.
+    const dx = p.x - it.x;
+    const dz = p.z - it.z;
+    const cos = Math.cos(it.rotation);
+    const sin = Math.sin(it.rotation);
+    const lx = dx * cos - dz * sin;
+    const lz = dx * sin + dz * cos;
+    if (Math.abs(lx) > w / 2 || Math.abs(lz) > d / 2) continue;
+    const t = base + h;
+    if (top === undefined || t > top) top = t;
+  }
+  return top;
+}
+
+/**
+ * Re-derive the elevation of every floor-mounted item from the decks in
+ * `items`. Call after a deck platform is added, edited, or removed so items
+ * standing on it don't float or intersect. Wall/ceiling/counter mounts and
+ * the decks themselves are untouched. Returns `items` unchanged when no
+ * elevation moved.
+ */
+export function restackFloorItems(items: PlacedItem[]): PlacedItem[] {
+  let changed = false;
+  const next = items.map((it) => {
+    if (it.defId === DECK_DEF_ID) return it;
+    const def = getItemDef(it.defId);
+    if (!def || def.mount !== "floor") return it;
+    const y = deckTopYAt(items, { x: it.x, z: it.z }, it.id);
+    if (y === it.y) return it;
+    changed = true;
+    return { ...it, y };
+  });
+  return changed ? next : items;
+}


### PR DESCRIPTION
## What

Floor-mounted items in Room Studio now auto-stack onto deck platforms. Previously anything placed or dragged onto a `deck-platform` stayed at floor level (y=0) and intersected the 6" deck; outdoor templates worked around it by hard-seeding `y = 6in`.

- **New `src/lib/studio/stacking.ts`** — `deckTopYAt()` (rotated-footprint point test in the deck's local frame; overlapping decks yield the highest top) and `restackFloorItems()` (re-derives every floor item's elevation from the decks).
- **Placement commit** (`Placement.tsx` onClick) and **drag commit** (`Items.tsx` pointerup) set the item's `y` to the deck top when its center lands on a deck, and clear it back to undefined when it leaves.
- **Store actions** (`addItem`/`updateItem`/`removeItem`/`duplicateItem`) restack floor items whenever a deck platform is added, moved, rotated, resized, removed, or duplicated, so riders never float or intersect after deck edits. `duplicateItem` recomputes the copy's elevation at its offset position.
- Wall/ceiling/counter mounts and deck platforms themselves are untouched. Everything computes on commit only — no per-frame zustand writes (studio perf contract).
- `e2e/deck-stacking.spec.ts` — in-process unit coverage (footprint math incl. 45° rotation discriminators, h overrides, overlap max, restack rules).

## Verification

- Live in the studio (sandbox demo room): place chair on deck → y = 0.1524m (exactly 6"); drag off → y cleared; drag back on → y restored; deck added under a chair lifts it; deck moved/resized/removed re-derives riders correctly.
- `npm run build` green, no console errors, spec passes under Playwright.
- Codex peer review, 2 rounds: round 1 flagged stale elevations on deck mutations + duplicateItem inheriting y (both fixed in 57afbdb); round 2 clean (nits only).

## Notes

- **Carries `claude/3d-designer-outdoor-spaces-201d00`** (not yet PR'd/merged) — this diff includes that branch's outdoor-spaces commit. Once that branch merges to main, this PR shrinks to the three stacking commits. Merge outdoor spaces first.
- Deliberately not changed: template pergolas keep their authored `y` (they seed without elevation while an interactively placed pergola on a deck now stacks — flagging as a possible follow-up rather than editing the outdoor branch's templates); the placement ghost previews at floor level and lifts on commit (task constraint: compute on commit only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)