### PR TITLE
a11y+perf: consolidate bot PRs (ARIA labels + chart code-splitting)

### DIFF
--- a/src/app/leads/[id]/contracts/LeadContractsClient.tsx
+++ b/src/app/leads/[id]/contracts/LeadContractsClient.tsx
@@ -4,7 +4,19 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { createContractFromTemplate, createContractBlank, sendContractToClient, deleteContract, getContractSigningHistory, updateContract } from "@/lib/actions";
 import { toast } from "sonner";
-import { ContractWysiwygEditor } from "@/components/ContractWysiwygEditor";
+import dynamic from "next/dynamic";
+
+const ContractWysiwygEditor = dynamic(
+    () => import("@/components/ContractWysiwygEditor").then((m) => m.ContractWysiwygEditor),
+    {
+        ssr: false,
+        loading: () => (
+            <div className="h-96 w-full animate-pulse rounded-lg bg-slate-100 flex items-center justify-center text-slate-400 text-sm">
+                Loading editor tools...
+            </div>
+        ),
+    }
+);
 
 interface Template { id: string; name: string; type: string; }
 interface SigningRecord {

--- a/src/app/projects/ProjectsClient.tsx
+++ b/src/app/projects/ProjectsClient.tsx
@@ -232,10 +232,10 @@ export default function ProjectsClient({ projects: initialProjects, initialStatu
                 </div>
                 <div className="flex items-center gap-3">
                     <div className="flex bg-slate-100 rounded-lg p-1 border border-slate-200">
-                        <button onClick={() => setViewMode("list")} className={`p-1.5 rounded-md transition ${viewMode === "list" ? "bg-white shadow-sm text-slate-800" : "text-slate-400 hover:text-slate-600"}`}>
+                        <button onClick={() => setViewMode("list")} aria-label="List view" title="List view" className={`p-1.5 rounded-md transition ${viewMode === "list" ? "bg-white shadow-sm text-slate-800" : "text-slate-400 hover:text-slate-600"}`}>
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
                         </button>
-                        <button onClick={() => setViewMode("kanban")} className={`p-1.5 rounded-md transition ${viewMode === "kanban" ? "bg-white shadow-sm text-slate-800" : "text-slate-400 hover:text-slate-600"}`}>
+                        <button onClick={() => setViewMode("kanban")} aria-label="Kanban view" title="Kanban view" className={`p-1.5 rounded-md transition ${viewMode === "kanban" ? "bg-white shadow-sm text-slate-800" : "text-slate-400 hover:text-slate-600"}`}>
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
                         </button>
                     </div>

--- a/src/app/projects/ProjectsKanbanBoard.tsx
+++ b/src/app/projects/ProjectsKanbanBoard.tsx
@@ -61,7 +61,7 @@ export default function ProjectsKanbanBoard({ projects: initialProjects, statuse
                                     {status.label}
                                     <span className="text-slate-400 font-medium ml-1">({colProjects.length})</span>
                                 </h3>
-                                <button onClick={onCustomizeClick} className="text-slate-400 hover:text-slate-700 transition">
+                                <button onClick={onCustomizeClick} aria-label="Customize status" title="Customize status" className="text-slate-400 hover:text-slate-700 transition">
                                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>
                                 </button>
                             </div>
@@ -92,8 +92,10 @@ export default function ProjectsKanbanBoard({ projects: initialProjects, statuse
                                                                 <div className="font-bold text-slate-800 mb-0.5 hover:text-indigo-600 transition-colors text-[15px] leading-tight line-clamp-2">
                                                                     {project.name}
                                                                 </div>
-                                                                <button 
+                                                                <button
                                                                     onClick={(e) => { e.preventDefault(); e.stopPropagation(); /* Future menu logic */ }}
+                                                                    aria-label="Project actions"
+                                                                    title="Project actions"
                                                                     className="text-slate-300 hover:text-slate-600 opacity-0 group-hover:opacity-100 transition-opacity p-1 -mt-1 -mr-1 rounded shrink-0"
                                                                 >
                                                                     <svg width="18" height="18" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="2"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>

--- a/src/app/projects/StatusModals.tsx
+++ b/src/app/projects/StatusModals.tsx
@@ -42,7 +42,7 @@ export function CustomizeStatusModal({ statuses, onClose, onSave, onManageClick 
             <div className="bg-white rounded-xl shadow-2xl w-full max-w-sm overflow-hidden flex flex-col">
                 <div className="flex items-center justify-between p-4 border-b border-slate-100">
                     <h2 className="text-xl font-bold text-slate-800">Customize</h2>
-                    <button onClick={onClose} className="text-slate-400 hover:text-slate-600">
+                    <button onClick={onClose} aria-label="Close" title="Close" className="text-slate-400 hover:text-slate-600">
                         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
                     </button>
                 </div>
@@ -142,7 +142,7 @@ export function ManageStatusModal({ statuses, onClose, onSave }: ManageStatusMod
             <div className="bg-white rounded-xl shadow-2xl w-full max-w-sm overflow-hidden flex flex-col">
                 <div className="flex items-center justify-between p-4 border-b border-slate-100">
                     <h2 className="text-xl font-bold text-slate-800">Manage Project Status</h2>
-                    <button onClick={onClose} className="text-slate-400 hover:text-slate-600">
+                    <button onClick={onClose} aria-label="Close" title="Close" className="text-slate-400 hover:text-slate-600">
                         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
                     </button>
                 </div>
@@ -152,18 +152,19 @@ export function ManageStatusModal({ statuses, onClose, onSave }: ManageStatusMod
                         <div key={status.value} className="group flex items-center justify-between p-2 rounded-lg hover:bg-slate-50 border-b border-slate-100 last:border-0 min-h-[44px]">
                             {editingValue === status.value ? (
                                 <div className="flex items-center gap-2 w-full animate-in fade-in">
-                                    <input 
+                                    <input
                                         autoFocus
-                                        type="text" 
+                                        type="text"
                                         value={editLabel}
                                         onChange={e => setEditLabel(e.target.value)}
-                                        className="hui-input flex-1 py-1 text-sm bg-white" 
+                                        aria-label="Edit status name"
+                                        className="hui-input flex-1 py-1 text-sm bg-white"
                                         onKeyDown={e => {
                                             if (e.key === 'Enter') handleEditSave(status.value);
                                             if (e.key === 'Escape') setEditingValue(null);
                                         }}
                                     />
-                                    <button onClick={() => handleEditSave(status.value)} className="text-sm font-semibold text-indigo-600 hover:text-indigo-800 shrink-0">Save</button>
+                                    <button onClick={() => handleEditSave(status.value)} aria-label="Save status" title="Save status" className="text-sm font-semibold text-indigo-600 hover:text-indigo-800 shrink-0">Save</button>
                                 </div>
                             ) : (
                                 <>
@@ -172,10 +173,10 @@ export function ManageStatusModal({ statuses, onClose, onSave }: ManageStatusMod
                                         <span className="text-sm text-slate-700 truncate">{status.label}</span>
                                     </div>
                                     <div className="flex items-center justify-end gap-2 opacity-0 group-hover:opacity-100 transition-opacity pl-2">
-                                        <button onClick={() => { setEditingValue(status.value); setEditLabel(status.label); }} className="text-slate-400 hover:text-indigo-600 p-1">
+                                        <button onClick={() => { setEditingValue(status.value); setEditLabel(status.label); }} aria-label="Edit status" title="Edit status" className="text-slate-400 hover:text-indigo-600 p-1">
                                             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                                         </button>
-                                        <button onClick={() => handleDelete(status.value)} className="text-slate-400 hover:text-red-500 p-1">
+                                        <button onClick={() => handleDelete(status.value)} aria-label="Delete status" title="Delete status" className="text-slate-400 hover:text-red-500 p-1">
                                             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M3 6h18M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
                                         </button>
                                     </div>
@@ -188,12 +189,13 @@ export function ManageStatusModal({ statuses, onClose, onSave }: ManageStatusMod
                 <div className="p-4 border-t border-slate-100 mt-2 bg-slate-50">
                     {isAdding ? (
                         <div className="flex items-center gap-2">
-                            <input 
+                            <input
                                 autoFocus
-                                type="text" 
+                                type="text"
                                 value={newStatusName}
                                 onChange={e => setNewStatusName(e.target.value)}
-                                className="hui-input flex-1 py-1.5 text-sm" 
+                                aria-label="New status name"
+                                className="hui-input flex-1 py-1.5 text-sm"
                                 placeholder="Status name"
                                 onKeyDown={e => e.key === 'Enter' && handleAdd()}
                             />

--- a/src/app/projects/[id]/financial-overview/components/financial-overview-content.tsx
+++ b/src/app/projects/[id]/financial-overview/components/financial-overview-content.tsx
@@ -4,7 +4,19 @@ import { useState, useEffect } from "react";
 import CashFlowCard from "./cash-flow-card";
 import IncomingPaymentsCard from "./incoming-payments-card";
 import OutgoingPaymentsCard from "./outgoing-payments-card";
-import CashFlowTrackerChart from "./cash-flow-tracker-chart";
+import dynamic from "next/dynamic";
+
+const CashFlowTrackerChart = dynamic(
+    () => import("./cash-flow-tracker-chart"),
+    {
+        ssr: false,
+        loading: () => (
+            <div className="h-80 w-full animate-pulse bg-slate-50 border border-slate-100 rounded-xl flex items-center justify-center text-slate-400 text-xs">
+                Loading financial tracker chart...
+            </div>
+        ),
+    }
+);
 import FinancialItemsSection from "./financial-items-section";
 
 // Basic switch replacement

--- a/src/components/ClientMessaging.tsx
+++ b/src/components/ClientMessaging.tsx
@@ -475,7 +475,7 @@ export default function ClientMessaging({
                                     return (
                                         <span key={email} className="bg-slate-100 text-slate-700 text-xs px-2 py-0.5 rounded-full flex items-center gap-1 border border-slate-200 shadow-sm">
                                             {tm ? tm.name : email}
-                                            <button type="button" onClick={(e) => { e.stopPropagation(); setCcEmails(prev => prev.filter(m => m !== email)); }} className="hover:text-red-500 ml-0.5">×</button>
+                                            <button type="button" aria-label="Remove email" onClick={(e) => { e.stopPropagation(); setCcEmails(prev => prev.filter(m => m !== email)); }} className="hover:text-red-500 ml-0.5">×</button>
                                         </span>
                                     );
                                 })}

--- a/src/components/CopyToProjectButton.tsx
+++ b/src/components/CopyToProjectButton.tsx
@@ -121,7 +121,7 @@ export function CopyToProjectModal(props: ModalProps) {
                         <p className="text-xs text-hui-textMuted mt-0.5">Copies all line items and payment schedule as a Draft.</p>
                     </div>
                     <button onClick={onClose} aria-label="Close modal" className="text-hui-textMuted hover:text-hui-textMain ml-4 shrink-0">
-                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
+                        <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
                     </button>
                 </div>
 
@@ -235,7 +235,7 @@ export default function CopyToProjectButton({
                 onClick={() => setOpen(true)}
                 className="text-slate-300 hover:text-slate-600 hover:bg-slate-100 rounded p-1.5 transition opacity-0 group-hover:opacity-100"
             >
-                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                     <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
                     <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
                 </svg>

--- a/src/components/DeleteEstimateButton.tsx
+++ b/src/components/DeleteEstimateButton.tsx
@@ -40,7 +40,7 @@ export default function DeleteEstimateButton({ estimateId, estimateTitle, status
                 onClick={() => setShowConfirm(true)}
                 className="text-slate-300 hover:text-red-500 hover:bg-red-50 rounded p-1.5 transition opacity-0 group-hover:opacity-100"
             >
-                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                     <polyline points="3 6 5 6 21 6" />
                     <path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6" />
                     <path d="M10 11v6M14 11v6" />

--- a/src/components/EntityContractsClient.tsx
+++ b/src/components/EntityContractsClient.tsx
@@ -10,9 +10,21 @@ import {
 } from "@/lib/actions";
 import { toast } from "sonner";
 import DOMPurify from "dompurify";
-import { ContractWysiwygEditor } from "@/components/ContractWysiwygEditor";
+import dynamic from "next/dynamic";
 import { CONTRACT_PROSE_CLASSES } from "@/lib/contract-styles";
 import DocumentSignModal from "@/components/DocumentSignModal";
+
+const ContractWysiwygEditor = dynamic(
+    () => import("@/components/ContractWysiwygEditor").then((m) => m.ContractWysiwygEditor),
+    {
+        ssr: false,
+        loading: () => (
+            <div className="h-96 w-full animate-pulse rounded-lg bg-slate-100 flex items-center justify-center text-slate-400 text-sm">
+                Loading editor tools...
+            </div>
+        ),
+    }
+);
 
 interface Template { id: string; name: string; type: string; }
 interface SigningRecord {
@@ -773,7 +785,7 @@ export default function EntityContractsClient({
                                     <span className="text-xl">✨</span>
                                     <h2 className="font-bold text-hui-textMain text-lg">AI Drafted Contract</h2>
                                 </div>
-                                <button onClick={() => setShowDraftPanel(false)} className="text-hui-textMuted hover:text-hui-textMain">
+                                <button aria-label="Close" onClick={() => setShowDraftPanel(false)} className="text-hui-textMuted hover:text-hui-textMain">
                                     <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
                                 </button>
                             </div>
@@ -909,7 +921,7 @@ export default function EntityContractsClient({
                     <div className="bg-white rounded-xl shadow-2xl max-w-lg w-full max-h-[80vh] flex flex-col overflow-hidden" onClick={e => e.stopPropagation()}>
                         <div className="px-6 pt-6 pb-4 border-b border-slate-200 flex items-center justify-between">
                             <h2 className="text-xl font-bold text-slate-800">Choose Template</h2>
-                            <button onClick={() => setShowTemplateModal(false)} className="text-slate-400 hover:text-slate-600 transition text-xl leading-none">×</button>
+                            <button aria-label="Close" onClick={() => setShowTemplateModal(false)} className="text-slate-400 hover:text-slate-600 transition text-xl leading-none">×</button>
                         </div>
                         <div className="px-6 py-4 flex items-center justify-between gap-4 border-b border-slate-100">
                             <div>
@@ -990,7 +1002,7 @@ export default function EntityContractsClient({
                     <div className="bg-white rounded-xl shadow-2xl max-w-lg w-full p-6 max-h-[80vh] overflow-hidden flex flex-col">
                         <div className="flex items-center justify-between mb-4">
                             <h3 className="text-lg font-bold text-hui-textMain">Signing History</h3>
-                            <button onClick={() => setHistoryModal(null)} className="text-slate-400 hover:text-slate-600 text-xl">&times;</button>
+                            <button aria-label="Close" onClick={() => setHistoryModal(null)} className="text-slate-400 hover:text-slate-600 text-xl">&times;</button>
                         </div>
                         <div className="flex-1 overflow-y-auto">
                             {loadingHistory ? (

--- a/src/components/FileBrowser.tsx
+++ b/src/components/FileBrowser.tsx
@@ -396,6 +396,7 @@ export default function FileBrowser({
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                     <button
+                        aria-label="More options"
                         className={`p-1.5 rounded-md text-slate-400 hover:text-slate-700 hover:bg-slate-100 transition ${HOVER_REVEAL}`}
                         onClick={e => e.stopPropagation()}
                     >
@@ -462,6 +463,7 @@ export default function FileBrowser({
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                     <button
+                        aria-label="More options"
                         className={`p-1 rounded-md text-slate-400 hover:text-slate-700 hover:bg-slate-100 transition ${HOVER_REVEAL}`}
                         onClick={e => e.stopPropagation()}
                     >
@@ -573,10 +575,10 @@ export default function FileBrowser({
                 </div>
                 <div className="flex items-center gap-2">
                     <div className="flex items-center gap-1 bg-slate-100 p-1 rounded-lg">
-                        <button onClick={() => setViewMode("grid")} className={`p-1.5 rounded-md transition ${viewMode === "grid" ? "bg-white shadow-sm" : "text-slate-400 hover:text-slate-600"}`}>
+                        <button onClick={() => setViewMode("grid")} aria-label="Grid view" className={`p-1.5 rounded-md transition ${viewMode === "grid" ? "bg-white shadow-sm" : "text-slate-400 hover:text-slate-600"}`}>
                             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
                         </button>
-                        <button onClick={() => setViewMode("list")} className={`p-1.5 rounded-md transition ${viewMode === "list" ? "bg-white shadow-sm" : "text-slate-400 hover:text-slate-600"}`}>
+                        <button onClick={() => setViewMode("list")} aria-label="List view" className={`p-1.5 rounded-md transition ${viewMode === "list" ? "bg-white shadow-sm" : "text-slate-400 hover:text-slate-600"}`}>
                             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/></svg>
                         </button>
                     </div>
@@ -806,7 +808,7 @@ export default function FileBrowser({
                     <div className="bg-white rounded-2xl shadow-2xl w-96 max-h-[60vh] flex flex-col" onClick={e => e.stopPropagation()}>
                         <div className="p-5 border-b border-slate-200 flex items-center justify-between">
                             <h3 className="font-bold text-hui-textMain">Move to Folder</h3>
-                            <button onClick={() => setMoveFileId(null)} className="text-slate-400 hover:text-slate-600 transition">
+                            <button onClick={() => setMoveFileId(null)} aria-label="Close move file modal" className="text-slate-400 hover:text-slate-600 transition">
                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6 6 18M6 6l12 12"/></svg>
                             </button>
                         </div>
@@ -852,7 +854,7 @@ export default function FileBrowser({
                         <img src={previewFile.url} alt={previewFile.name} className="max-w-full max-h-[80vh] rounded-xl shadow-2xl" />
                         <div className="absolute -top-10 right-0 flex items-center gap-3">
                             <p className="text-white text-sm font-medium">{previewFile.name}</p>
-                            <button onClick={() => setPreviewFile(null)} className="text-white/70 hover:text-white transition">
+                            <button onClick={() => setPreviewFile(null)} aria-label="Close file preview" className="text-white/70 hover:text-white transition">
                                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6 6 18M6 6l12 12"/></svg>
                             </button>
                         </div>

--- a/src/components/HelpChatWidget.tsx
+++ b/src/components/HelpChatWidget.tsx
@@ -250,10 +250,10 @@ export default function HelpChatWidget({ userRole }: { userId?: string; userRole
                 <button onClick={() => { setTab("history"); setHistoryMode("archived"); }} className={`px-2 py-1 rounded ${tab === "history" ? "bg-white/30 font-medium" : ""}`}>History</button>
                 {effectiveIsAdmin && <button onClick={() => setTab("requests")} className={`px-2 py-1 rounded ${tab === "requests" ? "bg-white/30 font-medium" : ""}`}>Requests</button>}
               </div>
-              <button onClick={() => { setMessages([]); setConversationId(null); }} className="text-white/80 hover:text-white ml-1" title="New conversation">
+              <button onClick={() => { setMessages([]); setConversationId(null); }} className="text-white/80 hover:text-white ml-1" title="New conversation" aria-label="New conversation">
                 <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 20h9" /><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" /></svg>
               </button>
-              <button onClick={() => setOpen(false)} className="text-white/80 hover:text-white">
+              <button onClick={() => setOpen(false)} className="text-white/80 hover:text-white" aria-label="Close help chat">
                 <svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
               </button>
             </div>

--- a/src/components/ProjectChat.tsx
+++ b/src/components/ProjectChat.tsx
@@ -276,6 +276,7 @@ export default function ProjectChat({
                     <button
                         onClick={handleSend}
                         disabled={!newMessage.trim() || sending}
+                        aria-label="Send message"
                         className={`hui-btn shrink-0 h-10 w-10 flex items-center justify-center rounded-lg transition-all ${
                             newMessage.trim() && !sending
                                 ? "hui-btn-green"

--- a/src/components/SendEstimateModal.tsx
+++ b/src/components/SendEstimateModal.tsx
@@ -168,7 +168,7 @@ export default function SendEstimateModal({ estimateId, clientEmail, onClose }: 
                         <h2 className="text-lg font-bold text-hui-textMain">Send Estimate to Client</h2>
                         <p className="text-xs text-hui-textMuted mt-0.5">The client will receive an email with a link to view and sign.</p>
                     </div>
-                    <button onClick={onClose} className="text-hui-textMuted hover:text-hui-textMain transition">
+                    <button onClick={onClose} aria-label="Close" className="text-hui-textMuted hover:text-hui-textMain transition">
                         <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
                     </button>
                 </div>

--- a/src/components/SendInvoiceModal.tsx
+++ b/src/components/SendInvoiceModal.tsx
@@ -33,7 +33,7 @@ export default function SendInvoiceModal({ invoiceId, clientEmail, onClose }: { 
                         <h2 className="text-lg font-bold text-hui-textMain">Send Invoice to Client</h2>
                         <p className="text-xs text-hui-textMuted mt-0.5">The client will receive an email with a link to view and pay online.</p>
                     </div>
-                    <button onClick={onClose} className="text-hui-textMuted hover:text-hui-textMain transition">
+                    <button onClick={onClose} aria-label="Close" className="text-hui-textMuted hover:text-hui-textMain transition">
                         <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
                     </button>
                 </div>


### PR DESCRIPTION
## Summary

Salvages the valid `src/**` changes from 8 closed/stale bot PRs (Palette/Bolt/Jules bots) that had gone stale and been auto-closed. Excludes all `.Jules/*.md`, `.jules/*.md`, lockfile, screenshot, and bench-script noise those PRs also carried.

**Source PRs consolidated:** #106, #108, #118, #119, #121, #122, #123, #125

### ARIA-label additions (a11y)
Icon-only buttons (modal close `×`/svg-X, send buttons, view toggles, per-row action buttons) were missing accessible names for screen readers. Added `aria-label` (and `aria-hidden="true"` on purely decorative icon svgs where the source PR included it) across:

- `src/components/ClientMessaging.tsx` — CC-chip remove button
- `src/components/EntityContractsClient.tsx` — draft panel / template modal / signing history modal close buttons
- `src/components/CopyToProjectButton.tsx` — modal close svg + trigger button svg (`aria-hidden`)
- `src/components/DeleteEstimateButton.tsx` — trash icon svg (`aria-hidden`)
- `src/components/SendEstimateModal.tsx`, `src/components/SendInvoiceModal.tsx` — close buttons
- `src/components/ProjectChat.tsx` — send button
- `src/components/FileBrowser.tsx` — "more options" triggers, grid/list view toggles, move-folder modal close, file preview close
- `src/components/HelpChatWidget.tsx` — new-conversation and close buttons
- `src/app/projects/ProjectsClient.tsx` — list/kanban view toggle
- `src/app/projects/ProjectsKanbanBoard.tsx` — customize-status button, project actions button
- `src/app/projects/StatusModals.tsx` — close buttons, edit/save/delete status buttons, status name inputs

**Dedup note:** #119/#108 overlapped heavily with #122/#125 on the same buttons (`CopyToProjectButton.tsx`, `DeleteEstimateButton.tsx`, `EntityContractsClient.tsx`). Each label was applied once, preferring the more complete version where one PR also added `aria-hidden="true"` to decorative svgs.

**Already fixed on main:** Several target buttons (`ClientMessaging.tsx` preview close, `CopyToProjectButton.tsx` labels, `DeleteEstimateButton.tsx` label, `DocumentSignModal.tsx` close) already carry equivalent `aria-label`s from other work that landed on main since these bot PRs went stale — those specific hunks were skipped rather than overwritten, since the a11y goal is already met there.

### Perf: code-splitting (#121)
Heavy Tiptap editor and Recharts chart deps were statically imported into client components, bloating the initial bundle. Converted to `next/dynamic` (`ssr: false`) with pulse-skeleton loading states:

- `src/app/leads/[id]/contracts/LeadContractsClient.tsx` — `ContractWysiwygEditor`
- `src/components/EntityContractsClient.tsx` — `ContractWysiwygEditor`
- `src/app/projects/[id]/financial-overview/components/financial-overview-content.tsx` — `CashFlowTrackerChart`

All three hunks applied cleanly against current code — no redesign needed.

### Skipped entirely
- `src/components/room-designer/**` references — that module no longer exists in this codebase.
- All `.Jules/*.md` / `.jules/*.md` bot-learning notes, lockfiles, screenshots, bench scripts from every source PR.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` passes with no errors (via temporary node_modules junction to an existing install)
- [ ] CI build/lint
- [ ] Manual click-through: modal close buttons, view toggles, status edit row, contract editor lazy-load, financial overview chart lazy-load

🤖 Generated with [Claude Code](https://claude.com/claude-code)