### PR TITLE
fix(security): remove hardcoded fallback secrets

### DIFF
--- a/src/app/api/portal/estimates/[id]/pdf-upload/route.ts
+++ b/src/app/api/portal/estimates/[id]/pdf-upload/route.ts
@@ -11,7 +11,9 @@ export const maxDuration = 60;
  */
 function verifyPdfUploadToken(estimateId: string, token: string): boolean {
     try {
-        const secret = process.env.NEXTAUTH_SECRET || "probuild-pdf-token-secret";
+        const secret = process.env.NEXTAUTH_SECRET;
+        if (!secret) return false;
+
         const parts = token.split(":");
         if (parts.length !== 3) return false;
         const [tokenEstimateId, expiryStr, sig] = parts;

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -136,7 +136,10 @@ function isAllowedCapturedPdfUrl(url: string): boolean {
  * where <expiry> is a Unix timestamp (seconds) and <sig> is HMAC-SHA256.
  */
 export async function generatePdfUploadToken(estimateId: string): Promise<string> {
-    const secret = process.env.NEXTAUTH_SECRET || "probuild-pdf-token-secret";
+    const secret = process.env.NEXTAUTH_SECRET;
+    if (!secret) {
+        throw new Error("NEXTAUTH_SECRET is not configured");
+    }
     const expiry = Math.floor(Date.now() / 1000) + 300; // 5 min
     const payload = `${estimateId}:${expiry}`;
     const sig = createHmac("sha256", secret).update(payload).digest("hex");

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -1,11 +1,14 @@
 import crypto from "crypto";
 
 const ALGORITHM = "aes-256-gcm";
-const SECRET = process.env.NEXTAUTH_SECRET || "development-secret-key-at-least-32-chars-long!!";
 
 // Derive a 256-bit key from the secret
 function getEncryptionKey(): Buffer {
-    return crypto.createHash("sha256").update(SECRET).digest();
+    const secret = process.env.NEXTAUTH_SECRET;
+    if (!secret) {
+        throw new Error("NEXTAUTH_SECRET is not configured");
+    }
+    return crypto.createHash("sha256").update(secret).digest();
 }
 
 /**

--- a/src/lib/subcontractor-actions.ts
+++ b/src/lib/subcontractor-actions.ts
@@ -6,9 +6,13 @@ import { sendNotification } from "./email";
 import { sendSMS } from "./sms";
 import { SignJWT } from "jose";
 
-const JWT_SECRET = new TextEncoder().encode(
-    process.env.SUB_PORTAL_SECRET || "sub-portal-dev-secret-change-me"
-);
+function getJwtSecret(): Uint8Array {
+    const secret = process.env.SUB_PORTAL_SECRET;
+    if (!secret) {
+        throw new Error("SUB_PORTAL_SECRET is not configured");
+    }
+    return new TextEncoder().encode(secret);
+}
 
 export async function getProjectSubcontractors(projectId: string) {
     const allSubs = await prisma.subcontractor.findMany({
@@ -97,7 +101,7 @@ export async function inviteNewSubcontractor(projectId: string, data: {
                 .setProtectedHeader({ alg: "HS256" })
                 .setIssuedAt()
                 .setExpirationTime("72h") // Invite links last longer than standard re-login ones
-                .sign(JWT_SECRET);
+                .sign(getJwtSecret());
                 
             portalUrl = `${process.env.NEXT_PUBLIC_APP_URL || "https://probuild.goldentouchremodeling.com"}/api/sub-portal/verify?token=${token}&next=/sub-portal/projects/${projectId}`;
         } catch (e) {
@@ -199,7 +203,7 @@ export async function resendSubcontractorInvite(projectId: string, subcontractor
             .setProtectedHeader({ alg: "HS256" })
             .setIssuedAt()
             .setExpirationTime("72h")
-            .sign(JWT_SECRET);
+            .sign(getJwtSecret());
             
         portalUrl = `${process.env.NEXT_PUBLIC_APP_URL || "https://probuild.goldentouchremodeling.com"}/api/sub-portal/verify?token=${token}&next=/sub-portal/projects/${projectId}`;
     } catch (e) {


### PR DESCRIPTION
Removes the four hardcoded fallback secrets (NEXTAUTH_SECRET x3, SUB_PORTAL_SECRET x1) so token signing/encryption fails loud instead of silently using a known string from the repo.

SUB_PORTAL_SECRET is now provisioned in Vercel (prod/preview/dev) — it was missing entirely, which also means the sub-portal verify path (which already failed loud) could never validate invites signed with the fallback. This PR + the env var repairs that flow.

Supersedes #147 and #150 (stale Sentinel branches — will close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)