### PR TITLE
feat(money): automated client payment reminders (rebuild of #28)

### DIFF
--- a/migrations/payment_reminders.sql
+++ b/migrations/payment_reminders.sql
@@ -1,0 +1,22 @@
+-- Payment reminders: additive columns only, no data loss.
+-- Project.paymentRemindersEnabled — per-project opt-out of the automated reminder cron.
+-- PaymentSchedule.lastReminderAt — throttle guard so a milestone gets at most ~1 reminder/week.
+
+BEGIN;
+
+ALTER TABLE "Project" ADD COLUMN IF NOT EXISTS "paymentRemindersEnabled" BOOLEAN NOT NULL DEFAULT true;
+
+ALTER TABLE "PaymentSchedule" ADD COLUMN IF NOT EXISTS "lastReminderAt" TIMESTAMPTZ;
+
+-- Verify
+SELECT
+  COUNT(*) FILTER (WHERE "paymentRemindersEnabled") AS reminders_enabled,
+  COUNT(*)                                           AS total
+FROM "Project";
+
+SELECT
+  COUNT(*) FILTER (WHERE "lastReminderAt" IS NOT NULL) AS with_last_reminder,
+  COUNT(*)                                              AS total
+FROM "PaymentSchedule";
+
+COMMIT;

--- a/migrations/payment_reminders.sql
+++ b/migrations/payment_reminders.sql
@@ -1,10 +1,13 @@
 -- Payment reminders: additive columns only, no data loss.
--- Project.paymentRemindersEnabled — per-project opt-out of the automated reminder cron.
+-- Project.paymentRemindersEnabled — per-project OPT-IN for the automated reminder cron.
+-- Defaults to false for both new and existing rows: reminders only start firing once
+-- someone explicitly flips the "Payment Reminders" toggle on a project's Client
+-- Dashboard settings page (/projects/[id]/client-portal).
 -- PaymentSchedule.lastReminderAt — throttle guard so a milestone gets at most ~1 reminder/week.
 
 BEGIN;
 
-ALTER TABLE "Project" ADD COLUMN IF NOT EXISTS "paymentRemindersEnabled" BOOLEAN NOT NULL DEFAULT true;
+ALTER TABLE "Project" ADD COLUMN IF NOT EXISTS "paymentRemindersEnabled" BOOLEAN NOT NULL DEFAULT false;
 
 ALTER TABLE "PaymentSchedule" ADD COLUMN IF NOT EXISTS "lastReminderAt" TIMESTAMPTZ;
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -224,6 +224,7 @@ model Project {
   code                String?
   tags                String?
   color               String?                      @default("#3b82f6") // Added color field
+  paymentRemindersEnabled Boolean                  @default(true) // Settings → Client Dashboard: send automated payment-due reminder emails to the client
   managerId           String?
   manager             User?                        @relation("ProjectManager", fields: [managerId], references: [id])
   estimates           Estimate[]
@@ -544,6 +545,7 @@ model PaymentSchedule {
   referenceNumber       String? // check # / confirmation #
   notes                 String? // free-form memo
   receiptSentAt         DateTime? // last time admin sent the receipt email
+  lastReminderAt        DateTime? // last time the automated payment-reminder cron emailed the client for this milestone
   paidAt                DateTime?
   createdAt             DateTime  @default(now())
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -224,7 +224,7 @@ model Project {
   code                String?
   tags                String?
   color               String?                      @default("#3b82f6") // Added color field
-  paymentRemindersEnabled Boolean                  @default(true) // Settings → Client Dashboard: send automated payment-due reminder emails to the client
+  paymentRemindersEnabled Boolean                  @default(false) // Settings → Client Dashboard: send automated payment-due reminder emails to the client. Opt-in — off by default, enabled per project.
   managerId           String?
   manager             User?                        @relation("ProjectManager", fields: [managerId], references: [id])
   estimates           Estimate[]

--- a/src/app/api/cron/payment-reminders/route.ts
+++ b/src/app/api/cron/payment-reminders/route.ts
@@ -11,8 +11,12 @@ export const maxDuration = 60;
  * milestone is claimed before it's sent, so overlapping/retried runs can't
  * double-send.
  *
- * ?dryRun=1 (or PAYMENT_REMINDERS_DRY_RUN=1) runs the full selection and
- * reports what would happen without sending any email or writing lastReminderAt.
+ * ?dryRun=1 runs the full selection and reports what would happen without sending any
+ * email or writing lastReminderAt. PAYMENT_REMINDERS_DRY_RUN=1 is the operational kill
+ * switch — it FORCES dry-run regardless of this query param (precedence is enforced in
+ * sendPaymentReminders, not here): when that env var is set, ?dryRun=0 cannot turn
+ * sending back on. Absent the env var, this query param can only turn dry-run on, never
+ * off — omitting it defaults to a real (non-dry) run.
  */
 export async function GET(request: Request) {
     // Any deployed environment (production or preview) requires the cron secret,

--- a/src/app/api/cron/payment-reminders/route.ts
+++ b/src/app/api/cron/payment-reminders/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { sendPaymentReminders } from "@/lib/payment-reminders";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+/**
+ * Daily client payment-reminder sweep: emails clients about payment-schedule
+ * milestones due soon or recently overdue (see sendPaymentReminders for the
+ * exact selection/throttle rules). Idempotent and safe on retries — each
+ * milestone is sent+updated independently.
+ */
+export async function GET(request: Request) {
+    // Any deployed environment (production or preview) requires the cron secret,
+    // and fails closed if CRON_SECRET is unset. Only local dev skips the check.
+    const authHeader = request.headers.get("authorization");
+    if (process.env.VERCEL_ENV && (!process.env.CRON_SECRET || authHeader !== `Bearer ${process.env.CRON_SECRET}`)) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const result = await sendPaymentReminders();
+    console.log("[cron/payment-reminders]", JSON.stringify(result));
+    return NextResponse.json(result);
+}

--- a/src/app/api/cron/payment-reminders/route.ts
+++ b/src/app/api/cron/payment-reminders/route.ts
@@ -8,7 +8,11 @@ export const maxDuration = 60;
  * Daily client payment-reminder sweep: emails clients about payment-schedule
  * milestones due soon or recently overdue (see sendPaymentReminders for the
  * exact selection/throttle rules). Idempotent and safe on retries — each
- * milestone is sent+updated independently.
+ * milestone is claimed before it's sent, so overlapping/retried runs can't
+ * double-send.
+ *
+ * ?dryRun=1 (or PAYMENT_REMINDERS_DRY_RUN=1) runs the full selection and
+ * reports what would happen without sending any email or writing lastReminderAt.
  */
 export async function GET(request: Request) {
     // Any deployed environment (production or preview) requires the cron secret,
@@ -18,7 +22,11 @@ export async function GET(request: Request) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const result = await sendPaymentReminders();
+    const { searchParams } = new URL(request.url);
+    const dryRunParam = searchParams.get("dryRun");
+    const dryRun = dryRunParam === null ? undefined : dryRunParam === "1" || dryRunParam === "true";
+
+    const result = await sendPaymentReminders({ dryRun });
     console.log("[cron/payment-reminders]", JSON.stringify(result));
     return NextResponse.json(result);
 }

--- a/src/app/projects/[id]/client-portal/page.tsx
+++ b/src/app/projects/[id]/client-portal/page.tsx
@@ -46,7 +46,7 @@ export default async function ClientPortalPage({ params }: Props) {
         showFiles: visibility?.showFiles ?? false,
         showDailyLogs: visibility?.showDailyLogs ?? false,
         showMessages: visibility?.showMessages ?? true,
-        paymentRemindersEnabled: project.paymentRemindersEnabled ?? true,
+        paymentRemindersEnabled: project.paymentRemindersEnabled ?? false,
         lastSharedAt: visibility?.lastSharedAt ?? null,
         lastShareEmailId: visibility?.lastShareEmailId ?? null,
         lastShareEmailStatus: visibility?.lastShareEmailStatus ?? null,

--- a/src/app/projects/[id]/client-portal/page.tsx
+++ b/src/app/projects/[id]/client-portal/page.tsx
@@ -46,6 +46,7 @@ export default async function ClientPortalPage({ params }: Props) {
         showFiles: visibility?.showFiles ?? false,
         showDailyLogs: visibility?.showDailyLogs ?? false,
         showMessages: visibility?.showMessages ?? true,
+        paymentRemindersEnabled: project.paymentRemindersEnabled ?? true,
         lastSharedAt: visibility?.lastSharedAt ?? null,
         lastShareEmailId: visibility?.lastShareEmailId ?? null,
         lastShareEmailStatus: visibility?.lastShareEmailStatus ?? null,

--- a/src/app/projects/[id]/settings/PortalVisibilityToggles.tsx
+++ b/src/app/projects/[id]/settings/PortalVisibilityToggles.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { savePortalVisibility } from "@/lib/actions";
+import { toast } from "sonner";
+import { savePortalVisibility, setPaymentRemindersEnabled } from "@/lib/actions";
 
 type VisibilityState = {
     showSchedule: boolean;
@@ -14,6 +15,7 @@ type VisibilityState = {
     showSelections?: boolean;
     showMoodBoards?: boolean;
     isPortalEnabled: boolean;
+    paymentRemindersEnabled: boolean;
     lastSharedAt?: Date | null;
     lastShareEmailId?: string | null;
     lastShareEmailStatus?: string | null;
@@ -29,6 +31,7 @@ const TOGGLE_CONFIG: { key: keyof VisibilityState; label: string; description: s
     { key: "showFiles", label: "Files & Documents", description: "Client can browse project files and documents" },
     { key: "showDailyLogs", label: "Daily Logs", description: "Client can view daily project logs and notes" },
     { key: "showMessages", label: "Messages", description: "Client can send and receive messages" },
+    { key: "paymentRemindersEnabled", label: "Payment Reminders", description: "Automatically email the client when a payment is due soon or overdue" },
 ];
 
 export default function PortalVisibilityToggles({
@@ -40,7 +43,6 @@ export default function PortalVisibilityToggles({
 }) {
     const [state, setState] = useState<VisibilityState>(initialState);
     const [isPending, startTransition] = useTransition();
-    const [message, setMessage] = useState("");
 
     const handleToggle = (key: keyof VisibilityState) => {
         setState((prev) => ({ ...prev, [key]: !prev[key] }));
@@ -49,12 +51,13 @@ export default function PortalVisibilityToggles({
     const handleSave = () => {
         startTransition(async () => {
             try {
-                await savePortalVisibility(projectId, state);
-                setMessage("Visibility settings saved!");
-                setTimeout(() => setMessage(""), 3000);
+                await Promise.all([
+                    savePortalVisibility(projectId, state),
+                    setPaymentRemindersEnabled(projectId, state.paymentRemindersEnabled),
+                ]);
+                toast.success("Visibility settings saved!");
             } catch {
-                setMessage("Failed to save settings");
-                setTimeout(() => setMessage(""), 3000);
+                toast.error("Failed to save settings");
             }
         });
     };
@@ -126,17 +129,6 @@ export default function PortalVisibilityToggles({
                 >
                     {isPending ? "Saving..." : "Save Settings"}
                 </button>
-                {message && (
-                    <span
-                        className={`text-sm font-medium ${
-                            message.includes("saved")
-                                ? "text-green-600"
-                                : "text-red-600"
-                        }`}
-                    >
-                        {message}
-                    </span>
-                )}
             </div>
         </div>
     );

--- a/src/app/projects/[id]/settings/PortalVisibilityToggles.tsx
+++ b/src/app/projects/[id]/settings/PortalVisibilityToggles.tsx
@@ -51,10 +51,20 @@ export default function PortalVisibilityToggles({
     const handleSave = () => {
         startTransition(async () => {
             try {
-                await Promise.all([
-                    savePortalVisibility(projectId, state),
-                    setPaymentRemindersEnabled(projectId, state.paymentRemindersEnabled),
-                ]);
+                // Sequential, not Promise.all: setPaymentRemindersEnabled returns
+                // { success, error } rather than throwing, so a parallel call could
+                // silently report "saved" even when the permission check failed. Check
+                // each result.
+                const visResult = await savePortalVisibility(projectId, state);
+                if (!visResult?.success) {
+                    toast.error("Failed to save visibility settings");
+                    return;
+                }
+                const remindersResult = await setPaymentRemindersEnabled(projectId, state.paymentRemindersEnabled);
+                if (!remindersResult?.success) {
+                    toast.error(remindersResult?.error || "Failed to save payment reminders setting");
+                    return;
+                }
                 toast.success("Visibility settings saved!");
             } catch {
                 toast.error("Failed to save settings");

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -7195,6 +7195,16 @@ export async function savePortalVisibility(projectId: string, data: {
     return { success: true };
 }
 
+export async function setPaymentRemindersEnabled(projectId: string, enabled: boolean) {
+    await prisma.project.update({
+        where: { id: projectId },
+        data: { paymentRemindersEnabled: enabled },
+    });
+    revalidatePath(`/projects/${projectId}/client-portal`);
+    revalidatePath(`/projects/${projectId}/settings`);
+    return { success: true };
+}
+
 // =============================================
 // Portal Dashboard Shared Actions
 // =============================================

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -12,7 +12,7 @@ import { formatCurrency } from "./utils";
 import { createHmac, timingSafeEqual } from "crypto";
 import { resolveSessionClientId } from "./portal-auth";
 import { persistSignature } from "./signature-storage";
-import { getCurrentUserWithPermissions, hasPermission } from "./permissions";
+import { getCurrentUserWithPermissions, hasPermission, canAccessProject } from "./permissions";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { enqueueMilestonePaid, drainPaymentNotifications } from "./payment-outbox";
 import { coLineCents } from "./co-tax";
@@ -7196,6 +7196,11 @@ export async function savePortalVisibility(projectId: string, data: {
 }
 
 export async function setPaymentRemindersEnabled(projectId: string, enabled: boolean) {
+    const user = await getCurrentUserWithPermissions();
+    if (!user) return { success: false, error: "Unauthorized" };
+    if (!hasPermission(user, "invoices")) return { success: false, error: "Forbidden" };
+    if (!canAccessProject(user, projectId)) return { success: false, error: "Forbidden" };
+
     await prisma.project.update({
         where: { id: projectId },
         data: { paymentRemindersEnabled: enabled },

--- a/src/lib/payment-reminders.ts
+++ b/src/lib/payment-reminders.ts
@@ -1,0 +1,188 @@
+import { prisma } from "@/lib/prisma";
+import { sendNotification } from "@/lib/email";
+import { formatCurrency } from "@/lib/utils";
+
+// Same writer as actions.ts's logActivity, but reached via a lazy dynamic import so this
+// module (imported by the cron route) never pulls in actions.ts's "use server"
+// surface — see billing-core.ts's logActivityLazy for the same convention.
+async function logActivityLazy(entry: Parameters<typeof import("./actions").logActivity>[0]) {
+    const { logActivity } = await import("./actions");
+    return logActivity(entry);
+}
+
+// Invoice statuses a client can actually see in the portal (mirrors the filter in
+// src/app/portal/page.tsx) — Draft/Paid/Canceled invoices never get a reminder.
+const CLIENT_VISIBLE_INVOICE_STATUSES = ["Issued", "Overdue", "Partially Paid"];
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const UPCOMING_WINDOW_DAYS = 3; // remind for milestones due within N days...
+const MAX_OVERDUE_DAYS = 60; // ...through N days overdue
+const THROTTLE_DAYS = 6; // at most ~1 reminder/week per milestone
+
+export type PaymentReminderResult = {
+    scanned: number;
+    sent: number;
+    skipped: number;
+    failed: number;
+    errors: string[];
+};
+
+function dueDateLabel(dueDate: Date, now: Date): string {
+    const daysUntil = Math.round((dueDate.getTime() - now.getTime()) / DAY_MS);
+    if (daysUntil > 1) return `due in ${daysUntil} days`;
+    if (daysUntil === 1) return "due tomorrow";
+    if (daysUntil === 0) return "due today";
+    const daysOverdue = Math.abs(daysUntil);
+    return `${daysOverdue} day${daysOverdue === 1 ? "" : "s"} overdue`;
+}
+
+function reminderEmailHtml(opts: {
+    clientName: string;
+    milestoneName: string;
+    invoiceCode: string;
+    amount: number | string | { toString(): string };
+    dueDate: Date;
+    now: Date;
+    payUrl: string;
+    companyName: string;
+    phone?: string | null;
+    email?: string | null;
+}) {
+    const { clientName, milestoneName, invoiceCode, amount, dueDate, now, payUrl, companyName, phone, email } = opts;
+    const isOverdue = dueDate.getTime() < now.getTime();
+    const dueLabel = dueDateLabel(dueDate, now);
+    return `<div style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:24px;">
+        <h2 style="color:${isOverdue ? "#b91c1c" : "#1e293b"};margin-bottom:8px;">Payment Reminder</h2>
+        <p>Hi ${clientName || "there"},</p>
+        <p>This is a reminder that <strong>${milestoneName}</strong> on Invoice #${invoiceCode} is <strong>${dueLabel}</strong>.</p>
+        <p>Amount due: <strong>${formatCurrency(amount)}</strong></p>
+        <p style="margin-top:24px;">
+            <a href="${payUrl}" style="background:#1e293b;color:white;padding:10px 20px;text-decoration:none;border-radius:6px;font-weight:600;">Pay Now</a>
+        </p>
+        <p style="color:#9ca3af;font-size:12px;margin-top:32px;">
+            ${companyName}${phone ? ` · ${phone}` : ""}${email ? ` · ${email}` : ""}
+        </p>
+    </div>`;
+}
+
+/**
+ * Daily sweep: email clients about payment-schedule milestones due soon or
+ * recently overdue. Selection rules (see migrations/payment_reminders.sql for the
+ * additive columns this depends on):
+ *   - PaymentSchedule.status === "Pending", dueDate set, due within the next 3
+ *     days through 60 days overdue.
+ *   - Invoice.status is one the client can actually see in the portal (Issued,
+ *     Overdue, Partially Paid) — never Draft/Paid/Canceled.
+ *   - Project.paymentRemindersEnabled is true (Settings → Client Dashboard toggle).
+ *   - lastReminderAt is null or older than 6 days, so a milestone gets at most
+ *     ~1 reminder/week.
+ * Each milestone is sent+updated independently so one failure can't abort the run.
+ * Never throws.
+ */
+export async function sendPaymentReminders(): Promise<PaymentReminderResult> {
+    const result: PaymentReminderResult = { scanned: 0, sent: 0, skipped: 0, failed: 0, errors: [] };
+    try {
+        const now = new Date();
+        const upcomingCutoff = new Date(now.getTime() + UPCOMING_WINDOW_DAYS * DAY_MS);
+        const overdueFloor = new Date(now.getTime() - MAX_OVERDUE_DAYS * DAY_MS);
+        const throttleCutoff = new Date(now.getTime() - THROTTLE_DAYS * DAY_MS);
+
+        const candidates = await prisma.paymentSchedule.findMany({
+            where: {
+                status: "Pending",
+                dueDate: { not: null, lte: upcomingCutoff, gte: overdueFloor },
+                OR: [{ lastReminderAt: null }, { lastReminderAt: { lt: throttleCutoff } }],
+                invoice: {
+                    status: { in: CLIENT_VISIBLE_INVOICE_STATUSES },
+                    project: { paymentRemindersEnabled: true },
+                },
+            },
+            select: {
+                id: true,
+                name: true,
+                amount: true,
+                dueDate: true,
+                qbInvoiceLink: true,
+                invoice: {
+                    select: {
+                        id: true,
+                        code: true,
+                        project: { select: { id: true, name: true } },
+                        client: { select: { name: true, email: true } },
+                    },
+                },
+            },
+            take: 250, // safety cap per run
+        });
+
+        result.scanned = candidates.length;
+        if (candidates.length === 0) return result;
+
+        const settings = await prisma.companySettings.findUnique({ where: { id: "singleton" } });
+        const companyName = settings?.companyName || "Golden Touch Remodeling";
+        const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://probuild.goldentouchremodeling.com";
+
+        for (const schedule of candidates) {
+            try {
+                const invoice = schedule.invoice;
+                const clientEmail = invoice.client?.email;
+                if (!clientEmail || !schedule.dueDate) {
+                    result.skipped++;
+                    continue;
+                }
+
+                const payUrl = schedule.qbInvoiceLink || `${appUrl}/portal/invoices/${invoice.id}`;
+                const send = await sendNotification(
+                    clientEmail,
+                    `Payment Reminder — Invoice #${invoice.code}`,
+                    reminderEmailHtml({
+                        clientName: invoice.client?.name || "",
+                        milestoneName: schedule.name,
+                        invoiceCode: invoice.code,
+                        amount: schedule.amount,
+                        dueDate: schedule.dueDate,
+                        now,
+                        payUrl,
+                        companyName,
+                        phone: settings?.phone,
+                        email: settings?.email,
+                    }),
+                    undefined,
+                    { fromName: companyName, replyTo: settings?.email ?? undefined }
+                );
+
+                if (!send.success) {
+                    result.failed++;
+                    result.errors.push(`schedule ${schedule.id}: send failed`);
+                    continue;
+                }
+
+                await prisma.paymentSchedule.update({
+                    where: { id: schedule.id },
+                    data: { lastReminderAt: now },
+                });
+
+                await logActivityLazy({
+                    projectId: invoice.project?.id ?? null,
+                    actorType: "SYSTEM",
+                    actorName: "Payment Reminders",
+                    action: "payment_reminder_sent",
+                    entityType: "invoice",
+                    entityId: invoice.id,
+                    entityName: `Invoice ${invoice.code}`,
+                    metadata: { milestone: schedule.name, amount: Number(schedule.amount.toString()), dueDate: schedule.dueDate.toISOString(), sentTo: clientEmail },
+                });
+
+                result.sent++;
+            } catch (err: any) {
+                result.failed++;
+                result.errors.push(`schedule ${schedule.id}: ${err?.message || "unexpected error"}`);
+            }
+        }
+        return result;
+    } catch (e: any) {
+        console.error("[sendPaymentReminders] failed:", e);
+        result.errors.push(e?.message || "unexpected error");
+        return result;
+    }
+}

--- a/src/lib/payment-reminders.ts
+++ b/src/lib/payment-reminders.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { sendNotification } from "@/lib/email";
 import { formatCurrency } from "@/lib/utils";
@@ -10,25 +11,48 @@ async function logActivityLazy(entry: Parameters<typeof import("./actions").logA
     return logActivity(entry);
 }
 
+// Local copy of the same one-liner used by src/app/api/client-messages/route.ts and the
+// portal contract components — this codebase doesn't have a shared text-utils module yet.
+function escapeHtml(s: string): string {
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function isHttpsUrl(url: string | null | undefined): url is string {
+    return !!url && /^https:\/\//i.test(url);
+}
+
 // Invoice statuses a client can actually see in the portal (mirrors the filter in
 // src/app/portal/page.tsx) — Draft/Paid/Canceled invoices never get a reminder.
 const CLIENT_VISIBLE_INVOICE_STATUSES = ["Issued", "Overdue", "Partially Paid"];
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-const UPCOMING_WINDOW_DAYS = 3; // remind for milestones due within N days...
-const MAX_OVERDUE_DAYS = 60; // ...through N days overdue
+const UPCOMING_WINDOW_DAYS = 3; // remind for milestones due within N calendar days...
+const MAX_OVERDUE_DAYS = 60; // ...through N calendar days overdue
 const THROTTLE_DAYS = 6; // at most ~1 reminder/week per milestone
+const BATCH_SIZE = 50; // per-run cap, oldest-due-first
 
 export type PaymentReminderResult = {
     scanned: number;
     sent: number;
     skipped: number;
     failed: number;
+    dryRun: boolean;
     errors: string[];
 };
 
-function dueDateLabel(dueDate: Date, now: Date): string {
-    const daysUntil = Math.round((dueDate.getTime() - now.getTime()) / DAY_MS);
+// ── Calendar-date helpers ──────────────────────────────────────────────────────
+// dueDate may carry an arbitrary time-of-day depending on how it was entered, but
+// "due in N days" / the reminder window are calendar-day concepts, not 24h-tick
+// concepts — comparing raw millisecond deltas would put a milestone due at 11pm
+// today a day off from one due at 1am today depending on what time the cron runs.
+// Everything below normalizes to UTC midnight before diffing.
+function utcMidnight(d: Date): Date {
+    return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+function daysBetweenUtc(from: Date, to: Date): number {
+    return Math.round((utcMidnight(to).getTime() - utcMidnight(from).getTime()) / DAY_MS);
+}
+function dueDateLabel(daysUntil: number): string {
     if (daysUntil > 1) return `due in ${daysUntil} days`;
     if (daysUntil === 1) return "due tomorrow";
     if (daysUntil === 0) return "due today";
@@ -41,26 +65,30 @@ function reminderEmailHtml(opts: {
     milestoneName: string;
     invoiceCode: string;
     amount: number | string | { toString(): string };
-    dueDate: Date;
-    now: Date;
-    payUrl: string;
+    daysUntil: number;
+    payUrl: string | null;
     companyName: string;
     phone?: string | null;
     email?: string | null;
 }) {
-    const { clientName, milestoneName, invoiceCode, amount, dueDate, now, payUrl, companyName, phone, email } = opts;
-    const isOverdue = dueDate.getTime() < now.getTime();
-    const dueLabel = dueDateLabel(dueDate, now);
+    const { clientName, milestoneName, invoiceCode, amount, daysUntil, payUrl, companyName, phone, email } = opts;
+    const isOverdue = daysUntil < 0;
+    const dueLabel = dueDateLabel(daysUntil);
+    // Only emit the pay link when it's https — qbInvoiceLink comes from QuickBooks and the
+    // portal fallback comes from our own env config, but neither is worth trusting blind.
+    const payButton = payUrl
+        ? `<p style="margin-top:24px;">
+            <a href="${escapeHtml(payUrl)}" style="background:#1e293b;color:white;padding:10px 20px;text-decoration:none;border-radius:6px;font-weight:600;">Pay Now</a>
+        </p>`
+        : "";
     return `<div style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:24px;">
         <h2 style="color:${isOverdue ? "#b91c1c" : "#1e293b"};margin-bottom:8px;">Payment Reminder</h2>
-        <p>Hi ${clientName || "there"},</p>
-        <p>This is a reminder that <strong>${milestoneName}</strong> on Invoice #${invoiceCode} is <strong>${dueLabel}</strong>.</p>
+        <p>Hi ${escapeHtml(clientName || "there")},</p>
+        <p>This is a reminder that <strong>${escapeHtml(milestoneName)}</strong> on Invoice #${escapeHtml(invoiceCode)} is <strong>${dueLabel}</strong>.</p>
         <p>Amount due: <strong>${formatCurrency(amount)}</strong></p>
-        <p style="margin-top:24px;">
-            <a href="${payUrl}" style="background:#1e293b;color:white;padding:10px 20px;text-decoration:none;border-radius:6px;font-weight:600;">Pay Now</a>
-        </p>
+        ${payButton}
         <p style="color:#9ca3af;font-size:12px;margin-top:32px;">
-            ${companyName}${phone ? ` · ${phone}` : ""}${email ? ` · ${email}` : ""}
+            ${escapeHtml(companyName)}${phone ? ` · ${escapeHtml(phone)}` : ""}${email ? ` · ${escapeHtml(email)}` : ""}
         </p>
     </div>`;
 }
@@ -70,60 +98,101 @@ function reminderEmailHtml(opts: {
  * recently overdue. Selection rules (see migrations/payment_reminders.sql for the
  * additive columns this depends on):
  *   - PaymentSchedule.status === "Pending", dueDate set, due within the next 3
- *     days through 60 days overdue.
+ *     calendar days through 60 calendar days overdue.
  *   - Invoice.status is one the client can actually see in the portal (Issued,
  *     Overdue, Partially Paid) — never Draft/Paid/Canceled.
- *   - Project.paymentRemindersEnabled is true (Settings → Client Dashboard toggle).
- *   - lastReminderAt is null or older than 6 days, so a milestone gets at most
- *     ~1 reminder/week.
- * Each milestone is sent+updated independently so one failure can't abort the run.
+ *   - Project.paymentRemindersEnabled is true (opt-in, off by default — Settings →
+ *     Client Dashboard toggle).
+ *   - Invoice.client.email is present (checked in the query so email-less rows
+ *     never occupy the per-run batch cap).
+ *   - lastReminderAt is null or <= 6 days ago, so a milestone gets at most ~1
+ *     reminder/week.
+ * A milestone whose sourceScheduleId points to an already-Paid EstimatePaymentSchedule
+ * is skipped defensively — the estimate side can settle without the invoice-side mirror
+ * following (known writer gap, tracked separately).
+ *
+ * Idempotent: each candidate is claimed with a conditional updateMany carrying the
+ * FULL eligibility predicate before it's sent, so overlapping/retried runs can't
+ * double-send (see the claim comment below). Each milestone is handled in its own
+ * try/catch so one failure can't abort the run.
+ *
+ * dryRun (opts.dryRun, ?dryRun=1 on the route, or PAYMENT_REMINDERS_DRY_RUN=1) runs the
+ * full selection and reports what would happen — no emails, no lastReminderAt writes.
  * Never throws.
  */
-export async function sendPaymentReminders(): Promise<PaymentReminderResult> {
-    const result: PaymentReminderResult = { scanned: 0, sent: 0, skipped: 0, failed: 0, errors: [] };
+export async function sendPaymentReminders(opts?: { dryRun?: boolean }): Promise<PaymentReminderResult> {
+    const dryRun = opts?.dryRun ?? process.env.PAYMENT_REMINDERS_DRY_RUN === "1";
+    const result: PaymentReminderResult = { scanned: 0, sent: 0, skipped: 0, failed: 0, dryRun, errors: [] };
     try {
         const now = new Date();
-        const upcomingCutoff = new Date(now.getTime() + UPCOMING_WINDOW_DAYS * DAY_MS);
-        const overdueFloor = new Date(now.getTime() - MAX_OVERDUE_DAYS * DAY_MS);
+        const todayStart = utcMidnight(now);
+        // Upper bound is an EXCLUSIVE start-of-day boundary (today + WINDOW + 1) so any
+        // dueDate time-of-day on the last eligible calendar day is still caught. Lower
+        // bound is an INCLUSIVE start-of-day boundary for the same reason.
+        const upcomingCutoff = new Date(todayStart.getTime() + (UPCOMING_WINDOW_DAYS + 1) * DAY_MS);
+        const overdueFloor = new Date(todayStart.getTime() - MAX_OVERDUE_DAYS * DAY_MS);
+        // lastReminderAt <= now - 6 days (inclusive: a milestone reminded exactly 6 days
+        // ago is eligible again today).
         const throttleCutoff = new Date(now.getTime() - THROTTLE_DAYS * DAY_MS);
 
-        const candidates = await prisma.paymentSchedule.findMany({
-            where: {
-                status: "Pending",
-                dueDate: { not: null, lte: upcomingCutoff, gte: overdueFloor },
-                OR: [{ lastReminderAt: null }, { lastReminderAt: { lt: throttleCutoff } }],
-                invoice: {
-                    status: { in: CLIENT_VISIBLE_INVOICE_STATUSES },
-                    project: { paymentRemindersEnabled: true },
-                },
+        const eligibilityWhere: Prisma.PaymentScheduleWhereInput = {
+            status: "Pending",
+            dueDate: { not: null, lt: upcomingCutoff, gte: overdueFloor },
+            OR: [{ lastReminderAt: null }, { lastReminderAt: { lte: throttleCutoff } }],
+            invoice: {
+                status: { in: CLIENT_VISIBLE_INVOICE_STATUSES },
+                project: { paymentRemindersEnabled: true },
+                client: { email: { not: null } },
             },
+        };
+
+        const candidates = await prisma.paymentSchedule.findMany({
+            where: eligibilityWhere,
             select: {
                 id: true,
                 name: true,
                 amount: true,
                 dueDate: true,
                 qbInvoiceLink: true,
+                sourceScheduleId: true,
                 invoice: {
                     select: {
                         id: true,
                         code: true,
                         project: { select: { id: true, name: true } },
-                        client: { select: { name: true, email: true } },
+                        client: { select: { id: true, name: true, email: true } },
                     },
                 },
             },
-            take: 250, // safety cap per run
+            orderBy: [{ dueDate: "asc" }, { id: "asc" }], // deterministic across runs
+            take: BATCH_SIZE,
         });
 
         result.scanned = candidates.length;
         if (candidates.length === 0) return result;
 
+        // Mirror safety: batch-check which of this run's sourceScheduleIds already
+        // settled on the estimate side.
+        const sourceIds = candidates.map(c => c.sourceScheduleId).filter((id): id is string => !!id);
+        const paidSourceIds = sourceIds.length
+            ? new Set(
+                  (await prisma.estimatePaymentSchedule.findMany({
+                      where: { id: { in: sourceIds }, status: "Paid" },
+                      select: { id: true },
+                  })).map(s => s.id)
+              )
+            : new Set<string>();
+
         const settings = await prisma.companySettings.findUnique({ where: { id: "singleton" } });
         const companyName = settings?.companyName || "Golden Touch Remodeling";
-        const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://probuild.goldentouchremodeling.com";
 
         for (const schedule of candidates) {
             try {
+                if (schedule.sourceScheduleId && paidSourceIds.has(schedule.sourceScheduleId)) {
+                    result.skipped++;
+                    continue;
+                }
+
                 const invoice = schedule.invoice;
                 const clientEmail = invoice.client?.email;
                 if (!clientEmail || !schedule.dueDate) {
@@ -131,7 +200,47 @@ export async function sendPaymentReminders(): Promise<PaymentReminderResult> {
                     continue;
                 }
 
-                const payUrl = schedule.qbInvoiceLink || `${appUrl}/portal/invoices/${invoice.id}`;
+                const daysUntil = daysBetweenUtc(now, schedule.dueDate);
+
+                if (dryRun) {
+                    // Full selection ran; report what would be sent without claiming or emailing.
+                    result.sent++;
+                    continue;
+                }
+
+                // Claim-before-send: an atomic conditional update using the FULL eligibility
+                // predicate (plus this row's id) as the where clause. Only the run that flips
+                // this row from eligible->claimed gets updateMany's count===1 and proceeds to
+                // send; a concurrent/overlapping run (or a retry racing the same minute) sees
+                // count===0 — lastReminderAt no longer satisfies the OR clause once claimed —
+                // and skips instead of double-sending. If the send itself then fails, the
+                // claim is reverted (matched by the exact claimed timestamp) so the next daily
+                // run can retry. The only gap this doesn't close is a crash between the claim
+                // and the send/revert: that suppresses one reminder for that milestone, and
+                // next week's run (throttle window) picks it back up — an acceptable tradeoff
+                // for never double-sending.
+                const claimedAt = new Date();
+                const claim = await prisma.paymentSchedule.updateMany({
+                    where: { ...eligibilityWhere, id: schedule.id },
+                    data: { lastReminderAt: claimedAt },
+                });
+                if (claim.count !== 1) {
+                    result.skipped++;
+                    continue;
+                }
+
+                // Portal fallback link routes through the same one-click client-login helper
+                // every other outbound portal email uses (buildClientPortalUrl — see
+                // billing-core.ts's change-order emails), so a logged-out client doesn't just
+                // 404 on /portal/invoices/[id].
+                const { buildClientPortalUrl } = await import("./client-portal-auth");
+                const portalUrl = await buildClientPortalUrl(invoice.client?.id, clientEmail, `/portal/invoices/${invoice.id}`);
+                const payUrl = isHttpsUrl(schedule.qbInvoiceLink)
+                    ? schedule.qbInvoiceLink
+                    : isHttpsUrl(portalUrl)
+                      ? portalUrl
+                      : null;
+
                 const send = await sendNotification(
                     clientEmail,
                     `Payment Reminder — Invoice #${invoice.code}`,
@@ -140,8 +249,7 @@ export async function sendPaymentReminders(): Promise<PaymentReminderResult> {
                         milestoneName: schedule.name,
                         invoiceCode: invoice.code,
                         amount: schedule.amount,
-                        dueDate: schedule.dueDate,
-                        now,
+                        daysUntil,
                         payUrl,
                         companyName,
                         phone: settings?.phone,
@@ -154,13 +262,14 @@ export async function sendPaymentReminders(): Promise<PaymentReminderResult> {
                 if (!send.success) {
                     result.failed++;
                     result.errors.push(`schedule ${schedule.id}: send failed`);
+                    // Revert the claim (only if it's still exactly what we set) so a future
+                    // run can retry instead of silently throttling a reminder that never sent.
+                    await prisma.paymentSchedule.updateMany({
+                        where: { id: schedule.id, lastReminderAt: claimedAt },
+                        data: { lastReminderAt: null },
+                    }).catch(() => {});
                     continue;
                 }
-
-                await prisma.paymentSchedule.update({
-                    where: { id: schedule.id },
-                    data: { lastReminderAt: now },
-                });
 
                 await logActivityLazy({
                     projectId: invoice.project?.id ?? null,
@@ -170,7 +279,12 @@ export async function sendPaymentReminders(): Promise<PaymentReminderResult> {
                     entityType: "invoice",
                     entityId: invoice.id,
                     entityName: `Invoice ${invoice.code}`,
-                    metadata: { milestone: schedule.name, amount: Number(schedule.amount.toString()), dueDate: schedule.dueDate.toISOString(), sentTo: clientEmail },
+                    metadata: {
+                        milestone: schedule.name,
+                        amount: Number(schedule.amount.toString()),
+                        dueDate: schedule.dueDate.toISOString(),
+                        sentTo: clientEmail,
+                    },
                 });
 
                 result.sent++;

--- a/src/lib/payment-reminders.ts
+++ b/src/lib/payment-reminders.ts
@@ -29,7 +29,10 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 const UPCOMING_WINDOW_DAYS = 3; // remind for milestones due within N calendar days...
 const MAX_OVERDUE_DAYS = 60; // ...through N calendar days overdue
 const THROTTLE_DAYS = 6; // at most ~1 reminder/week per milestone
-const BATCH_SIZE = 50; // per-run cap, oldest-due-first
+const BATCH_SIZE = 50; // per-run processing cap, oldest-due-first
+const SELECTION_WINDOW_SIZE = 200; // wider DB fetch so the paid-mirror filter (applied
+// before the cap — see below) doesn't starve the processing batch down below 50 real
+// candidates just because some of the first 50 DB rows happened to be paid mirrors.
 
 export type PaymentReminderResult = {
     scanned: number;
@@ -93,6 +96,17 @@ function reminderEmailHtml(opts: {
     </div>`;
 }
 
+/** Reverts a claim back to whatever lastReminderAt held before this run touched it — only
+ * if the row still holds the exact timestamp we claimed with (so a revert can never clobber
+ * a claim made by a different, later run). Used on send failure and on any unexpected throw
+ * after a successful claim. Never throws. */
+async function revertClaim(scheduleId: string, claimedAt: Date, priorLastReminderAt: Date | null): Promise<void> {
+    await prisma.paymentSchedule.updateMany({
+        where: { id: scheduleId, lastReminderAt: claimedAt },
+        data: { lastReminderAt: priorLastReminderAt },
+    }).catch(() => {});
+}
+
 /**
  * Daily sweep: email clients about payment-schedule milestones due soon or
  * recently overdue. Selection rules (see migrations/payment_reminders.sql for the
@@ -109,19 +123,28 @@ function reminderEmailHtml(opts: {
  *     reminder/week.
  * A milestone whose sourceScheduleId points to an already-Paid EstimatePaymentSchedule
  * is skipped defensively — the estimate side can settle without the invoice-side mirror
- * following (known writer gap, tracked separately).
+ * following (known writer gap, tracked separately). That check happens twice: once against
+ * a wider (200-row) candidate window BEFORE it's sliced down to the 50-row processing
+ * batch (so paid mirrors can't crowd out real candidates), and again against a freshly
+ * re-snapshotted paid set folded into each claim's atomic where clause (narrows, but per
+ * the claim comment below, doesn't fully close, the race with a mirror settling mid-run).
  *
  * Idempotent: each candidate is claimed with a conditional updateMany carrying the
  * FULL eligibility predicate before it's sent, so overlapping/retried runs can't
- * double-send (see the claim comment below). Each milestone is handled in its own
- * try/catch so one failure can't abort the run.
+ * double-send (see the claim comment below). All pre-send work that can throw — building
+ * the portal pay link, sending the email — happens after the claim, inside the same
+ * try/catch, so any failure (explicit or thrown) reverts the claim back to its prior
+ * value rather than leaking a throttle with nothing sent. Each milestone is handled in
+ * its own try/catch so one failure can't abort the run.
  *
- * dryRun (opts.dryRun, ?dryRun=1 on the route, or PAYMENT_REMINDERS_DRY_RUN=1) runs the
- * full selection and reports what would happen — no emails, no lastReminderAt writes.
- * Never throws.
+ * dryRun: PAYMENT_REMINDERS_DRY_RUN=1 always forces dry-run, regardless of opts.dryRun —
+ * it's the operational kill switch. Absent that env var, opts.dryRun (?dryRun=1 on the
+ * route) can turn dry-run on but never off. Dry-run runs the full selection and reports
+ * what would happen — no emails, no lastReminderAt writes. Never throws.
  */
 export async function sendPaymentReminders(opts?: { dryRun?: boolean }): Promise<PaymentReminderResult> {
-    const dryRun = opts?.dryRun ?? process.env.PAYMENT_REMINDERS_DRY_RUN === "1";
+    const envForcesDryRun = process.env.PAYMENT_REMINDERS_DRY_RUN === "1";
+    const dryRun = envForcesDryRun || (opts?.dryRun ?? false);
     const result: PaymentReminderResult = { scanned: 0, sent: 0, skipped: 0, failed: 0, dryRun, errors: [] };
     try {
         const now = new Date();
@@ -134,19 +157,27 @@ export async function sendPaymentReminders(opts?: { dryRun?: boolean }): Promise
         // lastReminderAt <= now - 6 days (inclusive: a milestone reminded exactly 6 days
         // ago is eligible again today).
         const throttleCutoff = new Date(now.getTime() - THROTTLE_DAYS * DAY_MS);
+        const throttleOr: Prisma.PaymentScheduleWhereInput[] = [
+            { lastReminderAt: null },
+            { lastReminderAt: { lte: throttleCutoff } },
+        ];
+
+        const invoiceFilter: Prisma.InvoiceWhereInput = {
+            status: { in: CLIENT_VISIBLE_INVOICE_STATUSES },
+            project: { paymentRemindersEnabled: true },
+            client: { email: { not: null } },
+        };
 
         const eligibilityWhere: Prisma.PaymentScheduleWhereInput = {
             status: "Pending",
             dueDate: { not: null, lt: upcomingCutoff, gte: overdueFloor },
-            OR: [{ lastReminderAt: null }, { lastReminderAt: { lte: throttleCutoff } }],
-            invoice: {
-                status: { in: CLIENT_VISIBLE_INVOICE_STATUSES },
-                project: { paymentRemindersEnabled: true },
-                client: { email: { not: null } },
-            },
+            OR: throttleOr,
+            invoice: invoiceFilter,
         };
 
-        const candidates = await prisma.paymentSchedule.findMany({
+        // Wide window (see SELECTION_WINDOW_SIZE) — filtered for paid mirrors, THEN sliced
+        // to the processing cap, so the cap always holds up to 50 real candidates.
+        const wideCandidates = await prisma.paymentSchedule.findMany({
             where: eligibilityWhere,
             select: {
                 id: true,
@@ -155,6 +186,7 @@ export async function sendPaymentReminders(opts?: { dryRun?: boolean }): Promise
                 dueDate: true,
                 qbInvoiceLink: true,
                 sourceScheduleId: true,
+                lastReminderAt: true,
                 invoice: {
                     select: {
                         id: true,
@@ -165,30 +197,61 @@ export async function sendPaymentReminders(opts?: { dryRun?: boolean }): Promise
                 },
             },
             orderBy: [{ dueDate: "asc" }, { id: "asc" }], // deterministic across runs
-            take: BATCH_SIZE,
+            take: SELECTION_WINDOW_SIZE,
         });
 
-        result.scanned = candidates.length;
-        if (candidates.length === 0) return result;
+        if (wideCandidates.length === 0) return result;
 
-        // Mirror safety: batch-check which of this run's sourceScheduleIds already
-        // settled on the estimate side.
-        const sourceIds = candidates.map(c => c.sourceScheduleId).filter((id): id is string => !!id);
-        const paidSourceIds = sourceIds.length
+        // Mirror safety, selection-time snapshot: drop already-Paid-on-the-estimate-side
+        // mirrors BEFORE slicing to the processing cap.
+        const wideSourceIds = wideCandidates.map(c => c.sourceScheduleId).filter((id): id is string => !!id);
+        const paidAtSelection = wideSourceIds.length
             ? new Set(
                   (await prisma.estimatePaymentSchedule.findMany({
-                      where: { id: { in: sourceIds }, status: "Paid" },
+                      where: { id: { in: wideSourceIds }, status: "Paid" },
                       select: { id: true },
                   })).map(s => s.id)
               )
             : new Set<string>();
 
+        const eligible = wideCandidates.filter(c => !(c.sourceScheduleId && paidAtSelection.has(c.sourceScheduleId)));
+        const candidates = eligible.slice(0, BATCH_SIZE);
+
+        result.scanned = candidates.length;
+        if (candidates.length === 0) return result;
+
+        // Mirror safety, re-snapshotted immediately before the claim loop: the
+        // selection-time snapshot above can go stale between that fetch and the claim
+        // below (an estimate deposit can settle mid-run). This narrows, but — being
+        // snapshot-based, since there's no Prisma relation to join sourceScheduleId
+        // against EstimatePaymentSchedule directly — does NOT fully close that window;
+        // a settlement landing between THIS snapshot and an individual claim a few
+        // milliseconds later would still slip through. That residual gap only matters
+        // while the known invoice-mirror writer bugs exist (tracked separately); once
+        // those are fixed, estimate-side settlement can't happen without the invoice
+        // side following in the same transaction, and this whole check becomes moot.
+        const claimSourceIds = candidates.map(c => c.sourceScheduleId).filter((id): id is string => !!id);
+        const paidAtClaim = claimSourceIds.length
+            ? new Set(
+                  (await prisma.estimatePaymentSchedule.findMany({
+                      where: { id: { in: claimSourceIds }, status: "Paid" },
+                      select: { id: true },
+                  })).map(s => s.id)
+              )
+            : new Set<string>();
+        const mirrorOr: Prisma.PaymentScheduleWhereInput[] = [
+            { sourceScheduleId: null },
+            { sourceScheduleId: { notIn: Array.from(paidAtClaim) } },
+        ];
+
         const settings = await prisma.companySettings.findUnique({ where: { id: "singleton" } });
         const companyName = settings?.companyName || "Golden Touch Remodeling";
 
         for (const schedule of candidates) {
+            let claimedAt: Date | null = null;
+            const priorLastReminderAt = schedule.lastReminderAt;
             try {
-                if (schedule.sourceScheduleId && paidSourceIds.has(schedule.sourceScheduleId)) {
+                if (schedule.sourceScheduleId && paidAtClaim.has(schedule.sourceScheduleId)) {
                     result.skipped++;
                     continue;
                 }
@@ -209,37 +272,49 @@ export async function sendPaymentReminders(opts?: { dryRun?: boolean }): Promise
                 }
 
                 // Claim-before-send: an atomic conditional update using the FULL eligibility
-                // predicate (plus this row's id) as the where clause. Only the run that flips
-                // this row from eligible->claimed gets updateMany's count===1 and proceeds to
-                // send; a concurrent/overlapping run (or a retry racing the same minute) sees
-                // count===0 — lastReminderAt no longer satisfies the OR clause once claimed —
-                // and skips instead of double-sending. If the send itself then fails, the
-                // claim is reverted (matched by the exact claimed timestamp) so the next daily
-                // run can retry. The only gap this doesn't close is a crash between the claim
-                // and the send/revert: that suppresses one reminder for that milestone, and
-                // next week's run (throttle window) picks it back up — an acceptable tradeoff
-                // for never double-sending.
-                const claimedAt = new Date();
+                // predicate (status/dueDate window/throttle/invoice-visibility/mirror-safety,
+                // plus this row's id) as the where clause. Only the run that flips this row
+                // from eligible->claimed gets updateMany's count===1 and proceeds to send; a
+                // concurrent/overlapping run (or a retry racing the same minute) sees
+                // count===0 — lastReminderAt no longer satisfies the throttle OR clause once
+                // claimed, or the mirror OR clause now excludes it — and skips instead of
+                // double-sending. If anything from here on fails or throws, the claim is
+                // reverted to its prior value (captured above, may be null) so a future run
+                // can retry. The only gap this doesn't close is a crash between the claim and
+                // the revert/send: that suppresses one reminder for that milestone, and next
+                // week's run (throttle window) picks it back up — an acceptable tradeoff for
+                // never double-sending.
+                claimedAt = new Date();
                 const claim = await prisma.paymentSchedule.updateMany({
-                    where: { ...eligibilityWhere, id: schedule.id },
+                    where: {
+                        id: schedule.id,
+                        status: "Pending",
+                        dueDate: { not: null, lt: upcomingCutoff, gte: overdueFloor },
+                        invoice: invoiceFilter,
+                        AND: [{ OR: throttleOr }, { OR: mirrorOr }],
+                    },
                     data: { lastReminderAt: claimedAt },
                 });
                 if (claim.count !== 1) {
+                    claimedAt = null; // nothing was claimed — no revert needed
                     result.skipped++;
                     continue;
                 }
 
-                // Portal fallback link routes through the same one-click client-login helper
-                // every other outbound portal email uses (buildClientPortalUrl — see
-                // billing-core.ts's change-order emails), so a logged-out client doesn't just
-                // 404 on /portal/invoices/[id].
-                const { buildClientPortalUrl } = await import("./client-portal-auth");
-                const portalUrl = await buildClientPortalUrl(invoice.client?.id, clientEmail, `/portal/invoices/${invoice.id}`);
-                const payUrl = isHttpsUrl(schedule.qbInvoiceLink)
-                    ? schedule.qbInvoiceLink
-                    : isHttpsUrl(portalUrl)
-                      ? portalUrl
-                      : null;
+                // Pay link: prefer the QBO hosted pay page when it's already https, and only
+                // build (and pay the async cost of) the portal fallback link when we actually
+                // need it.
+                let payUrl: string | null = isHttpsUrl(schedule.qbInvoiceLink) ? schedule.qbInvoiceLink : null;
+                if (!payUrl) {
+                    // Routes through the same one-click client-login helper every other
+                    // outbound portal email uses (buildClientPortalUrl — see billing-core.ts's
+                    // change-order emails), so a logged-out client doesn't just 404 on
+                    // /portal/invoices/[id]. This (and anything else below) can throw — it's
+                    // inside the try so a throw here still reverts the claim above.
+                    const { buildClientPortalUrl } = await import("./client-portal-auth");
+                    const portalUrl = await buildClientPortalUrl(invoice.client?.id, clientEmail, `/portal/invoices/${invoice.id}`);
+                    payUrl = isHttpsUrl(portalUrl) ? portalUrl : null;
+                }
 
                 const send = await sendNotification(
                     clientEmail,
@@ -262,12 +337,7 @@ export async function sendPaymentReminders(opts?: { dryRun?: boolean }): Promise
                 if (!send.success) {
                     result.failed++;
                     result.errors.push(`schedule ${schedule.id}: send failed`);
-                    // Revert the claim (only if it's still exactly what we set) so a future
-                    // run can retry instead of silently throttling a reminder that never sent.
-                    await prisma.paymentSchedule.updateMany({
-                        where: { id: schedule.id, lastReminderAt: claimedAt },
-                        data: { lastReminderAt: null },
-                    }).catch(() => {});
+                    await revertClaim(schedule.id, claimedAt, priorLastReminderAt);
                     continue;
                 }
 
@@ -291,6 +361,9 @@ export async function sendPaymentReminders(opts?: { dryRun?: boolean }): Promise
             } catch (err: any) {
                 result.failed++;
                 result.errors.push(`schedule ${schedule.id}: ${err?.message || "unexpected error"}`);
+                if (claimedAt) {
+                    await revertClaim(schedule.id, claimedAt, priorLastReminderAt);
+                }
             }
         }
         return result;

--- a/vercel.json
+++ b/vercel.json
@@ -23,6 +23,10 @@
     {
       "path": "/api/cron/ar-digest",
       "schedule": "0 15 * * 1"
+    },
+    {
+      "path": "/api/cron/payment-reminders",
+      "schedule": "0 16 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Daily cron (`/api/cron/payment-reminders`, 9am PT) emails clients about payment-schedule milestones that are due soon or recently overdue, so outstanding invoices get chased automatically instead of manually.
- Per-milestone throttle (`PaymentSchedule.lastReminderAt`) caps reminders to ~1/week; per-project **opt-in** (`Project.paymentRemindersEnabled`, **default OFF**) via a "Payment Reminders" toggle on the Client Dashboard settings page (`/projects/[id]/client-portal`).
- **Deploy order:** `migrations/payment_reminders.sql` (additive `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`) must be applied to prod *before* this deploys — the cron route and settings toggle both read/write the two new columns.

## Rollout (updated after review)
Reminders are **off by default for every project**, including existing ones — the migration adds `paymentRemindersEnabled` as `NOT NULL DEFAULT false`. The cron will scan and select nothing until someone opts a project in.

**How Justin enables it:** open a project, go to Client Dashboard (`/projects/[id]/client-portal`), flip the "Payment Reminders" toggle on, click Save Settings. Enable it project-by-project as a controlled rollout — there's no global on-switch.

**Dry-run first:** hit `/api/cron/payment-reminders?dryRun=1` (with the `CRON_SECRET` bearer token) any time to see exactly what the selection would do — full scan, real counts, zero emails sent, zero `lastReminderAt` writes. `PAYMENT_REMINDERS_DRY_RUN=1` as an env var does the same for the whole cron without touching the URL. Recommended: dry-run against a couple of opted-in test projects before trusting the daily schedule.

## Selection / throttle / safety rules (src/lib/payment-reminders.ts)
A `PaymentSchedule` row is reminded when all of:
- `status === "Pending"` and `dueDate` is set
- `dueDate` is within 3 calendar days from now through 60 calendar days overdue (UTC calendar-day math, not a raw 24h-tick delta — see the date-math section below)
- its `Invoice.status` is one the client can actually see in the portal: `Issued`, `Overdue`, or `Partially Paid` (mirrors the exact filter `src/app/portal/page.tsx` uses; excludes `Draft`/`Paid`/`Canceled`)
- its `Project.paymentRemindersEnabled` is `true` (opt-in, see Rollout above)
- its `Invoice.client.email` is present (checked in the query itself, not after fetching, so email-less rows can't occupy the batch cap)
- `lastReminderAt` is `null` or `<= now - 6 days` (about 1 reminder/week per milestone)
- it is not a mirror of an already-settled estimate deposit — a milestone whose `sourceScheduleId` points to an `EstimatePaymentSchedule` with `status === "Paid"` is skipped defensively (the estimate side can settle without the invoice-side copy following; that writer gap is being fixed separately)

Batch is capped at 50 per run, ordered deterministically (`dueDate asc, id asc`).

**Idempotency (claim-before-send):** before emailing, each candidate is claimed with a conditional `updateMany` carrying the full eligibility predicate (not just `id`) in its `where`, setting `lastReminderAt = now`. Only the run/attempt where that update's `count === 1` proceeds to send — a concurrent or retried run sees `count === 0` (the row no longer matches the throttle `OR` clause once claimed) and skips instead of double-sending. If the send itself fails, the claim is reverted with another conditional `updateMany` matched on the exact claimed timestamp, so a later run can retry. The one gap this doesn't close: a crash between the claim and the send/revert suppresses that one reminder — the next weekly cycle covers it. That tradeoff is documented inline.

Email uses `sendNotification` (`src/lib/email.ts`); client name, milestone name, invoice code, and company fields are HTML-escaped before interpolation (local `escapeHtml`, same one-liner already used in `src/app/api/client-messages/route.ts` and the portal contract components). Pay link prefers `PaymentSchedule.qbInvoiceLink` (the QBO hosted pay page, when that milestone has one); the fallback routes through `buildClientPortalUrl` (`src/lib/client-portal-auth.ts`) targeting the portal invoice page — the same one-click client-login helper every other outbound portal email uses (see `billing-core.ts`'s change-order emails) — instead of a bare `/portal/invoices/[id]` link that would 404 a logged-out client. Either link is only emitted if it's `https`.

On successful send: the claim's `lastReminderAt` stands, and one `activityLog` entry is written via `logActivity` (`action: "payment_reminder_sent"`) — the same writer other invoice events use, never a second writer. Each milestone is claimed/sent/logged inside its own try/catch, so one failure can't abort the run; the route returns `{ scanned, sent, skipped, failed, dryRun, errors }`.

Cron auth mirrors `src/app/api/cron/ar-digest/route.ts` exactly: Bearer `CRON_SECRET`, fails closed whenever `VERCEL_ENV` is set (only local dev skips the check).

## Auth on the new server action
`setPaymentRemindersEnabled` (in `src/lib/actions.ts`) now requires `getCurrentUserWithPermissions()` plus the `invoices` permission (same permission `emailInvoiceCopyToMe` uses) plus `canAccessProject()`, returning `{ success: false, error }` instead of throwing on failure. `PortalVisibilityToggles.tsx`'s save handler calls `savePortalVisibility` and `setPaymentRemindersEnabled` sequentially (not `Promise.all`) and checks each result, so a permission failure on the reminders toggle can't get silently reported as "saved" just because the other call succeeded.

Note: `savePortalVisibility` itself still has no auth check — that's a pre-existing gap on a function this PR didn't introduce, and it's being tracked/fixed separately, not folded into this PR.

## Date math
`dueDate` may carry an arbitrary time-of-day depending on how it was entered, so both the selection window and the "due in N days" / "N days overdue" copy are computed from UTC calendar-day differences (`utcMidnight` + day-diff), not millisecond deltas — a milestone due at 11pm today and one due at 1am today are both "due today," and the run time of the cron itself doesn't shift which calendar day counts as day 3 of the window.

## TypeScript caveat
This worktree has no node_modules of its own; I junctioned in another worktree's install to run `tsc --noEmit`, per instructions never running `prisma generate` against that shared client. `tsc` comes back with exactly 8 errors, all traceable to the two new Prisma fields (`Project.paymentRemindersEnabled`, `PaymentSchedule.lastReminderAt`) not existing in that stale shared client — `prisma/schema.prisma` has both fields, and CI regenerates its own client so it will see them and pass. No other errors were introduced.

## Test plan
- [ ] Apply `migrations/payment_reminders.sql` to prod before deploying
- [ ] CI tsc/build passes now that its own Prisma client knows the two new fields
- [ ] Hit `/api/cron/payment-reminders?dryRun=1` with the `CRON_SECRET` bearer token against a project with reminders enabled and a milestone due within 3 days; confirm the response reports it as would-send with zero emails/writes
- [ ] Re-run without dryRun; confirm the email sends, `lastReminderAt` stamps, and one `payment_reminder_sent` activity-log entry appears on the project
- [ ] Immediately re-run the cron for the same milestone and confirm it's now skipped (throttle/claim working, no duplicate send)
- [ ] Toggle "Payment Reminders" off on that project's Client Dashboard settings page and confirm the milestone is skipped on the next run
- [ ] Confirm a milestone whose sourceScheduleId estimate schedule is Paid is skipped even though the invoice-side status is still client-visible
- [ ] Confirm a user without the invoices permission (or without access to the project) gets `{ success: false }` from `setPaymentRemindersEnabled` and the UI surfaces an error toast rather than "saved"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
