### PR TITLE
fix(schedule): wire Sync to Calendar on the Calendar tab

### DIFF
--- a/src/app/projects/[id]/schedule/CalendarView.tsx
+++ b/src/app/projects/[id]/schedule/CalendarView.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import type { Task, PunchItem, EstimateSummary } from "./schedule-types";
 import ScheduleToolbar from "./ScheduleToolbar";
+import { useScheduleActions } from "./useScheduleActions";
 import {
     STATUS_OPTIONS,
     STATUS_COLORS,
@@ -59,6 +60,7 @@ function dayBucket(task: Task, day: Date): boolean {
 
 export default function CalendarView({ projectId, tasks, setTasks, estimates = [], initialPublished, viewMode, onViewModeChange, subMode, onSubModeChange }: Props) {
     const router = useRouter();
+    const actions = useScheduleActions(projectId, tasks, setTasks);
 
     const [anchor, setAnchor] = useState<Date>(() => todayUTC());
     const [isPending, startTransition] = useTransition();
@@ -217,7 +219,7 @@ export default function CalendarView({ projectId, tasks, setTasks, estimates = [
                 onToggleCriticalPath={() => {}}
                 linkMode={null}
                 onToggleLinkMode={() => {}}
-                onSyncCalendar={() => {}}
+                onSyncCalendar={actions.handleSyncCalendar}
                 isAiRisk={false}
                 onAiRisk={() => {}}
                 isImporting={false}


### PR DESCRIPTION
## Summary
- The Calendar tab passed a no-op `onSyncCalendar={() => {}}` to the shared `ScheduleToolbar`, so Tools > Sync to Calendar did nothing there. Gantt and Table already wire it via `useScheduleActions`.
- CalendarView now calls `useScheduleActions(projectId, tasks, setTasks)` and passes `actions.handleSyncCalendar`, matching the other two views. The hook is side-effect-free at mount (its only effect is gated on a selected task), so nothing else changes.

## Verification
- `tsc --noEmit` passes with 0 errors (after regenerating the stale worktree Prisma client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)