### PR TITLE
feat(schedule): export Gantt to .ics calendar

### DIFF
--- a/src/app/api/calendar/sync/route.ts
+++ b/src/app/api/calendar/sync/route.ts
@@ -1,19 +1,49 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { authenticateMobileOrSession, assertProjectAccess } from "@/lib/mobile-auth";
+
+export const dynamic = "force-dynamic";
 
 function escapeIcal(str: string): string {
     return str.replace(/\\/g, "\\\\").replace(/;/g, "\\;").replace(/,/g, "\\,").replace(/\n/g, "\\n");
 }
 
-function formatIcalDate(date: Date): string {
+// Full UTC datetime, e.g. 20260717T000000Z — used for regular (non all-day) tasks.
+function formatIcalDateTime(date: Date): string {
     return date.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}/, "");
 }
 
+// Date-only, e.g. 20260717 — used for all-day (milestone) VEVENTs.
+// Reads UTC calendar components directly so a date stored as a UTC-midnight
+// DateTime renders as the same calendar day, regardless of server timezone.
+function formatIcalDateOnly(date: Date): string {
+    const y = date.getUTCFullYear();
+    const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+    const d = String(date.getUTCDate()).padStart(2, "0");
+    return `${y}${m}${d}`;
+}
+
+function addUTCDays(date: Date, days: number): Date {
+    const d = new Date(date.getTime());
+    d.setUTCDate(d.getUTCDate() + days);
+    return d;
+}
+
+function isSameUTCDay(a: Date, b: Date): boolean {
+    return a.getUTCFullYear() === b.getUTCFullYear() && a.getUTCMonth() === b.getUTCMonth() && a.getUTCDate() === b.getUTCDate();
+}
+
 export async function GET(req: NextRequest) {
+    const auth = await authenticateMobileOrSession(req);
+    if (!auth.ok) return NextResponse.json({ error: auth.error }, { status: auth.status });
+
     const projectId = req.nextUrl.searchParams.get("projectId");
     if (!projectId) {
         return NextResponse.json({ error: "projectId is required" }, { status: 400 });
     }
+
+    const fail = await assertProjectAccess(auth.user, projectId);
+    if (fail) return fail;
 
     const project = await prisma.project.findUnique({
         where: { id: projectId },
@@ -38,12 +68,12 @@ export async function GET(req: NextRequest) {
         },
     });
 
-    const now = formatIcalDate(new Date());
+    const now = formatIcalDateTime(new Date());
     const calName = escapeIcal(`${project.name} — Schedule`);
 
     const events = tasks.map((task) => {
-        const start = formatIcalDate(new Date(task.startDate));
-        const end = formatIcalDate(new Date(task.endDate));
+        const start = new Date(task.startDate);
+        const end = new Date(task.endDate);
         const summary = escapeIcal(task.name);
         const desc = escapeIcal(
             [
@@ -56,12 +86,27 @@ export async function GET(req: NextRequest) {
                 .join("\\n")
         );
 
+        // Milestones and zero/one-day tasks render as all-day events so they
+        // land on the correct calendar day instead of a timed midnight block.
+        const isAllDay = task.type === "milestone" || isSameUTCDay(start, end);
+
+        const dtLines = isAllDay
+            ? [
+                  `DTSTART;VALUE=DATE:${formatIcalDateOnly(start)}`,
+                  // All-day DTEND is exclusive per RFC 5545, so a one-day event's
+                  // end is the day after its start.
+                  `DTEND;VALUE=DATE:${formatIcalDateOnly(addUTCDays(start, 1))}`,
+              ]
+            : [
+                  `DTSTART:${formatIcalDateTime(start)}`,
+                  `DTEND:${formatIcalDateTime(end)}`,
+              ];
+
         return [
             "BEGIN:VEVENT",
             `UID:${task.id}@probuild`,
             `DTSTAMP:${now}`,
-            `DTSTART:${start}`,
-            `DTEND:${end}`,
+            ...dtLines,
             `SUMMARY:${summary}`,
             `DESCRIPTION:${desc}`,
             `STATUS:${task.status === "Complete" ? "COMPLETED" : "CONFIRMED"}`,
@@ -80,7 +125,8 @@ export async function GET(req: NextRequest) {
         "END:VCALENDAR",
     ].join("\r\n");
 
-    const filename = `${project.name.replace(/[^a-zA-Z0-9]/g, "_")}_schedule.ics`;
+    const slug = project.name.trim().replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+    const filename = `${slug}-schedule.ics`;
 
     return new NextResponse(ical, {
         status: 200,


### PR DESCRIPTION
## Summary

The Gantt's "Sync to Calendar" toolbar action and its `/api/calendar/sync` route already existed in the codebase (shipped PR #11, then carried through the May toolbar consolidation into `ScheduleToolbar.tsx`'s Tools menu). This PR closes the two real gaps against the .ics export spec:

- **Auth**: the route had no session check at all — any authenticated-or-not caller with a `projectId` could pull a project's full schedule. Gated it with `authenticateMobileOrSession` + `assertProjectAccess`, the same pattern used by other `/api/projects/[id]/*` GET routes (e.g. `estimates/route.ts`).
- **All-day/timezone correctness**: every task, including milestones, was emitted as a timed `DTSTART`/`DTEND` VEVENT anchored at UTC midnight. Milestones and same-day tasks now render as `VALUE=DATE` all-day events with an RFC 5545 exclusive `DTEND` (start day + 1), reading UTC calendar components so a UTC-midnight-stored date lands on the correct day regardless of server timezone — verified with a standalone script (`2026-07-17T00:00:00Z` → `DTSTART;VALUE=DATE:20260717` / `DTEND;VALUE=DATE:20260718`).
- Also fixed the download filename to the spec'd `<project-name>-schedule.ics` (was `<project>_schedule.ics`).

No changes were needed in `GanttChart.tsx` — the "Sync to Calendar" action, wiring, and download trigger (`useScheduleActions.ts` → `handleSyncCalendar`) were already fully implemented; adding a second button would have duplicated existing UI.

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] Verified all-day date math with a standalone Node script (no off-by-one)
- [ ] Manually export a project's schedule and import the `.ics` into Google/Apple Calendar to confirm milestone dates and multi-day task spans render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)