### PR TITLE
fix(comments): session-derived authors + invoice mount; error-boundary gap-fill

### DIFF
--- a/src/app/estimates/error.tsx
+++ b/src/app/estimates/error.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function EstimatesError({
+    error,
+    reset,
+}: {
+    error: Error & { digest?: string };
+    reset: () => void;
+}) {
+    useEffect(() => {
+        console.error(error);
+    }, [error]);
+
+    return (
+        <div className="min-h-screen flex items-center justify-center bg-slate-50">
+            <div className="text-center max-w-md px-6">
+                <div className="text-4xl mb-4">⚠️</div>
+                <h2 className="text-xl font-semibold text-slate-800 mb-2">Something went wrong</h2>
+                <p className="text-slate-500 text-sm mb-6">
+                    An unexpected error occurred. Please try again, or contact support if the problem persists.
+                </p>
+                <button
+                    onClick={reset}
+                    className="px-4 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 transition"
+                >
+                    Try again
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/app/invoices/error.tsx
+++ b/src/app/invoices/error.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function InvoicesError({
+    error,
+    reset,
+}: {
+    error: Error & { digest?: string };
+    reset: () => void;
+}) {
+    useEffect(() => {
+        console.error(error);
+    }, [error]);
+
+    return (
+        <div className="min-h-screen flex items-center justify-center bg-slate-50">
+            <div className="text-center max-w-md px-6">
+                <div className="text-4xl mb-4">⚠️</div>
+                <h2 className="text-xl font-semibold text-slate-800 mb-2">Something went wrong</h2>
+                <p className="text-slate-500 text-sm mb-6">
+                    An unexpected error occurred. Please try again, or contact support if the problem persists.
+                </p>
+                <button
+                    onClick={reset}
+                    className="px-4 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 transition"
+                >
+                    Try again
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
@@ -3245,8 +3245,6 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                             <DocumentComments
                                 documentType="estimate"
                                 documentId={initialEstimate.id}
-                                currentUserId={undefined}
-                                currentUserName={undefined}
                                 showClientTab={true}
                             />
                         </div>

--- a/src/app/projects/[id]/invoices/[invoiceId]/InvoiceEditor.tsx
+++ b/src/app/projects/[id]/invoices/[invoiceId]/InvoiceEditor.tsx
@@ -9,6 +9,7 @@ import RecordPaymentModal from "@/components/RecordPaymentModal";
 import BulkActionBar from "@/components/BulkActionBar";
 import SendMilestonesModal from "@/components/SendMilestonesModal";
 import UndoPaymentModal from "@/components/UndoPaymentModal";
+import DocumentComments from "@/components/DocumentComments";
 import { toast } from "sonner";
 import { formatCurrency } from "@/lib/utils";
 
@@ -469,6 +470,17 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                             placeholder="Add internal notes or payment instructions that will be visible to the client..."
                             className="hui-input w-full h-24 resize-none text-sm"
                         />
+                    </div>
+
+                    {/* Comments */}
+                    <div className="hui-card p-6">
+                        <h2 className="font-semibold text-hui-textMain flex items-center gap-2 mb-3">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
+                            Comments
+                        </h2>
+                        <div className="h-96 border border-hui-border rounded-lg overflow-hidden">
+                            <DocumentComments documentType="invoice" documentId={initialInvoice.id} showClientTab={true} />
+                        </div>
                     </div>
 
                     {/* Payments Schedule */}

--- a/src/app/projects/[id]/invoices/[invoiceId]/page.tsx
+++ b/src/app/projects/[id]/invoices/[invoiceId]/page.tsx
@@ -14,6 +14,14 @@ export default async function InvoicePage({ params }: { params: Promise<{ id: st
         notFound();
     }
 
+    // The route's project id and the invoice's own projectId must agree —
+    // otherwise this would render an invoice from a different project inside
+    // this project's page (and its DocumentComments mount would read/write
+    // against invoiceId while every other action on this page trusts `id`).
+    if (initialInvoice.projectId !== id) {
+        notFound();
+    }
+
     return (
         <div className="h-full bg-slate-50 relative">
             <InvoiceEditor project={project} initialInvoice={initialInvoice} />

--- a/src/components/DocumentComments.tsx
+++ b/src/components/DocumentComments.tsx
@@ -17,14 +17,10 @@ type Comment = {
 export default function DocumentComments({
     documentType,
     documentId,
-    currentUserId,
-    currentUserName,
     showClientTab = true,
 }: {
     documentType: string;
     documentId: string;
-    currentUserId?: string;
-    currentUserName?: string;
     showClientTab?: boolean;
 }) {
     const [comments, setComments] = useState<Comment[]>([]);
@@ -51,8 +47,6 @@ export default function DocumentComments({
                 documentId,
                 text,
                 activeTab,
-                currentUserId,
-                currentUserName,
             );
             setComments((prev) => [...prev, { ...comment, createdAt: (comment as any).createdAt?.toISOString?.() || String((comment as any).createdAt) }]);
             setNewText("");
@@ -177,14 +171,15 @@ export default function DocumentComments({
                                 <div className="flex items-baseline gap-2">
                                     <span className="text-xs font-semibold text-slate-700">{getAuthorDisplay(c)}</span>
                                     <span className="text-[10px] text-slate-400">{formatTime(c.createdAt)}</span>
-                                    {c.authorId === currentUserId && (
-                                        <button
-                                            onClick={() => handleDelete(c.id)}
-                                            className="text-[10px] text-slate-300 hover:text-red-500 opacity-0 group-hover:opacity-100 transition ml-auto"
-                                        >
-                                            Delete
-                                        </button>
-                                    )}
+                                    {/* Visible affordance for every comment; the server is the
+                                        source of truth and rejects deletes that aren't the
+                                        author's own comment or an ADMIN/MANAGER. */}
+                                    <button
+                                        onClick={() => handleDelete(c.id)}
+                                        className="text-[10px] text-slate-300 hover:text-red-500 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto transition ml-auto"
+                                    >
+                                        Delete
+                                    </button>
                                 </div>
                                 <p className="text-sm text-slate-600 mt-0.5 whitespace-pre-wrap break-words">{c.text}</p>
                             </div>

--- a/src/components/DocumentComments.tsx
+++ b/src/components/DocumentComments.tsx
@@ -12,6 +12,8 @@ type Comment = {
     authorName: string | null;
     author: { id: string; name: string | null; email: string } | null;
     createdAt: string;
+    // Computed server-side (author-or-admin) — never derived client-side.
+    canDelete: boolean;
 };
 
 export default function DocumentComments({
@@ -171,15 +173,16 @@ export default function DocumentComments({
                                 <div className="flex items-baseline gap-2">
                                     <span className="text-xs font-semibold text-slate-700">{getAuthorDisplay(c)}</span>
                                     <span className="text-[10px] text-slate-400">{formatTime(c.createdAt)}</span>
-                                    {/* Visible affordance for every comment; the server is the
-                                        source of truth and rejects deletes that aren't the
-                                        author's own comment or an ADMIN/MANAGER. */}
-                                    <button
-                                        onClick={() => handleDelete(c.id)}
-                                        className="text-[10px] text-slate-300 hover:text-red-500 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto transition ml-auto"
-                                    >
-                                        Delete
-                                    </button>
+                                    {/* canDelete is computed server-side (author-or-admin); the
+                                        server still enforces it independently on delete. */}
+                                    {c.canDelete && (
+                                        <button
+                                            onClick={() => handleDelete(c.id)}
+                                            className="text-[10px] text-slate-300 hover:text-red-500 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto transition ml-auto"
+                                        >
+                                            Delete
+                                        </button>
+                                    )}
                                 </div>
                                 <p className="text-sm text-slate-600 mt-0.5 whitespace-pre-wrap break-words">{c.text}</p>
                             </div>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -9074,8 +9074,26 @@ export async function deleteRetainer(id: string) {
 // ========== DOCUMENT COMMENTS ==========
 
 export async function getDocumentComments(documentType: string, documentId: string) {
+    // Read-side gating mirrors the write side: staff sessions see both
+    // visibilities, portal clients see client-visible comments only, and
+    // anyone else (server actions are callable by any authenticated-or-not
+    // client) gets nothing back — otherwise an anonymous/portal caller who
+    // knows a documentId (e.g. from a portal URL) could read TEAM-visibility
+    // comments.
+    const staffUser = await getCurrentUserWithPermissions();
+    if (staffUser) {
+        return prisma.documentComment.findMany({
+            where: { documentType, documentId },
+            orderBy: { createdAt: "asc" },
+            include: { author: { select: { id: true, name: true, email: true } } },
+        });
+    }
+
+    const sessionClientId = await resolveSessionClientId();
+    if (!sessionClientId) return [];
+
     return prisma.documentComment.findMany({
-        where: { documentType, documentId },
+        where: { documentType, documentId, visibility: "client" },
         orderBy: { createdAt: "asc" },
         include: { author: { select: { id: true, name: true, email: true } } },
     });

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -9073,30 +9073,105 @@ export async function deleteRetainer(id: string) {
 
 // ========== DOCUMENT COMMENTS ==========
 
+// documentType is a free-typed string coming from a server action, i.e.
+// untrusted at runtime regardless of the TS signature — whitelist it.
+// Portal (non-staff) access is only wired up for "estimate" and "invoice"
+// below; the other two are staff-only surfaces (no portal ownership shape
+// resolved for them yet).
+const DOCUMENT_COMMENT_TYPES = ["estimate", "invoice", "change-order", "purchase-order", "contract"] as const;
+type DocumentCommentType = (typeof DOCUMENT_COMMENT_TYPES)[number];
+
+function assertValidDocumentType(documentType: string): asserts documentType is DocumentCommentType {
+    if (!(DOCUMENT_COMMENT_TYPES as readonly string[]).includes(documentType)) {
+        throw new Error("Invalid documentType");
+    }
+}
+
+function assertValidVisibility(visibility: string): asserts visibility is "team" | "client" {
+    if (visibility !== "team" && visibility !== "client") {
+        throw new Error("Invalid visibility");
+    }
+}
+
+// A staff session whose User row has flipped to DISABLED must not be trusted
+// here. getCurrentUserWithPermissions() doesn't filter on status (NextAuth's
+// jwt() callback only re-checks `role` on token refresh, not `status` — see
+// signIn() in lib/auth.ts, which only rejects DISABLED at initial login), so
+// an existing session survives a disable until the token expires. That's a
+// pre-existing gap in the shared helper across the whole app, not something
+// safe to fix here — see the PR body for the follow-up. Scoped locally:
+function activeStaffUser<T extends { status: string }>(user: T | null): T | null {
+    return user && user.status !== "DISABLED" ? user : null;
+}
+
+// Resolves the Client that owns a given document, for portal ownership
+// checks. Returns null for document types with no portal-ownership shape
+// (change-order, purchase-order, contract) or when the document isn't found.
+async function resolveDocumentOwnerClientId(documentType: DocumentCommentType, documentId: string): Promise<string | null> {
+    if (documentType === "estimate") {
+        const estimate = await prisma.estimate.findUnique({
+            where: { id: documentId },
+            select: {
+                project: { select: { clientId: true } },
+                lead: { select: { clientId: true } },
+            },
+        });
+        return estimate?.project?.clientId ?? estimate?.lead?.clientId ?? null;
+    }
+    if (documentType === "invoice") {
+        const invoice = await prisma.invoice.findUnique({
+            where: { id: documentId },
+            select: { clientId: true },
+        });
+        return invoice?.clientId ?? null;
+    }
+    return null;
+}
+
+function withCanDelete<T extends { authorId: string | null }>(
+    comments: T[],
+    staffUser: { id: string; role: string } | null,
+): (T & { canDelete: boolean })[] {
+    if (!staffUser) return comments.map((c) => ({ ...c, canDelete: false }));
+    const isAdminOrManager = ["ADMIN", "MANAGER"].includes(staffUser.role);
+    return comments.map((c) => ({ ...c, canDelete: isAdminOrManager || c.authorId === staffUser.id }));
+}
+
 export async function getDocumentComments(documentType: string, documentId: string) {
+    assertValidDocumentType(documentType);
+
     // Read-side gating mirrors the write side: staff sessions see both
-    // visibilities, portal clients see client-visible comments only, and
-    // anyone else (server actions are callable by any authenticated-or-not
-    // client) gets nothing back — otherwise an anonymous/portal caller who
-    // knows a documentId (e.g. from a portal URL) could read TEAM-visibility
+    // visibilities, portal clients see client-visible comments only for a
+    // document their session-resolved Client actually owns, and anyone else
+    // (server actions are callable by any authenticated-or-not client) gets
+    // nothing back — otherwise a caller who merely knows a documentId (e.g.
+    // from a portal URL) could read another client's, or TEAM-visibility,
     // comments.
-    const staffUser = await getCurrentUserWithPermissions();
+    const staffUser = activeStaffUser(await getCurrentUserWithPermissions());
     if (staffUser) {
-        return prisma.documentComment.findMany({
+        const comments = await prisma.documentComment.findMany({
             where: { documentType, documentId },
             orderBy: { createdAt: "asc" },
             include: { author: { select: { id: true, name: true, email: true } } },
         });
+        return withCanDelete(comments, staffUser);
     }
 
     const sessionClientId = await resolveSessionClientId();
     if (!sessionClientId) return [];
 
-    return prisma.documentComment.findMany({
+    const ownerClientId = await resolveDocumentOwnerClientId(documentType, documentId);
+    if (!ownerClientId || ownerClientId !== sessionClientId) return [];
+
+    const comments = await prisma.documentComment.findMany({
         where: { documentType, documentId, visibility: "client" },
         orderBy: { createdAt: "asc" },
         include: { author: { select: { id: true, name: true, email: true } } },
     });
+    // No portal mount exists for this component yet, so portal-authored
+    // deletes stay admin-only (deleteDocumentComment already enforces that —
+    // see its comment below) — canDelete is always false from this branch.
+    return withCanDelete(comments, null);
 }
 
 export async function addDocumentComment(
@@ -9105,18 +9180,22 @@ export async function addDocumentComment(
     text: string,
     visibility: "team" | "client",
 ) {
+    assertValidDocumentType(documentType);
+    assertValidVisibility(visibility);
+
     // Derive the author from the session — never trust a client-supplied
     // authorId/authorName (the old signature accepted both as plain args).
     // Team-visible comments are internal-only and require a signed-in staff
     // user. Client-visible comments may come from staff posting on the
-    // client's behalf, or from a logged-in portal client.
+    // client's behalf, or from a logged-in portal client whose
+    // session-resolved Client actually owns this document.
     const trimmed = text.trim();
     if (!trimmed) throw new Error("Comment text is required");
 
     let authorId: string | null = null;
     let authorName: string | null = null;
 
-    const staffUser = await getCurrentUserWithPermissions();
+    const staffUser = activeStaffUser(await getCurrentUserWithPermissions());
     if (staffUser) {
         authorId = staffUser.id;
         authorName = staffUser.name || staffUser.email;
@@ -9125,6 +9204,10 @@ export async function addDocumentComment(
     } else {
         const sessionClientId = await resolveSessionClientId();
         if (!sessionClientId) throw new Error("Unauthorized");
+
+        const ownerClientId = await resolveDocumentOwnerClientId(documentType, documentId);
+        if (!ownerClientId || ownerClientId !== sessionClientId) throw new Error("Unauthorized");
+
         const client = await prisma.client.findUnique({ where: { id: sessionClientId }, select: { name: true } });
         authorName = client?.name || "Client";
     }
@@ -9133,12 +9216,18 @@ export async function addDocumentComment(
         data: { documentType, documentId, text: trimmed, visibility, authorId, authorName },
         include: { author: { select: { id: true, name: true, email: true } } },
     });
-    return comment;
+    // The caller can always delete the comment they just created if they're
+    // staff (matches withCanDelete's authorId === staffUser.id branch);
+    // portal-authored comments stay non-deletable from the client's own view.
+    return { ...comment, canDelete: !!staffUser };
 }
 
 export async function deleteDocumentComment(commentId: string) {
     // Only the comment's own author, or an ADMIN/MANAGER, may delete it.
-    const staffUser = await getCurrentUserWithPermissions();
+    // Non-staff (portal) callers never satisfy either check today — there's
+    // no portal mount for this component yet, so portal-authored comments
+    // are deliberately admin-only to delete for now (see getDocumentComments).
+    const staffUser = activeStaffUser(await getCurrentUserWithPermissions());
     const comment = await prisma.documentComment.findUnique({ where: { id: commentId }, select: { authorId: true } });
     if (!comment) return { success: true };
 

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -9086,17 +9086,48 @@ export async function addDocumentComment(
     documentId: string,
     text: string,
     visibility: "team" | "client",
-    authorId?: string,
-    authorName?: string,
 ) {
+    // Derive the author from the session — never trust a client-supplied
+    // authorId/authorName (the old signature accepted both as plain args).
+    // Team-visible comments are internal-only and require a signed-in staff
+    // user. Client-visible comments may come from staff posting on the
+    // client's behalf, or from a logged-in portal client.
+    const trimmed = text.trim();
+    if (!trimmed) throw new Error("Comment text is required");
+
+    let authorId: string | null = null;
+    let authorName: string | null = null;
+
+    const staffUser = await getCurrentUserWithPermissions();
+    if (staffUser) {
+        authorId = staffUser.id;
+        authorName = staffUser.name || staffUser.email;
+    } else if (visibility === "team") {
+        throw new Error("Unauthorized");
+    } else {
+        const sessionClientId = await resolveSessionClientId();
+        if (!sessionClientId) throw new Error("Unauthorized");
+        const client = await prisma.client.findUnique({ where: { id: sessionClientId }, select: { name: true } });
+        authorName = client?.name || "Client";
+    }
+
     const comment = await prisma.documentComment.create({
-        data: { documentType, documentId, text, visibility, authorId: authorId || null, authorName: authorName || null },
+        data: { documentType, documentId, text: trimmed, visibility, authorId, authorName },
         include: { author: { select: { id: true, name: true, email: true } } },
     });
     return comment;
 }
 
 export async function deleteDocumentComment(commentId: string) {
+    // Only the comment's own author, or an ADMIN/MANAGER, may delete it.
+    const staffUser = await getCurrentUserWithPermissions();
+    const comment = await prisma.documentComment.findUnique({ where: { id: commentId }, select: { authorId: true } });
+    if (!comment) return { success: true };
+
+    const isOwnComment = !!staffUser && comment.authorId === staffUser.id;
+    const isAdminOrManager = !!staffUser && ["ADMIN", "MANAGER"].includes(staffUser.role);
+    if (!isOwnComment && !isAdminOrManager) throw new Error("Unauthorized");
+
     await prisma.documentComment.delete({ where: { id: commentId } });
     return { success: true };
 }


### PR DESCRIPTION
## Summary

- **Spoofing gap found and fixed**: `DocumentComments` (a polymorphic estimate/invoice/CO/PO comments feature with Client/Team tabs) already shipped in PR #12 back in April 2026 — it wasn't a stale prototype. Its `addDocumentComment`/`deleteDocumentComment` server actions trusted plain `authorId`/`authorName` arguments passed from the client, so any caller could post a "team" comment attributed to an arbitrary user id, or delete any comment by id. `getDocumentComments` had no auth check at all, so an anonymous/portal caller who knows a documentId (e.g. from a portal URL) could read TEAM-visibility comments. This PR hardens the existing implementation instead of building a second, parallel comments system on the same entity.
- `addDocumentComment` now derives the author from the server session: team-visibility writes require a signed-in staff session (`getCurrentUserWithPermissions`), client-visibility writes accept either a staff session (posting on the client's behalf) or a logged-in portal client (`resolveSessionClientId`) — the same dual-context pattern used by `getEstimateForPortal`/`getInvoiceForPortal`.
- `deleteDocumentComment` now requires the caller to be the comment's own author or an ADMIN/MANAGER.
- `getDocumentComments` now gates reads the same way: a staff session sees both visibilities; no staff session but a resolvable portal client sees client-visibility comments only; neither returns an empty list.
- `DocumentComments.tsx` no longer accepts or forwards `currentUserId`/`currentUserName` from the client; also fixed a hover-reveal accessibility gap on the delete button per project convention (no-hover devices).
- Mounted `DocumentComments` on the invoice editor (`documentType="invoice"`) the same way it's already mounted on the estimate editor — the model was already polymorphic, invoices just never got a comments surface.
- Added missing `error.tsx` route boundaries for `estimates` and `invoices` (the other section roots — leads, company, settings, manager, portal, sub-portal, time-clock — already had one), matching the existing `GlobalError` pattern.

No schema or migration changes — this hardens the live `DocumentComment` model rather than duplicating it.

## Round 2 (Codex review)

One blocker, three real issues:

1. **BLOCKER — cross-client isolation.** Round 1's portal-client paths checked that *a* client session resolved, but never that the resolved client actually **owns** the document being commented on — a logged-in portal client could read/write comments on any estimate or invoice id, not just their own. Added `resolveDocumentOwnerClientId(documentType, documentId)`, which derives the owning `clientId` for `"estimate"` (via `project.clientId` — Estimate can hang off a Project — or `lead.clientId` when it hangs off a Lead instead; both shapes are checked) and `"invoice"` (`clientId` is a direct required field on the model). Both `getDocumentComments` and `addDocumentComment` now require `ownerClientId === resolveSessionClientId()` before a portal caller can read/write client-visibility comments. Other `documentType` values have no portal-ownership shape resolved yet and are rejected outright for non-staff callers. Staff path is unchanged (staff already see everything).
2. **Runtime input validation.** Added a whitelist assertion for `documentType` (against the five known values: estimate, invoice, change-order, purchase-order, contract) and `visibility` (`"team"|"client"`) at the top of `getDocumentComments` and `addDocumentComment` — server actions receive untyped input at runtime regardless of the TS signature. (`deleteDocumentComment` takes neither param — only `commentId` — so there's nothing to whitelist there.)
3. **Invoice route pairing.** `src/app/projects/[id]/invoices/[invoiceId]/page.tsx` now calls `notFound()` if the loaded invoice's `projectId` doesn't match the route's `[id]`, instead of silently rendering a cross-project invoice (and, by extension, mounting `DocumentComments` against an invoice that doesn't belong to the project shown around it).
4. **Delete affordance.** `getDocumentComments` now returns a server-computed `canDelete` flag per comment (`author-or-admin` for staff, always `false` for the portal-client branch), and `DocumentComments.tsx` renders the Delete button only when `canDelete` is true — previously it was shown unconditionally and relied on the server to reject unauthorized attempts. Deliberately **not** adding an `authorClientId` schema column to let portal clients delete their own comments: there's no portal mount for this component yet, so portal-authored comments stay admin-only to delete until an actual portal use case exists. `deleteDocumentComment`'s own server-side check is unchanged and remains the real authority regardless of what the UI shows.

**Flagged but not fixed (deliberately, scoped-down per explicit direction):** `getCurrentUserWithPermissions()` doesn't filter on `User.status` — a session created before a staff account was flipped to `DISABLED` keeps working until its JWT expires. `signIn()` in `lib/auth.ts` only rejects `DISABLED` at initial login; the `jwt()` callback re-checks `role` on token refresh but never re-checks `status`. That helper is called from 10+ other actions across money paths (milestones, contracts, invoices), so changing its behavior globally isn't a safe blast radius for this PR without full regression coverage. Added a local `activeStaffUser()` wrapper scoped to just these three comment actions instead. **Follow-up needed**: decide whether to add a `status` re-check to the shared helper (with full money-path regression testing) or accept this as a known gap.

## Auth derivation per visibility

| Caller | Read (`getDocumentComments`) | Write `visibility: "team"` | Write `visibility: "client"` |
|---|---|---|---|
| Signed-in staff | Sees both visibilities, each with a computed `canDelete` | `authorId`/`authorName` from `getCurrentUserWithPermissions()` | Same — staff can post on the client thread under their own name |
| Logged-in portal client who **owns** the document | Sees `client`-visibility comments only, `canDelete: false` | Rejected (`Unauthorized`) | `authorId: null`, `authorName` from the `Client` row — requires `resolveDocumentOwnerClientId(...) === resolveSessionClientId()` |
| Logged-in portal client who does **not** own the document | Empty list | Rejected | Rejected (`Unauthorized`) |
| Unauthenticated / disabled staff account | Empty list | Rejected | Rejected |

Delete: allowed only if `comment.authorId === staffUser.id`, or the caller is ADMIN/MANAGER. Non-staff callers never satisfy either check today (no portal delete UI exists).

Both current mount points (estimate editor, invoice editor) are staff-only pages, so they keep seeing both tabs exactly as before — the ownership/ownership-gating changes only affect callers who aren't staff.

## Test plan

- [x] `npx tsc --noEmit` clean across all changed files (all three commits, including round 2)
- [ ] Click through estimate editor Comments tab (team + client) as a signed-in staff user
- [ ] Click through invoice editor Comments card as a signed-in staff user
- [ ] Confirm an unauthenticated/unauthorized delete attempt is rejected server-side
- [ ] Confirm an unauthenticated read of a known estimate/invoice id returns no team-visibility comments
- [ ] Confirm a portal client logged in as Client A cannot read/write comments on an estimate/invoice owned by Client B
- [ ] Confirm visiting `/projects/<wrong-id>/invoices/<real-invoice-id-of-a-different-project>` 404s

🤖 Generated with [Claude Code](https://claude.com/claude-code)
