### PR TITLE
fix(ai): robust JSON extraction from model responses

### DIFF
--- a/src/app/api/ai-estimate/assign-phases/route.ts
+++ b/src/app/api/ai-estimate/assign-phases/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 import Anthropic from "@anthropic-ai/sdk";
+import { extractJsonObject } from "@/lib/ai-json";
 
 type ItemInput = {
   id: string;
@@ -127,16 +128,9 @@ Rules:
       return NextResponse.json({ error: "No response from AI" }, { status: 502 });
     }
 
-    let parsed: any;
-    try {
-      parsed = JSON.parse(rawText);
-    } catch {
-      const objMatch = rawText.match(/\{[\s\S]*\}/);
-      if (objMatch) {
-        parsed = JSON.parse(objMatch[0]);
-      } else {
-        return NextResponse.json({ error: "Could not parse AI response" }, { status: 502 });
-      }
+    const parsed = extractJsonObject<any>(rawText);
+    if (!parsed) {
+      return NextResponse.json({ error: "Could not parse AI response" }, { status: 502 });
     }
 
     // Only trust IDs that were actually submitted — the model (or an injected

--- a/src/app/api/rooms/[id]/ai-furnish/route.ts
+++ b/src/app/api/rooms/[id]/ai-furnish/route.ts
@@ -6,6 +6,7 @@ import { getAnthropicText } from "@/lib/anthropic";
 import { CABINETS, APPLIANCES, FIXTURES, LIGHTING, FURNITURE, getItemDef } from "@/lib/studio/catalog";
 import type { DesignDoc, PlacedItem, ApiRoomAsset } from "@/lib/studio/doc";
 import { newItemId, toApiPayload } from "@/lib/studio/doc";
+import { extractJsonObject } from "@/lib/ai-json";
 import { generateUsdzForRoom } from "@/lib/studio/usdz-generator";
 
 export const maxDuration = 120;
@@ -137,16 +138,9 @@ Return JSON in this exact shape:
         });
 
         const rawText = getAnthropicText(response.content).trim();
-        let parsed: { items: any[] };
-        try {
-            parsed = JSON.parse(rawText);
-        } catch {
-            const objMatch = rawText.match(/\{[\s\S]*\}/);
-            if (objMatch) {
-                parsed = JSON.parse(objMatch[0]);
-            } else {
-                throw new Error("Could not parse JSON from AI response");
-            }
+        const parsed = extractJsonObject<{ items: any[] }>(rawText);
+        if (!parsed) {
+            throw new Error("Could not parse JSON from AI response");
         }
 
         // Validate model output before it touches the database: only known

--- a/src/lib/ai-json.ts
+++ b/src/lib/ai-json.ts
@@ -1,0 +1,39 @@
+// Extract a single JSON object from an LLM text response. Models sometimes
+// wrap JSON in markdown fences or append prose (which can itself contain
+// braces), so a greedy first-{-to-last-} regex is not safe. Strategy:
+// 1. straight parse, 2. fenced ```json block, 3. string-aware balanced-brace
+// scan that stops at the FIRST complete top-level object.
+export function extractJsonObject<T = unknown>(raw: string): T | null {
+    const text = raw.trim();
+
+    try { return JSON.parse(text) as T; } catch { /* keep going */ }
+
+    const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+    if (fence) {
+        try { return JSON.parse(fence[1].trim()) as T; } catch { /* keep going */ }
+    }
+
+    const start = text.indexOf("{");
+    if (start === -1) return null;
+    let depth = 0;
+    let inStr = false;
+    let esc = false;
+    for (let i = start; i < text.length; i++) {
+        const ch = text[i];
+        if (inStr) {
+            if (esc) esc = false;
+            else if (ch === "\\") esc = true;
+            else if (ch === '"') inStr = false;
+            continue;
+        }
+        if (ch === '"') inStr = true;
+        else if (ch === "{") depth++;
+        else if (ch === "}") {
+            depth--;
+            if (depth === 0) {
+                try { return JSON.parse(text.slice(start, i + 1)) as T; } catch { return null; }
+            }
+        }
+    }
+    return null;
+}


### PR DESCRIPTION
Follow-up to #196, found by exercising AI Furnish live in the browser: the model wrapped its JSON with surrounding text and the greedy `/\{[\s\S]*\}/` fallback captured prose between braces → `SyntaxError: Unexpected non-whitespace character after JSON` → 500.

New `src/lib/ai-json.ts` `extractJsonObject()`: straight parse → fenced ```json block → string-aware balanced-brace scan that stops at the first complete top-level object. Adopted by `ai-furnish` and `assign-phases`.

**Live-verified**: after this fix (hot-reloaded in dev), AI Furnish placed 31 validated items into the sandbox demo room end-to-end — Claude call → parse → CAS save → USDZ export to the revision-specific storage path (172KB uploaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)