### PR TITLE
fix(auth): revoke disabled-user sessions

### DIFF
--- a/e2e/auth-status.spec.ts
+++ b/e2e/auth-status.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test, type Page } from "@playwright/test";
+import { PrismaClient } from "@prisma/client";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getUserWithPermissionsByEmail } from "../src/lib/permissions";
+import { isStaffAccountEnabled } from "../src/lib/staff-status";
+
+const prisma = new PrismaClient();
+const STAFF_EMAIL = "auth-status-e2e@goldentouchremodeling.com";
+
+async function signInWithTestCredentials(page: Page) {
+  const csrfResponse = await page.request.get("/api/auth/csrf");
+  expect(csrfResponse.ok()).toBeTruthy();
+  const { csrfToken } = await csrfResponse.json();
+
+  await page.request.post("/api/auth/callback/credentials", {
+    form: {
+      csrfToken,
+      email: STAFF_EMAIL,
+      secret: process.env.PLAYWRIGHT_TEST_SECRET || "",
+    },
+  });
+}
+
+test.describe.serial("staff status revokes existing sessions", () => {
+  test.beforeAll(async () => {
+    await prisma.user.upsert({
+      where: { email: STAFF_EMAIL },
+      update: { name: "Auth Status E2E", role: "ADMIN", status: "ACTIVATED" },
+      create: {
+        email: STAFF_EMAIL,
+        name: "Auth Status E2E",
+        role: "ADMIN",
+        status: "ACTIVATED",
+      },
+    });
+  });
+
+  test.afterAll(async () => {
+    try {
+      await prisma.user.deleteMany({ where: { email: STAFF_EMAIL } });
+    } finally {
+      await prisma.$disconnect();
+    }
+  });
+
+  test("active test login works, then DISABLED blocks the stale session", async ({ page }) => {
+    await signInWithTestCredentials(page);
+
+    const activeSessionResponse = await page.request.get("/api/auth/session");
+    const activeSession = await activeSessionResponse.json();
+    expect(activeSession.user).toMatchObject({
+      email: STAFF_EMAIL,
+      role: "ADMIN",
+    });
+    expect(activeSession.user.id).toBeTruthy();
+    expect(await getUserWithPermissionsByEmail(STAFF_EMAIL)).not.toBeNull();
+    expect(await isStaffAccountEnabled(STAFF_EMAIL)).toBe(true);
+
+    await prisma.user.update({
+      where: { email: STAFF_EMAIL },
+      data: { status: "DISABLED" },
+    });
+
+    // Exercise the database-backed guards independently of JWT refresh. This
+    // catches regressions where the token is revoked but permission lookups or
+    // the production proxy still accept a disabled User row.
+    expect(await getUserWithPermissionsByEmail(STAFF_EMAIL)).toBeNull();
+    expect(await isStaffAccountEnabled(STAFF_EMAIL)).toBe(false);
+
+    if (process.env.CI) {
+      // Server Action requests are matched even on public portal routes. This
+      // closes the stale-cookie bypass around the normal protected-route proxy.
+      const publicActionReplay = await page.request.post("/portal", {
+        headers: { "next-action": "not-a-real-action-id" },
+        maxRedirects: 0,
+      });
+      expect(publicActionReplay.status()).toBe(403);
+    }
+
+    // Invalid JSON is deliberate: an active ADMIN reaches body validation (400),
+    // while a revoked session must stop before validation at an auth boundary.
+    const protectedResponse = await page.request.post("/api/admin/stripe-backfill", {
+      data: "not-json",
+      headers: { "content-type": "application/json" },
+      maxRedirects: 0,
+    });
+    if (process.env.CI) {
+      // `next start` exercises the production proxy. The stale JWT has not
+      // refreshed yet, so this proves the proxy checks current DB status.
+      expect(protectedResponse.status()).toBe(307);
+      expect(protectedResponse.headers().location).toContain("/login");
+    } else {
+      // The development proxy is intentionally bypassed; the route's shared
+      // permission guard must still reject the disabled user.
+      expect(protectedResponse.status()).toBe(403);
+    }
+
+    const bogusBearerResponse = await page.request.post("/api/admin/stripe-backfill", {
+      data: "not-json",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer not-a-real-mobile-token",
+      },
+      maxRedirects: 0,
+    });
+    if (process.env.CI) {
+      expect(bogusBearerResponse.status()).toBe(307);
+      expect(bogusBearerResponse.headers().location).toContain("/login");
+    } else {
+      expect(bogusBearerResponse.status()).toBe(403);
+    }
+
+    const disabledSessionResponse = await page.request.get("/api/auth/session");
+    expect(await disabledSessionResponse.json()).toEqual({});
+
+    await prisma.user.update({
+      where: { email: STAFF_EMAIL },
+      data: { status: "ACTIVATED" },
+    });
+
+    const reactivatedSessionResponse = await page.request.get("/api/auth/session");
+    const reactivatedSession = await reactivatedSessionResponse.json();
+    expect(reactivatedSession.user).toMatchObject({
+      email: STAFF_EMAIL,
+      role: "ADMIN",
+    });
+
+    await prisma.user.delete({ where: { email: STAFF_EMAIL } });
+
+    expect(await getUserWithPermissionsByEmail(STAFF_EMAIL)).toBeNull();
+    expect(await isStaffAccountEnabled(STAFF_EMAIL)).toBe(false);
+
+    const deletedUserSessionResponse = await page.request.get("/api/auth/session");
+    expect(await deletedUserSessionResponse.json()).toEqual({});
+  });
+
+  test("invoice mutations enforce authorization inside the server action", async () => {
+    const source = readFileSync(join(process.cwd(), "src/lib/actions.ts"), "utf8");
+
+    for (const actionName of ["deleteInvoice", "updateInvoiceNotes"]) {
+      const actionStart = source.indexOf(`export async function ${actionName}`);
+      expect(actionStart, `${actionName} must remain exported`).toBeGreaterThanOrEqual(0);
+      const nextAction = source.indexOf("\nexport async function ", actionStart + 1);
+      const actionSource = source.slice(actionStart, nextAction === -1 ? undefined : nextAction);
+      const authIndex = actionSource.indexOf("await assertInvoicePermission()");
+      const databaseIndex = actionSource.indexOf("prisma.");
+
+      expect(authIndex, `${actionName} must authorize internally`).toBeGreaterThanOrEqual(0);
+      expect(authIndex, `${actionName} must authorize before database access`).toBeLessThan(databaseIndex);
+    }
+  });
+});

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -2,19 +2,29 @@ import { test as setup, expect } from "@playwright/test";
 
 setup("authenticate", async ({ page }) => {
   const baseURL = "http://localhost:3000";
+  const email = "jadkins@goldentouchremodeling.com";
 
   // Get CSRF token from NextAuth (use page.request to share cookies with page)
   const csrfRes = await page.request.get(`${baseURL}/api/auth/csrf`);
   const { csrfToken } = await csrfRes.json();
 
   // POST directly to the credentials callback (bypasses custom login page)
-  await page.request.post(`${baseURL}/api/auth/callback/credentials`, {
+  const authRes = await page.request.post(`${baseURL}/api/auth/callback/credentials`, {
     form: {
       csrfToken,
-      email: "jadkins@goldentouchremodeling.com",
+      email,
       secret: process.env.PLAYWRIGHT_TEST_SECRET || "",
     },
   });
+  expect(authRes.ok(), `Credentials callback failed at ${authRes.url()}`).toBeTruthy();
+
+  // The app has a development-only unauthenticated UI fallback, so merely
+  // reaching /projects is not proof that the credentials session exists.
+  const sessionRes = await page.request.get(`${baseURL}/api/auth/session`);
+  expect(sessionRes.ok()).toBeTruthy();
+  const session = await sessionRes.json();
+  expect(session.user).toMatchObject({ email, role: "ADMIN" });
+  expect(session.user.id).toBeTruthy();
 
   // Navigate to a protected page to verify the session is active
   await page.goto("/projects", { waitUntil: "networkidle", timeout: 15_000 });

--- a/e2e/data.setup.ts
+++ b/e2e/data.setup.ts
@@ -7,6 +7,7 @@ const PROJECT_ID = "cmml6vt3y000lpwrh0p9p3k12";
 const ESTIMATE_ID = "cmml6vtx7001dpwrh8n65xzy6";
 const TEST_CLIENT_ID = "test-client-do-not-delete";
 const ADMIN_EMAIL = "jadkins@goldentouchremodeling.com";
+const DEV_ADMIN_EMAIL = "gtrsupport@goldentouchremodeling.com";
 const SENTINEL_PATH = resolve(__dirname, ".anthropic-status");
 
 // Substrings that identify the LIVE database. The e2e suite creates leads,
@@ -64,6 +65,20 @@ setup("guard prod DB + seed test data + probe anthropic", async () => {
             },
         });
         console.log("[data.setup] admin user upserted:", { id: admin.id, email: admin.email });
+
+        // Development mode intentionally falls back to this known ADMIN.
+        // Keep it database-backed so permission and status guards exercise the
+        // same path as real staff while the local UI remains usable pre-login.
+        await prisma.user.upsert({
+            where: { email: DEV_ADMIN_EMAIL },
+            update: { role: "ADMIN", status: "ACTIVATED" },
+            create: {
+                email: DEV_ADMIN_EMAIL,
+                name: "GTR Support",
+                role: "ADMIN",
+                status: "ACTIVATED",
+            },
+        });
 
         const client = await prisma.client.upsert({
             where: { id: TEST_CLIENT_ID },

--- a/e2e/financial-action-auth.spec.ts
+++ b/e2e/financial-action-auth.spec.ts
@@ -102,6 +102,14 @@ test("standalone financial data actions enforce permission and project access", 
   expectGuardBeforeDatabase(timeExpenseSource, "getTimeExpenseData", "await assertTimeExpenseProjectAccess(");
 });
 
+test("financial action payloads cannot override authorized relationship keys", () => {
+  const source = readFileSync(join(process.cwd(), "src/lib/actions.ts"), "utf8");
+  for (const name of ["createPurchaseOrder", "updatePurchaseOrder", "createBidPackage", "updateBidPackage", "addBidScope", "recordBidResponse"]) {
+    const action = exportSource(source, name);
+    expect(action, `${name} must not spread an untrusted data object into Prisma`).not.toMatch(/\.\.\.(?:data|poData)\b/);
+  }
+});
+
 test("company settings split public branding from status-aware staff configuration", () => {
   const source = readFileSync(join(process.cwd(), "src/lib/actions.ts"), "utf8");
   const publicSelectStart = source.indexOf("const publicCompanySettingsSelect");

--- a/e2e/financial-action-auth.spec.ts
+++ b/e2e/financial-action-auth.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+function exportSource(source: string, name: string): string {
+  const marker = new RegExp(`export\\s+(?:async function|const)\\s+${name}\\b`);
+  const match = marker.exec(source);
+  expect(match, `${name} must remain exported`).not.toBeNull();
+  const start = match!.index;
+  const remainder = source.slice(start + match![0].length);
+  const next = /\nexport\s+(?:async function|const)\s+/.exec(remainder);
+  return source.slice(start, next ? start + match![0].length + next.index : undefined);
+}
+
+function expectGuardBeforeDatabase(source: string, actionName: string, guard: string) {
+  const action = exportSource(source, actionName);
+  const guardIndex = action.indexOf(guard);
+  const databaseIndex = action.indexOf("prisma.");
+  expect(guardIndex, `${actionName} must call ${guard}`).toBeGreaterThanOrEqual(0);
+  if (databaseIndex >= 0) {
+    expect(guardIndex, `${actionName} must authorize before database access`).toBeLessThan(databaseIndex);
+  }
+}
+
+test("all staff financial actions authorize inside the exported action", () => {
+  const source = readFileSync(join(process.cwd(), "src/lib/actions.ts"), "utf8");
+
+  const estimates = [
+    "getEstimate", "getAllEstimates", "getEstimateActivity", "createDraftEstimate",
+    "createDraftLeadEstimate", "saveEstimate", "logEstimatePayment", "archiveEstimate",
+    "deleteEstimate", "duplicateEstimate", "saveEstimateAsTemplate", "getEstimateTemplates",
+    "createEstimateFromTemplate", "saveItemsAsAssembly", "deleteAssembly",
+    "getEstimateItemsForProject", "importEstimateToSchedule", "uploadEstimateFile",
+    "deleteEstimateFile", "getEstimateFiles", "updateItemApproval", "bulkUpdateItemApproval",
+    "addVoiceEstimateItem", "createEstimateFromRoomDesign",
+  ];
+  for (const name of estimates) expectGuardBeforeDatabase(source, name, "await assertEstimatePermission(");
+
+  const invoices = [
+    "deleteInvoice", "updateInvoiceNotes", "createInvoiceFromTimeEntries", "getInvoice",
+    "getProjectInvoices", "getAllInvoices", "issueInvoice", "createRetainer",
+    "updateRetainer", "deleteRetainer",
+  ];
+  for (const name of invoices) expectGuardBeforeDatabase(source, name, "await assertInvoicePermission(");
+
+  const changeOrders = ["createChangeOrder", "getChangeOrders", "getChangeOrder", "deleteChangeOrder"];
+  for (const name of changeOrders) expectGuardBeforeDatabase(source, name, "await assertChangeOrderPermission(");
+
+  const financialReports = [
+    "getPurchaseOrders", "getPurchaseOrder", "createPurchaseOrder", "createPurchaseOrderFromEstimate",
+    "updatePurchaseOrder", "deletePurchaseOrder", "updatePurchaseOrderStatus", "approvePurchaseOrder",
+    "uploadPurchaseOrderFile", "deletePurchaseOrderFile", "uploadPurchaseOrderFileFromBuffer",
+    "sendPurchaseOrder", "getProjectBidPackages", "getBidPackage", "createBidPackage",
+    "updateBidPackage", "deleteBidPackage", "addBidScope", "deleteBidScope", "inviteSubToBid",
+    "recordBidResponse", "awardBid", "linkPOToEstimateItem", "unlinkPOFromEstimateItem",
+    "quickCreatePOAndLink", "getProjectPurchaseOrdersForLinking",
+  ];
+  for (const name of financialReports) expectGuardBeforeDatabase(source, name, "await assertFinancialPermission(");
+
+  for (const name of ["getLeads", "getProjects", "getProject"]) {
+    expectGuardBeforeDatabase(source, name, "await assertActiveStaff(");
+  }
+
+  for (const name of ["deleteLead", "updateProjectStatus", "updateProjectName", "deleteProjects"]) {
+    expectGuardBeforeDatabase(source, name, "await assertActiveStaff(");
+  }
+  for (const name of ["saveCompanySettings", "updateCompanyProjectStatuses", "saveCompanySubcontractorTrades"]) {
+    expectGuardBeforeDatabase(source, name, "await assertCompanySettingsPermission(");
+  }
+});
+
+test("dual-auth financial actions keep explicit portal or machine authorization", () => {
+  const source = readFileSync(join(process.cwd(), "src/lib/actions.ts"), "utf8");
+  const billingCore = readFileSync(join(process.cwd(), "src/lib/billing-core.ts"), "utf8");
+
+  expectGuardBeforeDatabase(source, "generatePdfUploadToken", "await assertEstimateStaffOrPortalAccess(");
+  expectGuardBeforeDatabase(source, "ensureEstimatePayInFullSchedule", "await assertEstimateStaffOrPortalAccess(");
+  expectGuardBeforeDatabase(source, "markInvoiceViewed", "await assertInvoicePortalAccess(");
+  expectGuardBeforeDatabase(source, "createInvoiceFromEstimate", "await assertInvoicePermission(");
+  expectGuardBeforeDatabase(source, "sendEstimateToClient", "await assertEstimateSendPermission(");
+  expect(billingCore).toContain("export async function createInvoiceFromEstimateCore(");
+  expect(exportSource(billingCore, "createInvoiceFromEstimateGuarded")).toContain("createInvoiceFromEstimateCore(estimateId)");
+  expect(exportSource(billingCore, "createInvoiceFromEstimateGuarded")).not.toContain('import("./actions")');
+});
+
+test("standalone financial data actions enforce permission and project access", () => {
+  const budgetSource = readFileSync(join(process.cwd(), "src/lib/budget-actions.ts"), "utf8");
+  const timeExpenseSource = readFileSync(join(process.cwd(), "src/lib/time-expense-actions.ts"), "utf8");
+
+  expectGuardBeforeDatabase(budgetSource, "getBudgetData", "await assertFinancialProjectAccess(");
+  expectGuardBeforeDatabase(timeExpenseSource, "getTimeExpenseData", "await assertTimeExpenseProjectAccess(");
+});
+
+test("company settings split public branding from status-aware staff configuration", () => {
+  const source = readFileSync(join(process.cwd(), "src/lib/actions.ts"), "utf8");
+  const publicSelectStart = source.indexOf("const publicCompanySettingsSelect");
+  const cachedStaffStart = source.indexOf("const getCachedCompanySettings");
+  const publicGetterStart = source.indexOf("export async function getPublicCompanySettings");
+  const saveStart = source.indexOf("export async function saveCompanySettings");
+
+  expect(publicSelectStart).toBeGreaterThanOrEqual(0);
+  expect(cachedStaffStart).toBeGreaterThan(publicSelectStart);
+  expect(publicGetterStart).toBeGreaterThan(cachedStaffStart);
+  expect(saveStart).toBeGreaterThan(publicGetterStart);
+  const publicSelect = source.slice(publicSelectStart, cachedStaffStart);
+  expect(publicSelect).not.toContain("googleDriveRefreshToken");
+  for (const internalField of ["monthlyOverhead", "notificationEmail", "googleDriveEmail", "notificationToggles", "projectStatuses", "subcontractorTrades"]) {
+    expect(publicSelect).not.toContain(internalField);
+  }
+  expectGuardBeforeDatabase(source, "getCompanySettings", "await assertActiveStaff(");
+  expect(source.match(/getCompanySettings\(\)/g)).toHaveLength(1);
+  expect(source).toContain("const settings = await getCachedCompanySettings()");
+});

--- a/e2e/financial-action-auth.spec.ts
+++ b/e2e/financial-action-auth.spec.ts
@@ -46,16 +46,27 @@ test("all staff financial actions authorize inside the exported action", () => {
   const changeOrders = ["createChangeOrder", "getChangeOrders", "getChangeOrder", "deleteChangeOrder"];
   for (const name of changeOrders) expectGuardBeforeDatabase(source, name, "await assertChangeOrderPermission(");
 
-  const financialReports = [
-    "getPurchaseOrders", "getPurchaseOrder", "createPurchaseOrder", "createPurchaseOrderFromEstimate",
+  const projectScopedFinancialReports = [
+    "getPurchaseOrders", "createPurchaseOrder", "createPurchaseOrderFromEstimate",
+    "getProjectBidPackages", "createBidPackage", "updateBidPackage", "deleteBidPackage",
+    "addBidScope", "deleteBidScope", "inviteSubToBid", "recordBidResponse", "awardBid",
+    "getProjectPurchaseOrdersForLinking",
+  ];
+  for (const name of projectScopedFinancialReports) {
+    expectGuardBeforeDatabase(source, name, "await assertFinancialProjectAccess(");
+  }
+
+  const entityScopedFinancialReports = [
+    "getPurchaseOrder",
     "updatePurchaseOrder", "deletePurchaseOrder", "updatePurchaseOrderStatus", "approvePurchaseOrder",
     "uploadPurchaseOrderFile", "deletePurchaseOrderFile", "uploadPurchaseOrderFileFromBuffer",
-    "sendPurchaseOrder", "getProjectBidPackages", "getBidPackage", "createBidPackage",
-    "updateBidPackage", "deleteBidPackage", "addBidScope", "deleteBidScope", "inviteSubToBid",
-    "recordBidResponse", "awardBid", "linkPOToEstimateItem", "unlinkPOFromEstimateItem",
-    "quickCreatePOAndLink", "getProjectPurchaseOrdersForLinking",
+    "sendPurchaseOrder", "getBidPackage", "linkPOToEstimateItem", "unlinkPOFromEstimateItem",
+    "quickCreatePOAndLink",
   ];
-  for (const name of financialReports) expectGuardBeforeDatabase(source, name, "await assertFinancialPermission(");
+  for (const name of entityScopedFinancialReports) {
+    expectGuardBeforeDatabase(source, name, "await assertFinancialPermission(");
+    expect(exportSource(source, name)).toContain("assertFinancialProjectScope(");
+  }
 
   for (const name of ["getLeads", "getProjects", "getProject"]) {
     expectGuardBeforeDatabase(source, name, "await assertActiveStaff(");

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -608,7 +608,15 @@ const handler = createMcpHandler(
                     });
                 }
                 const { sendEstimateToClient } = await import("@/lib/actions");
-                const result = await sendEstimateToClient(estimateId, undefined, overrideEmail, undefined, customMessage);
+                const result = await sendEstimateToClient(
+                    estimateId,
+                    undefined,
+                    overrideEmail,
+                    undefined,
+                    customMessage,
+                    undefined,
+                    process.env.MCP_SECRET,
+                );
                 if (!result.success) return { ...textResult({ error: result.error }), isError: true };
                 return textResult({ ...result, note: "The customer reviews and signs via the portal link; signing auto-creates the invoice in ProBuild." });
             },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import "./globals.css";
 import Providers from "@/components/Providers";
 import AppLayout from "@/components/AppLayout";
 import { Toaster } from "sonner";
-import { getCompanySettings } from "@/lib/actions";
+import { getPublicCompanySettings } from "@/lib/actions";
 import { getSessionOrDev } from "@/lib/auth";
 import HelpChatWidgetWrapper from "@/components/HelpChatWidgetWrapper";
 import VersionWatcher from "@/components/VersionWatcher";
@@ -48,7 +48,7 @@ export default async function RootLayout({
   let settings = null;
   let session: any = null;
   try {
-    settings = await getCompanySettings();
+    settings = await getPublicCompanySettings();
     session = await getSessionOrDev();
   } catch {
     // During build-time static generation, DATABASE_URL may not exist — gracefully skip.

--- a/src/app/portal/change-orders/[id]/page.tsx
+++ b/src/app/portal/change-orders/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { getChangeOrderForPortal, getCompanySettings, getPortalVisibility } from "@/lib/actions";
+import { getChangeOrderForPortal, getPublicCompanySettings, getPortalVisibility } from "@/lib/actions";
 import { notFound } from "next/navigation";
 import PortalChangeOrderClient from "./PortalChangeOrderClient";
 import Link from "next/link";
@@ -6,7 +6,7 @@ import Link from "next/link";
 export default async function PortalChangeOrderPage({ params }: { params: Promise<{ id: string }> }) {
     const resolvedParams = await params;
     const changeOrder = await getChangeOrderForPortal(resolvedParams.id);
-    const settings = await getCompanySettings();
+    const settings = await getPublicCompanySettings();
 
     if (!changeOrder) {
         return notFound();

--- a/src/app/portal/contracts/[id]/page.tsx
+++ b/src/app/portal/contracts/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { getContractForPortal, getCompanySettings, getPortalVisibility, getExecutedContractPdf } from "@/lib/actions";
+import { getContractForPortal, getPublicCompanySettings, getPortalVisibility, getExecutedContractPdf } from "@/lib/actions";
 import { notFound } from "next/navigation";
 import PortalContractClient from "./PortalContractClient";
 import Link from "next/link";
@@ -24,7 +24,7 @@ export default async function PortalContractPage({
         notFound();
     }
 
-    const settings = await getCompanySettings();
+    const settings = await getPublicCompanySettings();
 
     // Check portal visibility if contract belongs to a project
     if (contract!.projectId) {

--- a/src/app/portal/estimates/[id]/page.tsx
+++ b/src/app/portal/estimates/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { getEstimateForPortal, getCompanySettings, getPortalVisibility } from "@/lib/actions";
+import { getEstimateForPortal, getPublicCompanySettings, getPortalVisibility } from "@/lib/actions";
 import { notFound, redirect } from "next/navigation";
 import PortalEstimateClient from "./PortalEstimateClient";
 import Link from "next/link";
@@ -35,7 +35,7 @@ export default async function PortalEstimatePage({ params }: { params: Promise<{
     }
 
     const estimate = await getEstimateForPortal(resolvedParams.id);
-    const settings = await getCompanySettings();
+    const settings = await getPublicCompanySettings();
 
     if (!estimate) {
         return notFound();

--- a/src/app/portal/invoices/[id]/page.tsx
+++ b/src/app/portal/invoices/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { getInvoiceForPortal, getCompanySettings, getPortalVisibility } from "@/lib/actions";
+import { getInvoiceForPortal, getPublicCompanySettings, getPortalVisibility } from "@/lib/actions";
 import { notFound, redirect } from "next/navigation";
 import PortalInvoiceClient from "./PortalInvoiceClient";
 import Link from "next/link";
@@ -117,7 +117,7 @@ export default async function PortalInvoicePage({
     }
 
     const invoice = await getInvoiceForPortal(resolvedParams.id);
-    const settings = await getCompanySettings();
+    const settings = await getPublicCompanySettings();
 
     if (!invoice) {
         return notFound();

--- a/src/app/projects/[id]/bid-packages/[bidId]/edit/page.tsx
+++ b/src/app/projects/[id]/bid-packages/[bidId]/edit/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { getBidPackage } from "@/lib/actions";
 import { getProjectSubcontractors } from "@/lib/subcontractor-actions";
 import BidPackageEditor from "./BidPackageEditor";
+import { canUseDevAuthFallback, getCurrentUserWithPermissions, hasPermission } from "@/lib/permissions";
 
 interface Props {
     params: Promise<{ id: string; bidId: string }>;
@@ -14,6 +15,11 @@ export default async function BidPackageEditPage({ params }: Props) {
 
     const session = await getSessionOrDev();
     if (!session?.user) return redirect("/login");
+    const user = await getCurrentUserWithPermissions();
+    const devAllowed = await canUseDevAuthFallback();
+    if ((!user || !hasPermission(user, "financialReports")) && !devAllowed) {
+        return redirect(`/projects/${id}`);
+    }
 
     const [pkg, subs] = await Promise.all([
         getBidPackage(bidId),

--- a/src/app/projects/[id]/bid-packages/page.tsx
+++ b/src/app/projects/[id]/bid-packages/page.tsx
@@ -3,6 +3,7 @@ import { getSessionOrDev } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { getProjectBidPackages } from "@/lib/actions";
 import { prisma } from "@/lib/prisma";
+import { canUseDevAuthFallback, getCurrentUserWithPermissions, hasPermission } from "@/lib/permissions";
 import BidPackagesClient from "./BidPackagesClient";
 
 interface Props {
@@ -14,6 +15,11 @@ export default async function BidPackagesPage({ params }: Props) {
 
     const session = await getSessionOrDev();
     if (!session?.user) return redirect("/login");
+    const user = await getCurrentUserWithPermissions();
+    const devAllowed = await canUseDevAuthFallback();
+    if ((!user || !hasPermission(user, "financialReports")) && !devAllowed) {
+        return redirect(`/projects/${id}`);
+    }
 
     const [packages, project] = await Promise.all([
         getProjectBidPackages(id),

--- a/src/app/projects/[id]/costing/JobCostingClient.tsx
+++ b/src/app/projects/[id]/costing/JobCostingClient.tsx
@@ -26,6 +26,14 @@ type CostCodeSummary = {
 type SortKey = "code" | "budget" | "actual" | "variance" | "pct";
 type SortDir = "asc" | "desc";
 
+function num(value: unknown): number {
+    if (value === null || value === undefined) return 0;
+    const parsed = typeof value === "object" && "toNumber" in (value as Record<string, unknown>)
+        ? (value as { toNumber: () => number }).toNumber()
+        : Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
 const ChartBarIcon = () => (
     <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
@@ -81,7 +89,7 @@ export default function JobCostingClient({
         estimates.forEach(est => {
             est.items.forEach((item: any) => {
                 const group = getGroup(item.costCodeId, item.costCode?.name, item.costCode?.code);
-                const total = (item.quantity * item.unitCost);
+                const total = num(item.quantity) * num(item.unitCost);
                 const itemCategory = (item.costType?.name || item.type || "").toLowerCase();
                 if (itemCategory.includes("labor")) group.budgetLabor += total;
                 else group.budgetMaterial += total;
@@ -89,13 +97,14 @@ export default function JobCostingClient({
         });
         timeEntries.forEach(te => {
             const group = getGroup(te.costCodeId, te.costCode?.name, te.costCode?.code);
-            group.actualLabor += (te.laborCost || 0);
+            group.actualLabor += num(te.laborCost);
         });
         expenses.forEach(ex => {
             const group = getGroup(ex.costCodeId, ex.costCode?.name, ex.costCode?.code);
-            group.actualMaterial += (ex.amount || 0);
+            const amount = num(ex.amount);
+            group.actualMaterial += amount;
             if (ex.purchaseOrderId) {
-                group.committedMaterial -= (ex.amount || 0);
+                group.committedMaterial -= amount;
             }
         });
         purchaseOrders.forEach(po => {
@@ -104,7 +113,7 @@ export default function JobCostingClient({
             if (po.status !== "Draft") {
                 po.items?.forEach((item: any) => {
                     const group = getGroup(item.costCodeId, item.costCode?.name, item.costCode?.code);
-                    group.committedMaterial += (item.total || 0);
+                    group.committedMaterial += num(item.total);
                 });
             }
         });

--- a/src/components/EntitySidebar.tsx
+++ b/src/components/EntitySidebar.tsx
@@ -70,7 +70,7 @@ export default function EntitySidebar({
                     { label: "Room Designer", href: `/projects/${id}/room-designer`, permission: "roomDesigner" },
                     { label: "Mood Boards", href: `/projects/${id}/mood-boards` },
                     { label: "Selection Boards", href: `/projects/${id}/selections` },
-                    { label: "Bids", href: `/projects/${id}/bid-packages` },
+                    { label: "Bids", href: `/projects/${id}/bid-packages`, permission: "financialReports" },
                 ],
             },
             {

--- a/src/components/ProjectInnerSidebar.tsx
+++ b/src/components/ProjectInnerSidebar.tsx
@@ -63,7 +63,7 @@ export default function ProjectInnerSidebar({ projectId, projectName, clientName
                 { label: "Room Designer", href: `/projects/${projectId}/room-designer`, permission: "roomDesigner" },
                 { label: "Mood Boards", href: `/projects/${projectId}/mood-boards` },
                 { label: "Selection Boards", href: `/projects/${projectId}/selections` },
-                { label: "Bids", href: `/projects/${projectId}/bid-packages` },
+                { label: "Bids", href: `/projects/${projectId}/bid-packages`, permission: "financialReports" },
             ],
         },
         {

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -12,7 +12,7 @@ import { formatCurrency } from "./utils";
 import { createHmac, timingSafeEqual } from "crypto";
 import { resolveSessionClientId } from "./portal-auth";
 import { persistSignature } from "./signature-storage";
-import { getCurrentUserWithPermissions, hasPermission, canAccessProject } from "./permissions";
+import { canUseDevAuthFallback, getCurrentUserWithPermissions, hasPermission, canAccessProject } from "./permissions";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { enqueueMilestonePaid, drainPaymentNotifications } from "./payment-outbox";
 import { approveChangeOrderCore, deleteChangeOrderCore, updateChangeOrderCore } from "./change-order-core";
@@ -139,6 +139,7 @@ function isAllowedCapturedPdfUrl(url: string): boolean {
  * where <expiry> is a Unix timestamp (seconds) and <sig> is HMAC-SHA256.
  */
 export async function generatePdfUploadToken(estimateId: string): Promise<string> {
+    await assertEstimateStaffOrPortalAccess(estimateId);
     const secret = process.env.NEXTAUTH_SECRET;
     if (!secret) {
         throw new Error("NEXTAUTH_SECRET is not configured");
@@ -150,6 +151,7 @@ export async function generatePdfUploadToken(estimateId: string): Promise<string
 }
 
 export async function getLeads() {
+    await assertActiveStaff();
     const leads = await prisma.lead.findMany({
         orderBy: { createdAt: "desc" },
         include: {
@@ -302,7 +304,7 @@ export async function createLead(data: { name: string; clientName: string; clien
     revalidatePath("/leads");
 
     try {
-        const settings = await getCompanySettings();
+        const settings = await getCachedCompanySettings();
         if (settings.notificationEmail && isNotificationEnabled(settings, "newLead")) {
             await sendNotification(
                 settings.notificationEmail,
@@ -338,6 +340,7 @@ export async function updateLeadMetadata(id: string, updates: { isUnread?: boole
 }
 
 export async function deleteLead(id: string) {
+    await assertActiveStaff();
     // Prevent deletion of leads that have a linked project — checking the FK directly is
     // authoritative. Previously this only checked stage === "Won", but any stage can be
     // linked to a project, and with unlink removed there is no recovery path from a
@@ -982,6 +985,7 @@ export async function deleteLeadMeeting(meetingId: string) {
 }
 
 export async function getProjects() {
+    await assertActiveStaff();
     const projects = await prisma.project.findMany({
         orderBy: { viewedAt: "desc" },
         include: {
@@ -995,6 +999,7 @@ export async function getProjects() {
     }))));
 }
 export const getProject = cache(async function getProject(id: string) {
+    await assertActiveStaff();
     const include = {
         client: true,
         estimates: {
@@ -1194,6 +1199,7 @@ export async function createProject(data: {
 }
 
 export async function createDraftEstimate(projectId: string) {
+    await assertEstimatePermission();
     // WA is destination-based: default the rate from the job-site address,
     // falling back to the company default (null fields) when unresolvable.
     const taxDefault = await defaultTaxForNewEstimate({ projectId });
@@ -1219,6 +1225,7 @@ export async function createDraftEstimate(projectId: string) {
 }
 
 export async function createDraftLeadEstimate(leadId: string) {
+    await assertEstimatePermission();
     const taxDefault = await defaultTaxForNewEstimate({ leadId });
     const estimate = await prisma.estimate.create({
         data: {
@@ -1411,6 +1418,7 @@ export async function listRoomsForLead(leadId: string) {
 }
 
 export const getEstimate = cache(async function getEstimate(id: string) {
+    await assertEstimatePermission();
     try {
         // Full query — works when all schema columns exist in DB
         return await prisma.estimate.findUnique({
@@ -1701,6 +1709,7 @@ export const getEstimateForPortal = cache(async function getEstimateForPortal(id
  *  Race-safe: catches P2002 on concurrent creates and re-reads the winner. */
 export async function ensureEstimatePayInFullSchedule(estimateId: string): Promise<string> {
     "use server";
+    await assertEstimateStaffOrPortalAccess(estimateId);
     // Derive amount from canonical server data — never accept it from the client
     const estimate = await prisma.estimate.findUnique({
         where: { id: estimateId },
@@ -1743,6 +1752,7 @@ export async function ensureEstimatePayInFullSchedule(estimateId: string): Promi
 }
 
 export const getAllEstimates = cache(async function getAllEstimates() {
+    await assertEstimatePermission();
     return await prisma.estimate.findMany({
         orderBy: { createdAt: "desc" },
         select: {
@@ -1954,7 +1964,7 @@ export async function markEstimateViewed(estimateId: string) {
 
         const clientName = estimate.project?.client?.name || estimate.lead?.client?.name || "A client";
         const projectName = estimate.project?.name || estimate.lead?.name || "";
-        const settings = await getCompanySettings();
+        const settings = await getCachedCompanySettings();
         if (settings.notificationEmail && isNotificationEnabled(settings, "estimateViewed")) {
             await sendNotification(
                 settings.notificationEmail,
@@ -2004,6 +2014,7 @@ export type EstimateActivityEvent = {
  * so payment history is always complete without any extra logging.
  */
 export async function getEstimateActivity(estimateId: string): Promise<EstimateActivityEvent[]> {
+    await assertEstimatePermission();
     const [estimate, logs, invoice] = await Promise.all([
         prisma.estimate.findUnique({
             where: { id: estimateId },
@@ -2128,7 +2139,7 @@ export async function markContractViewed(contractId: string, accessToken?: strin
 
         const clientName = contract.project?.client?.name || contract.lead?.client?.name || "A client";
         const projectName = contract.project?.name || contract.lead?.name || "";
-        const settings = await getCompanySettings();
+        const settings = await getCachedCompanySettings();
         if (settings.notificationEmail) {
             await sendNotification(
                 settings.notificationEmail,
@@ -2227,7 +2238,7 @@ async function ensureProjectAndDepositInvoiceForEstimate(estimateId: string): Pr
         select: { id: true, code: true },
     });
     if (!invoice) {
-        const created = await createInvoiceFromEstimate(estimateId);
+        const created = await createInvoiceFromEstimateInternal(estimateId);
         invoice = await prisma.invoice.update({
             where: { id: created.id },
             data: { status: "Issued", issueDate: new Date() },
@@ -2354,7 +2365,7 @@ export async function approveEstimate(estimateId: string, signatureName: string,
         entityName: `Estimate ${estimate?.code || estimateId}`,
     });
 
-    const settings = await getCompanySettings();
+    const settings = await getCachedCompanySettings();
     const companyName = settings.companyName || "Golden Touch Remodeling";
     const estimateCode = estimate?.code || estimateId;
     const projectName = estimate?.project?.name || estimate?.lead?.name || "your project";
@@ -2542,6 +2553,7 @@ export async function approveEstimate(estimateId: string, signatureName: string,
 }
 
 export async function deleteInvoice(invoiceId: string) {
+    await assertInvoicePermission();
     const invoice = await prisma.invoice.findUnique({
         where: { id: invoiceId },
         include: { payments: true },
@@ -2561,6 +2573,7 @@ export async function deleteInvoice(invoiceId: string) {
 }
 
 export async function updateInvoiceNotes(invoiceId: string, notes: string) {
+    await assertInvoicePermission();
     const invoice = await prisma.invoice.update({
         where: { id: invoiceId },
         data: { notes },
@@ -2652,6 +2665,22 @@ export async function getInvoiceForPortal(id: string) {
 }
 
 export async function markInvoiceViewed(invoiceId: string) {
+    const sessionClientId = await assertInvoicePortalAccess();
+    if (!sessionClientId) return;
+
+    const claim = await prisma.invoice.updateMany({
+        where: {
+            id: invoiceId,
+            viewedAt: null,
+            OR: [
+                { clientId: sessionClientId },
+                { project: { clientId: sessionClientId } },
+            ],
+        },
+        data: { viewedAt: new Date() },
+    });
+    if (claim.count === 0) return;
+
     const invoice = await prisma.invoice.findUnique({
         where: { id: invoiceId },
         select: {
@@ -2660,15 +2689,11 @@ export async function markInvoiceViewed(invoiceId: string) {
             client: { select: { name: true } },
         },
     });
-    if (invoice && !invoice.viewedAt) {
-        await prisma.invoice.update({
-            where: { id: invoiceId },
-            data: { viewedAt: new Date() },
-        });
+    if (invoice) {
         const clientName = invoice.client?.name || invoice.project?.client?.name || "A client";
         const projectName = invoice.project?.name || "";
         try {
-            const settings = await getCompanySettings();
+            const settings = await getCachedCompanySettings();
             if (settings.notificationEmail && isNotificationEnabled(settings, "invoiceViewed")) {
                 const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
                 const editorUrl = invoice.projectId ? `${appUrl}/projects/${invoice.projectId}/invoices/${invoiceId}` : `${appUrl}/invoices`;
@@ -2754,6 +2779,7 @@ export async function emailInvoiceCopyToMe(
 }
 
 export async function saveEstimate(estimateId: string, contextId: string, contextType: "project" | "lead", data: any, items: any[]) {
+    await assertEstimatePermission();
     // Update estimate inside a transaction to guarantee atomicity and avoid partial write inconsistencies.
     // targetMarginPercent must live in safeData so a failure on the main payload does
     // not silently revert the AI budget target to the default.
@@ -3053,6 +3079,7 @@ export async function saveEstimate(estimateId: string, contextId: string, contex
 
 export async function logEstimatePayment(estimateId: string, data: { amount: number; paymentMethod: string; date: string; referenceNumber?: string }) {
     "use server";
+    await assertEstimatePermission();
     // One transaction, estimate locked FIRST (canonical Estimate → Invoice order; this flow
     // touches only the estimate). Without the lock two concurrent logs each read the same
     // balanceDue and each write balanceDue − amount, losing one decrement. The lock serializes
@@ -3107,6 +3134,7 @@ export async function logEstimatePayment(estimateId: string, data: { amount: num
 
 export async function archiveEstimate(estimateId: string) {
     "use server";
+    await assertEstimatePermission();
     const estimate = await prisma.estimate.findUnique({
         where: { id: estimateId },
         select: safeEstimateSelect,
@@ -3163,95 +3191,13 @@ async function getDefaultSalesTaxRate(): Promise<number> {
 }
 
 export async function createInvoiceFromEstimate(estimateId: string) {
-    const estimate = await prisma.estimate.findUnique({ where: { id: estimateId } });
-    if (!estimate) throw new Error("Estimate not found");
+    await assertInvoicePermission();
+    return createInvoiceFromEstimateInternal(estimateId);
+}
 
-    const project = await prisma.project.findUnique({ where: { id: estimate.projectId! } });
-    if (!project) throw new Error("Project not found");
-
-    const total = toNum(estimate.totalAmount || 0);
-    const rate = estimate.taxRatePercent != null
-        ? Number(estimate.taxRatePercent)
-        : await getDefaultSalesTaxRate();
-    const tax = deriveInvoiceTaxFields(total, rate, !!estimate.taxExempt);
-
-    const invoice = await prisma.invoice.create({
-        data: {
-            code: "INV-TEMP",
-            projectId: estimate.projectId!,
-            clientId: project.clientId,
-            estimateId: estimate.id,
-            status: "Draft",
-            totalAmount: total,
-            balanceDue: total,
-            subtotal: tax.subtotal,
-            taxRate: tax.taxRate,
-            taxAmount: tax.taxAmount,
-        },
-    });
-
-    // Use DB-assigned autoincrement for collision-free code
-    const invoiceCode = `INV-${String(invoice.number).padStart(5, "0")}`;
-    await prisma.invoice.update({ where: { id: invoice.id }, data: { code: invoiceCode } });
-
-    const schedules = await prisma.estimatePaymentSchedule.findMany({
-        where: { estimateId },
-        orderBy: { order: "asc" },
-    });
-
-    let paidAmount = 0;
-    if (schedules.length > 0) {
-        for (const schedule of schedules) {
-            const isPaid = schedule.status === "Paid";
-            if (isPaid) {
-                paidAmount += toNum(schedule.amount);
-            }
-            await prisma.paymentSchedule.create({
-                data: {
-                    invoiceId: invoice.id,
-                    sourceScheduleId: schedule.id,
-                    name: schedule.name,
-                    amount: schedule.amount,
-                    status: schedule.status,
-                    dueDate: schedule.dueDate || null,
-                    paymentDate: schedule.paymentDate || null,
-                    paidAt: schedule.paidAt || null,
-                    stripeSessionId: schedule.stripeSessionId || null,
-                    stripePaymentIntentId: schedule.stripePaymentIntentId || null,
-                    paymentMethod: schedule.paymentMethod || null,
-                    referenceNumber: schedule.referenceNumber || null,
-                    notes: schedule.notes || null,
-                },
-            });
-        }
-    } else {
-        await prisma.paymentSchedule.create({
-            data: {
-                invoiceId: invoice.id,
-                name: "Initial Payment",
-                amount: estimate.totalAmount || 0,
-                status: "Pending",
-            },
-        });
-    }
-
-    const newBalanceDue = Math.max(0, total - paidAmount);
-    let invoiceStatus = "Draft";
-    if (paidAmount > 0) {
-        invoiceStatus = newBalanceDue <= 0 ? "Paid" : "Partially Paid";
-    }
-
-    await prisma.invoice.update({
-        where: { id: invoice.id },
-        data: {
-            code: invoiceCode,
-            balanceDue: newBalanceDue,
-            status: invoiceStatus,
-        }
-    });
-
-    revalidatePath(`/projects/${estimate.projectId}/invoices`);
-    return { id: invoice.id, projectId: estimate.projectId };
+async function createInvoiceFromEstimateInternal(estimateId: string) {
+    const { createInvoiceFromEstimateCore } = await import("./billing-core");
+    return createInvoiceFromEstimateCore(estimateId);
 }
 
 export async function createOneOffInvoice(
@@ -3308,7 +3254,7 @@ export async function createOneOffInvoice(
 }
 
 export async function createInvoiceFromTimeEntries(projectId: string, timeEntryIds: string[]) {
-    "use server";
+    await assertInvoicePermission();
     if (!timeEntryIds.length) throw new Error("No time entries selected");
 
     const project = await prisma.project.findUnique({ where: { id: projectId } });
@@ -3372,6 +3318,7 @@ export async function createInvoiceFromTimeEntries(projectId: string, timeEntryI
 }
 
 export async function getInvoice(id: string) {
+    await assertInvoicePermission();
     const invoice = await prisma.invoice.findUnique({
         where: { id },
         include: {
@@ -4026,11 +3973,89 @@ export async function unrecordEstimatePayment(paymentId: string, estimateId: str
     return { success: true };
 }
 
-async function assertInvoicePermission() {
+async function assertActiveStaff(): Promise<any> {
     const user = await getCurrentUserWithPermissions();
-    if (!user) throw new Error("Unauthorized");
-    if (!hasPermission(user, "invoices")) throw new Error("Forbidden");
+    if (user) return user;
+
+    if (await canUseDevAuthFallback()) {
+        const devSession = await getSessionOrDev();
+        if ((devSession?.user as { role?: string } | undefined)?.role) return devSession.user;
+    }
+    throw new Error("Unauthorized");
+}
+
+async function assertStaffPermission(permission: "estimates" | "invoices" | "changeOrders" | "financialReports" | "companySettings") {
+    const user = await assertActiveStaff();
+    if (!hasPermission(user, permission)) throw new Error("Forbidden");
     return user;
+}
+
+async function assertEstimatePermission() {
+    return assertStaffPermission("estimates");
+}
+
+async function assertInvoicePermission() {
+    return assertStaffPermission("invoices");
+}
+
+async function assertChangeOrderPermission() {
+    return assertStaffPermission("changeOrders");
+}
+
+async function assertFinancialPermission() {
+    return assertStaffPermission("financialReports");
+}
+
+async function assertCompanySettingsPermission() {
+    return assertStaffPermission("companySettings");
+}
+
+async function assertEstimateStaffOrPortalAccess(estimateId: string) {
+    const user = await getCurrentUserWithPermissions();
+    if (user) {
+        if (!hasPermission(user, "estimates") && !hasPermission(user, "invoices")) {
+            throw new Error("Forbidden");
+        }
+        return;
+    }
+    if (await canUseDevAuthFallback()) {
+        await assertActiveStaff();
+        return;
+    }
+
+    const clientId = await resolveSessionClientId();
+    if (!clientId) throw new Error("Unauthorized");
+    const owned = await prisma.estimate.findFirst({
+        where: {
+            id: estimateId,
+            OR: [
+                { project: { is: { clientId } } },
+                { lead: { is: { clientId } } },
+            ],
+        },
+        select: { id: true },
+    });
+    if (!owned) throw new Error("Unauthorized");
+}
+
+async function assertInvoicePortalAccess(): Promise<string | null> {
+    // Staff previews must never register as client views.
+    if (await getCurrentUserWithPermissions()) return null;
+    if (await canUseDevAuthFallback()) {
+        await assertActiveStaff();
+        return null;
+    }
+    return resolveSessionClientId();
+}
+
+async function assertEstimateSendPermission(mcpSecret?: string) {
+    const configuredSecret = process.env.MCP_SECRET;
+    if (mcpSecret && configuredSecret) {
+        const supplied = Buffer.from(mcpSecret);
+        const configured = Buffer.from(configuredSecret);
+        if (supplied.length === configured.length && timingSafeEqual(supplied, configured)) return;
+    }
+    await assertEstimatePermission();
 }
 
 export async function addInvoiceMilestone(
@@ -4274,6 +4299,7 @@ export async function unrecordPayment(paymentId: string, invoiceId: string) {
 }
 
 export async function getProjectInvoices(projectId: string) {
+    await assertInvoicePermission();
     return await prisma.invoice.findMany({
         where: { projectId },
         orderBy: { createdAt: "desc" },
@@ -4282,6 +4308,7 @@ export async function getProjectInvoices(projectId: string) {
 }
 
 export async function getAllInvoices() {
+    await assertInvoicePermission();
     return await prisma.invoice.findMany({
         orderBy: { createdAt: "desc" },
         include: {
@@ -4292,6 +4319,7 @@ export async function getAllInvoices() {
 }
 
 export async function issueInvoice(invoiceId: string) {
+    await assertInvoicePermission();
     const invoice = await prisma.invoice.update({
         where: { id: invoiceId },
         data: {
@@ -4330,9 +4358,77 @@ async function generateBudgetForEstimate(estimateId: string, projectId: string) 
 }
 
 
-export const getCompanySettings = unstable_cache(
+const staffCompanySettingsSelect = {
+    id: true,
+    companyName: true,
+    address: true,
+    phone: true,
+    email: true,
+    website: true,
+    logoUrl: true,
+    licenseNumber: true,
+    notificationEmail: true,
+    googleDriveEmail: true,
+    projectStatuses: true,
+    subcontractorTrades: true,
+    stripeEnabled: true,
+    enableCard: true,
+    enableBankTransfer: true,
+    enableAffirm: true,
+    enableKlarna: true,
+    passProcessingFee: true,
+    cardProcessingRate: true,
+    cardProcessingFlat: true,
+    monthlyOverhead: true,
+    workDays: true,
+    workdayStart: true,
+    workdayEnd: true,
+    salesTaxes: true,
+    letterheadMode: true,
+    letterheadImageUrl: true,
+    letterheadLogoPosition: true,
+    letterheadFields: true,
+    letterheadAccentColor: true,
+    letterheadDivider: true,
+    notificationToggles: true,
+    requireContractCountersign: true,
+    updatedAt: true,
+} as const;
+
+const publicCompanySettingsSelect = {
+    id: true,
+    companyName: true,
+    address: true,
+    phone: true,
+    email: true,
+    website: true,
+    logoUrl: true,
+    licenseNumber: true,
+    stripeEnabled: true,
+    enableCard: true,
+    enableBankTransfer: true,
+    enableAffirm: true,
+    enableKlarna: true,
+    passProcessingFee: true,
+    cardProcessingRate: true,
+    cardProcessingFlat: true,
+    salesTaxes: true,
+    letterheadMode: true,
+    letterheadImageUrl: true,
+    letterheadLogoPosition: true,
+    letterheadFields: true,
+    letterheadAccentColor: true,
+    letterheadDivider: true,
+    requireContractCountersign: true,
+    updatedAt: true,
+} as const;
+
+const getCachedCompanySettings = unstable_cache(
     async () => {
-        let settings = await prisma.companySettings.findUnique({ where: { id: "singleton" } });
+        let settings = await prisma.companySettings.findUnique({
+            where: { id: "singleton" },
+            select: staffCompanySettingsSelect,
+        });
 
         if (!settings) {
             settings = await prisma.companySettings.create({
@@ -4340,6 +4436,7 @@ export const getCompanySettings = unstable_cache(
                     id: "singleton",
                     companyName: "My Construction Co.",
                 },
+                select: staffCompanySettingsSelect,
             });
         }
 
@@ -4349,7 +4446,29 @@ export const getCompanySettings = unstable_cache(
     { revalidate: 300, tags: ["company-settings"] }
 );
 
+const getCachedPublicCompanySettings = unstable_cache(
+    async () => {
+        const settings = await prisma.companySettings.findUnique({
+            where: { id: "singleton" },
+            select: publicCompanySettingsSelect,
+        });
+        return settings ? JSON.parse(JSON.stringify(settings)) : null;
+    },
+    ["public-company-settings"],
+    { revalidate: 300, tags: ["company-settings"] },
+);
+
+export async function getCompanySettings() {
+    await assertActiveStaff();
+    return getCachedCompanySettings();
+}
+
+export async function getPublicCompanySettings() {
+    return getCachedPublicCompanySettings();
+}
+
 export async function saveCompanySettings(data: any) {
+    await assertCompanySettingsPermission();
     await prisma.companySettings.update({
         where: { id: "singleton" },
         data: {
@@ -4394,6 +4513,7 @@ export async function saveCompanySettings(data: any) {
 }
 
 export async function deleteEstimate(estimateId: string): Promise<{ success: boolean; error?: string }> {
+    await assertEstimatePermission();
     const estimate = await prisma.estimate.findUnique({
         where: { id: estimateId },
         select: { projectId: true, leadId: true, status: true },
@@ -4451,6 +4571,7 @@ export async function deleteEstimate(estimateId: string): Promise<{ success: boo
 // =============================================
 
 export async function duplicateEstimate(estimateId: string, targetProjectId?: string, newTitle?: string) {
+    await assertEstimatePermission();
     const original = await prisma.estimate.findUnique({
         where: { id: estimateId },
         include: {
@@ -4592,6 +4713,7 @@ export async function duplicateEstimates(
 // =============================================
 
 export async function saveEstimateAsTemplate(estimateId: string, templateName: string) {
+    await assertEstimatePermission();
     const estimate = await prisma.estimate.findUnique({
         where: { id: estimateId },
         include: { items: { orderBy: { order: "asc" } } },
@@ -4637,6 +4759,7 @@ export async function saveEstimateAsTemplate(estimateId: string, templateName: s
 }
 
 export async function getEstimateTemplates() {
+    await assertEstimatePermission();
     return await prisma.estimateTemplate.findMany({
         orderBy: { createdAt: "desc" },
         include: { items: { orderBy: [{ order: "asc" }, { id: "asc" }] } },
@@ -4644,6 +4767,7 @@ export async function getEstimateTemplates() {
 }
 
 export async function createEstimateFromTemplate(projectId: string, templateId: string) {
+    await assertEstimatePermission();
     const template = await prisma.estimateTemplate.findUnique({
         where: { id: templateId },
         include: { items: { orderBy: [{ order: "asc" }, { id: "asc" }] } },
@@ -4706,6 +4830,7 @@ export async function createEstimateFromTemplate(projectId: string, templateId: 
 // =============================================
 
 export async function saveItemsAsAssembly(name: string, items: { name: string; description?: string; type: string; quantity: number; baseCost: number; markupPercent: number; unitCost: number; order: number; parentId?: string | null; costCodeId?: string | null; costTypeId?: string | null; isSection?: boolean }[]) {
+    await assertEstimatePermission();
     const itemRows = items.map((item, idx) => ({
         name: item.name,
         description: item.description || "",
@@ -4746,6 +4871,7 @@ export async function saveItemsAsAssembly(name: string, items: { name: string; d
 }
 
 export async function deleteAssembly(templateId: string) {
+    await assertEstimatePermission();
     await prisma.estimateTemplate.delete({ where: { id: templateId } });
     return { success: true };
 }
@@ -4806,7 +4932,8 @@ export async function deleteDocumentTemplate(id: string) {
 // Send Estimate to Client
 // =============================================
 
-export async function sendEstimateToClient(estimateId: string, templateId?: string, overrideEmail?: string, ccEmails?: string[], customMessage?: string, capturedPdfUrl?: string): Promise<{ success: true; sentTo: string } | { success: false; error: string }> {
+export async function sendEstimateToClient(estimateId: string, templateId?: string, overrideEmail?: string, ccEmails?: string[], customMessage?: string, capturedPdfUrl?: string, mcpSecret?: string): Promise<{ success: true; sentTo: string } | { success: false; error: string }> {
+    await assertEstimateSendPermission(mcpSecret);
     try {
     // --- Server-side CC validation ---
     const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -5979,7 +6106,7 @@ export async function approveContract(contractId: string, signatureName: string,
         });
     });
 
-    const settings = await getCompanySettings();
+    const settings = await getCachedCompanySettings();
     if (settings.notificationEmail && isNotificationEnabled(settings, "contractSigned")) {
         const isRecurring = contract.recurringDays && contract.recurringDays > 0;
         await sendNotification(
@@ -6266,6 +6393,7 @@ export async function getDashboardTasks(projectId: string) {
 }
 
 export async function getEstimateItemsForProject(projectId: string) {
+    await assertEstimatePermission();
     const items = await prisma.estimateItem.findMany({
         where: { estimate: { projectId }, type: { not: "Section" } },
         orderBy: { order: "asc" },
@@ -6469,6 +6597,7 @@ export async function unlinkTasks(predecessorId: string, dependentId: string) {
 }
 
 export async function importEstimateToSchedule(projectId: string, estimateId: string) {
+    await assertEstimatePermission();
     const estimate = await prisma.estimate.findUnique({
         where: { id: estimateId },
         include: {
@@ -6983,6 +7112,7 @@ export async function getActiveSubcontractors() {
 // ========== PROJECT BOARD ACTIONS ==========
 
 export async function updateProjectStatus(projectId: string, status: string) {
+    await assertActiveStaff();
     await prisma.project.update({
         where: { id: projectId },
         data: { status }
@@ -7013,6 +7143,7 @@ export async function updateProjectTags(projectId: string, tags: string) {
 }
 
 export async function updateProjectName(projectId: string, name: string) {
+    await assertActiveStaff();
     await prisma.project.update({
         where: { id: projectId },
         data: { name }
@@ -7045,6 +7176,7 @@ export async function updateProjectLocation(projectId: string, location: string)
 }
 
 export async function deleteProjects(projectIds: string[]) {
+    await assertActiveStaff();
     await prisma.project.deleteMany({
         where: { id: { in: projectIds } }
     });
@@ -7053,6 +7185,7 @@ export async function deleteProjects(projectIds: string[]) {
 }
 
 export async function updateCompanyProjectStatuses(statuses: string) {
+    await assertCompanySettingsPermission();
     await prisma.companySettings.update({
         where: { id: "singleton" },
         data: { projectStatuses: statuses }
@@ -7293,6 +7426,7 @@ export async function getCompanySubcontractorTrades() {
 }
 
 export async function saveCompanySubcontractorTrades(trades: string[]) {
+    await assertCompanySettingsPermission();
     await prisma.companySettings.update({
         where: { id: "singleton" },
         data: { subcontractorTrades: JSON.stringify(trades) },
@@ -7332,7 +7466,7 @@ export async function saveSubcontractorExplicitProjects(subId: string, projectId
 // =============================================
 
 export async function createChangeOrder(projectId: string, estimateId: string, itemIds?: string[]) {
-    "use server";
+    await assertChangeOrderPermission();
 
     const estimate = await prisma.estimate.findUnique({
         where: { id: estimateId },
@@ -7445,7 +7579,7 @@ export async function createSuggestedChangeOrder(
 }
 
 export async function getChangeOrders(projectId: string) {
-    "use server";
+    await assertChangeOrderPermission();
     return await prisma.changeOrder.findMany({
         where: { projectId },
         orderBy: { createdAt: "desc" },
@@ -7454,7 +7588,7 @@ export async function getChangeOrders(projectId: string) {
 }
 
 export async function getChangeOrder(id: string) {
-    "use server";
+    await assertChangeOrderPermission();
     return await prisma.changeOrder.findUnique({
         where: { id },
         include: {
@@ -7519,10 +7653,7 @@ export async function updateChangeOrder(id: string, data: ChangeOrderUpdateInput
 }
 
 export async function deleteChangeOrder(id: string) {
-    "use server";
-    const user = await getCurrentUserWithPermissions();
-    if (!user) throw new Error("Unauthorized");
-    if (!hasPermission(user, "changeOrders")) throw new Error("Forbidden");
+    const user = await assertChangeOrderPermission();
     const target = await prisma.changeOrder.findUnique({ where: { id }, select: { projectId: true } });
     if (!target) return;
     if (!canAccessProject(user, target.projectId)) throw new Error("Forbidden");
@@ -7953,7 +8084,7 @@ export async function deleteVendorTag(id: string) {
 // Purchase Orders
 // ==========================================
 export async function getPurchaseOrders(projectId: string) {
-    "use server";
+    await assertFinancialPermission();
     return prisma.purchaseOrder.findMany({
         where: { projectId },
         include: { vendor: true, items: true },
@@ -7962,7 +8093,7 @@ export async function getPurchaseOrders(projectId: string) {
 }
 
 export async function getPurchaseOrder(id: string) {
-    "use server";
+    await assertFinancialPermission();
     return prisma.purchaseOrder.findUnique({
         where: { id },
         include: { vendor: true, items: { include: { costCode: true } }, files: true, expenses: { include: { costCode: true } } }
@@ -7970,7 +8101,7 @@ export async function getPurchaseOrder(id: string) {
 }
 
 export async function createPurchaseOrder(projectId: string, data: any) {
-    "use server";
+    await assertFinancialPermission();
     const count = await prisma.purchaseOrder.count({ where: { projectId } });
     const code = `PO-${(count + 1).toString().padStart(3, "0")}`;
     
@@ -7991,7 +8122,7 @@ export async function createPurchaseOrder(projectId: string, data: any) {
 }
 
 export async function createPurchaseOrderFromEstimate(projectId: string, estimateId: string, itemIds: string[], vendorId: string) {
-    "use server";
+    await assertFinancialPermission();
     
     // Validate inputs
     if (!itemIds || itemIds.length === 0) throw new Error("No items selected");
@@ -8050,7 +8181,7 @@ export async function createPurchaseOrderFromEstimate(projectId: string, estimat
 }
 
 export async function updatePurchaseOrder(id: string, data: any) {
-    "use server";
+    await assertFinancialPermission();
     const { items, vendorId, ...poData } = data;
     
     let updateData: any = { ...poData };
@@ -8088,7 +8219,7 @@ export async function updatePurchaseOrder(id: string, data: any) {
 }
 
 export async function deletePurchaseOrder(id: string) {
-    "use server";
+    await assertFinancialPermission();
     const po = await prisma.purchaseOrder.findUnique({ where: { id } });
     if (!po) return;
     await prisma.purchaseOrder.delete({ where: { id } });
@@ -8096,7 +8227,7 @@ export async function deletePurchaseOrder(id: string) {
 }
 
 export async function updatePurchaseOrderStatus(id: string, status: string) {
-    "use server";
+    await assertFinancialPermission();
     const po = await prisma.purchaseOrder.update({
         where: { id },
         data: { status }
@@ -8107,7 +8238,7 @@ export async function updatePurchaseOrderStatus(id: string, status: string) {
 }
 
 export async function approvePurchaseOrder(id: string, signatureName: string) {
-    "use server";
+    await assertFinancialPermission();
     const approvedAt = new Date();
     const po = await prisma.purchaseOrder.update({
         where: { id },
@@ -8124,7 +8255,7 @@ export async function approvePurchaseOrder(id: string, signatureName: string) {
 }
 
 export async function uploadPurchaseOrderFile(purchaseOrderId: string, formData: FormData) {
-    "use server";
+    await assertFinancialPermission();
     const file = formData.get("file") as File;
     if (!file) throw new Error("No file uploaded");
 
@@ -8168,7 +8299,7 @@ export async function uploadPurchaseOrderFile(purchaseOrderId: string, formData:
 }
 
 export async function deletePurchaseOrderFile(fileId: string) {
-    "use server";
+    await assertFinancialPermission();
     const file = await prisma.purchaseOrderFile.findUnique({ where: { id: fileId }, include: { purchaseOrder: true } });
     if (!file) return;
 
@@ -8182,9 +8313,7 @@ export async function uploadPurchaseOrderFileFromBuffer(
     projectId: string,
     formData: FormData
 ) {
-    "use server";
-    const session = await getServerSession(authOptions);
-    if (!session?.user?.email) throw new Error("Unauthorized");
+    await assertFinancialPermission();
 
     const file = formData.get("file") as File;
     if (!file) return;
@@ -8225,7 +8354,7 @@ export async function uploadPurchaseOrderFileFromBuffer(
 }
 
 export async function uploadEstimateFile(estimateId: string, formData: FormData) {
-    "use server";
+    await assertEstimatePermission();
     const file = formData.get("file") as File;
     if (!file) throw new Error("No file uploaded");
 
@@ -8272,7 +8401,7 @@ export async function uploadEstimateFile(estimateId: string, formData: FormData)
 }
 
 export async function deleteEstimateFile(fileId: string) {
-    "use server";
+    await assertEstimatePermission();
     const file = await prisma.estimateFile.findUnique({ where: { id: fileId }, include: { estimate: { select: { id: true, code: true, title: true, status: true, totalAmount: true, projectId: true, leadId: true } } } });
     if (!file) return;
 
@@ -8283,7 +8412,7 @@ export async function deleteEstimateFile(fileId: string) {
 }
 
 export async function getEstimateFiles(estimateId: string) {
-    "use server";
+    await assertEstimatePermission();
     return prisma.estimateFile.findMany({
         where: { estimateId },
         orderBy: { createdAt: "desc" },
@@ -8292,7 +8421,7 @@ export async function getEstimateFiles(estimateId: string) {
 
 
 export async function sendPurchaseOrder(id: string, toEmail: string, message: string) {
-    "use server";
+    await assertFinancialPermission();
     const { sendNotification } = await import("./email");
     const { generatePurchaseOrderPdf } = await import("./pdf");
 
@@ -8483,7 +8612,7 @@ export async function sendSelectionBoardToClient(boardId: string) {
     // Email the client
     const clientEmail = board.project.client?.email;
     if (clientEmail) {
-        const settings = await getCompanySettings();
+        const settings = await getCachedCompanySettings();
         const { buildClientPortalUrl } = await import("./client-portal-auth");
         const portalUrl = await buildClientPortalUrl(board.project.client?.id, clientEmail, `/portal/projects/${board.projectId}/selections`);
         const selectionCc = buildCc(clientEmail, (board.project.client as any)?.additionalEmail);
@@ -8535,7 +8664,7 @@ export async function submitClientSelections(boardId: string, selections: Record
     });
 
     // Notify PM
-    const settings = await getCompanySettings();
+    const settings = await getCachedCompanySettings();
     if (settings.notificationEmail) {
         const selectedSummary = board.categories.map(cat => {
             const selectedOpt = cat.options.find(o => selections[cat.id] === o.id);
@@ -8891,6 +9020,7 @@ export async function deleteLeadScheduleTask(taskId: string, leadId: string) {
 // ─── Bid Packages ─────────────────────────────────────────────────────────
 
 export async function getProjectBidPackages(projectId: string) {
+    await assertFinancialPermission();
     return prisma.bidPackage.findMany({
         where: { projectId },
         include: { scopes: { orderBy: { order: "asc" } }, invitations: true },
@@ -8899,6 +9029,7 @@ export async function getProjectBidPackages(projectId: string) {
 }
 
 export async function getBidPackage(id: string) {
+    await assertFinancialPermission();
     const pkg = await prisma.bidPackage.findUnique({
         where: { id },
         include: {
@@ -8930,7 +9061,7 @@ export async function createBidPackage(projectId: string, data: {
     dueDate?: Date | null;
     totalBudget?: number | null;
 }) {
-    "use server";
+    await assertFinancialPermission();
     const pkg = await prisma.bidPackage.create({
         data: { projectId, ...data },
     });
@@ -8945,7 +9076,7 @@ export async function updateBidPackage(id: string, projectId: string, data: {
     status?: string;
     totalBudget?: number | null;
 }) {
-    "use server";
+    await assertFinancialPermission();
     const pkg = await prisma.bidPackage.update({ where: { id }, data });
     revalidatePath(`/projects/${projectId}/bid-packages`);
     revalidatePath(`/projects/${projectId}/bid-packages/${id}/edit`);
@@ -8953,7 +9084,7 @@ export async function updateBidPackage(id: string, projectId: string, data: {
 }
 
 export async function deleteBidPackage(id: string, projectId: string) {
-    "use server";
+    await assertFinancialPermission();
     await prisma.bidPackage.delete({ where: { id } });
     revalidatePath(`/projects/${projectId}/bid-packages`);
     return { success: true };
@@ -8964,7 +9095,7 @@ export async function addBidScope(packageId: string, projectId: string, data: {
     description?: string;
     budgetAmount?: number | null;
 }) {
-    "use server";
+    await assertFinancialPermission();
     const scope = await prisma.bidScope.create({
         data: { packageId, ...data },
     });
@@ -8973,7 +9104,7 @@ export async function addBidScope(packageId: string, projectId: string, data: {
 }
 
 export async function deleteBidScope(scopeId: string, packageId: string, projectId: string) {
-    "use server";
+    await assertFinancialPermission();
     await prisma.bidScope.delete({ where: { id: scopeId } });
     revalidatePath(`/projects/${projectId}/bid-packages/${packageId}/edit`);
     return { success: true };
@@ -8983,7 +9114,7 @@ export async function inviteSubToBid(packageId: string, projectId: string, data:
     email: string;
     subcontractorId?: string;
 }) {
-    "use server";
+    await assertFinancialPermission();
     const inv = await prisma.bidInvitation.create({
         data: { packageId, email: data.email, subcontractorId: data.subcontractorId || null, sentAt: new Date() },
     });
@@ -8996,7 +9127,7 @@ export async function recordBidResponse(invitationId: string, packageId: string,
     bidAmount?: number | null;
     notes?: string;
 }) {
-    "use server";
+    await assertFinancialPermission();
     const inv = await prisma.bidInvitation.update({
         where: { id: invitationId },
         data: { ...data, respondedAt: new Date() },
@@ -9006,7 +9137,7 @@ export async function recordBidResponse(invitationId: string, packageId: string,
 }
 
 export async function awardBid(packageId: string, invitationId: string, projectId: string) {
-    "use server";
+    await assertFinancialPermission();
     await prisma.$transaction([
         prisma.bidInvitation.update({ where: { id: invitationId }, data: { status: "Awarded" } }),
         prisma.bidPackage.update({ where: { id: packageId }, data: { status: "Awarded" } }),
@@ -9022,6 +9153,7 @@ export async function createRetainer(projectId: string, data: {
     notes?: string;
     dueDate?: string;
 }) {
+    await assertInvoicePermission();
     const project = await prisma.project.findUnique({
         where: { id: projectId },
         select: { clientId: true },
@@ -9056,6 +9188,7 @@ export async function updateRetainer(id: string, data: {
     dueDate?: string | null;
     status?: string;
 }) {
+    await assertInvoicePermission();
     const existing = await prisma.retainer.findUnique({ where: { id }, select: { projectId: true, amountPaid: true } });
     if (!existing) throw new Error("Retainer not found");
 
@@ -9078,6 +9211,7 @@ export async function updateRetainer(id: string, data: {
 }
 
 export async function deleteRetainer(id: string) {
+    await assertInvoicePermission();
     const retainer = await prisma.retainer.findUnique({ where: { id }, select: { projectId: true } });
     if (!retainer) return { success: false };
 
@@ -9106,17 +9240,6 @@ function assertValidVisibility(visibility: string): asserts visibility is "team"
     if (visibility !== "team" && visibility !== "client") {
         throw new Error("Invalid visibility");
     }
-}
-
-// A staff session whose User row has flipped to DISABLED must not be trusted
-// here. getCurrentUserWithPermissions() doesn't filter on status (NextAuth's
-// jwt() callback only re-checks `role` on token refresh, not `status` — see
-// signIn() in lib/auth.ts, which only rejects DISABLED at initial login), so
-// an existing session survives a disable until the token expires. That's a
-// pre-existing gap in the shared helper across the whole app, not something
-// safe to fix here — see the PR body for the follow-up. Scoped locally:
-function activeStaffUser<T extends { status: string }>(user: T | null): T | null {
-    return user && user.status !== "DISABLED" ? user : null;
 }
 
 // Resolves the Client that owns a given document, for portal ownership
@@ -9162,7 +9285,7 @@ export async function getDocumentComments(documentType: string, documentId: stri
     // nothing back — otherwise a caller who merely knows a documentId (e.g.
     // from a portal URL) could read another client's, or TEAM-visibility,
     // comments.
-    const staffUser = activeStaffUser(await getCurrentUserWithPermissions());
+    const staffUser = await getCurrentUserWithPermissions();
     if (staffUser) {
         const comments = await prisma.documentComment.findMany({
             where: { documentType, documentId },
@@ -9210,7 +9333,7 @@ export async function addDocumentComment(
     let authorId: string | null = null;
     let authorName: string | null = null;
 
-    const staffUser = activeStaffUser(await getCurrentUserWithPermissions());
+    const staffUser = await getCurrentUserWithPermissions();
     if (staffUser) {
         authorId = staffUser.id;
         authorName = staffUser.name || staffUser.email;
@@ -9242,7 +9365,7 @@ export async function deleteDocumentComment(commentId: string) {
     // Non-staff (portal) callers never satisfy either check today — there's
     // no portal mount for this component yet, so portal-authored comments
     // are deliberately admin-only to delete for now (see getDocumentComments).
-    const staffUser = activeStaffUser(await getCurrentUserWithPermissions());
+    const staffUser = await getCurrentUserWithPermissions();
     const comment = await prisma.documentComment.findUnique({ where: { id: commentId }, select: { authorId: true } });
     if (!comment) return { success: true };
 
@@ -9257,6 +9380,7 @@ export async function deleteDocumentComment(commentId: string) {
 // ========== PER-ITEM APPROVAL ==========
 
 export async function updateItemApproval(itemId: string, status: "approved" | "rejected" | null, note?: string) {
+    await assertEstimatePermission();
     try {
         return await prisma.estimateItem.update({
             where: { id: itemId },
@@ -9269,6 +9393,7 @@ export async function updateItemApproval(itemId: string, status: "approved" | "r
 }
 
 export async function bulkUpdateItemApproval(itemIds: string[], status: "approved" | "rejected" | null) {
+    await assertEstimatePermission();
     try {
         await prisma.estimateItem.updateMany({
             where: { id: { in: itemIds } },
@@ -9283,8 +9408,7 @@ export async function bulkUpdateItemApproval(itemIds: string[], status: "approve
 
 export async function linkPOToEstimateItem(estimateItemId: string, purchaseOrderId: string) {
     "use server";
-    const session = await getServerSession(authOptions);
-    if (!session) throw new Error("Unauthorized");
+    await assertFinancialPermission();
 
     const item = await prisma.estimateItem.findUnique({
         where: { id: estimateItemId },
@@ -9307,8 +9431,7 @@ export async function linkPOToEstimateItem(estimateItemId: string, purchaseOrder
 
 export async function unlinkPOFromEstimateItem(estimateItemId: string) {
     "use server";
-    const session = await getServerSession(authOptions);
-    if (!session) throw new Error("Unauthorized");
+    await assertFinancialPermission();
 
     const item = await prisma.estimateItem.findUnique({
         where: { id: estimateItemId },
@@ -9325,8 +9448,7 @@ export async function unlinkPOFromEstimateItem(estimateItemId: string) {
 
 export async function quickCreatePOAndLink(estimateItemId: string, data: { vendorId: string; amount: number; notes?: string }) {
     "use server";
-    const session = await getServerSession(authOptions);
-    if (!session) throw new Error("Unauthorized");
+    await assertFinancialPermission();
 
     const item = await prisma.estimateItem.findUnique({
         where: { id: estimateItemId },
@@ -9373,8 +9495,7 @@ export async function quickCreatePOAndLink(estimateItemId: string, data: { vendo
 
 export async function getProjectPurchaseOrdersForLinking(projectId: string) {
     "use server";
-    const session = await getServerSession(authOptions);
-    if (!session) throw new Error("Unauthorized");
+    await assertFinancialPermission();
 
     return prisma.purchaseOrder.findMany({
         where: { projectId },
@@ -9384,9 +9505,7 @@ export async function getProjectPurchaseOrdersForLinking(projectId: string) {
 }
 
 export async function createEstimateFromRoomDesign(roomId: string) {
-    "use server";
-    const session = await getServerSession(authOptions);
-    if (!session) throw new Error("Unauthorized");
+    await assertEstimatePermission();
 
     const room = await prisma.roomDesign.findUnique({
         where: { id: roomId },
@@ -9589,6 +9708,7 @@ export async function createEstimateFromRoomDesign(roomId: string) {
 }
 
 export async function addVoiceEstimateItem(projectId: string, name: string, quantity: number, unitCost: number) {
+    await assertEstimatePermission();
     const estimate = await prisma.estimate.findFirst({
         where: { projectId },
         orderBy: { createdAt: "desc" }
@@ -9654,11 +9774,8 @@ async function assertOfficeTaskAccess() {
         return { id: null as string | null, role: sessionRole as string };
     }
 
-    // Otherwise, re-resolve the caller from the DB instead of trusting the
-    // session's role/id: auth.ts's jwt() callback leaves token.role/userId
-    // untouched when the DB lookup finds no user (deleted user, live token),
-    // and never encodes `status` into the token at all — so a disabled user's
-    // token would still read role: ADMIN until it expires.
+    // Otherwise, re-resolve the caller from the DB as defense in depth. The
+    // shared JWT callback already suppresses missing and DISABLED staff users.
     const user = sessionUserId
         ? await prisma.user.findUnique({ where: { id: sessionUserId }, select: { id: true, role: true, status: true } })
         : sessionEmail

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -4006,6 +4006,17 @@ async function assertFinancialPermission() {
     return assertStaffPermission("financialReports");
 }
 
+function assertFinancialProjectScope(user: any, projectId: string) {
+    if (["ADMIN", "MANAGER", "FINANCE"].includes(user.role)) return;
+    if (!canAccessProject(user, projectId)) throw new Error("Forbidden");
+}
+
+async function assertFinancialProjectAccess(projectId: string) {
+    const user = await assertFinancialPermission();
+    assertFinancialProjectScope(user, projectId);
+    return user;
+}
+
 async function assertCompanySettingsPermission() {
     return assertStaffPermission("companySettings");
 }
@@ -8084,7 +8095,7 @@ export async function deleteVendorTag(id: string) {
 // Purchase Orders
 // ==========================================
 export async function getPurchaseOrders(projectId: string) {
-    await assertFinancialPermission();
+    await assertFinancialProjectAccess(projectId);
     return prisma.purchaseOrder.findMany({
         where: { projectId },
         include: { vendor: true, items: true },
@@ -8093,15 +8104,17 @@ export async function getPurchaseOrders(projectId: string) {
 }
 
 export async function getPurchaseOrder(id: string) {
-    await assertFinancialPermission();
-    return prisma.purchaseOrder.findUnique({
+    const user = await assertFinancialPermission();
+    const purchaseOrder = await prisma.purchaseOrder.findUnique({
         where: { id },
         include: { vendor: true, items: { include: { costCode: true } }, files: true, expenses: { include: { costCode: true } } }
     });
+    if (purchaseOrder) assertFinancialProjectScope(user, purchaseOrder.projectId);
+    return purchaseOrder;
 }
 
 export async function createPurchaseOrder(projectId: string, data: any) {
-    await assertFinancialPermission();
+    await assertFinancialProjectAccess(projectId);
     const count = await prisma.purchaseOrder.count({ where: { projectId } });
     const code = `PO-${(count + 1).toString().padStart(3, "0")}`;
     
@@ -8122,7 +8135,7 @@ export async function createPurchaseOrder(projectId: string, data: any) {
 }
 
 export async function createPurchaseOrderFromEstimate(projectId: string, estimateId: string, itemIds: string[], vendorId: string) {
-    await assertFinancialPermission();
+    await assertFinancialProjectAccess(projectId);
     
     // Validate inputs
     if (!itemIds || itemIds.length === 0) throw new Error("No items selected");
@@ -8134,6 +8147,7 @@ export async function createPurchaseOrderFromEstimate(projectId: string, estimat
     });
 
     if (!estimate) throw new Error("Estimate not found");
+    if (estimate.projectId !== projectId) throw new Error("Estimate does not belong to this project");
 
     const selectedItems = estimate.items.filter((item: any) => itemIds.includes(item.id));
     if (selectedItems.length === 0) throw new Error("No valid items found");
@@ -8181,7 +8195,10 @@ export async function createPurchaseOrderFromEstimate(projectId: string, estimat
 }
 
 export async function updatePurchaseOrder(id: string, data: any) {
-    await assertFinancialPermission();
+    const user = await assertFinancialPermission();
+    const existing = await prisma.purchaseOrder.findUnique({ where: { id }, select: { projectId: true } });
+    if (!existing) throw new Error("Purchase order not found");
+    assertFinancialProjectScope(user, existing.projectId);
     const { items, vendorId, ...poData } = data;
     
     let updateData: any = { ...poData };
@@ -8219,15 +8236,19 @@ export async function updatePurchaseOrder(id: string, data: any) {
 }
 
 export async function deletePurchaseOrder(id: string) {
-    await assertFinancialPermission();
+    const user = await assertFinancialPermission();
     const po = await prisma.purchaseOrder.findUnique({ where: { id } });
     if (!po) return;
+    assertFinancialProjectScope(user, po.projectId);
     await prisma.purchaseOrder.delete({ where: { id } });
     revalidatePath(`/projects/${po.projectId}/purchase-orders`);
 }
 
 export async function updatePurchaseOrderStatus(id: string, status: string) {
-    await assertFinancialPermission();
+    const user = await assertFinancialPermission();
+    const existing = await prisma.purchaseOrder.findUnique({ where: { id }, select: { projectId: true } });
+    if (!existing) throw new Error("Purchase order not found");
+    assertFinancialProjectScope(user, existing.projectId);
     const po = await prisma.purchaseOrder.update({
         where: { id },
         data: { status }
@@ -8238,7 +8259,10 @@ export async function updatePurchaseOrderStatus(id: string, status: string) {
 }
 
 export async function approvePurchaseOrder(id: string, signatureName: string) {
-    await assertFinancialPermission();
+    const user = await assertFinancialPermission();
+    const existing = await prisma.purchaseOrder.findUnique({ where: { id }, select: { projectId: true } });
+    if (!existing) throw new Error("Purchase order not found");
+    assertFinancialProjectScope(user, existing.projectId);
     const approvedAt = new Date();
     const po = await prisma.purchaseOrder.update({
         where: { id },
@@ -8255,7 +8279,10 @@ export async function approvePurchaseOrder(id: string, signatureName: string) {
 }
 
 export async function uploadPurchaseOrderFile(purchaseOrderId: string, formData: FormData) {
-    await assertFinancialPermission();
+    const user = await assertFinancialPermission();
+    const existing = await prisma.purchaseOrder.findUnique({ where: { id: purchaseOrderId }, select: { projectId: true } });
+    if (!existing) throw new Error("Purchase order not found");
+    assertFinancialProjectScope(user, existing.projectId);
     const file = formData.get("file") as File;
     if (!file) throw new Error("No file uploaded");
 
@@ -8299,9 +8326,10 @@ export async function uploadPurchaseOrderFile(purchaseOrderId: string, formData:
 }
 
 export async function deletePurchaseOrderFile(fileId: string) {
-    await assertFinancialPermission();
+    const user = await assertFinancialPermission();
     const file = await prisma.purchaseOrderFile.findUnique({ where: { id: fileId }, include: { purchaseOrder: true } });
     if (!file) return;
+    assertFinancialProjectScope(user, file.purchaseOrder.projectId);
 
     await prisma.purchaseOrderFile.delete({ where: { id: fileId } });
     revalidatePath(`/projects/${file.purchaseOrder.projectId}/purchase-orders/${file.purchaseOrderId}`);
@@ -8313,7 +8341,10 @@ export async function uploadPurchaseOrderFileFromBuffer(
     projectId: string,
     formData: FormData
 ) {
-    await assertFinancialPermission();
+    const user = await assertFinancialPermission();
+    const existing = await prisma.purchaseOrder.findUnique({ where: { id: purchaseOrderId }, select: { projectId: true } });
+    if (!existing || existing.projectId !== projectId) return;
+    assertFinancialProjectScope(user, existing.projectId);
 
     const file = formData.get("file") as File;
     if (!file) return;
@@ -8421,7 +8452,7 @@ export async function getEstimateFiles(estimateId: string) {
 
 
 export async function sendPurchaseOrder(id: string, toEmail: string, message: string) {
-    await assertFinancialPermission();
+    const user = await assertFinancialPermission();
     const { sendNotification } = await import("./email");
     const { generatePurchaseOrderPdf } = await import("./pdf");
 
@@ -8430,6 +8461,7 @@ export async function sendPurchaseOrder(id: string, toEmail: string, message: st
         include: { project: true, vendor: true }
     });
     if (!po) throw new Error("PO not found");
+    assertFinancialProjectScope(user, po.projectId);
 
     const pdfBuffer = await generatePurchaseOrderPdf(id);
 
@@ -9020,7 +9052,7 @@ export async function deleteLeadScheduleTask(taskId: string, leadId: string) {
 // ─── Bid Packages ─────────────────────────────────────────────────────────
 
 export async function getProjectBidPackages(projectId: string) {
-    await assertFinancialPermission();
+    await assertFinancialProjectAccess(projectId);
     return prisma.bidPackage.findMany({
         where: { projectId },
         include: { scopes: { orderBy: { order: "asc" } }, invitations: true },
@@ -9029,7 +9061,7 @@ export async function getProjectBidPackages(projectId: string) {
 }
 
 export async function getBidPackage(id: string) {
-    await assertFinancialPermission();
+    const user = await assertFinancialPermission();
     const pkg = await prisma.bidPackage.findUnique({
         where: { id },
         include: {
@@ -9040,6 +9072,7 @@ export async function getBidPackage(id: string) {
     });
 
     if (!pkg) return null;
+    assertFinancialProjectScope(user, pkg.projectId);
 
     return {
         ...pkg,
@@ -9061,7 +9094,7 @@ export async function createBidPackage(projectId: string, data: {
     dueDate?: Date | null;
     totalBudget?: number | null;
 }) {
-    await assertFinancialPermission();
+    await assertFinancialProjectAccess(projectId);
     const pkg = await prisma.bidPackage.create({
         data: { projectId, ...data },
     });
@@ -9076,7 +9109,9 @@ export async function updateBidPackage(id: string, projectId: string, data: {
     status?: string;
     totalBudget?: number | null;
 }) {
-    await assertFinancialPermission();
+    await assertFinancialProjectAccess(projectId);
+    const existing = await prisma.bidPackage.findUnique({ where: { id }, select: { projectId: true } });
+    if (!existing || existing.projectId !== projectId) throw new Error("Bid package not found");
     const pkg = await prisma.bidPackage.update({ where: { id }, data });
     revalidatePath(`/projects/${projectId}/bid-packages`);
     revalidatePath(`/projects/${projectId}/bid-packages/${id}/edit`);
@@ -9084,7 +9119,9 @@ export async function updateBidPackage(id: string, projectId: string, data: {
 }
 
 export async function deleteBidPackage(id: string, projectId: string) {
-    await assertFinancialPermission();
+    await assertFinancialProjectAccess(projectId);
+    const existing = await prisma.bidPackage.findUnique({ where: { id }, select: { projectId: true } });
+    if (!existing || existing.projectId !== projectId) throw new Error("Bid package not found");
     await prisma.bidPackage.delete({ where: { id } });
     revalidatePath(`/projects/${projectId}/bid-packages`);
     return { success: true };
@@ -9095,7 +9132,9 @@ export async function addBidScope(packageId: string, projectId: string, data: {
     description?: string;
     budgetAmount?: number | null;
 }) {
-    await assertFinancialPermission();
+    await assertFinancialProjectAccess(projectId);
+    const pkg = await prisma.bidPackage.findUnique({ where: { id: packageId }, select: { projectId: true } });
+    if (!pkg || pkg.projectId !== projectId) throw new Error("Bid package not found");
     const scope = await prisma.bidScope.create({
         data: { packageId, ...data },
     });
@@ -9104,7 +9143,14 @@ export async function addBidScope(packageId: string, projectId: string, data: {
 }
 
 export async function deleteBidScope(scopeId: string, packageId: string, projectId: string) {
-    await assertFinancialPermission();
+    await assertFinancialProjectAccess(projectId);
+    const existing = await prisma.bidScope.findUnique({
+        where: { id: scopeId },
+        select: { packageId: true, package: { select: { projectId: true } } },
+    });
+    if (!existing || existing.packageId !== packageId || existing.package.projectId !== projectId) {
+        throw new Error("Bid scope not found");
+    }
     await prisma.bidScope.delete({ where: { id: scopeId } });
     revalidatePath(`/projects/${projectId}/bid-packages/${packageId}/edit`);
     return { success: true };
@@ -9114,7 +9160,9 @@ export async function inviteSubToBid(packageId: string, projectId: string, data:
     email: string;
     subcontractorId?: string;
 }) {
-    await assertFinancialPermission();
+    await assertFinancialProjectAccess(projectId);
+    const pkg = await prisma.bidPackage.findUnique({ where: { id: packageId }, select: { projectId: true } });
+    if (!pkg || pkg.projectId !== projectId) throw new Error("Bid package not found");
     const inv = await prisma.bidInvitation.create({
         data: { packageId, email: data.email, subcontractorId: data.subcontractorId || null, sentAt: new Date() },
     });
@@ -9127,7 +9175,14 @@ export async function recordBidResponse(invitationId: string, packageId: string,
     bidAmount?: number | null;
     notes?: string;
 }) {
-    await assertFinancialPermission();
+    await assertFinancialProjectAccess(projectId);
+    const existing = await prisma.bidInvitation.findUnique({
+        where: { id: invitationId },
+        select: { packageId: true, package: { select: { projectId: true } } },
+    });
+    if (!existing || existing.packageId !== packageId || existing.package.projectId !== projectId) {
+        throw new Error("Bid invitation not found");
+    }
     const inv = await prisma.bidInvitation.update({
         where: { id: invitationId },
         data: { ...data, respondedAt: new Date() },
@@ -9137,7 +9192,14 @@ export async function recordBidResponse(invitationId: string, packageId: string,
 }
 
 export async function awardBid(packageId: string, invitationId: string, projectId: string) {
-    await assertFinancialPermission();
+    await assertFinancialProjectAccess(projectId);
+    const invitation = await prisma.bidInvitation.findUnique({
+        where: { id: invitationId },
+        select: { packageId: true, package: { select: { projectId: true } } },
+    });
+    if (!invitation || invitation.packageId !== packageId || invitation.package.projectId !== projectId) {
+        throw new Error("Bid invitation not found");
+    }
     await prisma.$transaction([
         prisma.bidInvitation.update({ where: { id: invitationId }, data: { status: "Awarded" } }),
         prisma.bidPackage.update({ where: { id: packageId }, data: { status: "Awarded" } }),
@@ -9407,8 +9469,7 @@ export async function bulkUpdateItemApproval(itemIds: string[], status: "approve
 }
 
 export async function linkPOToEstimateItem(estimateItemId: string, purchaseOrderId: string) {
-    "use server";
-    await assertFinancialPermission();
+    const user = await assertFinancialPermission();
 
     const item = await prisma.estimateItem.findUnique({
         where: { id: estimateItemId },
@@ -9416,6 +9477,7 @@ export async function linkPOToEstimateItem(estimateItemId: string, purchaseOrder
     });
     if (!item) throw new Error("Estimate item not found");
     if (!item.estimate.projectId) throw new Error("Purchase orders require a project");
+    assertFinancialProjectScope(user, item.estimate.projectId);
 
     const po = await prisma.purchaseOrder.findUnique({ where: { id: purchaseOrderId } });
     if (!po) throw new Error("Purchase order not found");
@@ -9430,13 +9492,15 @@ export async function linkPOToEstimateItem(estimateItemId: string, purchaseOrder
 }
 
 export async function unlinkPOFromEstimateItem(estimateItemId: string) {
-    "use server";
-    await assertFinancialPermission();
+    const user = await assertFinancialPermission();
 
     const item = await prisma.estimateItem.findUnique({
         where: { id: estimateItemId },
         include: { estimate: { select: { projectId: true } } },
     });
+    if (!item) throw new Error("Estimate item not found");
+    if (!item.estimate.projectId) throw new Error("Purchase orders require a project");
+    assertFinancialProjectScope(user, item.estimate.projectId);
     await prisma.estimateItem.update({
         where: { id: estimateItemId },
         data: { purchaseOrderId: null },
@@ -9447,8 +9511,7 @@ export async function unlinkPOFromEstimateItem(estimateItemId: string) {
 }
 
 export async function quickCreatePOAndLink(estimateItemId: string, data: { vendorId: string; amount: number; notes?: string }) {
-    "use server";
-    await assertFinancialPermission();
+    const user = await assertFinancialPermission();
 
     const item = await prisma.estimateItem.findUnique({
         where: { id: estimateItemId },
@@ -9458,6 +9521,7 @@ export async function quickCreatePOAndLink(estimateItemId: string, data: { vendo
     if (!item.estimate.projectId) throw new Error("Purchase orders require a project");
 
     const projectId = item.estimate.projectId;
+    assertFinancialProjectScope(user, projectId);
 
     // Retry loop to handle TOCTOU race: two concurrent creates could pick the same count
     let po: any;
@@ -9494,8 +9558,7 @@ export async function quickCreatePOAndLink(estimateItemId: string, data: { vendo
 }
 
 export async function getProjectPurchaseOrdersForLinking(projectId: string) {
-    "use server";
-    await assertFinancialPermission();
+    await assertFinancialProjectAccess(projectId);
 
     return prisma.purchaseOrder.findMany({
         where: { projectId },

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -8117,16 +8117,28 @@ export async function createPurchaseOrder(projectId: string, data: any) {
     await assertFinancialProjectAccess(projectId);
     const count = await prisma.purchaseOrder.count({ where: { projectId } });
     const code = `PO-${(count + 1).toString().padStart(3, "0")}`;
-    
-    const { items, ...poData } = data;
+    const items = data.items;
     
     const po = await prisma.purchaseOrder.create({
         data: {
-            ...poData,
             projectId,
             code,
+            vendorId: data.vendorId,
+            status: data.status,
+            totalAmount: data.totalAmount,
+            notes: data.notes,
+            memos: data.memos,
+            terms: data.terms,
             items: {
-                create: items || []
+                create: (items || []).map((item: any) => ({
+                    description: item.description,
+                    quantity: item.quantity,
+                    unitCost: item.unitCost,
+                    total: item.total,
+                    order: item.order,
+                    costCodeId: item.costCodeId,
+                    costTypeId: item.costTypeId,
+                })),
             }
         }
     });
@@ -8199,10 +8211,15 @@ export async function updatePurchaseOrder(id: string, data: any) {
     const existing = await prisma.purchaseOrder.findUnique({ where: { id }, select: { projectId: true } });
     if (!existing) throw new Error("Purchase order not found");
     assertFinancialProjectScope(user, existing.projectId);
-    const { items, vendorId, ...poData } = data;
-    
-    let updateData: any = { ...poData };
-    if (vendorId) updateData.vendorId = vendorId;
+    const items = data.items;
+    const updateData = {
+        ...(data.vendorId ? { vendorId: data.vendorId } : {}),
+        status: data.status,
+        totalAmount: data.totalAmount,
+        notes: data.notes,
+        memos: data.memos,
+        terms: data.terms,
+    };
 
     const po = await prisma.purchaseOrder.update({
         where: { id },
@@ -9096,7 +9113,13 @@ export async function createBidPackage(projectId: string, data: {
 }) {
     await assertFinancialProjectAccess(projectId);
     const pkg = await prisma.bidPackage.create({
-        data: { projectId, ...data },
+        data: {
+            projectId,
+            title: data.title,
+            description: data.description,
+            dueDate: data.dueDate,
+            totalBudget: data.totalBudget,
+        },
     });
     revalidatePath(`/projects/${projectId}/bid-packages`);
     return pkg;
@@ -9112,7 +9135,16 @@ export async function updateBidPackage(id: string, projectId: string, data: {
     await assertFinancialProjectAccess(projectId);
     const existing = await prisma.bidPackage.findUnique({ where: { id }, select: { projectId: true } });
     if (!existing || existing.projectId !== projectId) throw new Error("Bid package not found");
-    const pkg = await prisma.bidPackage.update({ where: { id }, data });
+    const pkg = await prisma.bidPackage.update({
+        where: { id },
+        data: {
+            title: data.title,
+            description: data.description,
+            dueDate: data.dueDate,
+            status: data.status,
+            totalBudget: data.totalBudget,
+        },
+    });
     revalidatePath(`/projects/${projectId}/bid-packages`);
     revalidatePath(`/projects/${projectId}/bid-packages/${id}/edit`);
     return pkg;
@@ -9136,7 +9168,12 @@ export async function addBidScope(packageId: string, projectId: string, data: {
     const pkg = await prisma.bidPackage.findUnique({ where: { id: packageId }, select: { projectId: true } });
     if (!pkg || pkg.projectId !== projectId) throw new Error("Bid package not found");
     const scope = await prisma.bidScope.create({
-        data: { packageId, ...data },
+        data: {
+            packageId,
+            name: data.name,
+            description: data.description,
+            budgetAmount: data.budgetAmount,
+        },
     });
     revalidatePath(`/projects/${projectId}/bid-packages/${packageId}/edit`);
     return scope;
@@ -9185,7 +9222,12 @@ export async function recordBidResponse(invitationId: string, packageId: string,
     }
     const inv = await prisma.bidInvitation.update({
         where: { id: invitationId },
-        data: { ...data, respondedAt: new Date() },
+        data: {
+            status: data.status,
+            bidAmount: data.bidAmount,
+            notes: data.notes,
+            respondedAt: new Date(),
+        },
     });
     revalidatePath(`/projects/${projectId}/bid-packages/${packageId}/edit`);
     return inv;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,7 +1,13 @@
 import { NextAuthOptions, getServerSession } from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
 import CredentialsProvider from "next-auth/providers/credentials";
+import type { JWT } from "next-auth/jwt";
 import { prisma } from "@/lib/prisma";
+
+type StaffJWT = JWT & {
+    userId?: string;
+    accountDisabled?: boolean;
+};
 
 const providers: NextAuthOptions["providers"] = [
     GoogleProvider({
@@ -26,7 +32,7 @@ if (process.env.PLAYWRIGHT_TEST_SECRET) {
                 const user = await prisma.user.findUnique({
                     where: { email: email.toLowerCase() },
                 });
-                if (!user) return null;
+                if (!user || user.status === "DISABLED") return null;
                 return { id: user.id, name: user.name, email: user.email };
             },
         })
@@ -68,26 +74,36 @@ export const authOptions: NextAuthOptions = {
             return true;
         },
         async jwt({ token, user, trigger }) {
-            // Always read the latest role + DB id from DB.
+            const staffToken = token as StaffJWT;
+            // Always read the latest role, status, and DB id from DB.
             // token.sub on Google sign-ins is the OAuth subject, NOT the local
             // User.id, so anything storing token.sub as a User foreign key fails.
             if (token.email) {
                 const dbUser = await prisma.user.findUnique({
                     where: { email: (token.email as string).toLowerCase() },
-                    select: { id: true, role: true },
+                    select: { id: true, role: true, status: true },
                 });
-                if (dbUser) {
-                    token.role = dbUser.role;
-                    (token as any).userId = dbUser.id;
+                if (!dbUser || dbUser.status === "DISABLED") {
+                    // Keep the email so a later refresh can observe reactivation
+                    // or a recreated account, but strip authorization claims now.
+                    delete token.role;
+                    delete staffToken.userId;
+                    staffToken.accountDisabled = true;
+                    return token;
                 }
+                delete staffToken.accountDisabled;
+                token.role = dbUser.role;
+                staffToken.userId = dbUser.id;
             }
             return token;
         },
         async session({ session, token }) {
+            const staffToken = token as StaffJWT;
+            if (staffToken.accountDisabled) return {} as typeof session;
             if (session?.user) {
                 // Only expose the local DB User.id. token.sub is the OAuth subject
                 // (Google sub for Google sign-ins) and is NOT a valid User.id.
-                (session.user as any).id = (token as any).userId ?? null;
+                (session.user as any).id = staffToken.userId ?? null;
                 (session.user as any).role = token.role;
             }
             return session;

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -16,6 +16,7 @@ import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { sendNotification } from "./email";
 import { formatCurrency } from "./utils";
 import { coTaxRate, coTaxLabel, coLineCents } from "./co-tax";
+import { deriveInvoiceTaxFields, toNum } from "./prisma-helpers";
 
 // Session-free cores of the billing flows, shared by the permission-gated server
 // actions in actions.ts and the MCP connector (whose auth is the shared secret at
@@ -215,10 +216,109 @@ export async function sendArDigest() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Invoice creation from a signed estimate, with the duplicate guard the raw
-// action lacks (it's also called by the customer signing flow, so it must stay
-// ungated and unmodified — the guard lives here).
+// Invoice creation from a signed estimate. The core is intentionally kept in
+// this non-Server-Action module so authenticated machine callers do not have to
+// bypass the staff-session guard on actions.ts's public wrapper.
 // ─────────────────────────────────────────────────────────────────────────────
+
+async function getDefaultSalesTaxRate(): Promise<number> {
+    const settings = await prisma.companySettings.findUnique({
+        where: { id: "singleton" },
+        select: { salesTaxes: true },
+    });
+    if (!settings?.salesTaxes) return 0;
+    try {
+        const taxes = JSON.parse(settings.salesTaxes) as Array<{ rate?: number; isDefault?: boolean }>;
+        if (!Array.isArray(taxes) || taxes.length === 0) return 0;
+        const selected = taxes.find((tax) => tax.isDefault) || taxes[0];
+        return typeof selected.rate === "number" ? selected.rate : 0;
+    } catch {
+        return 0;
+    }
+}
+
+export async function createInvoiceFromEstimateCore(estimateId: string) {
+    const estimate = await prisma.estimate.findUnique({ where: { id: estimateId } });
+    if (!estimate) throw new Error("Estimate not found");
+
+    const project = await prisma.project.findUnique({ where: { id: estimate.projectId! } });
+    if (!project) throw new Error("Project not found");
+
+    const total = toNum(estimate.totalAmount || 0);
+    const rate = estimate.taxRatePercent != null
+        ? Number(estimate.taxRatePercent)
+        : await getDefaultSalesTaxRate();
+    const tax = deriveInvoiceTaxFields(total, rate, !!estimate.taxExempt);
+
+    const invoice = await prisma.invoice.create({
+        data: {
+            code: "INV-TEMP",
+            projectId: estimate.projectId!,
+            clientId: project.clientId,
+            estimateId: estimate.id,
+            status: "Draft",
+            totalAmount: total,
+            balanceDue: total,
+            subtotal: tax.subtotal,
+            taxRate: tax.taxRate,
+            taxAmount: tax.taxAmount,
+        },
+    });
+
+    const invoiceCode = `INV-${String(invoice.number).padStart(5, "0")}`;
+    await prisma.invoice.update({ where: { id: invoice.id }, data: { code: invoiceCode } });
+
+    const schedules = await prisma.estimatePaymentSchedule.findMany({
+        where: { estimateId },
+        orderBy: { order: "asc" },
+    });
+
+    let paidAmount = 0;
+    if (schedules.length > 0) {
+        for (const schedule of schedules) {
+            if (schedule.status === "Paid") paidAmount += toNum(schedule.amount);
+            await prisma.paymentSchedule.create({
+                data: {
+                    invoiceId: invoice.id,
+                    sourceScheduleId: schedule.id,
+                    name: schedule.name,
+                    amount: schedule.amount,
+                    status: schedule.status,
+                    dueDate: schedule.dueDate || null,
+                    paymentDate: schedule.paymentDate || null,
+                    paidAt: schedule.paidAt || null,
+                    stripeSessionId: schedule.stripeSessionId || null,
+                    stripePaymentIntentId: schedule.stripePaymentIntentId || null,
+                    paymentMethod: schedule.paymentMethod || null,
+                    referenceNumber: schedule.referenceNumber || null,
+                    notes: schedule.notes || null,
+                },
+            });
+        }
+    } else {
+        await prisma.paymentSchedule.create({
+            data: {
+                invoiceId: invoice.id,
+                name: "Initial Payment",
+                amount: estimate.totalAmount || 0,
+                status: "Pending",
+            },
+        });
+    }
+
+    const newBalanceDue = Math.max(0, total - paidAmount);
+    const invoiceStatus = paidAmount > 0
+        ? (newBalanceDue <= 0 ? "Paid" : "Partially Paid")
+        : "Draft";
+
+    await prisma.invoice.update({
+        where: { id: invoice.id },
+        data: { code: invoiceCode, balanceDue: newBalanceDue, status: invoiceStatus },
+    });
+
+    revalidatePath(`/projects/${estimate.projectId}/invoices`);
+    return { id: invoice.id, projectId: estimate.projectId };
+}
 
 export async function createInvoiceFromEstimateGuarded(estimateId: string) {
     const estimate = await prisma.estimate.findUnique({
@@ -250,8 +350,7 @@ export async function createInvoiceFromEstimateGuarded(estimateId: string) {
     // concurrent call created an invoice first, delete ours (untouched, seconds
     // old, milestones cascade) and return the winner. Deterministic: earliest
     // createdAt wins, id breaks ties.
-    const { createInvoiceFromEstimate } = await import("./actions");
-    const created = await createInvoiceFromEstimate(estimateId);
+    const created = await createInvoiceFromEstimateCore(estimateId);
 
     const all = await prisma.invoice.findMany({
         where: { estimateId },

--- a/src/lib/budget-actions.ts
+++ b/src/lib/budget-actions.ts
@@ -2,8 +2,18 @@
 
 import { prisma } from "@/lib/prisma";
 import { toNum } from "@/lib/prisma-helpers";
+import { canAccessProject, canUseDevAuthFallback, getCurrentUserWithPermissions, hasPermission } from "@/lib/permissions";
+
+async function assertFinancialProjectAccess(projectId: string) {
+    const user = await getCurrentUserWithPermissions();
+    if (!user && await canUseDevAuthFallback()) return;
+    if (!user) throw new Error("Unauthorized");
+    if (!hasPermission(user, "financialReports")) throw new Error("Forbidden");
+    if (user.role !== "FINANCE" && !canAccessProject(user, projectId)) throw new Error("Forbidden");
+}
 
 export async function getBudgetData(projectId: string) {
+    await assertFinancialProjectAccess(projectId);
     const estimates = await prisma.estimate.findMany({
         where: { projectId },
         select: {

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth/next";
+import { cookies } from "next/headers";
 import { authOptions } from "@/lib/auth";
 
 export type PermissionKey =
@@ -20,8 +21,27 @@ export async function getCurrentUserWithPermissions() {
     const session = await getServerSession(authOptions);
     if (!session?.user?.email) return null;
 
+    return getUserWithPermissionsByEmail(session.user.email);
+}
+
+export async function canUseDevAuthFallback() {
+    if (process.env.NODE_ENV !== "development") return false;
+    try {
+        const cookieStore = await cookies();
+        return !cookieStore.getAll().some(({ name }) =>
+            name === "next-auth.session-token"
+            || name.startsWith("next-auth.session-token.")
+            || name === "__Secure-next-auth.session-token"
+            || name.startsWith("__Secure-next-auth.session-token.")
+        );
+    } catch {
+        return false;
+    }
+}
+
+export async function getUserWithPermissionsByEmail(email: string) {
     const user = await prisma.user.findUnique({
-        where: { email: session.user.email },
+        where: { email: email.toLowerCase() },
         include: {
             permissions: true,
             projectAccess: { select: { projectId: true } },
@@ -29,7 +49,7 @@ export async function getCurrentUserWithPermissions() {
         },
     });
 
-    return user;
+    return user?.status === "DISABLED" ? null : user;
 }
 
 // Check if user has a specific permission

--- a/src/lib/staff-status.ts
+++ b/src/lib/staff-status.ts
@@ -1,0 +1,14 @@
+import { prisma } from "@/lib/prisma";
+
+/**
+ * Resolve staff account status from the database instead of trusting a JWT.
+ * Missing users and explicitly disabled users both fail closed.
+ */
+export async function isStaffAccountEnabled(email: string): Promise<boolean> {
+    const user = await prisma.user.findUnique({
+        where: { email: email.toLowerCase() },
+        select: { status: true },
+    });
+
+    return !!user && user.status !== "DISABLED";
+}

--- a/src/lib/time-expense-actions.ts
+++ b/src/lib/time-expense-actions.ts
@@ -4,7 +4,15 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
-import { getCurrentUserWithPermissions, hasPermission, canAccessProject } from "@/lib/permissions";
+import { canUseDevAuthFallback, getCurrentUserWithPermissions, hasPermission, canAccessProject } from "@/lib/permissions";
+
+async function assertTimeExpenseProjectAccess(projectId: string) {
+    const user = await getCurrentUserWithPermissions();
+    if (!user && await canUseDevAuthFallback()) return;
+    if (!user) throw new Error("Unauthorized");
+    if (!hasPermission(user, "timeClock")) throw new Error("Forbidden");
+    if (user.role !== "FINANCE" && !canAccessProject(user, projectId)) throw new Error("Forbidden");
+}
 
 // ─── Time Entry Actions ────────────────────────────────────────
 
@@ -229,6 +237,7 @@ export async function getExpenses(projectId: string) {
 // ─── Combined Data Fetching ───────────────────────────────────
 
 export async function getTimeExpenseData(projectId: string) {
+    await assertTimeExpenseProjectAccess(projectId);
     const timeEntries = await prisma.timeEntry.findMany({
         where: { projectId },
         include: {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,36 @@
 import { withAuth } from "next-auth/middleware";
+import { getToken } from "next-auth/jwt";
 import { NextResponse } from "next/server";
+import { isStaffAccountEnabled } from "@/lib/staff-status";
+
+// These shared web/mobile API handlers always call authenticateMobileOrSession,
+// so they can safely receive bearer requests without a browser session. Keep
+// this allowlist exact: a generic Bearer shortcut would bypass proxy auth for
+// pages and Server Actions that rely on this boundary.
+const MOBILE_AUTHENTICATED_ROUTE_PATTERNS = [
+    /^\/api\/calendar\/sync\/?$/,
+    /^\/api\/manager\/dashboard\/?$/,
+    /^\/api\/manager\/(?:jobs|employees)(?:\/[^/]+)?\/?$/,
+    /^\/api\/time-entries(?:\/[^/]+)?\/?$/,
+    /^\/api\/files\/(?:signed-upload|register)\/?$/,
+    /^\/api\/(?:expenses|receipts\/parse)\/?$/,
+    /^\/api\/rooms\/scan-import\/?$/,
+    /^\/api\/rooms\/[^/]+\/(?:usdz|ai-furnish)\/?$/,
+    /^\/api\/projects\/?$/,
+    /^\/api\/projects\/[^/]+\/(?:cost-codes|buckets|estimate-items|estimates)\/?$/,
+];
+
+const PUBLIC_PROXY_BYPASS_PATTERN = /^\/(?:api\/(?:auth|cron|twilio|webhook|payments|portal|integrations|mcp(?:\/|$)|version|pdf\/(?:estimates|invoices)|sub-portal|mobile)(?:\/|$)|login(?:\/|$)|portal(?:\/|$)|sub-portal(?:\/|$)|share(?:\/|$)|_next\/(?:static|image)(?:\/|$)|favicon\.ico$|.*\.(?:png|jpg|svg|webmanifest)$)/;
+
+function hasNextAuthSessionCookie(req: any) {
+    const requestCookies = req.cookies?.getAll?.() ?? [];
+    return requestCookies.some(({ name }: { name: string }) =>
+        name === "next-auth.session-token"
+        || name.startsWith("next-auth.session-token.")
+        || name === "__Secure-next-auth.session-token"
+        || name.startsWith("__Secure-next-auth.session-token.")
+    );
+}
 
 export default async function middleware(req: any, event: any) {
     // Bypass authentication entirely during development for local testing
@@ -9,11 +40,35 @@ export default async function middleware(req: any, event: any) {
         return NextResponse.next();
     }
 
-    // API requests carrying `Authorization: Bearer <jwt>` are mobile clients. Their
-    // route handlers verify the JWT via authenticateMobileOrSession themselves; redirecting
-    // them to /login (a browser flow) would 307-redirect every mobile API call.
+    const pathname = req.nextUrl?.pathname;
+    const isServerAction = typeof req.headers?.get?.("next-action") === "string";
+
+    // Public portal routes must remain reachable without a staff session, but a
+    // stale staff cookie must never use those routes to bypass the production
+    // auth matcher and replay a Server Action. Anonymous portal actions still
+    // authorize through their own client/token checks inside the action.
+    if (isServerAction && hasNextAuthSessionCookie(req)) {
+        const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+        if (!token?.email || (token as any).accountDisabled === true || !await isStaffAccountEnabled(token.email)) {
+            return new NextResponse("Forbidden", { status: 403 });
+        }
+    }
+
+    if (isServerAction && typeof pathname === "string" && PUBLIC_PROXY_BYPASS_PATTERN.test(pathname)) {
+        return NextResponse.next();
+    }
+
+    // Approved shared API routes verify mobile JWTs in their own handlers. Do not
+    // extend this to arbitrary Bearer requests: many web routes rely on Proxy as
+    // their authentication boundary.
     const authHeader = req.headers?.get?.("authorization");
-    if (typeof authHeader === "string" && authHeader.toLowerCase().startsWith("bearer ")) {
+    const handlerVerifiesBearer = typeof pathname === "string"
+        && MOBILE_AUTHENTICATED_ROUTE_PATTERNS.some((pattern) => pattern.test(pathname));
+    if (
+        handlerVerifiesBearer
+        && typeof authHeader === "string"
+        && authHeader.toLowerCase().startsWith("bearer ")
+    ) {
         return NextResponse.next();
     }
 
@@ -22,6 +77,12 @@ export default async function middleware(req: any, event: any) {
         pages: {
             signIn: "/login",
         },
+        callbacks: {
+            async authorized({ token }) {
+                if (!token?.email || token.accountDisabled === true) return false;
+                return isStaffAccountEnabled(token.email);
+            },
+        },
     });
 
     return authMiddleware(req as any, event);
@@ -29,6 +90,10 @@ export default async function middleware(req: any, event: any) {
 
 export const config = {
     matcher: [
+        {
+            source: "/:path*",
+            has: [{ type: "header", key: "next-action" }],
+        },
         /*
          * Match all request paths except for the ones starting with:
          * - api/auth (NextAuth endpoints)


### PR DESCRIPTION
## Summary
- fail closed for DISABLED or deleted staff in permission lookup, JWT refresh, sessions, credentials login, and the production Proxy
- DB-check stale staff cookies on Server Action requests even when posted through public portal routes
- audit and guard financial Server Actions, including project/entity scope and explicit Prisma payload allowlists
- preserve portal and MCP machine flows through session-free internal billing cores
- split public company branding from staff-only settings so stored/internal fields are not exposed
- retain development login/mock behavior without allowing a disabled real-session cookie to fall back to the dev admin
- normalize serialized costing money values found by the full E2E review

Follow-up to #207, which documented the global status-revocation gap after adding a document-comment-local guard.

## Review fixes
- narrowed the former arbitrary Bearer bypass to exact mobile-authenticated routes
- failed closed for deleted users as well as DISABLED users
- added a stale-cookie Next-Action boundary for public portal routes
- guarded previously exposed company-settings and room-design estimate actions
- moved MCP invoice creation to a session-free internal core
- redacted public company settings and kept portal internals on a non-exported reader
- aligned bid navigation/pages with financial permissions
- enforced project ownership on PO/bid/linking actions for non-global finance users
- replaced untrusted Prisma payload spreads with explicit field allowlists
- rebased without regressing #205 change-order lifecycle/locking/pricing safeguards

## Verification
- `npm run typecheck` — pass
- `npm run build` — pass
- focused production auth/financial/money Playwright — 31 passed
- full production Playwright after rebase — 192 passed, 4 skipped
- development login/status Playwright — 4 passed
- codex-peer-review — approved, no actionable findings
- independent QAS — Approved for RTE
- independent SecEng — PASS

## Notes
The focused suite intentionally exercises active login, disabled/deleted session revocation, reactivation, stale-cookie Server Action blocking, financial guard placement, project/entity scoping, portal/MCP exceptions, and payload relationship-key protection.