### PR TITLE
fix(change-orders): enforce lifecycle invariants [PR-205]

### DIFF
--- a/e2e/money-pipeline.spec.ts
+++ b/e2e/money-pipeline.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { PrismaClient } from "@prisma/client";
+import { approveChangeOrderCore, deleteChangeOrderCore, updateChangeOrderCore } from "../src/lib/change-order-core";
+import { sendChangeOrderToClientCore } from "../src/lib/billing-core";
 
 /**
  * Money-pipeline regression net — born from the June 2026 lifecycle audit.
@@ -445,5 +447,391 @@ test.describe.serial("Money pipeline: concurrent payments never lose a balance u
     expect(notes, "one outbox row per concurrent settle").toHaveLength(2);
     expect(notes.every((n) => n.scheduleType === "invoice")).toBe(true);
     expect(notes.every((n) => n.status === "PROCESSED"), "both delivered by the inline drain").toBe(true);
+  });
+});
+
+const COI = {
+  client: "co-invariant-e2e-client",
+  project: "co-invariant-e2e-project",
+  estimate: "co-invariant-e2e-estimate",
+  rawDraft: "co-invariant-raw-draft",
+  draftApproval: "co-invariant-draft-approval",
+  emptySent: "co-invariant-empty-sent",
+  zeroSent: "co-invariant-zero-sent",
+  validSent: "co-invariant-valid-sent",
+  approved: "co-invariant-approved",
+  race: "co-invariant-race",
+  duplicate: "co-invariant-duplicate",
+  duplicateItem: "co-invariant-duplicate-item",
+  stale: "co-invariant-stale",
+  staleItem: "co-invariant-stale-item",
+  driftSend: "co-invariant-drift-send",
+  driftSendItem: "co-invariant-drift-send-item",
+  driftApproval: "co-invariant-drift-approval",
+  driftApprovalItem: "co-invariant-drift-approval-item",
+  approvedDelete: "co-invariant-approved-delete",
+  unsigned: "co-invariant-unsigned",
+  companySigned: "co-invariant-company-signed",
+  companySignedItem: "co-invariant-company-signed-item",
+  noOpSent: "co-invariant-no-op-sent",
+  noOpSentItem: "co-invariant-no-op-sent-item",
+  legacySignedDraft: "co-invariant-legacy-signed-draft",
+};
+const coInvariantPrisma = new PrismaClient();
+
+async function rejectionMessage(operation: Promise<unknown>): Promise<string> {
+  try {
+    await operation;
+    return "";
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+test.describe.serial("Money pipeline: change-order lifecycle invariants", () => {
+  test.beforeAll(async () => {
+    await coInvariantPrisma.client.upsert({
+      where: { id: COI.client },
+      update: {},
+      create: { id: COI.client, name: "CO Invariant Client", initials: "CI" },
+    });
+    await coInvariantPrisma.project.upsert({
+      where: { id: COI.project },
+      update: {},
+      create: { id: COI.project, name: "CO Invariant Project", clientId: COI.client, status: "In Progress" },
+    });
+    await coInvariantPrisma.estimate.upsert({
+      where: { id: COI.estimate },
+      update: {},
+      create: {
+        id: COI.estimate,
+        title: "CO Invariant Estimate",
+        code: "EST-CO-INVARIANT",
+        projectId: COI.project,
+        status: "Approved",
+        taxExempt: true,
+        totalAmount: 1000,
+        balanceDue: 1000,
+      },
+    });
+
+    const ids = [
+      COI.rawDraft, COI.draftApproval, COI.emptySent, COI.zeroSent, COI.validSent,
+      COI.approved, COI.race, COI.duplicate, COI.stale, COI.driftSend,
+      COI.driftApproval, COI.approvedDelete, COI.unsigned, COI.companySigned,
+      COI.noOpSent, COI.legacySignedDraft,
+    ];
+    await coInvariantPrisma.changeOrder.deleteMany({ where: { id: { in: ids } } });
+
+    async function createChangeOrder(id: string, status: string, totalAmount: number, withItem: boolean, itemId?: string) {
+      await coInvariantPrisma.changeOrder.create({
+        data: {
+          id,
+          code: `CO-${id}`,
+          title: `Title ${id}`,
+          description: `Description ${id}`,
+          projectId: COI.project,
+          estimateId: COI.estimate,
+          status,
+          totalAmount,
+          balanceDue: totalAmount,
+          ...(status === "Sent" ? { sentAt: new Date("2026-07-17T12:00:00.000Z") } : {}),
+          ...(withItem
+            ? {
+                items: {
+                  create: {
+                    ...(itemId ? { id: itemId } : {}),
+                    name: "Invariant item",
+                    quantity: 1,
+                    unitCost: totalAmount,
+                    total: totalAmount,
+                    order: 0,
+                  },
+                },
+              }
+            : {}),
+        },
+      });
+    }
+
+    await createChangeOrder(COI.rawDraft, "Draft", 100, true);
+    await createChangeOrder(COI.draftApproval, "Draft", 100, true);
+    await createChangeOrder(COI.emptySent, "Sent", 100, false);
+    await createChangeOrder(COI.zeroSent, "Sent", 0, true);
+    await createChangeOrder(COI.validSent, "Sent", 100, true);
+    await createChangeOrder(COI.approved, "Approved", 100, true);
+    await createChangeOrder(COI.race, "Sent", 100, true);
+    await createChangeOrder(COI.duplicate, "Draft", 100, true, COI.duplicateItem);
+    await createChangeOrder(COI.stale, "Sent", 100, true, COI.staleItem);
+    await createChangeOrder(COI.driftSend, "Sent", 110, true, COI.driftSendItem);
+    await createChangeOrder(COI.driftApproval, "Sent", 110, true, COI.driftApprovalItem);
+    await createChangeOrder(COI.approvedDelete, "Approved", 100, true);
+    await createChangeOrder(COI.unsigned, "Sent", 100, true);
+    await createChangeOrder(COI.companySigned, "Sent", 100, true, COI.companySignedItem);
+    await createChangeOrder(COI.noOpSent, "Sent", 100, true, COI.noOpSentItem);
+    await createChangeOrder(COI.legacySignedDraft, "Draft", 100, true);
+    await coInvariantPrisma.changeOrderItem.updateMany({
+      where: { id: { in: [COI.driftSendItem, COI.driftApprovalItem] } },
+      data: { unitCost: 100, total: 100 },
+    });
+    await coInvariantPrisma.changeOrder.update({
+      where: { id: COI.companySigned },
+      data: { companySignedBy: "Company Signer", companySignedAt: new Date(), companySignatureUrl: "data:image/png;base64,AA==" },
+    });
+    await coInvariantPrisma.changeOrder.update({
+      where: { id: COI.legacySignedDraft },
+      data: { companySignedBy: "Legacy Company Signer", companySignedAt: new Date(), companySignatureUrl: "data:image/png;base64,AA==" },
+    });
+  });
+
+  test.afterAll(async () => {
+    try {
+      await coInvariantPrisma.changeOrder.deleteMany({ where: { projectId: COI.project } });
+      await coInvariantPrisma.estimate.deleteMany({ where: { id: COI.estimate } });
+      await coInvariantPrisma.project.deleteMany({ where: { id: COI.project } });
+      await coInvariantPrisma.client.deleteMany({ where: { id: COI.client } });
+    } finally {
+      await coInvariantPrisma.$disconnect();
+    }
+  });
+
+  test("CO1: generic updates cannot perform Draft -> Sent", async () => {
+    const message = await rejectionMessage(updateChangeOrderCore(COI.rawDraft, { status: "Sent" }));
+    expect(message).toContain("Send for Approval");
+    const co = await coInvariantPrisma.changeOrder.findUniqueOrThrow({ where: { id: COI.rawDraft } });
+    expect(co.status).toBe("Draft");
+    expect(co.sentAt).toBeNull();
+  });
+
+  test("CO2: approval requires the Sent state", async () => {
+    const message = await rejectionMessage(approveChangeOrderCore(COI.draftApproval, {
+      signatureName: "Invariant Signer",
+      clientSignatureUrl: "data:image/png;base64,AA==",
+      approvedAt: new Date(),
+    }));
+    expect(message).toContain("must be Sent");
+    expect((await coInvariantPrisma.changeOrder.findUniqueOrThrow({ where: { id: COI.draftApproval } })).status).toBe("Draft");
+  });
+
+  test("CO3: approval requires at least one item", async () => {
+    const message = await rejectionMessage(approveChangeOrderCore(COI.emptySent, {
+      signatureName: "Invariant Signer",
+      clientSignatureUrl: "data:image/png;base64,AA==",
+      approvedAt: new Date(),
+    }));
+    expect(message).toContain("priced item");
+    expect((await coInvariantPrisma.changeOrder.findUniqueOrThrow({ where: { id: COI.emptySent } })).status).toBe("Sent");
+  });
+
+  test("CO4: approval requires a positive subtotal", async () => {
+    const message = await rejectionMessage(approveChangeOrderCore(COI.zeroSent, {
+      signatureName: "Invariant Signer",
+      clientSignatureUrl: "data:image/png;base64,AA==",
+      approvedAt: new Date(),
+    }));
+    expect(message).toContain("positive subtotal");
+    expect((await coInvariantPrisma.changeOrder.findUniqueOrThrow({ where: { id: COI.zeroSent } })).status).toBe("Sent");
+  });
+
+  test("CO5: a valid Sent change order approves exactly once", async () => {
+    const attempts = await Promise.allSettled([
+      approveChangeOrderCore(COI.validSent, {
+        signatureName: "First Signer",
+        clientSignatureUrl: "data:image/png;base64,AA==",
+        approvedAt: new Date(),
+      }),
+      approveChangeOrderCore(COI.validSent, {
+        signatureName: "Second Signer",
+        clientSignatureUrl: "data:image/png;base64,AQ==",
+        approvedAt: new Date(),
+      }),
+    ]);
+    expect(attempts.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(attempts.filter((result) => result.status === "rejected")).toHaveLength(1);
+    const winner = attempts.find((result) => result.status === "fulfilled");
+    expect(winner?.status === "fulfilled" ? winner.value?.transitioned : false).toBe(true);
+
+    const co = await coInvariantPrisma.changeOrder.findUniqueOrThrow({ where: { id: COI.validSent } });
+    expect(co.status).toBe("Approved");
+    expect(["First Signer", "Second Signer"]).toContain(co.approvedBy);
+  });
+
+  test("CO6: Approved scope metadata is immutable", async () => {
+    const original = await coInvariantPrisma.changeOrder.findUniqueOrThrow({
+      where: { id: COI.approved },
+      include: { items: true },
+    });
+    const titleMessage = await rejectionMessage(updateChangeOrderCore(COI.approved, { title: "Mutated signed title" }));
+    expect(titleMessage).toContain("signed scope is locked");
+    const descriptionMessage = await rejectionMessage(updateChangeOrderCore(COI.approved, { description: "Mutated signed description" }));
+    expect(descriptionMessage).toContain("signed scope is locked");
+    const itemsMessage = await rejectionMessage(updateChangeOrderCore(COI.approved, {
+      items: [{ id: original.items[0].id, name: "Mutated item", quantity: 2, unitCost: 100, order: 0 }],
+    }));
+    expect(itemsMessage).toContain("signed scope is locked");
+
+    const after = await coInvariantPrisma.changeOrder.findUniqueOrThrow({
+      where: { id: COI.approved },
+      include: { items: true },
+    });
+    expect(after.title).toBe(original.title);
+    expect(after.description).toBe(original.description);
+    expect(after.items).toEqual(original.items);
+  });
+
+  test("CO7: approval validation serializes with a concurrent item repricing", async () => {
+    let releaseWriter!: () => void;
+    const writerMayCommit = new Promise<void>((resolve) => { releaseWriter = resolve; });
+    let writerLocked!: () => void;
+    const writerHasLock = new Promise<void>((resolve) => { writerLocked = resolve; });
+
+    const writer = coInvariantPrisma.$transaction(async (tx) => {
+      await tx.$queryRaw`SELECT "id" FROM "ChangeOrder" WHERE "id" = ${COI.race} FOR UPDATE`;
+      await tx.changeOrderItem.deleteMany({ where: { changeOrderId: COI.race } });
+      await tx.changeOrder.update({ where: { id: COI.race }, data: { totalAmount: 0, balanceDue: 0 } });
+      writerLocked();
+      await writerMayCommit;
+    }, { timeout: 15_000 });
+
+    await writerHasLock;
+    const approval = approveChangeOrderCore(COI.race, {
+      signatureName: "Racing Signer",
+      clientSignatureUrl: "data:image/png;base64,AA==",
+      approvedAt: new Date(),
+    });
+    try {
+      await expect.poll(async () => {
+        const rows = await coInvariantPrisma.$queryRaw<Array<{ count: number }>>`
+          SELECT COUNT(*)::int AS "count"
+          FROM pg_stat_activity
+          WHERE wait_event_type = 'Lock'
+            AND state = 'active'
+            AND query LIKE '%FROM "ChangeOrder"%FOR UPDATE%'`;
+        return rows[0]?.count ?? 0;
+      }, { timeout: 5_000, intervals: [25, 50, 100] }).toBeGreaterThan(0);
+    } finally {
+      releaseWriter();
+    }
+    await writer;
+
+    const message = await rejectionMessage(approval);
+    expect(message).toMatch(/priced item|positive subtotal/);
+    const co = await coInvariantPrisma.changeOrder.findUniqueOrThrow({
+      where: { id: COI.race },
+      include: { items: true },
+    });
+    expect(co.status).toBe("Sent");
+    expect(co.items).toHaveLength(0);
+    expect(Number(co.totalAmount)).toBe(0);
+  });
+
+  test("CO8: duplicate item IDs cannot inflate the stored subtotal", async () => {
+    const message = await rejectionMessage(updateChangeOrderCore(COI.duplicate, {
+      items: [
+        { id: COI.duplicateItem, name: "Invariant item", quantity: 1, unitCost: 100, order: 0 },
+        { id: COI.duplicateItem, name: "Invariant item", quantity: 1, unitCost: 100, order: 1 },
+      ],
+    }));
+    expect(message).toContain("Duplicate change-order item ID");
+
+    const co = await coInvariantPrisma.changeOrder.findUniqueOrThrow({
+      where: { id: COI.duplicate },
+      include: { items: true },
+    });
+    expect(co.items).toHaveLength(1);
+    expect(Number(co.items[0].total)).toBe(100);
+    expect(Number(co.totalAmount)).toBe(100);
+    expect(Number(co.balanceDue)).toBe(100);
+  });
+
+  test("CO9: editing Sent scope demotes it to Draft and invalidates a stale approval", async () => {
+    const updated = await updateChangeOrderCore(COI.stale, {
+      title: "Repriced after client render",
+      items: [{ id: COI.staleItem, name: "Invariant item", quantity: 1, unitCost: 200, order: 0 }],
+    });
+    expect(updated.status).toBe("Draft");
+    expect(updated.sentAt).toBeNull();
+    expect(Number(updated.totalAmount)).toBe(200);
+
+    const message = await rejectionMessage(approveChangeOrderCore(COI.stale, {
+      signatureName: "Stale-page Signer",
+      clientSignatureUrl: "data:image/png;base64,AA==",
+      approvedAt: new Date(),
+    }));
+    expect(message).toContain("must be Sent");
+  });
+
+  test("CO10: guarded send rejects stored subtotal drift from rendered items", async () => {
+    const result = await sendChangeOrderToClientCore(COI.driftSend);
+    expect(result.success).toBe(false);
+    expect(result.success ? "" : result.error).toContain("out of sync");
+    expect((await coInvariantPrisma.changeOrder.findUniqueOrThrow({ where: { id: COI.driftSend } })).status).toBe("Sent");
+  });
+
+  test("CO11: approval rejects stored subtotal drift from rendered items", async () => {
+    const message = await rejectionMessage(approveChangeOrderCore(COI.driftApproval, {
+      signatureName: "Drift Signer",
+      clientSignatureUrl: "data:image/png;base64,AA==",
+      approvedAt: new Date(),
+    }));
+    expect(message).toContain("out of sync");
+    expect((await coInvariantPrisma.changeOrder.findUniqueOrThrow({ where: { id: COI.driftApproval } })).status).toBe("Sent");
+  });
+
+  test("CO12: signed change orders cannot be deleted", async () => {
+    const message = await rejectionMessage(deleteChangeOrderCore(COI.approvedDelete));
+    expect(message).toContain("Only unsigned Draft change orders can be deleted");
+    expect(await coInvariantPrisma.changeOrder.findUnique({ where: { id: COI.approvedDelete } })).not.toBeNull();
+  });
+
+  test("CO13: approval requires a persisted client signature", async () => {
+    const message = await rejectionMessage(approveChangeOrderCore(COI.unsigned, {
+      signatureName: "Unsigned Signer",
+      clientSignatureUrl: null,
+      approvedAt: new Date(),
+    }));
+    expect(message).toContain("signature is required");
+    expect((await coInvariantPrisma.changeOrder.findUniqueOrThrow({ where: { id: COI.unsigned } })).status).toBe("Sent");
+  });
+
+  test("CO14: company-countersigned scope is immutable before client approval", async () => {
+    const message = await rejectionMessage(updateChangeOrderCore(COI.companySigned, {
+      items: [{ id: COI.companySignedItem, name: "Mutated after company signature", quantity: 1, unitCost: 200, order: 0 }],
+    }));
+    expect(message).toContain("signed scope is locked");
+    const co = await coInvariantPrisma.changeOrder.findUniqueOrThrow({ where: { id: COI.companySigned } });
+    expect(co.status).toBe("Sent");
+    expect(Number(co.totalAmount)).toBe(100);
+  });
+
+  test("CO15: a no-op save preserves Sent status and its delivery timestamp", async () => {
+    const before = await coInvariantPrisma.changeOrder.findUniqueOrThrow({
+      where: { id: COI.noOpSent },
+      include: { items: true },
+    });
+    const updated = await updateChangeOrderCore(COI.noOpSent, {
+      title: before.title,
+      description: before.description,
+      items: before.items.map((item) => ({
+        id: item.id,
+        name: item.name,
+        description: item.description,
+        type: item.type,
+        quantity: item.quantity,
+        unitCost: Number(item.unitCost),
+        order: item.order,
+        costCodeId: item.costCodeId,
+        costTypeId: item.costTypeId,
+      })),
+    });
+
+    expect(updated.status).toBe("Sent");
+    expect(updated.sentAt?.toISOString()).toBe(before.sentAt?.toISOString());
+  });
+
+  test("CO16: a legacy company-signed Draft cannot be deleted", async () => {
+    const message = await rejectionMessage(deleteChangeOrderCore(COI.legacySignedDraft));
+    expect(message).toContain("Only unsigned Draft change orders can be deleted");
+    expect(await coInvariantPrisma.changeOrder.findUnique({ where: { id: COI.legacySignedDraft } })).not.toBeNull();
   });
 });

--- a/src/app/portal/change-orders/[id]/PortalChangeOrderClient.tsx
+++ b/src/app/portal/change-orders/[id]/PortalChangeOrderClient.tsx
@@ -41,6 +41,7 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
     };
 
     const isApproved = initialData.status === "Approved";
+    const isSent = initialData.status === "Sent";
     const companyName = companySettings?.companyName || "Golden Touch Remodeling";
     const companyPhone = companySettings?.phone || "";
     const companyEmail = companySettings?.email || "";
@@ -242,7 +243,7 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
                     </div>
 
                     {/* Signature / Approval Area */}
-                    {!isApproved && (
+                    {isSent && (
                         <div className="px-10 pb-10 print:hidden">
                             <div className="border-t-2 border-slate-200 pt-8">
                                 <div className="text-center max-w-lg mx-auto">
@@ -307,6 +308,14 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
                                         </div>
                                     )}
                                 </div>
+                            </div>
+                        </div>
+                    )}
+                    {!isApproved && !isSent && (
+                        <div className="px-10 pb-10 print:hidden">
+                            <div className="border-t-2 border-slate-200 pt-8 text-center">
+                                <h3 className="text-lg font-bold text-slate-800 mb-2">Change Order Under Revision</h3>
+                                <p className="text-sm text-slate-500">This change order is not currently available for approval. Please use the newest link from your contractor.</p>
                             </div>
                         </div>
                     )}

--- a/src/app/projects/[id]/change-orders/[coId]/ChangeOrderEditor.tsx
+++ b/src/app/projects/[id]/change-orders/[coId]/ChangeOrderEditor.tsx
@@ -23,9 +23,20 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
     const [isSigning, setIsSigning] = useState(false);
     const [isSending, setIsSending] = useState(false);
 
-    // A signed CO is a contract: its items are locked (the server rejects item
-    // writes on Approved COs; only title/description remain editable).
-    const isApproved = initialData.status === "Approved";
+    // A signed CO is a contract: title, description, and items are the approved
+    // scope and remain immutable after approval. The server enforces the same
+    // rule; these disabled controls make that invariant visible in the editor.
+    const isApproved = status === "Approved";
+    const hasSignatureAudit = !!(
+        initialData.approvedBy
+        || initialData.approvedAt
+        || initialData.clientSignatureUrl
+        || initialData.companySignedBy
+        || initialData.companySignedAt
+        || initialData.companySignatureUrl
+    );
+    const isScopeLocked = isApproved || hasSignatureAudit;
+    const canCountersign = status === "Sent" || status === "Approved";
 
     // Same integer-cents math as the server's item sync and billChangeOrderCore,
     // so the Revised Amount shown here is exactly what billing will charge.
@@ -57,6 +68,10 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
     // a signature request when the save failed (they'd sign the stale amounts).
     async function handleSave(): Promise<boolean> {
         if (isDeleting) return false; // Prevent saving if we are in the middle of deleting
+        if (isScopeLocked) {
+            toast.error("Signed change orders are locked. Create a new change order for additional work.");
+            return false;
+        }
         setIsSaving(true);
         const mappedItems = items.map((item, index) => ({
             id: item.id,
@@ -76,11 +91,12 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
             // tax-inclusive total here is what inflated billed amounts before.
             // Status is never sent: sendChangeOrderToClientCore owns Draft -> Sent,
             // and Approved/Declined belong to the signature flows.
-            await updateChangeOrder(initialData.id, {
+            const updated = await updateChangeOrder(initialData.id, {
                 title,
                 description,
-                ...(isApproved ? {} : { items: mappedItems }),
+                items: mappedItems,
             });
+            setStatus(updated.status);
             toast.success("Change Order saved");
             router.refresh();
             return true;
@@ -185,13 +201,15 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
                     </a>
                     <button
                         onClick={handleDelete}
-                        disabled={isDeleting}
+                        disabled={isDeleting || status !== "Draft" || hasSignatureAudit}
+                        title={status !== "Draft" || hasSignatureAudit ? "Only unsigned Draft change orders can be deleted" : undefined}
                         className="hui-btn hui-btn-secondary text-red-600 border-red-200 hover:bg-red-50 disabled:opacity-50"
                     >
                         Delete
                     </button>
                     <button
-                        disabled={isSending}
+                        disabled={isSending || isApproved}
+                        title={isApproved ? "Approved change orders cannot be resent" : undefined}
                         onClick={async () => {
                             if (!confirm("Save and send this change order to the client for approval?")) return;
                             setIsSending(true);
@@ -201,7 +219,7 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
                                 // sign amounts that never persisted. The Sent status
                                 // is owned by sendChangeOrderToClientCore; the local
                                 // badge only updates after a confirmed send.
-                                const saved = await handleSave();
+                                const saved = isScopeLocked ? true : await handleSave();
                                 if (!saved) return;
                                 const result = await sendChangeOrderToClient(initialData.id);
                                 if (result.success) {
@@ -223,7 +241,8 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
                     </button>
                     <button
                         onClick={handleSave}
-                        disabled={isSaving}
+                        disabled={isSaving || isScopeLocked}
+                        title={isScopeLocked ? "Signed change orders are locked" : undefined}
                         className="hui-btn hui-btn-primary bg-amber-600 hover:bg-amber-700 border-amber-600 text-white disabled:opacity-50"
                     >
                         {isSaving ? "Saving..." : "Save"}
@@ -240,6 +259,7 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
                                 <input
                                     type="text"
                                     value={title}
+                                    disabled={isScopeLocked}
                                     onChange={e => setTitle(e.target.value)}
                                     className="text-4xl font-extrabold tracking-tight text-slate-800 w-full focus:outline-none focus:bg-slate-50 hover:bg-slate-50 transition-colors rounded-lg px-3 py-2 -ml-3 placeholder:text-slate-300 bg-transparent"
                                     placeholder="Change Order Title"
@@ -281,7 +301,7 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
                                                     <input
                                                         type="text"
                                                         value={item.name}
-                                                        disabled={isApproved}
+                                                        disabled={isScopeLocked}
                                                         onChange={e => updateItem(index, "name", e.target.value)}
                                                         className="w-full bg-transparent focus:outline-none focus:bg-white focus:ring-1 ring-hui-border rounded px-2 py-1 -ml-2 transition text-sm font-medium text-hui-textMain"
                                                     />
@@ -290,7 +310,7 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
                                                     <input
                                                         type="number"
                                                         value={item.quantity}
-                                                        disabled={isApproved}
+                                                        disabled={isScopeLocked}
                                                         onChange={e => updateItem(index, "quantity", e.target.value)}
                                                         className="w-full bg-transparent focus:outline-none focus:bg-white focus:ring-1 ring-slate-200 rounded px-2 py-1 text-right hover:bg-slate-50 transition text-sm font-medium text-slate-700"
                                                     />
@@ -300,7 +320,7 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
                                                     <input
                                                         type="number"
                                                         value={item.unitCost}
-                                                        disabled={isApproved}
+                                                        disabled={isScopeLocked}
                                                         onChange={e => updateItem(index, "unitCost", e.target.value)}
                                                         className="w-full bg-transparent focus:outline-none focus:bg-white focus:ring-1 ring-slate-200 rounded px-2 py-1 pl-6 text-right hover:bg-slate-50 transition text-sm font-medium text-slate-700"
                                                     />
@@ -309,7 +329,7 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
                                                     {formatCurrency(itemTotal)}
                                                 </div>
                                                 <div className="w-10 pt-1.5 flex justify-end">
-                                                    {!isApproved && (
+                                                    {!isScopeLocked && (
                                                         <button onClick={() => removeItem(index)} className="text-slate-300 hover:text-red-500 hover:bg-red-50 rounded p-1.5 transition opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto">
                                                             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6 6 18M6 6l12 12" /></svg>
                                                         </button>
@@ -323,7 +343,7 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
                                     )}
                                 </div>
 
-                                {!isApproved && (
+                                {!isScopeLocked && (
                                     <div className="p-4 px-8 border-t border-slate-100 bg-white hover:bg-slate-50 transition-colors flex items-center gap-4 cursor-pointer group" onClick={addItem}>
                                         <button className="text-sm font-semibold text-amber-600 group-hover:text-amber-700 flex items-center gap-2 transition">
                                             <span className="bg-amber-50 text-amber-600 group-hover:bg-amber-100 rounded p-1">
@@ -368,8 +388,9 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
                                     className="hui-input w-full h-40 resize-y"
                                     placeholder="Enter details around the need for this change order..."
                                     value={description}
+                                    disabled={isScopeLocked}
                                     onChange={(e) => setDescription(e.target.value)}
-                                    onBlur={handleSave}
+                                    onBlur={isScopeLocked || description === (initialData.description || "") ? undefined : handleSave}
                                 />
                             </div>
                         </div>
@@ -440,7 +461,12 @@ export default function ChangeOrderEditor({ context, initialData }: { context: a
                                                 <p className="text-sm text-slate-700 font-medium">Ready to sign?</p>
                                                 <p className="text-xs text-slate-500 mt-1">Sign on behalf of the company.</p>
                                             </div>
-                                            <button onClick={() => setShowSignModal(true)} className="text-amber-600 hover:text-amber-700 font-medium text-sm mt-1">Sign Now →</button>
+                                            <button
+                                                onClick={() => setShowSignModal(true)}
+                                                disabled={!canCountersign}
+                                                title={!canCountersign ? "Send the change order before countersigning" : undefined}
+                                                className="text-amber-600 hover:text-amber-700 font-medium text-sm mt-1 disabled:text-slate-400 disabled:cursor-not-allowed"
+                                            >Sign Now →</button>
                                         </div>
                                     )}
                                 </div>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -15,7 +15,8 @@ import { persistSignature } from "./signature-storage";
 import { getCurrentUserWithPermissions, hasPermission, canAccessProject } from "./permissions";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { enqueueMilestonePaid, drainPaymentNotifications } from "./payment-outbox";
-import { coLineCents } from "./co-tax";
+import { approveChangeOrderCore, deleteChangeOrderCore, updateChangeOrderCore } from "./change-order-core";
+import type { ChangeOrderUpdateInput } from "./change-order-core";
 import { emptyDoc } from "@/lib/studio/doc";
 import type { RoomType } from "@/lib/studio/templates";
 import { normalizeE164 } from "./phone";
@@ -7473,16 +7474,21 @@ export async function getChangeOrderForPortal(id: string) {
 
     // IDOR-4 fix: portal clients are gated by their session's clientId
     let clientFilter = {};
+    let lifecycleFilter = {};
     if (!isStaff) {
         const sessionClientId = await resolveSessionClientId();
         if (!sessionClientId) return null;
         clientFilter = { project: { clientId: sessionClientId } };
+        // Draft includes never-sent and invalidated-after-edit versions. A
+        // leaked/stale portal URL must not expose either to the client.
+        lifecycleFilter = { status: { in: ["Sent", "Approved", "Declined"] } };
     }
 
     return await prisma.changeOrder.findFirst({
         where: {
             id,
             ...clientFilter,
+            ...lifecycleFilter,
         },
         include: {
             project: { include: { client: true } },
@@ -7493,7 +7499,7 @@ export async function getChangeOrderForPortal(id: string) {
     });
 }
 
-export async function updateChangeOrder(id: string, data: any) {
+export async function updateChangeOrder(id: string, data: ChangeOrderUpdateInput) {
     "use server";
     // Money-path: this is a remotely invokable server action — gate it like
     // sendChangeOrderToClient and whitelist fields so callers can't write
@@ -7501,90 +7507,11 @@ export async function updateChangeOrder(id: string, data: any) {
     const user = await getCurrentUserWithPermissions();
     if (!user) throw new Error("Unauthorized");
     if (!hasPermission(user, "changeOrders")) throw new Error("Forbidden");
+    const target = await prisma.changeOrder.findUnique({ where: { id }, select: { projectId: true } });
+    if (!target) throw new Error("Change order not found");
+    if (!canAccessProject(user, target.projectId)) throw new Error("Forbidden");
 
-    const items: any[] | undefined = Array.isArray(data.items) ? data.items : undefined;
-
-    const co = await prisma.$transaction(async (tx) => {
-        // Row lock (same style as billChangeOrderCore): a concurrent approval or
-        // billing run serializes on this row, so we can't read a stale status and
-        // re-price a CO that gets approved mid-save — approve/bill writers block
-        // until this transaction commits, and vice versa.
-        const locked = await tx.$queryRaw<Array<{ status: string; totalAmount: unknown }>>`
-            SELECT "status", "totalAmount" FROM "ChangeOrder" WHERE "id" = ${id} FOR UPDATE`;
-        const current = locked[0];
-        if (!current) throw new Error("Change order not found");
-
-        const scalarData: Record<string, unknown> = {};
-        if (data.title !== undefined) scalarData.title = data.title;
-        if (data.description !== undefined) scalarData.description = data.description;
-        if (data.status !== undefined && data.status !== current.status) {
-            // The editor only moves Draft <-> Sent. Approved/Declined are owned by
-            // the signature/decline flows (approveChangeOrder drives billing) — a
-            // raw status write in either direction would bypass them.
-            if (!["Draft", "Sent"].includes(data.status) || !["Draft", "Sent"].includes(current.status)) {
-                throw new Error(`Status can only move between Draft and Sent here — "${current.status}" is owned by the signature flow.`);
-            }
-            scalarData.status = data.status;
-        }
-
-        if (items) {
-            // Integer-cents line math (mirrors createChangeOrderDraft) so float dust
-            // can't mis-round a line. totalAmount is the PRE-TAX subtotal — billing
-            // (billChangeOrderCore) adds the estimate's tax on top when invoicing —
-            // and is recomputed here from the items, never trusted from the client.
-            let totalCents = 0;
-            const rows = items.map((item: any, idx: number) => {
-                const quantity = parseFloat(item.quantity) || 0;
-                const unitCost = parseFloat(item.unitCost) || 0;
-                const unitCents = Math.round(unitCost * 100);
-                const lineCents = coLineCents(quantity, unitCost);
-                totalCents += lineCents;
-                return {
-                    id: item.id || undefined,
-                    name: item.name || "",
-                    description: item.description || null,
-                    ...(item.type ? { type: item.type } : {}),
-                    quantity,
-                    unitCost: unitCents / 100,
-                    total: lineCents / 100,
-                    order: item.order ?? idx,
-                    costCodeId: item.costCodeId || null,
-                    costTypeId: item.costTypeId || null,
-                };
-            });
-
-            // An Approved CO's items are what the customer signed and what billing
-            // put on the invoice — any item write here (amounts, quantities, cost
-            // codes) would desync the signed document from the billed milestone.
-            // Title/description edits stay allowed via the scalar path.
-            if (current.status === "Approved") {
-                throw new Error("This change order is approved and billed — its items are locked. Create a new change order for additional work.");
-            }
-
-            // Differential item sync (same pattern as saveEstimate): delete rows the
-            // editor removed, update surviving rows, create new ones.
-            const existing = await tx.changeOrderItem.findMany({ where: { changeOrderId: id }, select: { id: true } });
-            const existingIds = new Set(existing.map(i => i.id));
-            const incomingIds = new Set(rows.map(r => r.id).filter(Boolean));
-            const toDelete = existing.filter(i => !incomingIds.has(i.id)).map(i => i.id);
-            if (toDelete.length > 0) {
-                await tx.changeOrderItem.deleteMany({ where: { id: { in: toDelete }, changeOrderId: id } });
-            }
-            for (const row of rows) {
-                const { id: itemId, ...itemData } = row;
-                if (itemId && existingIds.has(itemId)) {
-                    await tx.changeOrderItem.update({ where: { id: itemId }, data: itemData });
-                } else {
-                    await tx.changeOrderItem.create({ data: { ...itemData, ...(itemId ? { id: itemId } : {}), changeOrderId: id } });
-                }
-            }
-
-            scalarData.totalAmount = totalCents / 100;
-            scalarData.balanceDue = totalCents / 100;
-        }
-
-        return tx.changeOrder.update({ where: { id }, data: scalarData });
-    }, { timeout: 15_000 });
+    const co = await updateChangeOrderCore(id, data);
 
     revalidatePath(`/projects/${co.projectId}/change-orders/${id}`);
     revalidatePath(`/projects/${co.projectId}/change-orders`);
@@ -7593,9 +7520,15 @@ export async function updateChangeOrder(id: string, data: any) {
 
 export async function deleteChangeOrder(id: string) {
     "use server";
-    const co = await prisma.changeOrder.findUnique({ where: { id } });
+    const user = await getCurrentUserWithPermissions();
+    if (!user) throw new Error("Unauthorized");
+    if (!hasPermission(user, "changeOrders")) throw new Error("Forbidden");
+    const target = await prisma.changeOrder.findUnique({ where: { id }, select: { projectId: true } });
+    if (!target) return;
+    if (!canAccessProject(user, target.projectId)) throw new Error("Forbidden");
+
+    const co = await deleteChangeOrderCore(id);
     if (!co) return;
-    await prisma.changeOrder.delete({ where: { id } });
     revalidatePath(`/projects/${co.projectId}/change-orders`);
 }
 
@@ -7626,32 +7559,28 @@ export async function approveChangeOrder(id: string, signatureName: string, user
         if (!owned) return null;
     }
 
+    const normalizedSignatureName = signatureName.trim();
+    if (!normalizedSignatureName) throw new Error("Your full legal name is required");
+    if (!signatureDataUrl) throw new Error("A drawn signature is required");
+
     // Move the signature image into Storage (avoids the PgBouncer pooler message-size
     // error on large data-URLs); falls back to the data-URL when Storage isn't configured.
     const clientSignatureUrl = await persistSignature(signatureDataUrl, `change-orders/${id}/client`);
 
-    // Atomic transition: only the FIRST approval flips the status (a concurrent
-    // or repeated signing matches zero rows), which also preserves the original
-    // signer's audit trail instead of overwriting it.
+    // The core takes the same CO row lock as editing/sending/billing and enforces
+    // Sent + item existence + positive subtotal in that transaction before the
+    // one-time Approved write.
     const approvedAt = new Date();
-    const transition = await prisma.changeOrder.updateMany({
-        where: { id, status: { not: "Approved" } },
-        data: {
-            status: "Approved",
-            approvedBy: signatureName,
-            approvedAt,
-            clientSignatureUrl,
-        },
-    });
-    const co = await prisma.changeOrder.findUnique({ where: { id } });
-    if (!co) return null;
+    const approval = await approveChangeOrderCore(id, { signatureName: normalizedSignatureName, clientSignatureUrl, approvedAt });
+    if (!approval) return null;
+    const { co, transitioned } = approval;
 
     // Exactly-once post-approval automation: bill the CO onto the invoice and send
     // the payment link (the signature on the exact amount is the approval), with a
     // team notification either way. Scheduled AFTER the response so the customer's
     // signing screen never waits on QuickBooks; falls back to inline best-effort
     // outside a request context.
-    if (transition.count === 1) {
+    if (transitioned) {
         const runAutomation = async () => {
             try {
                 const { handleChangeOrderApproved } = await import("./billing-core");
@@ -7695,8 +7624,11 @@ export async function countersignChangeOrderAsCompany(id: string, signerName: st
     }
 
     // Verify the change order exists (clear 404-style error) and grab projectId for revalidation.
-    const existing = await prisma.changeOrder.findUnique({ where: { id }, select: { id: true, projectId: true } });
+    const existing = await prisma.changeOrder.findUnique({ where: { id }, select: { id: true, projectId: true, status: true } });
     if (!existing) throw new Error("Change order not found");
+    if (existing.status !== "Sent" && existing.status !== "Approved") {
+        throw new Error("Change order must be Sent before it can be countersigned");
+    }
 
     // Move the signature image into Storage (avoids the PgBouncer pooler message-size
     // error on large data-URLs); falls back to the data-URL when Storage isn't configured.
@@ -7705,7 +7637,7 @@ export async function countersignChangeOrderAsCompany(id: string, signerName: st
     // Atomic idempotency guard — updateMany only matches rows where companySignedAt IS NULL,
     // so two concurrent requests can't both succeed (eliminates TOCTOU race).
     const result = await prisma.changeOrder.updateMany({
-        where: { id, companySignedAt: null },
+        where: { id, companySignedAt: null, status: { in: ["Sent", "Approved"] } },
         data: {
             companySignedBy: signerName.trim(),
             companySignedAt: new Date(),
@@ -7727,6 +7659,9 @@ export async function sendChangeOrderToClient(changeOrderId: string): Promise<{ 
     const user = await getCurrentUserWithPermissions();
     if (!user) return { success: false, error: "Unauthorized" };
     if (!hasPermission(user, "changeOrders")) return { success: false, error: "Forbidden" };
+    const target = await prisma.changeOrder.findUnique({ where: { id: changeOrderId }, select: { projectId: true } });
+    if (!target) return { success: false, error: "Change order not found" };
+    if (!canAccessProject(user, target.projectId)) return { success: false, error: "Forbidden" };
     const { sendChangeOrderToClientCore } = await import("./billing-core");
     return sendChangeOrderToClientCore(changeOrderId);
 }

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -15,7 +15,7 @@ import { prisma } from "@/lib/prisma";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { sendNotification } from "./email";
 import { formatCurrency } from "./utils";
-import { coTaxRate, coTaxLabel } from "./co-tax";
+import { coTaxRate, coTaxLabel, coLineCents } from "./co-tax";
 
 // Session-free cores of the billing flows, shared by the permission-gated server
 // actions in actions.ts and the MCP connector (whose auth is the shared secret at
@@ -971,10 +971,20 @@ export async function sendChangeOrderToClientCore(changeOrderId: string): Promis
         // An unpriced draft (e.g. an AI-suggested CO the PM hasn't priced yet)
         // must never reach the client for signature at $0 — once approved it
         // bills and locks, and a $0 approved CO can't be repaired.
-        const itemCount = await tx.changeOrderItem.count({ where: { changeOrderId } });
-        const rawSubtotal = Math.round(Number(co.totalAmount) * 100) / 100;
-        if (itemCount === 0 || rawSubtotal <= 0) {
+        const items = await tx.changeOrderItem.findMany({
+            where: { changeOrderId },
+            select: { quantity: true, unitCost: true },
+        });
+        const storedSubtotalCents = Math.round(Number(co.totalAmount) * 100);
+        const renderedSubtotalCents = items.reduce(
+            (sum, item) => sum + coLineCents(item.quantity, Number(item.unitCost)),
+            0,
+        );
+        if (items.length === 0 || storedSubtotalCents <= 0 || renderedSubtotalCents <= 0) {
             return { kind: "error", error: `Change order ${co.code} has no priced items yet — add pricing before sending it to the client.` };
+        }
+        if (storedSubtotalCents !== renderedSubtotalCents) {
+            return { kind: "error", error: `Change order ${co.code} pricing is out of sync with its items — save it before sending.` };
         }
 
         const project = await tx.project.findUnique({

--- a/src/lib/change-order-core.ts
+++ b/src/lib/change-order-core.ts
@@ -1,0 +1,286 @@
+import { prisma } from "./prisma";
+import { coLineCents } from "./co-tax";
+
+type ChangeOrderItemInput = {
+    id?: string;
+    name?: string;
+    description?: string | null;
+    type?: string;
+    quantity?: string | number;
+    unitCost?: string | number;
+    order?: number;
+    costCodeId?: string | null;
+    costTypeId?: string | null;
+};
+
+export type ChangeOrderUpdateInput = {
+    title?: string;
+    description?: string | null;
+    status?: unknown;
+    items?: ChangeOrderItemInput[] | unknown;
+    [key: string]: unknown;
+};
+
+function itemSubtotalCents(items: Array<{ quantity: number; unitCost: unknown }>): number {
+    return items.reduce((sum, item) => sum + coLineCents(item.quantity, Number(item.unitCost)), 0);
+}
+
+/**
+ * Session-free change-order persistence used by the permission-gated server
+ * action. Keeping the transaction outside actions.ts lets money-path tests
+ * exercise the real row locks and writes without exposing an auth-free server
+ * action (only exports from a `"use server"` module are remotely invokable).
+ */
+export async function updateChangeOrderCore(id: string, data: ChangeOrderUpdateInput) {
+    const items = Array.isArray(data.items) ? data.items as ChangeOrderItemInput[] : undefined;
+
+    return prisma.$transaction(async (tx) => {
+        // Serialize editors with send, approval, billing, and co-audit repair.
+        const locked = await tx.$queryRaw<Array<{
+            status: string;
+            title: string;
+            description: string | null;
+            totalAmount: unknown;
+            approvedBy: string | null;
+            approvedAt: Date | null;
+            clientSignatureUrl: string | null;
+            companySignedBy: string | null;
+            companySignedAt: Date | null;
+            companySignatureUrl: string | null;
+        }>>`
+            SELECT "status", "title", "description", "totalAmount",
+                   "approvedBy", "approvedAt", "clientSignatureUrl",
+                   "companySignedBy", "companySignedAt", "companySignatureUrl"
+            FROM "ChangeOrder" WHERE "id" = ${id} FOR UPDATE`;
+        const current = locked[0];
+        if (!current) throw new Error("Change order not found");
+
+        // Status transitions are lifecycle operations, never generic field
+        // updates. In particular, Draft -> Sent must go through
+        // sendChangeOrderToClientCore so item/subtotal validation and sentAt are
+        // inseparable from the client notification path.
+        if (Object.prototype.hasOwnProperty.call(data, "status")) {
+            throw new Error("Change order status cannot be updated here. Use Send for Approval so the guarded send workflow owns the transition.");
+        }
+
+        // An Approved CO is the scope and amount the customer signed and billing
+        // consumed. Lock all signed scope fields, not only line items, so the
+        // portal/PDF cannot drift from the approval audit trail afterward.
+        const hasScopeWrite = ["title", "description", "items"].some((field) => Object.prototype.hasOwnProperty.call(data, field));
+        const hasSignatureAudit = Boolean(
+            current.approvedBy
+            || current.approvedAt
+            || current.clientSignatureUrl
+            || current.companySignedBy
+            || current.companySignedAt
+            || current.companySignatureUrl,
+        );
+        if ((current.status === "Approved" || hasSignatureAudit) && hasScopeWrite) {
+            throw new Error("This change order's signed scope is locked. Create a new change order for additional work.");
+        }
+
+        const scalarData: Record<string, unknown> = {};
+        let scopeChanged = false;
+        if (data.title !== undefined) {
+            scalarData.title = data.title;
+            scopeChanged = data.title !== current.title;
+        }
+        if (data.description !== undefined) {
+            const nextDescription = data.description === "" ? null : data.description;
+            scalarData.description = nextDescription;
+            scopeChanged = scopeChanged || nextDescription !== current.description;
+        }
+
+        if (items) {
+            const itemIds = items
+                .map((item) => item.id)
+                .filter((itemId): itemId is string => typeof itemId === "string" && itemId.length > 0);
+            const seenItemIds = new Set<string>();
+            const duplicateItemId = itemIds.find((itemId) => {
+                if (seenItemIds.has(itemId)) return true;
+                seenItemIds.add(itemId);
+                return false;
+            });
+            if (duplicateItemId) {
+                throw new Error(`Duplicate change-order item ID: ${duplicateItemId}`);
+            }
+
+            let totalCents = 0;
+            const rows = items.map((item, idx) => {
+                const quantity = parseFloat(String(item.quantity ?? "")) || 0;
+                const unitCost = parseFloat(String(item.unitCost ?? "")) || 0;
+                const unitCents = Math.round(unitCost * 100);
+                const lineCents = coLineCents(quantity, unitCost);
+                totalCents += lineCents;
+                return {
+                    id: item.id || undefined,
+                    name: item.name || "",
+                    description: item.description || null,
+                    ...(item.type ? { type: item.type } : {}),
+                    quantity,
+                    unitCost: unitCents / 100,
+                    total: lineCents / 100,
+                    order: item.order ?? idx,
+                    costCodeId: item.costCodeId || null,
+                    costTypeId: item.costTypeId || null,
+                };
+            });
+
+            const existing = await tx.changeOrderItem.findMany({
+                where: { changeOrderId: id },
+                select: {
+                    id: true,
+                    name: true,
+                    description: true,
+                    type: true,
+                    quantity: true,
+                    unitCost: true,
+                    total: true,
+                    order: true,
+                    costCodeId: true,
+                    costTypeId: true,
+                },
+            });
+            const existingIds = new Set(existing.map(i => i.id));
+            const existingById = new Map(existing.map((item) => [item.id, item]));
+            const incomingIds = new Set(rows.map(r => r.id).filter(Boolean));
+            const toDelete = existing.filter(i => !incomingIds.has(i.id)).map(i => i.id);
+            const itemRowsChanged = rows.length !== existing.length || rows.some((row) => {
+                if (!row.id) return true;
+                const prior = existingById.get(row.id);
+                if (!prior) return true;
+                return prior.name !== row.name
+                    || prior.description !== row.description
+                    || (row.type !== undefined && prior.type !== row.type)
+                    || prior.quantity !== row.quantity
+                    || Number(prior.unitCost) !== row.unitCost
+                    || Number(prior.total) !== row.total
+                    || prior.order !== row.order
+                    || prior.costCodeId !== row.costCodeId
+                    || prior.costTypeId !== row.costTypeId;
+            });
+            scopeChanged = scopeChanged
+                || itemRowsChanged
+                || Math.round(Number(current.totalAmount) * 100) !== totalCents;
+            if (toDelete.length > 0) {
+                await tx.changeOrderItem.deleteMany({ where: { id: { in: toDelete }, changeOrderId: id } });
+            }
+            for (const row of rows) {
+                const { id: itemId, ...itemData } = row;
+                if (itemId && existingIds.has(itemId)) {
+                    await tx.changeOrderItem.update({ where: { id: itemId }, data: itemData });
+                } else {
+                    await tx.changeOrderItem.create({ data: { ...itemData, ...(itemId ? { id: itemId } : {}), changeOrderId: id } });
+                }
+            }
+
+            scalarData.totalAmount = totalCents / 100;
+            scalarData.balanceDue = totalCents / 100;
+        }
+
+        // A client may already have the Sent document open. An actual scope
+        // change invalidates that render, so atomically return the CO to Draft
+        // and force a fresh guarded send before approval can succeed. No-op saves
+        // remain Sent.
+        if (current.status === "Sent" && scopeChanged) {
+            scalarData.status = "Draft";
+            scalarData.sentAt = null;
+            scalarData.viewedAt = null;
+        }
+
+        return tx.changeOrder.update({ where: { id }, data: scalarData });
+    }, { timeout: 15_000 });
+}
+
+export async function approveChangeOrderCore(
+    id: string,
+    approval: { signatureName: string; clientSignatureUrl: string | null; approvedAt: Date },
+) {
+    return prisma.$transaction(async (tx) => {
+        // The same parent-row lock is taken by editing, sending, billing, and
+        // co-audit repair. Status, item existence, subtotal validation, and the
+        // approval write therefore observe one serialized state and commit as a
+        // single invariant-preserving transition.
+        const locked = await tx.$queryRaw<Array<{ id: string; code: string; status: string; totalAmount: unknown }>>`
+            SELECT "id", "code", "status", "totalAmount"
+            FROM "ChangeOrder" WHERE "id" = ${id} FOR UPDATE`;
+        const current = locked[0];
+        if (!current) return null;
+
+        if (current.status !== "Sent") {
+            throw new Error(`Change order ${current.code} must be Sent before it can be approved.`);
+        }
+
+        if (!approval.signatureName.trim() || !approval.clientSignatureUrl) {
+            throw new Error("A client name and persisted signature is required to approve a change order.");
+        }
+
+        const items = await tx.changeOrderItem.findMany({
+            where: { changeOrderId: id },
+            select: { quantity: true, unitCost: true },
+        });
+        if (items.length === 0) {
+            throw new Error(`Change order ${current.code} must contain at least one priced item before it can be approved.`);
+        }
+
+        const storedSubtotalCents = Math.round(Number(current.totalAmount) * 100);
+        const renderedSubtotalCents = itemSubtotalCents(items);
+        if (storedSubtotalCents <= 0 || renderedSubtotalCents <= 0) {
+            throw new Error(`Change order ${current.code} must have a positive subtotal before it can be approved.`);
+        }
+        if (storedSubtotalCents !== renderedSubtotalCents) {
+            throw new Error(`Change order ${current.code} pricing is out of sync with its items — save and resend it before approval.`);
+        }
+
+        const co = await tx.changeOrder.update({
+            where: { id },
+            data: {
+                status: "Approved",
+                approvedBy: approval.signatureName.trim(),
+                approvedAt: approval.approvedAt,
+                clientSignatureUrl: approval.clientSignatureUrl,
+            },
+        });
+        return { co, transitioned: true };
+    }, { timeout: 15_000 });
+}
+
+/**
+ * Session-free delete core. The permission-gated server action is the only
+ * remote entry point; lifecycle and signature-audit checks remain in this
+ * locked transaction.
+ */
+export async function deleteChangeOrderCore(id: string) {
+    return prisma.$transaction(async (tx) => {
+        const locked = await tx.$queryRaw<Array<{
+            id: string;
+            projectId: string;
+            status: string;
+            approvedBy: string | null;
+            approvedAt: Date | null;
+            clientSignatureUrl: string | null;
+            companySignedBy: string | null;
+            companySignedAt: Date | null;
+            companySignatureUrl: string | null;
+        }>>`
+            SELECT "id", "projectId", "status",
+                   "approvedBy", "approvedAt", "clientSignatureUrl",
+                   "companySignedBy", "companySignedAt", "companySignatureUrl"
+            FROM "ChangeOrder" WHERE "id" = ${id} FOR UPDATE`;
+        const current = locked[0];
+        if (!current) return null;
+        const hasSignatureAudit = Boolean(
+            current.approvedBy
+            || current.approvedAt
+            || current.clientSignatureUrl
+            || current.companySignedBy
+            || current.companySignedAt
+            || current.companySignatureUrl,
+        );
+        if (current.status !== "Draft" || hasSignatureAudit) {
+            throw new Error("Only unsigned Draft change orders can be deleted. Sent and signed records must remain in the audit trail.");
+        }
+        await tx.changeOrder.delete({ where: { id } });
+        return current;
+    }, { timeout: 15_000 });
+}


### PR DESCRIPTION
## Summary

Closes the pre-existing lifecycle bypass identified after PR #205.

- routes Draft → Sent exclusively through the guarded send core
- atomically requires Sent status, persisted signature, priced items, positive subtotal, and stored/rendered subtotal parity before approval
- demotes materially edited Sent change orders back to Draft while preserving true no-op saves
- locks title, description, and items after client/company signature audit evidence exists
- limits deletion to unsigned Draft records and adds project-level authorization to update/send/delete
- hides invalidated Draft revisions from client portal links

## Root cause

`updateChangeOrder` allowed raw status mutation and `approveChangeOrder` did not validate lifecycle or pricing state inside the approval transaction. That allowed a zero-dollar or never-sent change order to become client-visible/Approved without the guard added in PR #205.

## Validation

- `npm run build` — passed from a clean detached worktree at `a71afaac`
- focused `e2e/money-pipeline.spec.ts` CO1–CO16 — 16/16 passed on disposable PostgreSQL
- full money pipeline — 22/22 passed during implementation
- Codex peer review — no blocking findings
- Security review — approved, no scoped findings
- QAS — Approved for RTE

## Follow-up

A losing/replayed approval can still leave an unused signature object after pre-transaction upload. This is non-blocking storage hygiene and does not bypass the lifecycle or billing invariant.

## Production plan

After required GitHub checks pass: rebase-merge to `main`, deploy the exact merged SHA to the linked Vercel production project, then verify `/api/health`, auth redirect behavior, and the public portal shell.