### PR TITLE
feat(company-dashboard): crew assignment, admin money/hours overlays, estimate-driven schedule generation

### DIFF
--- a/.specs/PB-pipeline-002-code-review.md
+++ b/.specs/PB-pipeline-002-code-review.md
@@ -1,0 +1,29 @@
+## Prior findings
+
+1. “Generation reads stale milestone state before acquiring the project lock.” — **Addressed.** Minimal identity lookup occurs at `src/lib/schedule-core.ts:707-718`, the project is locked at `src/lib/schedule-core.ts:722`, and the full estimate is reread afterward at `src/lib/schedule-core.ts:732-745`.
+
+2. “Non-divisible task windows end early.” — **Addressed.** Non-packed tasks use proportional start/end boundaries at `src/lib/schedule-core.ts:939-942`; five tasks over 42 days now span `[0,42)` exactly.
+
+3. “A disabled assigned crew member makes the picker unusable.” — **Addressed.** Inactive assignments are exposed as removable options at `src/app/company-dashboard/CompanyDashboardClient.tsx:83-118`, while final-set validation remains at `src/lib/schedule-core.ts:1160-1163`.
+
+4. “Packed schedules create zero-duration tasks.” — **Addressed.** Packed placement is detected at `src/lib/schedule-core.ts:936`; each packed task ends one day after its proportional start at `src/lib/schedule-core.ts:939-942`. The 5/3-day result is `[0,1] [0,1] [1,2] [1,2] [2,3]`.
+
+## New findings
+
+None.
+
+## Checklist pass
+
+1. Functional requirements: no remaining findings.
+2. Code quality: boundary behavior is explicit and documented.
+3. Architecture: lock-before-full-read sequencing remains correct.
+4. Multi-tenancy/RLS: no new finding.
+5. Money/financial data: no new finding.
+6. Outbound effects/field UX: no new finding.
+7. Error handling: no new finding.
+8. Security: authorization and ADMIN-only data boundaries remain intact.
+9. Performance: no new practical regression found.
+
+Requester-provided evidence reports typecheck with zero errors and all verification checks passing. The repository-local `.claude/skills/TRIP-review/checklist.md` remains absent, so this uses the same checklist sections and gate as the prior reviews.
+
+APPROVED

--- a/.specs/PB-pipeline-002-crew-money-overlays.md
+++ b/.specs/PB-pipeline-002-crew-money-overlays.md
@@ -1,0 +1,239 @@
+# PB-pipeline-002 — Crew + Money Overlays on the Company Dashboard, and Estimate→Schedule Generation
+
+**Status:** TRIP-1 plan gate — round 2 (addresses Codex review R1)
+**Date:** 2026-07-20
+**Requester:** Owner ("continue" after PB-pipeline-001)
+**Builds on:** PB-pipeline-001 (PR #214; schedule-core.ts, /company-dashboard,
+Project.startDate/endDate, scheduleTaskId FKs on both milestone models, MCP v1.7.0).
+
+## Codebase context (delta from PB-pipeline-001's map)
+
+- `EstimateItem` has `parentId`/`subItems` — phases are top-level items with children —
+  `scheduleTask ScheduleTask?` (back-relation of `ScheduleTask.estimateItemId @unique`),
+  `budgetUnit`, legacy `type`, and `costType.name`. **It has NO `unit` field** (schema:453);
+  the MCP `unit` input is not persisted (ai-estimate-transform.ts:98).
+- `Expense`: `estimateId` (join project via `estimate.projectId`), `amount`, `vendor`,
+  `date DateTime?`, `status` (Pending/Reviewed).
+- `TimeEntry`: `userId`, `projectId`, `startTime`, `durationHours`, `laborCost`, `burdenCost`.
+  Profitability convention uses **burdened labor** (laborCost + burdenCost —
+  reports/profitability/page.tsx:121).
+- Crew: `Project.crew User[]` m-n ("CrewAssignments") — used today only for access filtering;
+  NO action exists to set a project's crew.
+- `getTeamMembers()` (actions.ts:7104) returns PENDING and DISABLED users too — pickers must
+  filter to ACTIVATED.
+- `importEstimateToSchedule` (actions.ts:6615) — EXISTING estimate→schedule importer; must be
+  routed through the new core so all paths share preconditions/idempotency.
+- Signed-estimate flow pushes pending milestones to QBO at approval (actions.ts:2262) — most
+  PaymentSchedule clones on signed jobs carry `qbInvoiceId`.
+- Company dashboard from P1: page.tsx gates `hasPermission(financialReports)`, ADMIN-only
+  financial serialization, canEdit = ADMIN|MANAGER; P1 shift rules: Project row FOR UPDATE,
+  entire-`sourceScheduleId`-group skip on QB-flagged clones **for due-date WRITES**.
+
+## Problem (owner's original sentence, completing it)
+
+"Tie milestone payments to the project calendar **and tasks to the estimate getting
+completed**, and eventually we can **assign crew** to it and **project cashflow, expense,
+hours, income all on the schedule**, but this info is only good for admins to see."
+
+P1 shipped the calendar, start-date moves, and the milestone↔task link mechanism. What
+remains: (A) generate a job's schedule from its completed estimate, (B) assign + see crew
+on the company calendar with conflict visibility, (C) money/hours overlays — admin-only.
+
+## Schema changes (`scripts/apply-schedule-provenance-schema.mjs` + `prisma generate`)
+
+- `ScheduleTask.generatedFromEstimateId String?` FK → `Estimate` (onDelete: SetNull) + index
+  — generation provenance for EVERY generated task kind (phase parents, children,
+  milestones) so regenerate can identify them without touching manual tasks (R1 fix 1).
+
+## Workstream A — Estimate → schedule generation ("tasks tied to the estimate")
+
+New in `schedule-core.ts`: `generateScheduleFromEstimate({ estimateId, mode, actor })`.
+**Everything runs in ONE transaction** (withTxRetry; Project row `FOR UPDATE` first, same
+lock family as P1) — lock → read → delete(regenerate) → create → link → ActivityLog (R1 fix 1).
+
+- **Preconditions:** estimate status in (`Approved`, `Invoiced`, `Partially Paid`, `Paid`);
+  owner is a **project** (lead-owned: actionable error suggesting conversion); project has
+  `startDate` (actionable error otherwise).
+- **Deterministic estimate selection at the project level** (R1 fix 6): the dashboard
+  button and any project-scoped caller resolve to the project's **most recent qualifying
+  estimate** — the same selection P1's `contractValue` uses (status in the list above,
+  latest `createdAt`) — and the chosen estimate `code` is returned in the result. The MCP
+  tool and the rewired importer pass an explicit `estimateId`.
+- **`importEstimateToSchedule` rewiring** (R1 fix 6): its internals delegate to
+  `generateScheduleFromEstimate` (mode "merge"), preserving its current signature/response
+  shape for existing UI call sites (adapt the wrapper, or update call sites if the shape
+  cannot be preserved — implementer reports which).
+- **Structure:** top-level items (phases) → parent `ScheduleTask`s (with
+  `generatedFromEstimateId`); `subItems` → child tasks linked via `estimateItemId` (+
+  provenance); phase-less estimates → flat tasks (with provenance).
+- **Labor classification & hours** (R1 fix 5 — no `unit` exists): a line counts as Labor
+  when `costType?.name ?? type` equals "Labor" (case-insensitive). Child-task
+  `estimatedHours` = `quantity` when `budgetUnit` is hour-like (`hr|hrs|hour|hours`,
+  case-insensitive); else null.
+- **Phase windows** (R2 fix): window = startDate → endDate if set, else startDate + 42 days;
+  if the phase count exceeds the window's days, the window extends to `phaseCount` days.
+  Allocation: **reserve 1 day per phase first, then distribute the remaining
+  `windowDays − phaseCount` days proportionally by labor-dollar share** (each phase's
+  ideal share of the remainder is floored; leftover days go to the phases with the
+  **largest fractional remainder**, ties broken by phase order — Hamilton/largest-remainder
+  apportionment — so slices sum exactly to the window) (R3 fix: one algorithm, stated once). Calendar days (existing scheduler spans
+  weekends). Bounds: `[start, end)` end-exclusive as in P1; a 1-day task ends the next
+  UTC day.
+- **Phase-less placement** (R1 fix 7): flat tasks placed sequentially in estimate `order`,
+  equal share of the window (`windowDays / taskCount`, min 1 day each); when taskCount >
+  windowDays, multiple tasks share a start day (order preserved via `order`).
+- **Milestones — ONE canonical date rule** (R1 fix 3, R2 fixes): order EPS rows by
+  **`(EPS.order, EPS.id)`** (business sequence, not percentage value) and accumulate each
+  row's percentage → the cumulative-percentage point of the window (fixed-amount/unordered
+  rows at window end). The milestone task date = `EPS.dueDate` if set, else that derived
+  point. Then **initialize `dueDate` from that date ONLY on rows that are `Pending` AND
+  `dueDate IS NULL` AND not QB-pushed** (R2 fix — paid/settled rows are NEVER rewritten;
+  their historical task date is derived without any write; QB-pushed clones keep their
+  QB-visible date and are reported in notes). Existing dueDates always win.
+  **Income-overlay fallback** (R2 fix, R3 fix): define ONE `effectiveDueDate =
+  dueDate ?? linked milestone task's startDate` (via `scheduleTaskId`) and use it in BOTH
+  the calendar income layer AND the project strip's "Income due" — so AI-imported
+  milestones whose local dueDate is null but are already QBO-pushed still appear as
+  *projected* income on the generated task date. Overlays and tasks agree by construction.
+- **Milestone linking** (R1 fix 2): set `scheduleTaskId` on the EPS row AND every unpaid
+  clone in its `sourceScheduleId` group — **regardless of `qbInvoiceId`** (linking is not a
+  QBO mutation; the QB whole-group skip applies ONLY to due-date WRITES, per P1). Done under
+  the same FOR UPDATE row locks as P1.
+- **Idempotency & regenerate** (R1 fix 1, R2 fix): `mode: "merge"` (default) skips items
+  already task-linked. `mode: "regenerate"` deletes generated tasks then rebuilds, where
+  **deletable** means the FULL eligibility predicate: `generatedFromEstimateId = estimateId
+  AND progress = 0 AND status = "Not Started" AND no timeEntries AND no comments AND no
+  punchItems AND no assignments AND no subAssignments AND no dependency rows** — evaluated
+  at delete time (no dirty-flag hooks needed). Because `ScheduleTask.parent` is
+  `onDelete: Cascade`, eligibility is decided **per phase subtree**: a subtree is deleted
+  only when EVERY descendant task is deletable; if any descendant is protected, the whole
+  subtree is kept and reported in notes (never a cascade through protected work).
+  Milestone re-link is upsert-style (skip where already set).
+- **Result:** `{ estimateCode, created, skipped, milestonesLinked, notes[] }`; ActivityLog
+  "generated_schedule" (TEAM/SYSTEM as in P1).
+- **Entry points:** server action `generateProjectScheduleAction` (ADMIN/MANAGER inline
+  role check; revalidates dashboard + project schedule); dashboard button on
+  Waiting/Scheduled rows when the project has a qualifying estimate AND zero schedule
+  tasks; MCP tool `generate_project_schedule` (explicit estimateId).
+
+## Workstream B — Crew on the company calendar
+
+- `setProjectCrew({ projectId, userIds, actor })` in schedule-core: replaces `Project.crew`
+  via connect/disconnect diff; **validates all ids are ACTIVATED users** (picker lists are
+  pre-filtered to ACTIVATED in the dashboard page — `getTeamMembers()` itself is unchanged
+  for other callers) (R1 fix 9); ActivityLog "set_project_crew". Server action
+  `updateProjectCrewAction` (ADMIN/MANAGER; revalidates dashboard).
+- Dashboard UI: Waiting/Scheduled/In-Progress rows gain a compact crew picker (checkbox
+  popover); calendar project chips show up to 3 crew initials + overflow count. FINANCE:
+  read-only (P1 canEdit rule).
+- **Crew conflict panel** (ADMIN/MANAGER, read-only): conflicts computed from **the same
+  relation the picker writes — `Project.crew`** (R1 fix 4): a project's window =
+  startDate → (endDate ?? latest task endDate ?? startDate + 1 day) (R2 fix — the
+  zero-length fallback is one day so two crews booked on the same day DO conflict);
+  overlap uses half-open `[start, end)` bounds; a conflict = one user in the crew of two
+  different projects whose windows overlap within the visible month.
+  `getCrewConflicts(from, to)`: bounded queries (projects with crew + latest task end per
+  project), overlap computed in memory; returns `{ userId, name, pairs: [{projectA,
+  projectB, overlapStart, overlapEnd}] }`. TaskAssignment-level precision is Phase 3.
+
+## Workstream C — Money/hours overlays (ADMIN-only, data-layer enforced as in P1)
+
+All read-only; **only queried and serialized when `user.role === "ADMIN"`**.
+- Page data assembly extracted into **`getCompanyDashboardData(userLike, month)`** in
+  schedule-core (page stays thin; directly testable per R1 fix 10): overlays included only
+  when `userLike.role === "ADMIN"`.
+- `getCalendarOverlays(from, to)` (ADMIN path only): **income** = P1 milestone data;
+  **expenses** = `Expense.date` in range → sum per UTC day (join project via estimate);
+  **hours** = `TimeEntry.startTime` date in range → sum `durationHours` per UTC day.
+- Calendar UI: toggleable layer chips (Income green / Expenses red / Hours blue), small
+  per-day totals; default: income on, others off.
+- **Per-project month strip** (ADMIN) with exact semantics (R1 fix 8, R3 fix):
+  **Income due** = Pending milestone sums by **`effectiveDueDate`** (the shared
+  `dueDate ?? linkedTask.startDate` rule — same dates as the calendar income layer); **Received** = Paid milestone sums
+  by `COALESCE(paymentDate, paidAt)`; **Expenses** = sum by `Expense.date`; **Labor (actual,
+  burdened)** = `laborCost + burdenCost` sums; **Hours** = actual TimeEntry hours vs
+  `estimatedHours` of tasks overlapping the month; **Net** = Received − Expenses − burdened
+  Labor (profitability convention). Columns labeled exactly this way.
+
+## MCP changes (server → v1.8.0)
+
+- `get_company_schedule`: gains per-project `crew` (ids+names) and a `crewConflicts` block
+  (project-window rule). NO expense/hours data (lean read surface per connector convention).
+- `generate_project_schedule` (write): `{ estimateId, mode? }` → workstream A core.
+- `assign_project_crew` (write, idempotent replace): `{ projectId, userIds }` →
+  `setProjectCrew`, actor SYSTEM/"ChatGPT connector".
+- Instructions extended (estimate must be Approved+, project needs startDate first; crew
+  conflicts come from project windows).
+
+## Verification
+
+- `scripts/verify-crew-overlays.ts` (verify-*.ts pattern), fixtures cleaned up:
+  (a) generation builds phase/child/milestone tasks with correct dates, provenance, and
+  estimateItemId links; merge idempotent; regenerate replaces ONLY provenance-tagged
+  untouched tasks (a manually-created lookalike task survives);
+  (b) milestone canonical-date rule: existing dueDate wins; null dueDates initialized ONLY
+  on Pending non-QB mirrors (a Paid EPS row is never rewritten); `scheduleTaskId` set on
+  EPS + ALL unpaid clones incl. QB-flagged; QB-pushed null-date clone appears in the income
+  overlay as projected income on its linked task date;
+  (b2) regenerate eligibility: a manually-edited generated task (status changed / comment /
+  assignment / dependency added) survives; a phase subtree with one protected descendant is
+  kept whole;
+  (c) phase-less placement + rounding edge cases (taskCount > windowDays) and a mixed-weight phase allocation case (labor-heavy vs zero-labor phases) asserting exact window coverage under largest-remainder apportionment;
+  (d) setProjectCrew diff + non-ACTIVATED rejection; picker list is ACTIVATED-filtered;
+  (e) conflict detection flags a seeded two-project crew overlap, ignores same-project;
+  (f) overlays: seeded Expense/TimeEntry sums on the right UTC days; Received bucketed by
+  paymentDate not dueDate; Net uses burdened labor; **`effectiveDueDate` appears
+  identically in the calendar income layer AND the project strip Income due** (R3);
+  (g) **`getCompanyDashboardData` role matrix** (R1 fix 10): MANAGER and FINANCE users get
+  NO overlay fields and NO per-project strip; ADMIN gets them;
+  (h) rewired `importEstimateToSchedule` delegates to the core (merge) — one round trip.
+- `tsc --noEmit` 0 errors (standing rule).
+- Dev smoke: ADMIN sees picker + conflict panel + toggles; FINANCE read-only; FIELD_CREW
+  denied (P1 matrix unchanged).
+
+## Money-path note
+
+C reads money tables; A writes `scheduleTaskId` on mirrors (any QB state) and `dueDate`
+ONLY where the row is **Pending** AND null-dated AND not QB-pushed — never
+amounts/status/QB fields — under P1 locking →
+TRIP-2 codex review before merge; `e2e/money-pipeline.spec.ts` must stay green.
+
+## Explicitly out of scope (Phase 3+)
+
+- Auto-generating the schedule when an estimate is signed (approval-flow hook).
+- TaskAssignment-level crew assignment/conflicts from the dashboard (exists per-project).
+- Conflict notifications; weekly capacity planning; sub view; drill-down modals.
+
+## R1 changelog (Codex review round 1 → this revision)
+
+1. Generation provenance: new `ScheduleTask.generatedFromEstimateId` (schema migration);
+   regenerate deletes only provenance-tagged untouched tasks; generation is one transaction.
+2. Milestone linking no longer QB-skips (linking ≠ QBO mutation); QB whole-group skip stays
+   for due-date WRITES only.
+3. One canonical milestone date: existing dueDate > percentage-derived; null non-QB
+   dueDates initialized from it; overlays and tasks agree by construction.
+4. Crew conflicts computed from `Project.crew` project windows (same relation the picker
+   writes); TaskAssignment precision deferred to Phase 3.
+5. No `unit` field exists — Labor via `costType?.name ?? type`; hours via `budgetUnit`.
+6. Deterministic estimate selection (P1 contractValue rule) + `importEstimateToSchedule`
+   rewired through the new core.
+7. Phase-less placement + integer rounding/bounds/min-day rules specified.
+8. Received by payment date (COALESCE(paymentDate, paidAt)); Net uses burdened labor per
+   the profitability convention; columns relabeled.
+9. Crew picker filtered to ACTIVATED (getTeamMembers unchanged for other callers).
+10. Page data assembly extracted to `getCompanyDashboardData` — role-matrix assertions in
+    the verify script prove MANAGER/FINANCE never receive overlays.
+
+## R2 changelog (Codex review round 2 → this revision)
+
+1. Phase allocation: reserve 1 day per phase, then distribute the remainder proportionally (floor + largest-remainder); phaseCount > windowDays extends the window to phaseCount days.
+2. Regenerate: full eligibility predicate (status/comments/punchItems/assignments/dependencies/timeEntries), evaluated per phase SUBTREE — any protected descendant keeps the whole subtree (parent delete is onDelete: Cascade).
+3. Due-date initialization restricted to Pending rows — settled milestones are never rewritten; income overlay falls back to the linked milestone task date for QBO-pushed null-date rows (projected income).
+4. Conflict-window zero-length fallback is startDate + 1 day; half-open [start, end) overlap stated.
+5. Milestone cumulative ordering pinned to (EPS.order, EPS.id).
+
+## R3 changelog (Codex review round 3 → this revision)
+
+1. One effectiveDueDate (dueDate ?? linkedTask.startDate) used by BOTH the calendar income layer and the project strip Income Due.
+2. Phase-remainder algorithm unified on Hamilton/largest-remainder (floor, leftover days to largest fractional remainders, ties by phase order); mixed-weight verification case added to (c).
+3. Money-path summary now states the Pending restriction on due-date initialization.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -403,6 +403,8 @@ model Estimate {
 
   changeOrders       ChangeOrder[]
   files              EstimateFile[]
+  // Tasks generated from this estimate by generateScheduleFromEstimate.
+  generatedScheduleTasks ScheduleTask[]
 
   @@index([createdAt])
   @@index([projectId])
@@ -845,6 +847,11 @@ model ScheduleTask {
   type           String         @default("task") // "task" | "milestone"
   estimateItemId String?        @unique
   estimateItem   EstimateItem?  @relation(fields: [estimateItemId], references: [id], onDelete: SetNull)
+  // Generation provenance: set on every task kind created by
+  // generateScheduleFromEstimate (phase parents, children, flat tasks,
+  // milestones) so regenerate can identify them without touching manual tasks.
+  generatedFromEstimateId String?
+  generatedFromEstimate   Estimate? @relation(fields: [generatedFromEstimateId], references: [id], onDelete: SetNull)
   createdAt      DateTime       @default(now())
   updatedAt      DateTime       @updatedAt
 
@@ -867,6 +874,7 @@ model ScheduleTask {
 
   @@index([projectId])
   @@index([leadId])
+  @@index([generatedFromEstimateId])
 }
 
 model TaskDependency {

--- a/scripts/apply-schedule-provenance-schema.mjs
+++ b/scripts/apply-schedule-provenance-schema.mjs
@@ -1,0 +1,52 @@
+// One-off additive migration for the Crew + Money Overlays feature
+// (.specs/PB-pipeline-002-crew-money-overlays.md).
+// Adds the generation-provenance column on ScheduleTask (nullable + index only)
+// so regenerate can identify generated tasks without touching manual ones.
+// Safe to run against the live DB while the deployed (old) client is in use.
+// Mirrors scripts/apply-company-schedule-schema.mjs.
+//
+// Run:  node scripts/apply-schedule-provenance-schema.mjs
+// (DDL via $executeRawUnsafe over the Supabase transaction pooler — the working
+//  path in this project; psql / prisma db push / migrate dev do not work here.)
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+function resolveDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const f of [".env", ".env.local"]) {
+    if (!fs.existsSync(f)) continue;
+    const m = fs.readFileSync(f, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+    if (m) return m[1];
+  }
+  throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const prisma = new PrismaClient({ datasources: { db: { url: resolveDatabaseUrl() } } });
+
+const statements = [
+  // Generation provenance: which estimate generated this task (phase parents,
+  // children, flat tasks, and milestone tasks alike). FK constraints have no
+  // IF NOT EXISTS in Postgres — guard with a DO block so the script stays
+  // re-runnable.
+  `ALTER TABLE "ScheduleTask"
+     ADD COLUMN IF NOT EXISTS "generatedFromEstimateId" TEXT`,
+  `DO $$ BEGIN
+     ALTER TABLE "ScheduleTask"
+       ADD CONSTRAINT "ScheduleTask_generatedFromEstimateId_fkey"
+       FOREIGN KEY ("generatedFromEstimateId") REFERENCES "Estimate"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+   EXCEPTION WHEN duplicate_object THEN NULL; END $$`,
+  `CREATE INDEX IF NOT EXISTS "ScheduleTask_generatedFromEstimateId_idx" ON "ScheduleTask" ("generatedFromEstimateId")`,
+];
+
+try {
+  for (const sql of statements) {
+    await prisma.$executeRawUnsafe(sql);
+    console.log("✔ applied:", sql.split("\n")[0]);
+  }
+  console.log("Done.");
+} catch (e) {
+  console.error("Migration failed:", e);
+  process.exitCode = 1;
+} finally {
+  await prisma.$disconnect();
+}

--- a/scripts/verify-crew-overlays.ts
+++ b/scripts/verify-crew-overlays.ts
@@ -1,0 +1,389 @@
+// E2E checks for PB-pipeline-002: estimate→schedule generation, crew
+// assignment/conflicts, and money/hours overlays (src/lib/schedule-core.ts).
+// Creates its own fixtures (far-future 2030 dates, "DELETE ME" names) and
+// cleans them all up. Mirrors scripts/verify-company-schedule.ts. Run AFTER
+// scripts/apply-schedule-provenance-schema.mjs has been applied.
+//
+// NOTE: concurrency behavior (FOR UPDATE serialization) is not reproducible
+// from a single-threaded script; it is covered by the same lock family as P1.
+import fs from "node:fs";
+import { prisma } from "../src/lib/prisma";
+import {
+    generateScheduleFromEstimate,
+    setProjectCrew,
+    getCrewConflicts,
+    getCalendarOverlays,
+    getCompanyDashboardData,
+} from "../src/lib/schedule-core";
+import { importEstimateToSchedule } from "../src/lib/actions";
+
+const DAY = 86_400_000;
+const base = Date.UTC(2030, 0, 1); // 2030-01-01 UTC — far-future, no real data
+const TEAM = { type: "TEAM" as const, name: "Verify UI" };
+
+async function main() {
+    const checks: [string, boolean][] = [];
+    const iso = (ms: number) => new Date(ms).toISOString();
+
+    // ── Fixtures ──
+    const client = await prisma.client.create({ data: { name: "CREW VERIFY DELETE ME", initials: "CV" } });
+    const userA = await prisma.user.create({
+        data: { email: "crew-verify-a@example.invalid", name: "Crew Verify Alice", role: "FIELD_CREW", status: "ACTIVATED" },
+    });
+    const userB = await prisma.user.create({
+        data: { email: "crew-verify-b@example.invalid", name: "Crew Verify Bob", role: "FIELD_CREW", status: "PENDING" },
+    });
+    const userC = await prisma.user.create({
+        data: { email: "crew-verify-c@example.invalid", name: "Crew Verify Carol", role: "FIELD_CREW", status: "DISABLED" },
+    });
+
+    const projectG = await prisma.project.create({
+        data: { name: "Crew verify gen — delete me", clientId: client.id, status: "Waiting to Start", startDate: new Date(base) },
+    });
+    const estimateG = await prisma.estimate.create({
+        data: { title: "Crew verify estimate G", projectId: projectG.id, code: "EST-CREW-VERIFY-G", status: "Approved", totalAmount: 3000, balanceDue: 3000 },
+    });
+    const phaseA = await prisma.estimateItem.create({
+        data: { estimateId: estimateG.id, name: "Phase Alpha", type: "Material", quantity: 1, total: 0, order: 0 },
+    });
+    const childA1 = await prisma.estimateItem.create({
+        data: { estimateId: estimateG.id, name: "Framing labor", type: "Labor", quantity: 10, budgetUnit: "hours", total: 2000, order: 1, parentId: phaseA.id },
+    });
+    const childA2 = await prisma.estimateItem.create({
+        data: { estimateId: estimateG.id, name: "Lumber", type: "Material", quantity: 1, total: 500, order: 2, parentId: phaseA.id },
+    });
+    const phaseB = await prisma.estimateItem.create({
+        data: { estimateId: estimateG.id, name: "Phase Beta", type: "Material", quantity: 1, total: 0, order: 3 },
+    });
+    const childB1 = await prisma.estimateItem.create({
+        data: { estimateId: estimateG.id, name: "Cleanup labor", type: "Labor", quantity: 5, budgetUnit: "hrs", total: 500, order: 4, parentId: phaseB.id },
+    });
+    const eps1 = await prisma.estimatePaymentSchedule.create({
+        data: { estimateId: estimateG.id, name: "Deposit", percentage: 30, amount: 150, dueDate: null, status: "Pending", order: 0 },
+    });
+    const eps2 = await prisma.estimatePaymentSchedule.create({
+        data: { estimateId: estimateG.id, name: "Final", percentage: 70, amount: 200, dueDate: new Date(base + 50 * DAY), status: "Pending", order: 1 },
+    });
+    const eps3 = await prisma.estimatePaymentSchedule.create({
+        data: { estimateId: estimateG.id, name: "Settled fee", percentage: null, amount: 75, dueDate: null, status: "Paid", order: 2 },
+    });
+    const invoiceG = await prisma.invoice.create({
+        data: { code: "INV-CREW-VERIFY-G", projectId: projectG.id, clientId: client.id, estimateId: estimateG.id, status: "Issued", totalAmount: 350, balanceDue: 350 },
+    });
+    const c1a = await prisma.paymentSchedule.create({
+        data: { invoiceId: invoiceG.id, sourceScheduleId: eps1.id, name: "Deposit", amount: 100, status: "Pending", dueDate: null },
+    });
+    const c1b = await prisma.paymentSchedule.create({
+        data: { invoiceId: invoiceG.id, sourceScheduleId: eps1.id, name: "Deposit (QB)", amount: 50, status: "Pending", dueDate: null, qbInvoiceId: "qb-crew-verify-1" },
+    });
+    const c2 = await prisma.paymentSchedule.create({
+        data: { invoiceId: invoiceG.id, sourceScheduleId: eps2.id, name: "Final", amount: 200, status: "Pending", dueDate: null },
+    });
+    // Overlay fixtures (right-UTC-day sums; Received by paymentDate).
+    const expenseG = await prisma.expense.create({
+        data: { estimateId: estimateG.id, amount: 123.45, vendor: "VerifyVendor", date: new Date(base + 5 * DAY), status: "Pending" },
+    });
+    const timeG = await prisma.timeEntry.create({
+        data: { userId: userA.id, projectId: projectG.id, startTime: new Date(base + 6 * DAY), durationHours: 3.5, laborCost: 100, burdenCost: 20 },
+    });
+
+    // Mixed-weight phases (labor-heavy vs zero-labor) — largest-remainder case.
+    const projectM = await prisma.project.create({
+        data: { name: "Crew verify mixed — delete me", clientId: client.id, status: "Waiting to Start", startDate: new Date(base), endDate: new Date(base + 8 * DAY) },
+    });
+    const estimateM = await prisma.estimate.create({
+        data: { title: "Crew verify estimate M", projectId: projectM.id, code: "EST-CREW-VERIFY-M", status: "Approved", totalAmount: 2900, balanceDue: 2900 },
+    });
+    const phaseL1 = await prisma.estimateItem.create({ data: { estimateId: estimateM.id, name: "Phase L1", type: "Material", quantity: 1, total: 0, order: 0 } });
+    await prisma.estimateItem.create({ data: { estimateId: estimateM.id, name: "L1 labor", type: "Labor", quantity: 4, budgetUnit: "hours", total: 1000, order: 1, parentId: phaseL1.id } });
+    const phaseL2 = await prisma.estimateItem.create({ data: { estimateId: estimateM.id, name: "Phase L2", type: "Material", quantity: 1, total: 0, order: 2 } });
+    await prisma.estimateItem.create({ data: { estimateId: estimateM.id, name: "L2 labor", type: "Labor", quantity: 4, budgetUnit: "hours", total: 1000, order: 3, parentId: phaseL2.id } });
+    const phaseZ = await prisma.estimateItem.create({ data: { estimateId: estimateM.id, name: "Phase Z", type: "Material", quantity: 1, total: 0, order: 4 } });
+    await prisma.estimateItem.create({ data: { estimateId: estimateM.id, name: "Z materials", type: "Material", quantity: 1, total: 900, order: 5, parentId: phaseZ.id } });
+
+    // Phase-less, taskCount > windowDays (packing).
+    const projectF = await prisma.project.create({
+        data: { name: "Crew verify flat — delete me", clientId: client.id, status: "Waiting to Start", startDate: new Date(base), endDate: new Date(base + 3 * DAY) },
+    });
+    const estimateF = await prisma.estimate.create({
+        data: { title: "Crew verify estimate F", projectId: projectF.id, code: "EST-CREW-VERIFY-F", status: "Approved", totalAmount: 500, balanceDue: 500 },
+    });
+    for (let i = 0; i < 5; i++) {
+        await prisma.estimateItem.create({
+            data: { estimateId: estimateF.id, name: `Flat item ${i + 1}`, type: i === 0 ? "Labor" : "Material", quantity: i === 0 ? 8 : 1, budgetUnit: i === 0 ? "hours" : null, total: 100, order: i },
+        });
+    }
+
+    // Phase-less, non-divisible window (5 tasks / 42 days — finding 2).
+    const projectF2 = await prisma.project.create({
+        data: { name: "Crew verify flat2 — delete me", clientId: client.id, status: "Waiting to Start", startDate: new Date(base) },
+    });
+    const estimateF2 = await prisma.estimate.create({
+        data: { title: "Crew verify estimate F2", projectId: projectF2.id, code: "EST-CREW-VERIFY-F2", status: "Approved", totalAmount: 500, balanceDue: 500 },
+    });
+    for (let i = 0; i < 5; i++) {
+        await prisma.estimateItem.create({
+            data: { estimateId: estimateF2.id, name: `Flat2 item ${i + 1}`, type: "Material", quantity: 1, total: 100, order: i },
+        });
+    }
+
+    // Importer round-trip fixture (h).
+    const projectH = await prisma.project.create({
+        data: { name: "Crew verify import — delete me", clientId: client.id, status: "Waiting to Start", startDate: new Date(base) },
+    });
+    const estimateH = await prisma.estimate.create({
+        data: { title: "Crew verify estimate H", projectId: projectH.id, code: "EST-CREW-VERIFY-H", status: "Approved", totalAmount: 100, balanceDue: 100 },
+    });
+    await prisma.estimateItem.create({ data: { estimateId: estimateH.id, name: "Only line", type: "Material", quantity: 1, total: 100, order: 0 } });
+
+    // Conflict fixtures (e).
+    const projectC2 = await prisma.project.create({
+        data: { name: "Crew verify C2 — delete me", clientId: client.id, status: "Waiting to Start", startDate: new Date(base + 10 * DAY), crew: { connect: { id: userA.id } } },
+    });
+    const projectC3 = await prisma.project.create({
+        data: { name: "Crew verify C3 — delete me", clientId: client.id, status: "Waiting to Start", startDate: new Date(base + 60 * DAY), crew: { connect: { id: userA.id } } },
+    });
+
+    const allProjectIds = [projectG.id, projectM.id, projectF.id, projectF2.id, projectH.id, projectC2.id, projectC3.id];
+
+    try {
+        // ── (a) generation: structure, dates, provenance, links; merge idempotent ──
+        const gen1 = await generateScheduleFromEstimate({ estimateId: estimateG.id, mode: "merge", actor: TEAM });
+        checks.push(["(a) generation returns estimate code", gen1.estimateCode === "EST-CREW-VERIFY-G"]);
+        checks.push(["(a) 8 tasks created (2 phases + 3 children + 3 milestones)", gen1.created.length === 8]);
+        const tasksG = await prisma.scheduleTask.findMany({ where: { projectId: projectG.id }, orderBy: { order: "asc" } });
+        const parentA = tasksG.find(t => t.estimateItemId === phaseA.id)!;
+        const parentB = tasksG.find(t => t.estimateItemId === phaseB.id)!;
+        checks.push(["(a) phase A window [base, base+33)", parentA.startDate.getTime() === base && parentA.endDate.getTime() === base + 33 * DAY]);
+        checks.push(["(a) phase B window [base+33, base+42)", parentB.startDate.getTime() === base + 33 * DAY && parentB.endDate.getTime() === base + 42 * DAY]);
+        const taskA1 = tasksG.find(t => t.estimateItemId === childA1.id)!;
+        const taskA2 = tasksG.find(t => t.estimateItemId === childA2.id)!;
+        const taskB1 = tasksG.find(t => t.estimateItemId === childB1.id)!;
+        checks.push(["(a) children linked under phase parent", taskA1.parentId === parentA.id && taskA2.parentId === parentA.id && taskB1.parentId === parentB.id]);
+        checks.push(["(a) child A1 window [base, base+16)", taskA1.startDate.getTime() === base && taskA1.endDate.getTime() === base + 16 * DAY]);
+        checks.push(["(a) child hours from hour-like budgetUnit", taskA1.estimatedHours === 10 && taskB1.estimatedHours === 5 && taskA2.estimatedHours === null]);
+        checks.push(["(a) provenance on every generated task", tasksG.every(t => t.generatedFromEstimateId === estimateG.id)]);
+        const milestonesG = tasksG.filter(t => t.type === "milestone");
+        checks.push(["(a) 3 milestone tasks", milestonesG.length === 3]);
+
+        const taskCountBefore = tasksG.length;
+        const gen2 = await generateScheduleFromEstimate({ estimateId: estimateG.id, mode: "merge", actor: TEAM });
+        const tasksGAfter2 = await prisma.scheduleTask.findMany({ where: { projectId: projectG.id } });
+        checks.push(["(a) merge re-run creates nothing", gen2.created.length === 0 && tasksGAfter2.length === taskCountBefore]);
+        checks.push(["(a) merge re-run reports skips", gen2.skipped > 0]);
+
+        // ── (b) milestone canonical-date rule + mirror initialization/linking ──
+        const mTask1 = milestonesG.find(t => t.name === "Deposit")!;
+        const mTask2 = milestonesG.find(t => t.name === "Final")!;
+        const mTask3 = milestonesG.find(t => t.name === "Settled fee")!;
+        checks.push(["(b) percentage-derived milestone date (30% of 42d → base+13)", mTask1.startDate.getTime() === base + 13 * DAY]);
+        checks.push(["(b) existing EPS dueDate wins (base+50)", mTask2.startDate.getTime() === base + 50 * DAY]);
+        checks.push(["(b) unordered/paid row lands at window end", mTask3.startDate.getTime() === base + 42 * DAY]);
+        const eps1After = await prisma.estimatePaymentSchedule.findUniqueOrThrow({ where: { id: eps1.id } });
+        const eps2After = await prisma.estimatePaymentSchedule.findUniqueOrThrow({ where: { id: eps2.id } });
+        const eps3After = await prisma.estimatePaymentSchedule.findUniqueOrThrow({ where: { id: eps3.id } });
+        const c1aAfter = await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: c1a.id } });
+        const c1bAfter = await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: c1b.id } });
+        const c2AfterB = await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: c2.id } });
+        checks.push(["(b) null EPS dueDate initialized (Pending only)", eps1After.dueDate?.getTime() === base + 13 * DAY]);
+        checks.push(["(b) existing EPS dueDate untouched", eps2After.dueDate?.getTime() === base + 50 * DAY]);
+        checks.push(["(b) Paid EPS row never rewritten", eps3After.dueDate === null]);
+        checks.push(["(b) non-QB Pending clone initialized", c1aAfter.dueDate?.getTime() === base + 13 * DAY]);
+        checks.push(["(b) QB clone keeps empty local date", c1bAfter.dueDate === null]);
+        checks.push(["(b) QB-pushed clone reported in notes", gen1.notes.some(n => /quickbooks/i.test(n))]);
+        checks.push(["(b) scheduleTaskId on EPS + ALL unpaid clones incl. QB-flagged",
+            eps1After.scheduleTaskId === mTask1.id &&
+            c1aAfter.scheduleTaskId === mTask1.id &&
+            c1bAfter.scheduleTaskId === mTask1.id &&
+            c2AfterB.scheduleTaskId === mTask2.id]);
+        const overlaysB = await getCalendarOverlays(new Date(base - 7 * DAY), new Date(base + 90 * DAY));
+        const incomeC1b = overlaysB.income.find(i => i.id === c1b.id);
+        checks.push(["(b) QB null-date clone is projected income on its task date", incomeC1b?.effectiveDueDate === iso(base + 13 * DAY)]);
+
+        // ── (b2) regenerate eligibility: protected subtree kept whole ──
+        const manualLookalike = await prisma.scheduleTask.create({
+            data: { projectId: projectG.id, name: "Phase Alpha", startDate: new Date(base), endDate: new Date(base + 5 * DAY) },
+        });
+        await prisma.taskComment.create({ data: { taskId: taskA1.id, text: "protect me", subcontractorName: "verify" } });
+        const oldMilestoneTaskId = mTask1.id;
+        const regen = await generateScheduleFromEstimate({ estimateId: estimateG.id, mode: "regenerate", actor: TEAM });
+        const tasksAfterRegen = await prisma.scheduleTask.findMany({ where: { projectId: projectG.id } });
+        const keptA = tasksAfterRegen.find(t => t.id === parentA.id);
+        checks.push(["(b2) protected phase subtree kept whole (parent + both children keep ids)",
+            !!keptA && tasksAfterRegen.some(t => t.id === taskA1.id) && tasksAfterRegen.some(t => t.id === taskA2.id)]);
+        const rebuiltB = tasksAfterRegen.find(t => t.estimateItemId === phaseB.id);
+        checks.push(["(b2) untouched phase subtree rebuilt with new ids", !!rebuiltB && rebuiltB.id !== parentB.id]);
+        checks.push(["(b2) rebuilt phase B window unchanged", rebuiltB!.startDate.getTime() === base + 33 * DAY && rebuiltB!.endDate.getTime() === base + 42 * DAY]);
+        checks.push(["(b2) manual lookalike survives", tasksAfterRegen.some(t => t.id === manualLookalike.id)]);
+        checks.push(["(b2) kept subtree reported in notes", regen.notes.some(n => /kept/i.test(n))]);
+        const eps1Regen = await prisma.estimatePaymentSchedule.findUniqueOrThrow({ where: { id: eps1.id } });
+        checks.push(["(b2) EPS re-linked to rebuilt milestone task",
+            eps1Regen.scheduleTaskId !== null && eps1Regen.scheduleTaskId !== oldMilestoneTaskId &&
+            tasksAfterRegen.some(t => t.id === eps1Regen.scheduleTaskId)]);
+        checks.push(["(b2) initialized dueDate not overwritten on regenerate", eps1Regen.dueDate?.getTime() === base + 13 * DAY]);
+
+        // ── (c) mixed-weight phases + phase-less packing ──
+        await generateScheduleFromEstimate({ estimateId: estimateM.id, mode: "merge", actor: TEAM });
+        const tasksM = await prisma.scheduleTask.findMany({ where: { projectId: projectM.id }, orderBy: { order: "asc" } });
+        const tL1 = tasksM.find(t => t.estimateItemId === phaseL1.id)!;
+        const tL2 = tasksM.find(t => t.estimateItemId === phaseL2.id)!;
+        const tZ = tasksM.find(t => t.estimateItemId === phaseZ.id)!;
+        checks.push(["(c) labor-heavy L1 gets 4 of 8 days (floor + largest remainder, tie by order)",
+            tL1.startDate.getTime() === base && tL1.endDate.getTime() === base + 4 * DAY]);
+        checks.push(["(c) L2 gets 3 days, adjacent", tL2.startDate.getTime() === base + 4 * DAY && tL2.endDate.getTime() === base + 7 * DAY]);
+        checks.push(["(c) zero-labor phase keeps its reserved day", tZ.startDate.getTime() === base + 7 * DAY && tZ.endDate.getTime() === base + 8 * DAY]);
+        checks.push(["(c) slices cover the window exactly",
+            tL1.startDate.getTime() === base && tZ.endDate.getTime() === base + 8 * DAY &&
+            tL1.endDate.getTime() === tL2.startDate.getTime() && tL2.endDate.getTime() === tZ.startDate.getTime()]);
+
+        await generateScheduleFromEstimate({ estimateId: estimateF.id, mode: "merge", actor: TEAM });
+        const tasksF = await prisma.scheduleTask.findMany({ where: { projectId: projectF.id }, orderBy: { order: "asc" } });
+        // Packed (5 tasks / 3 days): proportional start offsets floor(k·3/5), each end
+        // clamped to start + 1 day (one-day minimum — proportional ends would coincide).
+        const expectedStarts = [0, 0, 1, 1, 2].map(d => base + d * DAY);
+        const expectedEnds = [1, 1, 2, 2, 3].map(d => base + d * DAY);
+        checks.push(["(c) phase-less: 5 flat tasks packed over 3 days (shared start days), order preserved",
+            tasksF.length === 5 && tasksF.every((t, i) => t.startDate.getTime() === expectedStarts[i] && t.endDate.getTime() === expectedEnds[i])]);
+        checks.push(["(c) packed slices still span the window", tasksF[0].startDate.getTime() === base && tasksF[4].endDate.getTime() === base + 3 * DAY]);
+        checks.push(["(c) packed tasks all have >= 1 day duration", tasksF.every(t => t.endDate.getTime() - t.startDate.getTime() >= DAY)]);
+        checks.push(["(c) flat labor line gets hours from budgetUnit", tasksF[0].estimatedHours === 8 && tasksF[1].estimatedHours === null]);
+
+        // Non-divisible window (finding 2): 5 tasks / 42 days must cover exactly.
+        await generateScheduleFromEstimate({ estimateId: estimateF2.id, mode: "merge", actor: TEAM });
+        const tasksF2 = await prisma.scheduleTask.findMany({ where: { projectId: projectF2.id }, orderBy: { order: "asc" } });
+        const exp2Starts = [0, 8, 16, 25, 33].map(d => base + d * DAY);
+        const exp2Ends = [8, 16, 25, 33, 42].map(d => base + d * DAY);
+        checks.push(["(c) non-divisible window: proportional boundaries",
+            tasksF2.length === 5 && tasksF2.every((t, i) => t.startDate.getTime() === exp2Starts[i] && t.endDate.getTime() === exp2Ends[i])]);
+        checks.push(["(c) non-divisible: exact coverage, last task ends at window end",
+            tasksF2.length === 5 && tasksF2[0].startDate.getTime() === base &&
+            tasksF2[tasksF2.length - 1].endDate.getTime() === base + 42 * DAY &&
+            tasksF2.every((t, i) => i === 0 || t.startDate.getTime() === tasksF2[i - 1].endDate.getTime())]);
+
+        // ── (d) setProjectCrew diff + ACTIVATED validation + picker filter ──
+        const crewSet1 = await setProjectCrew({ projectId: projectG.id, userIds: [userA.id], actor: TEAM });
+        checks.push(["(d) crew set", crewSet1.crew.length === 1 && crewSet1.crew[0].id === userA.id]);
+        let rejected = false;
+        try {
+            await setProjectCrew({ projectId: projectG.id, userIds: [userA.id, userB.id], actor: TEAM });
+        } catch (e: any) {
+            rejected = /ACTIVATED/i.test(String(e?.message));
+        }
+        checks.push(["(d) non-ACTIVATED member rejected", rejected]);
+        const crewAfterReject = await prisma.project.findUniqueOrThrow({ where: { id: projectG.id }, select: { crew: { select: { id: true } } } });
+        checks.push(["(d) rejected replace left crew unchanged", crewAfterReject.crew.length === 1 && crewAfterReject.crew[0].id === userA.id]);
+        const crewSet2 = await setProjectCrew({ projectId: projectG.id, userIds: [userA.id], actor: TEAM });
+        checks.push(["(d) idempotent re-set", crewSet2.crew.length === 1 && crewSet2.crew[0].id === userA.id]);
+        const dashAdminForPicker = await getCompanyDashboardData({ role: "ADMIN" }, "2030-01");
+        checks.push(["(d) picker list is ACTIVATED-filtered",
+            (dashAdminForPicker.teamMembers ?? []).some(u => u.id === userA.id) && !(dashAdminForPicker.teamMembers ?? []).some(u => u.id === userB.id)]);
+
+        // ── (e) crew conflicts ──
+        const conflicts = await getCrewConflicts(new Date(base), new Date(base + 90 * DAY));
+        const conflictA = conflicts.find(c => c.userId === userA.id);
+        checks.push(["(e) overlapping two-project crew flagged",
+            !!conflictA && conflictA.pairs.some(pr =>
+                (pr.projectA.id === projectG.id && pr.projectB.id === projectC2.id) ||
+                (pr.projectA.id === projectC2.id && pr.projectB.id === projectG.id))]);
+        checks.push(["(e) non-overlapping project not flagged",
+            !conflicts.some(c => c.pairs.some(pr => pr.projectA.id === projectC3.id || pr.projectB.id === projectC3.id))]);
+
+        // ── (d2) inactive assigned crew member is a removable picker entry ──
+        await prisma.project.update({ where: { id: projectH.id }, data: { crew: { connect: [{ id: userA.id }, { id: userC.id }] } } });
+        const dashInactive = await getCompanyDashboardData({ role: "ADMIN" }, "2030-01");
+        const rowH = [...dashInactive.pipeline.waitingToStart, ...dashInactive.pipeline.scheduled, ...dashInactive.pipeline.inProgress]
+            .find(r => r.id === projectH.id);
+        const inactiveEntry = rowH?.crew.find(c => c.id === userC.id);
+        checks.push(["(d2) DISABLED member appears as an assigned-inactive entry", !!inactiveEntry && inactiveEntry.status !== "ACTIVATED"]);
+        checks.push(["(d2) picker list excludes the DISABLED member", !(dashInactive.teamMembers ?? []).some(u => u.id === userC.id)]);
+        const crewFix = await setProjectCrew({ projectId: projectH.id, userIds: [userA.id], actor: TEAM });
+        checks.push(["(d2) save with the inactive id omitted succeeds and removes them",
+            crewFix.crew.length === 1 && crewFix.crew[0].id === userA.id]);
+
+        // ── (f) overlays + strip semantics ──
+        // c2 becomes Paid with a paymentDate INSIDE the month and a dueDate OUTSIDE —
+        // Received must bucket by paymentDate, never dueDate.
+        await prisma.paymentSchedule.update({ where: { id: c2.id }, data: { status: "Paid", paymentDate: new Date(base + 7 * DAY) } });
+        const overlays = await getCalendarOverlays(new Date(Date.UTC(2029, 11, 31)), new Date(Date.UTC(2030, 1, 11)));
+        const expenseSum = overlays.expenses.filter(e => e.date.slice(0, 10) === iso(base + 5 * DAY).slice(0, 10)).reduce((s, e) => s + e.amount, 0);
+        const hoursSum = overlays.hours.filter(h => h.startTime.slice(0, 10) === iso(base + 6 * DAY).slice(0, 10)).reduce((s, h) => s + h.durationHours, 0);
+        checks.push(["(f) expense summed on its UTC day", Math.abs(expenseSum - 123.45) < 0.005]);
+        checks.push(["(f) hours summed on their UTC day", Math.abs(hoursSum - 3.5) < 0.005]);
+        const incomeC1bOv = overlays.income.find(i => i.id === c1b.id);
+        checks.push(["(f) income layer uses effectiveDueDate for QB null-date clone", incomeC1bOv?.effectiveDueDate === iso(base + 13 * DAY)]);
+
+        const dashAdmin = await getCompanyDashboardData({ role: "ADMIN" }, "2030-01");
+        const stripG = (dashAdmin.strip ?? []).find(r => r.projectId === projectG.id);
+        checks.push(["(f) strip exists for ADMIN with the project row", !!stripG]);
+        checks.push(["(f) Income due by effectiveDueDate (incl. projected QB clone)", Math.abs((stripG?.incomeDue ?? 0) - 150) < 0.005]);
+        checks.push(["(f) Received by paymentDate not dueDate", Math.abs((stripG?.received ?? 0) - 200) < 0.005]);
+        checks.push(["(f) Expenses in strip", Math.abs((stripG?.expenses ?? 0) - 123.45) < 0.005]);
+        checks.push(["(f) burdened Labor = laborCost + burdenCost", Math.abs((stripG?.laborBurdened ?? 0) - 120) < 0.005]);
+        checks.push(["(f) Hours actual vs estimated", Math.abs((stripG?.hoursActual ?? 0) - 3.5) < 0.005 && Math.abs((stripG?.hoursEstimated ?? 0) - 15) < 0.005]);
+        checks.push(["(f) Net = Received − Expenses − burdened Labor", Math.abs((stripG?.net ?? 0) - (200 - 123.45 - 120)) < 0.005]);
+        // effectiveDueDate parity: the same date drives the income layer AND the strip.
+        checks.push(["(f) effectiveDueDate identical in income layer and strip",
+            incomeC1bOv?.effectiveDueDate === iso(base + 13 * DAY) &&
+            (dashAdmin.overlays?.income.find(i => i.id === c1b.id)?.effectiveDueDate ?? null) === incomeC1bOv?.effectiveDueDate &&
+            Math.abs((stripG?.incomeDue ?? 0) - 150) < 0.005]);
+
+        // ── (g) getCompanyDashboardData role matrix ──
+        const dashManager = await getCompanyDashboardData({ role: "MANAGER" }, "2030-01");
+        const dashFinance = await getCompanyDashboardData({ role: "FINANCE" }, "2030-01");
+        checks.push(["(g) ADMIN gets overlays + strip + cashflow", !!dashAdmin.overlays && !!dashAdmin.strip && !!dashAdmin.cashflow]);
+        checks.push(["(g) MANAGER gets NO overlays/strip/cashflow", !dashManager.overlays && !dashManager.strip && !dashManager.cashflow]);
+        checks.push(["(g) MANAGER still gets picker list + conflicts", !!dashManager.teamMembers && !!dashManager.crewConflicts]);
+        checks.push(["(g) FINANCE gets NO overlays/strip/cashflow/picker/conflicts",
+            !dashFinance.overlays && !dashFinance.strip && !dashFinance.cashflow && !dashFinance.teamMembers && !dashFinance.crewConflicts]);
+
+        // ── (h) rewired importer delegates to the core ──
+        let importerRan = false;
+        let importerErr = "";
+        try {
+            const createdRows = await importEstimateToSchedule(projectH.id, estimateH.id);
+            importerRan = true;
+            checks.push(["(h) importer returns created rows (shape preserved)", Array.isArray(createdRows)]);
+        } catch (e: any) {
+            importerErr = String(e?.message ?? e);
+            if (importerErr.includes("static generation store")) importerRan = true; // ran; revalidate threw post-commit
+        }
+        if (importerRan) {
+            const tasksH = await prisma.scheduleTask.findMany({ where: { projectId: projectH.id } });
+            checks.push(["(h) importer created tasks via core (provenance)", tasksH.length === 1 && tasksH[0].generatedFromEstimateId === estimateH.id]);
+        } else {
+            // Server-action auth wall in a plain script context — fall back to a
+            // static delegation proof (the rewired body routes through the core).
+            const authWalled = /outside a request scope|Unauthorized/i.test(importerErr);
+            const src = fs.readFileSync(new URL("../src/lib/actions.ts", import.meta.url), "utf8");
+            const bodyStart = src.indexOf("export async function importEstimateToSchedule");
+            const body = src.slice(bodyStart, src.indexOf("\n}\n", bodyStart));
+            checks.push(["(h) importer delegates to generateScheduleFromEstimate (static proof)",
+                body.includes("generateScheduleFromEstimate") && !body.includes("TYPE_COLORS")]);
+            checks.push(["(h) runtime round trip blocked only by script auth wall", authWalled]);
+            console.log(`(h) runtime round trip skipped — server-action auth wall (${importerErr.slice(0, 60)}…)`);
+        }
+    } finally {
+        // Full cleanup, parent rows last (FK constraints).
+        await prisma.activityLog.deleteMany({ where: { projectId: { in: allProjectIds } } });
+        await prisma.paymentSchedule.deleteMany({ where: { invoiceId: invoiceG.id } });
+        await prisma.invoice.delete({ where: { id: invoiceG.id } });
+        await prisma.estimatePaymentSchedule.deleteMany({ where: { estimateId: { in: [estimateG.id, estimateM.id, estimateF.id, estimateF2.id, estimateH.id] } } });
+        await prisma.estimateItem.deleteMany({ where: { estimateId: { in: [estimateG.id, estimateM.id, estimateF.id, estimateF2.id, estimateH.id] } } });
+        await prisma.expense.delete({ where: { id: expenseG.id } });
+        await prisma.timeEntry.delete({ where: { id: timeG.id } });
+        await prisma.taskComment.deleteMany({ where: { task: { projectId: { in: allProjectIds } } } });
+        await prisma.scheduleTask.deleteMany({ where: { projectId: { in: allProjectIds } } });
+        await prisma.estimate.deleteMany({ where: { id: { in: [estimateG.id, estimateM.id, estimateF.id, estimateF2.id, estimateH.id] } } });
+        await prisma.project.deleteMany({ where: { id: { in: allProjectIds } } });
+        await prisma.user.deleteMany({ where: { id: { in: [userA.id, userB.id, userC.id] } } });
+        await prisma.client.delete({ where: { id: client.id } });
+        console.log("cleanup done");
+    }
+
+    let failed = 0;
+    for (const [label, ok] of checks) { console.log(`${ok ? "PASS" : "FAIL"}  ${label}`); if (!ok) failed++; }
+    if (failed) throw new Error(`${failed} checks failed`);
+    console.log("ALL CHECKS PASSED");
+}
+
+main().then(() => process.exit(0)).catch(e => { console.error(e); process.exit(1); });

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { createEstimateFromPhases, updateEstimateFromPhases, templateToPhases, estimateToPhases, CLOSED_PROJECT_STATUSES, CLOSED_LEAD_STAGES } from "@/lib/gpt-estimate";
 import { getProjectBilling, sendMilestoneInvoicesCore, resendInvoiceCore, createChangeOrderDraft, billChangeOrderCore, sendChangeOrderToClientCore, listReceivables, createInvoiceFromEstimateGuarded } from "@/lib/billing-core";
-import { getCompanyPipeline, getStartCalendar, setProjectStartDate, parseStartDateInput } from "@/lib/schedule-core";
+import { getCompanyPipeline, getStartCalendar, setProjectStartDate, parseStartDateInput, generateScheduleFromEstimate, setProjectCrew, getCrewConflicts } from "@/lib/schedule-core";
 import { coTaxRate, coTaxLabel } from "@/lib/co-tax";
 import { ALLOWED_FILE_EXTENSIONS, fileExtension, mimeTypeForFileName, saveProjectFile } from "@/lib/project-files";
 
@@ -866,10 +866,16 @@ const handler = createMcpHandler(
                 // getStartCalendar's `to` is exclusive, so from + N days lists
                 // exactly N calendar days (today through today+N-1).
                 const to = new Date(from.getTime() + horizonDays * 86_400_000);
-                const [pipeline, calendar] = await Promise.all([
+                const [pipeline, calendar, crewConflicts] = await Promise.all([
                     getCompanyPipeline(),
                     getStartCalendar(from, to, { includeFinancials: false }),
+                    getCrewConflicts(from, to),
                 ]);
+                // Crew per project (ids + names) — joined onto the start list too.
+                const crewOf = new Map<string, { id: string; name: string }[]>();
+                for (const p of [...pipeline.waitingToStart, ...pipeline.scheduled, ...pipeline.inProgress, ...pipeline.substantialCompletion]) {
+                    crewOf.set(p.id, p.crew);
+                }
                 return textResult({
                     pipeline: {
                         estimating: pipeline.estimating.length,
@@ -879,17 +885,21 @@ const handler = createMcpHandler(
                         substantialCompletion: pipeline.substantialCompletion.length,
                     },
                     waitingToStart: pipeline.waitingToStart.map(p => ({
-                        projectId: p.id, name: p.name, client: p.client, contractValue: p.contractValue,
+                        projectId: p.id, name: p.name, client: p.client, contractValue: p.contractValue, crew: p.crew,
                     })),
                     upcomingStarts: {
                         windowDays: horizonDays,
                         projects: calendar.projectStarts.map(p => ({
                             projectId: p.id, name: p.name, client: p.client, status: p.status, startDate: p.startDate.slice(0, 10),
+                            crew: crewOf.get(p.id) ?? [],
                         })),
                         leads: calendar.leadStarts.map(l => ({
                             leadId: l.id, name: l.name, client: l.client, stage: l.stage, expectedStartDate: l.expectedStartDate.slice(0, 10),
                         })),
                     },
+                    // Double-booked crew from project windows (startDate →
+                    // endDate ?? latest task end ?? startDate+1d, half-open).
+                    crewConflicts,
                 });
             },
         );
@@ -925,9 +935,66 @@ const handler = createMcpHandler(
                 }
             },
         );
+
+        server.registerTool(
+            "generate_project_schedule",
+            {
+                title: "Generate a project's schedule from its estimate",
+                description:
+                    "Builds the job's schedule from an estimate: phase parent tasks with children (or flat tasks for phase-less " +
+                    "estimates) apportioned across the project window by labor-dollar share, plus milestone tasks — and links the " +
+                    "payment milestones to them. Preconditions: the estimate must be Approved, Invoiced, Partially Paid, or Paid, " +
+                    "owned by a PROJECT (not a lead), and the project must have a start date first (set_project_start_date). " +
+                    "mode 'merge' (default) skips items already task-linked; 'regenerate' deletes untouched generated tasks and rebuilds. " +
+                    "Idempotent — safe to re-run.",
+                inputSchema: {
+                    estimateId: z.string().max(50).describe("Estimate id (from find_job or list_project_billing) — must be Approved+ and on a project with a start date"),
+                    mode: z.enum(["merge", "regenerate"]).optional().describe("'merge' (default) fills gaps; 'regenerate' rebuilds untouched generated tasks"),
+                },
+            },
+            async ({ estimateId, mode }) => {
+                try {
+                    const result = await generateScheduleFromEstimate({
+                        estimateId,
+                        mode: mode ?? "merge",
+                        actor: { type: "SYSTEM", name: "ChatGPT connector" },
+                    });
+                    return textResult(result);
+                } catch (e: any) {
+                    return { ...textResult({ error: e?.message ?? "Failed to generate schedule" }), isError: true };
+                }
+            },
+        );
+
+        server.registerTool(
+            "assign_project_crew",
+            {
+                title: "Assign crew to a project (idempotent replace)",
+                description:
+                    "Replaces the project's crew with exactly the given user ids (connect/disconnect diff — re-running with the " +
+                    "same list is a no-op). Every id must be an ACTIVATED team member. Crew drives the company-calendar chips and " +
+                    "the crewConflicts block in get_company_schedule (double-bookings across overlapping project windows).",
+                inputSchema: {
+                    projectId: z.string().max(50).describe("Project id from get_company_schedule or list_projects"),
+                    userIds: z.array(z.string().max(50)).max(50).describe("ACTIVATED user ids to assign — the FULL crew (not a delta); empty array clears the crew"),
+                },
+            },
+            async ({ projectId, userIds }) => {
+                try {
+                    const result = await setProjectCrew({
+                        projectId,
+                        userIds,
+                        actor: { type: "SYSTEM", name: "ChatGPT connector" },
+                    });
+                    return textResult(result);
+                } catch (e: any) {
+                    return { ...textResult({ error: e?.message ?? "Failed to assign crew" }), isError: true };
+                }
+            },
+        );
     },
     {
-        serverInfo: { name: "probuild", version: "1.7.0" },
+        serverInfo: { name: "probuild", version: "1.8.0" },
         capabilities: { tools: {} },
         instructions:
             "ProBuild is Golden Touch Remodeling's construction management system. " +
@@ -950,9 +1017,13 @@ const handler = createMcpHandler(
             "FILES: upload_file parks documents (RFQs, RFIs, spec sheets, generated spreadsheets) on a project's or lead's Files tab — base64 content, ~3 MB max, optional folder. " +
             "Uploads default to internal visibility; only pass visibility 'shared' (customer-visible in the portal) when the user explicitly asks. " +
             "SCHEDULING: get_company_schedule answers 'what jobs are waiting to start?' and lists upcoming project starts (plus lead expected starts) " +
-            "for the next N days. set_project_start_date moves a project's company start date — for a project still Waiting to Start it also shifts " +
+            "for the next N days, with each project's crew and a crewConflicts block (double-bookings across overlapping project windows). " +
+            "set_project_start_date moves a project's company start date — for a project still Waiting to Start it also shifts " +
             "the job's tasks and linked milestones by the same delta (pass shiftJobTasks false to move only the marker); milestone groups already pushed " +
             "to QuickBooks are never shifted and come back in skippedQbMilestones for manual fixing. " +
+            "generate_project_schedule builds a project's schedule from its estimate (the estimate must be Approved/Invoiced/Partially Paid/Paid and " +
+            "the project needs a start date first — set one with set_project_start_date); default 'merge' mode is idempotent, 'regenerate' rebuilds untouched generated tasks. " +
+            "assign_project_crew replaces a project's crew with the given ACTIVATED user ids (full list, not a delta). " +
             "QuickBooks is handled server-side; never ask the user for QuickBooks credentials.",
     },
     { basePath: "/api/mcp", maxDuration: 60 },

--- a/src/app/company-dashboard/CompanyDashboardClient.tsx
+++ b/src/app/company-dashboard/CompanyDashboardClient.tsx
@@ -4,8 +4,9 @@ import { useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import type { CashflowOutlook, CompanyPipeline, StartCalendar } from "@/lib/schedule-core";
-import { updateProjectStartDateAction } from "@/lib/actions";
+import type { CompanyDashboardData, DashboardProjectRow, ProjectCrewMember } from "@/lib/schedule-core";
+import { PROJECT_STATUSES } from "@/lib/project-status";
+import { generateProjectScheduleAction, updateProjectCrewAction, updateProjectStartDateAction } from "@/lib/actions";
 import {
     formatCurrency,
     formatDate,
@@ -35,10 +36,119 @@ function shiftMonth(month: string, delta: number): string {
     return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
 }
 
-// Inline date setter for one waiting-to-start project. Setting a date moves
-// the project into "Scheduled" on the funnel; the server action revalidates
-// and we refresh to pull the new grid.
-function StartDateRow({ project }: { project: CompanyPipeline["waitingToStart"][number] }) {
+function initials(name: string): string {
+    const parts = name.trim().split(/\s+/);
+    return parts.map(p => p[0]).join("").toUpperCase().slice(0, 2) || "?";
+}
+
+function statusColor(status: string): string {
+    return PROJECT_STATUSES.find(s => s.value === status)?.color ?? "bg-slate-100 text-slate-700";
+}
+
+// Compact crew picker (checkbox popover) — the list is pre-filtered to
+// ACTIVATED users server-side; every toggle replaces the crew idempotently.
+function CrewPicker({
+    projectId,
+    crew,
+    teamMembers,
+}: {
+    projectId: string;
+    crew: ProjectCrewMember[];
+    teamMembers: { id: string; name: string; email: string }[];
+}) {
+    const router = useRouter();
+    const [open, setOpen] = useState(false);
+    const [isPending, startTransition] = useTransition();
+
+    // Selection mirrors the server crew unless the user just toggled (the
+    // override keys on the crew contents, so refreshed props take back over).
+    const crewKey = crew.map(c => c.id).sort().join(",");
+    const [override, setOverride] = useState<{ key: string; ids: string[] } | null>(null);
+    const selected = override && override.key === crewKey ? override.ids : crew.map(c => c.id);
+
+    function toggle(userId: string) {
+        const next = selected.includes(userId) ? selected.filter(id => id !== userId) : [...selected, userId];
+        setOverride({ key: crewKey, ids: next });
+        startTransition(async () => {
+            try {
+                await updateProjectCrewAction(projectId, next);
+                router.refresh();
+            } catch (err: any) {
+                toast.error(err?.message || "Failed to update crew");
+                setOverride(null);
+            }
+        });
+    }
+
+    // Option list: the ACTIVATED team list PLUS any currently-assigned member
+    // who is no longer ACTIVATED — rendered as a removable "(inactive)" entry,
+    // checked by default (they ARE assigned); unchecking them before saving
+    // removes them (the core validates the FINAL set).
+    const inactiveAssigned = crew.filter(c => !teamMembers.some(m => m.id === c.id));
+    const options = [
+        ...teamMembers.map(m => ({ id: m.id, label: m.name || m.email })),
+        ...inactiveAssigned.map(c => ({ id: c.id, label: `${c.name} (inactive)` })),
+    ];
+    const selectedNames = options.filter(o => selected.includes(o.id));
+    return (
+        <div className="relative">
+            <button
+                type="button"
+                onClick={() => setOpen(o => !o)}
+                disabled={isPending}
+                className="hui-btn hui-btn-secondary text-xs px-2 py-1"
+                title="Assign crew"
+            >
+                {selectedNames.length === 0 ? "Assign crew" : selectedNames.map(o => initials(o.label)).join(" ")}
+            </button>
+            {open && (
+                <>
+                    <div className="fixed inset-0 z-20" onClick={() => setOpen(false)} />
+                    <div className="absolute z-30 mt-1 w-56 bg-white border border-hui-border rounded-lg shadow-lg p-2 max-h-64 overflow-y-auto">
+                        {options.length === 0 && <p className="text-xs text-hui-textMuted px-2 py-1">No active team members.</p>}
+                        {options.map(o => (
+                            <label key={o.id} className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-slate-50 cursor-pointer">
+                                <input
+                                    type="checkbox"
+                                    checked={selected.includes(o.id)}
+                                    onChange={() => toggle(o.id)}
+                                    className="accent-hui-primary"
+                                />
+                                <span className="text-sm text-hui-textMain">{o.label}</span>
+                            </label>
+                        ))}
+                    </div>
+                </>
+            )}
+        </div>
+    );
+}
+
+// "Generate schedule" button — Waiting/Scheduled rows with a qualifying
+// estimate and zero tasks (the server resolves the most recent qualifying one).
+function GenerateScheduleButton({ projectId }: { projectId: string }) {
+    const router = useRouter();
+    const [isPending, startTransition] = useTransition();
+    function handle() {
+        startTransition(async () => {
+            try {
+                const result = await generateProjectScheduleAction(projectId);
+                toast.success(`Schedule generated from ${result.estimateCode} — ${result.created.length} task${result.created.length === 1 ? "" : "s"}, ${result.milestonesLinked} milestone${result.milestonesLinked === 1 ? "" : "s"} linked`);
+                router.refresh();
+            } catch (err: any) {
+                toast.error(err?.message || "Schedule generation failed");
+            }
+        });
+    }
+    return (
+        <button onClick={handle} disabled={isPending} className="hui-btn hui-btn-green text-xs px-2 py-1 whitespace-nowrap">
+            {isPending ? "Generating..." : "Generate schedule"}
+        </button>
+    );
+}
+
+// Inline date setter for one waiting-to-start project (P1).
+function StartDateRow({ project }: { project: DashboardProjectRow }) {
     const router = useRouter();
     const [date, setDate] = useState("");
     const [isPending, startTransition] = useTransition();
@@ -96,20 +206,15 @@ function StartDateRow({ project }: { project: CompanyPipeline["waitingToStart"][
     );
 }
 
-export default function CompanyDashboardClient({
-    pipeline,
-    calendar,
-    cashflow,
-    month,
-    canEdit,
-}: {
-    pipeline: CompanyPipeline;
-    calendar: StartCalendar;
-    cashflow: CashflowOutlook | null;
-    month: string;
-    canEdit: boolean;
-}) {
+export default function CompanyDashboardClient({ data }: { data: CompanyDashboardData }) {
     const router = useRouter();
+    const { month, canEdit, isAdmin, pipeline, calendar, cashflow, teamMembers, crewConflicts, overlays, strip } = data;
+
+    // Overlay layer toggles (ADMIN only): income default on, others off.
+    const [showIncome, setShowIncome] = useState(true);
+    const [showExpenses, setShowExpenses] = useState(false);
+    const [showHours, setShowHours] = useState(false);
+
     const anchor = parseUTCDate(`${month}-01`);
     const days = getMonthGrid(anchor);
     const today = todayUTC();
@@ -117,27 +222,44 @@ export default function CompanyDashboardClient({
     const monthLabel = `${MONTH_LABELS[anchor.getUTCMonth()]} ${anchor.getUTCFullYear()}`;
 
     // Bucket calendar entries by UTC day key (YYYY-MM-DD) for O(1) cell lookup.
-    const projectStartsByDay = new Map<string, StartCalendar["projectStarts"]>();
+    const projectStartsByDay = new Map<string, typeof calendar.projectStarts>();
     for (const p of calendar.projectStarts) {
         const key = p.startDate.slice(0, 10);
         projectStartsByDay.set(key, [...(projectStartsByDay.get(key) ?? []), p]);
     }
-    const leadStartsByDay = new Map<string, StartCalendar["leadStarts"]>();
+    const leadStartsByDay = new Map<string, typeof calendar.leadStarts>();
     for (const l of calendar.leadStarts) {
         const key = l.expectedStartDate.slice(0, 10);
         leadStartsByDay.set(key, [...(leadStartsByDay.get(key) ?? []), l]);
     }
-    // Per-day milestone totals are only present for ADMIN (server omits the
-    // data entirely otherwise).
-    const milestoneTotalsByDay = new Map<string, number>();
-    for (const m of calendar.milestones ?? []) {
-        const key = m.dueDate.slice(0, 10);
-        milestoneTotalsByDay.set(key, (milestoneTotalsByDay.get(key) ?? 0) + m.amount);
+
+    // Crew per project (chips show up to 3 initials + overflow count).
+    const crewByProject = new Map<string, ProjectCrewMember[]>();
+    for (const row of [...pipeline.waitingToStart, ...pipeline.scheduled, ...pipeline.inProgress, ...pipeline.substantialCompletion]) {
+        crewByProject.set(row.id, row.crew);
     }
 
-    const sumContract = (rows: CompanyPipeline["waitingToStart"]) =>
-        rows.reduce((s, r) => s + (r.contractValue ?? 0), 0);
+    // Overlay per-day totals (income uses the shared effectiveDueDate rule).
+    const incomeByDay = new Map<string, number>();
+    for (const m of overlays?.income ?? []) {
+        const key = m.effectiveDueDate.slice(0, 10);
+        incomeByDay.set(key, (incomeByDay.get(key) ?? 0) + m.amount);
+    }
+    const expensesByDay = new Map<string, number>();
+    for (const e of overlays?.expenses ?? []) {
+        const key = e.date.slice(0, 10);
+        expensesByDay.set(key, (expensesByDay.get(key) ?? 0) + e.amount);
+    }
+    const hoursByDay = new Map<string, number>();
+    for (const h of overlays?.hours ?? []) {
+        const key = h.startTime.slice(0, 10);
+        hoursByDay.set(key, (hoursByDay.get(key) ?? 0) + h.durationHours);
+    }
+
+    const sumContract = (rows: { contractValue: number | null }[]) => rows.reduce((s, r) => s + (r.contractValue ?? 0), 0);
     const estimatingTotal = pipeline.estimating.reduce((s, l) => s + (l.targetRevenue ?? 0), 0);
+
+    const crewRows = [...pipeline.waitingToStart, ...pipeline.scheduled, ...pipeline.inProgress];
 
     return (
         <div className="max-w-6xl mx-auto py-8 px-6">
@@ -145,7 +267,7 @@ export default function CompanyDashboardClient({
             <div className="flex items-center justify-between mb-6">
                 <div>
                     <h1 className="text-xl font-bold text-hui-textMain">Company Dashboard</h1>
-                    <p className="text-sm text-hui-textMuted mt-1">The whole book of work — pipeline, project starts, and cash outlook.</p>
+                    <p className="text-sm text-hui-textMuted mt-1">The whole book of work — pipeline, project starts, crew, and cash outlook.</p>
                 </div>
             </div>
 
@@ -162,6 +284,28 @@ export default function CompanyDashboardClient({
                 <div className="flex items-center justify-between px-4 py-3 border-b border-hui-border">
                     <h2 className="text-base font-semibold text-hui-textMain">Project Starts — {monthLabel}</h2>
                     <div className="flex items-center gap-2">
+                        {isAdmin && overlays && (
+                            <div className="flex items-center gap-1 mr-3">
+                                <button
+                                    onClick={() => setShowIncome(v => !v)}
+                                    className={`text-xs font-semibold px-2 py-1 rounded-full border transition ${showIncome ? "bg-green-100 text-green-700 border-green-300" : "bg-white text-hui-textMuted border-hui-border"}`}
+                                >
+                                    Income
+                                </button>
+                                <button
+                                    onClick={() => setShowExpenses(v => !v)}
+                                    className={`text-xs font-semibold px-2 py-1 rounded-full border transition ${showExpenses ? "bg-red-100 text-red-700 border-red-300" : "bg-white text-hui-textMuted border-hui-border"}`}
+                                >
+                                    Expenses
+                                </button>
+                                <button
+                                    onClick={() => setShowHours(v => !v)}
+                                    className={`text-xs font-semibold px-2 py-1 rounded-full border transition ${showHours ? "bg-blue-100 text-blue-700 border-blue-300" : "bg-white text-hui-textMuted border-hui-border"}`}
+                                >
+                                    Hours
+                                </button>
+                            </div>
+                        )}
                         <button onClick={() => router.push(`?month=${shiftMonth(month, -1)}`)} className="hui-btn hui-btn-secondary text-sm">← Prev</button>
                         <button onClick={() => router.push("?")} className="hui-btn hui-btn-secondary text-sm">Today</button>
                         <button onClick={() => router.push(`?month=${shiftMonth(month, 1)}`)} className="hui-btn hui-btn-secondary text-sm">Next →</button>
@@ -179,7 +323,9 @@ export default function CompanyDashboardClient({
                         const isCurrentMonth = day.getUTCMonth() === currentMonth;
                         const projectStarts = projectStartsByDay.get(dayKey) ?? [];
                         const leadStarts = leadStartsByDay.get(dayKey) ?? [];
-                        const milestoneTotal = milestoneTotalsByDay.get(dayKey);
+                        const incomeTotal = showIncome ? incomeByDay.get(dayKey) : undefined;
+                        const expenseTotal = showExpenses ? expensesByDay.get(dayKey) : undefined;
+                        const hoursTotal = showHours ? hoursByDay.get(dayKey) : undefined;
                         return (
                             <div
                                 key={idx}
@@ -189,16 +335,24 @@ export default function CompanyDashboardClient({
                                     {day.getUTCDate()}
                                 </span>
                                 <div className="mt-1 flex flex-col gap-0.5">
-                                    {projectStarts.map(p => (
-                                        <Link
-                                            key={p.id}
-                                            href={`/projects/${p.id}`}
-                                            title={`${p.name}${p.client ? ` — ${p.client}` : ""}`}
-                                            className="block text-[11px] px-1.5 py-0.5 rounded truncate bg-hui-primary text-white hover:opacity-90 transition"
-                                        >
-                                            {p.name}
-                                        </Link>
-                                    ))}
+                                    {projectStarts.map(p => {
+                                        const crew = crewByProject.get(p.id) ?? [];
+                                        return (
+                                            <Link
+                                                key={p.id}
+                                                href={`/projects/${p.id}`}
+                                                title={`${p.name}${p.client ? ` — ${p.client}` : ""}${crew.length ? ` — crew: ${crew.map(c => c.name).join(", ")}` : ""}`}
+                                                className="block text-[11px] px-1.5 py-0.5 rounded bg-hui-primary text-white hover:opacity-90 transition"
+                                            >
+                                                <span className="block truncate">{p.name}</span>
+                                                {crew.length > 0 && (
+                                                    <span className="block text-[9px] opacity-90">
+                                                        {crew.slice(0, 3).map(c => initials(c.name)).join(" ")}{crew.length > 3 ? ` +${crew.length - 3}` : ""}
+                                                    </span>
+                                                )}
+                                            </Link>
+                                        );
+                                    })}
                                     {leadStarts.map(l => (
                                         <Link
                                             key={l.id}
@@ -209,9 +363,19 @@ export default function CompanyDashboardClient({
                                             {l.name}
                                         </Link>
                                     ))}
-                                    {milestoneTotal != null && milestoneTotal > 0 && (
-                                        <span className="text-[10px] font-medium text-amber-700 px-1.5" title="Milestones due this day">
-                                            {formatCurrency(milestoneTotal)} due
+                                    {incomeTotal != null && incomeTotal > 0 && (
+                                        <span className="text-[10px] font-medium text-green-700 px-1.5" title="Income due this day (effective due date)">
+                                            {formatCurrency(incomeTotal)} due
+                                        </span>
+                                    )}
+                                    {expenseTotal != null && expenseTotal > 0 && (
+                                        <span className="text-[10px] font-medium text-red-700 px-1.5" title="Expenses this day">
+                                            −{formatCurrency(expenseTotal)}
+                                        </span>
+                                    )}
+                                    {hoursTotal != null && hoursTotal > 0 && (
+                                        <span className="text-[10px] font-medium text-blue-700 px-1.5" title="Hours logged this day">
+                                            {hoursTotal.toFixed(1)}h
                                         </span>
                                     )}
                                 </div>
@@ -221,7 +385,70 @@ export default function CompanyDashboardClient({
                 </div>
             </div>
 
-            {/* Waiting to start — ADMIN/MANAGER editor only */}
+            {/* Schedule & crew */}
+            <div className="hui-card mb-6">
+                <div className="px-4 py-3 border-b border-hui-border">
+                    <h2 className="text-base font-semibold text-hui-textMain">Schedule &amp; crew</h2>
+                    <p className="text-xs text-hui-textMuted mt-1">
+                        Assign crew to jobs, or generate a job&apos;s schedule from its approved estimate (phases, tasks, and milestone dates).
+                    </p>
+                </div>
+                {crewRows.length === 0 ? (
+                    <p className="px-4 py-8 text-sm text-hui-textMuted text-center">No open projects.</p>
+                ) : (
+                    <table className="w-full">
+                        <thead>
+                            <tr className="border-b border-hui-border bg-slate-50">
+                                <th className="text-left px-4 py-3 text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Project</th>
+                                <th className="text-left px-4 py-3 text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Status</th>
+                                <th className="text-left px-4 py-3 text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Crew</th>
+                                <th className="text-left px-4 py-3 text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Schedule</th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-slate-100">
+                            {crewRows.map(p => {
+                                const canGenerate =
+                                    (p.status === "Waiting to Start") && p.hasQualifyingEstimate && p.taskCount === 0;
+                                return (
+                                    <tr key={p.id} className="hover:bg-slate-50 transition">
+                                        <td className="px-4 py-3">
+                                            <Link href={`/projects/${p.id}`} className="text-sm font-medium text-hui-textMain hover:text-hui-primary">
+                                                {p.name}
+                                            </Link>
+                                            <span className="block text-xs text-hui-textMuted">{p.client ?? "—"}</span>
+                                        </td>
+                                        <td className="px-4 py-3">
+                                            <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${statusColor(p.status)}`}>
+                                                {p.status === "Waiting to Start" && p.startDate ? "Scheduled" : p.status}
+                                            </span>
+                                        </td>
+                                        <td className="px-4 py-3">
+                                            {canEdit && teamMembers ? (
+                                                <CrewPicker projectId={p.id} crew={p.crew} teamMembers={teamMembers} />
+                                            ) : (
+                                                <span className="text-xs text-hui-textMuted">
+                                                    {p.crew.length === 0 ? "—" : p.crew.map(c => initials(c.name)).join(" ")}
+                                                </span>
+                                            )}
+                                        </td>
+                                        <td className="px-4 py-3">
+                                            {canEdit && canGenerate ? (
+                                                <GenerateScheduleButton projectId={p.id} />
+                                            ) : (
+                                                <span className="text-xs text-hui-textMuted">
+                                                    {p.taskCount > 0 ? `${p.taskCount} task${p.taskCount === 1 ? "" : "s"}` : "—"}
+                                                </span>
+                                            )}
+                                        </td>
+                                    </tr>
+                                );
+                            })}
+                        </tbody>
+                    </table>
+                )}
+            </div>
+
+            {/* Waiting to start — ADMIN/MANAGER editor only (P1) */}
             {canEdit && (
                 <div className="hui-card mb-6">
                     <div className="px-4 py-3 border-b border-hui-border">
@@ -253,9 +480,39 @@ export default function CompanyDashboardClient({
                 </div>
             )}
 
+            {/* Crew conflicts — ADMIN/MANAGER (read-only) */}
+            {canEdit && crewConflicts && (
+                <div className="hui-card mb-6">
+                    <div className="px-4 py-3 border-b border-hui-border">
+                        <h2 className="text-base font-semibold text-hui-textMain">Crew conflicts</h2>
+                    </div>
+                    {crewConflicts.length === 0 ? (
+                        <p className="px-4 py-8 text-sm text-hui-textMuted text-center">No crew conflicts this month.</p>
+                    ) : (
+                        <ul className="divide-y divide-slate-100">
+                            {crewConflicts.map(c => (
+                                <li key={c.userId} className="px-4 py-3">
+                                    <p className="text-sm font-semibold text-hui-textMain">{c.name}</p>
+                                    <ul className="mt-1 space-y-0.5">
+                                        {c.pairs.map((pair, i) => (
+                                            <li key={i} className="text-xs text-hui-textMuted">
+                                                <Link href={`/projects/${pair.projectA.id}`} className="text-hui-primary hover:underline">{pair.projectA.name}</Link>
+                                                {" × "}
+                                                <Link href={`/projects/${pair.projectB.id}`} className="text-hui-primary hover:underline">{pair.projectB.name}</Link>
+                                                {` — ${pair.overlapStart.slice(0, 10)} → ${pair.overlapEnd.slice(0, 10)}`}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+            )}
+
             {/* Cashflow outlook — ADMIN only (never serialized for other roles) */}
             {cashflow && (
-                <div className="hui-card">
+                <div className="hui-card mb-6">
                     <div className="px-4 py-3 border-b border-hui-border">
                         <h2 className="text-base font-semibold text-hui-textMain">Cash expected</h2>
                         <p className="text-xs text-hui-textMuted mt-1">
@@ -284,6 +541,54 @@ export default function CompanyDashboardClient({
                             <p className="text-xs text-hui-textMuted">{cashflow.days61to90.count} milestone{cashflow.days61to90.count === 1 ? "" : "s"}</p>
                         </div>
                     </div>
+                </div>
+            )}
+
+            {/* Per-project month strip — ADMIN only */}
+            {isAdmin && strip && (
+                <div className="hui-card">
+                    <div className="px-4 py-3 border-b border-hui-border">
+                        <h2 className="text-base font-semibold text-hui-textMain">This month by project</h2>
+                        <p className="text-xs text-hui-textMuted mt-1">Income due, received, expenses, burdened labor, and hours for {monthLabel}.</p>
+                    </div>
+                    {strip.length === 0 ? (
+                        <p className="px-4 py-8 text-sm text-hui-textMuted text-center">No project activity this month.</p>
+                    ) : (
+                        <div className="overflow-x-auto">
+                            <table className="w-full">
+                                <thead>
+                                    <tr className="border-b border-hui-border bg-slate-50">
+                                        <th className="text-left px-4 py-3 text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Project</th>
+                                        <th className="text-right px-4 py-3 text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Income due</th>
+                                        <th className="text-right px-4 py-3 text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Received</th>
+                                        <th className="text-right px-4 py-3 text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Expenses</th>
+                                        <th className="text-right px-4 py-3 text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Labor (actual, burdened)</th>
+                                        <th className="text-right px-4 py-3 text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Hours</th>
+                                        <th className="text-right px-4 py-3 text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Net</th>
+                                    </tr>
+                                </thead>
+                                <tbody className="divide-y divide-slate-100">
+                                    {strip.map(r => (
+                                        <tr key={r.projectId} className="hover:bg-slate-50 transition">
+                                            <td className="px-4 py-3">
+                                                <Link href={`/projects/${r.projectId}`} className="text-sm font-medium text-hui-textMain hover:text-hui-primary">
+                                                    {r.projectName}
+                                                </Link>
+                                            </td>
+                                            <td className="px-4 py-3 text-sm text-right text-green-700">{formatCurrency(r.incomeDue)}</td>
+                                            <td className="px-4 py-3 text-sm text-right text-hui-textMain">{formatCurrency(r.received)}</td>
+                                            <td className="px-4 py-3 text-sm text-right text-red-700">{formatCurrency(r.expenses)}</td>
+                                            <td className="px-4 py-3 text-sm text-right text-hui-textMain">{formatCurrency(r.laborBurdened)}</td>
+                                            <td className="px-4 py-3 text-sm text-right text-hui-textMuted">{r.hoursActual.toFixed(1)} / {r.hoursEstimated.toFixed(1)}h</td>
+                                            <td className={`px-4 py-3 text-sm text-right font-semibold ${r.net >= 0 ? "text-green-700" : "text-red-700"}`}>
+                                                {formatCurrency(r.net)}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    )}
                 </div>
             )}
         </div>

--- a/src/app/company-dashboard/page.tsx
+++ b/src/app/company-dashboard/page.tsx
@@ -2,20 +2,18 @@ export const dynamic = "force-dynamic";
 import { redirect } from "next/navigation";
 import { getSessionOrDev } from "@/lib/auth";
 import { getUserWithPermissionsByEmail, hasPermission } from "@/lib/permissions";
-import { getCompanyPipeline, getStartCalendar, getCashflowOutlook } from "@/lib/schedule-core";
-import { getMonthGrid, parseUTCDate } from "@/app/projects/[id]/schedule/schedule-utils";
+import { getCompanyDashboardData } from "@/lib/schedule-core";
 import CompanyDashboardClient from "./CompanyDashboardClient";
 
-// Company-wide pipeline dashboard (.specs/PB-pipeline-001-company-dashboard.md):
-// funnel (Estimating → Waiting to Start → Scheduled → In Progress), the
-// month-grid start calendar, the waiting-to-start editor (ADMIN/MANAGER), and
-// the ADMIN-only cashflow strip.
+// Company-wide pipeline dashboard (PB-pipeline-001 + PB-pipeline-002):
+// funnel, start calendar with crew + money/hours overlays, waiting-to-start
+// editor, crew conflicts, and the ADMIN-only cashflow/per-project strips.
 //
-// Authorization: the page admits anyone holding the `financialReports`
-// permission (hasPermission — honors explicit per-user overrides, so nav and
-// page can never disagree). Milestone amounts and the cashflow strip are only
-// QUERIED and serialized when role === "ADMIN" — managers/finance never
-// receive financial data in the payload (owner requirement).
+// Authorization (unchanged from P1): the page admits anyone holding the
+// `financialReports` permission (hasPermission — honors explicit per-user
+// overrides, so nav and page can never disagree). Overlays and per-project
+// financial data are only QUERIED and serialized when role === "ADMIN"
+// (enforced inside getCompanyDashboardData); editing is ADMIN/MANAGER only.
 export default async function CompanyDashboardPage({
     searchParams,
 }: {
@@ -31,9 +29,6 @@ export default async function CompanyDashboardPage({
     if (!effectiveUser || !hasPermission(effectiveUser, "financialReports")) {
         return <div className="p-8 text-red-500">Access Denied.</div>;
     }
-    const role = effectiveUser.role;
-    const isAdmin = role === "ADMIN";
-    const canEdit = role === "ADMIN" || role === "MANAGER";
 
     // Month navigation is URL-driven (?month=YYYY-MM) so every navigation is a
     // server re-fetch; anything unparseable falls back to the current month.
@@ -43,26 +38,6 @@ export default async function CompanyDashboardPage({
     const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
     const month = /^\d{4}-(0[1-9]|1[0-2])$/.test(rawMonth) ? rawMonth : currentMonth;
 
-    // Fetch the whole 42-day grid (not just the month) so adjacent-month
-    // spillover cells are populated. getStartCalendar's `to` is exclusive,
-    // so pass the day after the grid's last date.
-    const grid = getMonthGrid(parseUTCDate(`${month}-01`));
-    const from = grid[0];
-    const to = new Date(grid[grid.length - 1].getTime() + 86_400_000);
-
-    const [pipeline, calendar, cashflow] = await Promise.all([
-        getCompanyPipeline(),
-        getStartCalendar(from, to, { includeFinancials: isAdmin }),
-        isAdmin ? getCashflowOutlook() : Promise.resolve(null),
-    ]);
-
-    return (
-        <CompanyDashboardClient
-            pipeline={pipeline}
-            calendar={calendar}
-            cashflow={cashflow}
-            month={month}
-            canEdit={canEdit}
-        />
-    );
+    const data = await getCompanyDashboardData(effectiveUser, month);
+    return <CompanyDashboardClient data={data} />;
 }

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -17,7 +17,7 @@ import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { enqueueMilestonePaid, drainPaymentNotifications } from "./payment-outbox";
 import { deleteChangeOrderCore, updateChangeOrderCore } from "./change-order-core";
 import { approveChangeOrderWithSignature } from "./change-order-approval";
-import { setProjectStartDate, parseStartDateInput } from "./schedule-core";
+import { setProjectStartDate, parseStartDateInput, generateScheduleFromEstimate, setProjectCrew, CONTRACT_ESTIMATE_STATUSES } from "./schedule-core";
 import type { ChangeOrderUpdateInput } from "./change-order-core";
 import { emptyDoc } from "@/lib/studio/doc";
 import type { RoomType } from "@/lib/studio/templates";
@@ -6614,78 +6614,18 @@ export async function unlinkTasks(predecessorId: string, dependentId: string) {
 
 export async function importEstimateToSchedule(projectId: string, estimateId: string) {
     await assertEstimatePermission();
-    const estimate = await prisma.estimate.findUnique({
-        where: { id: estimateId },
-        include: {
-            items: {
-                where: { parentId: null },
-                orderBy: { order: "asc" },
-                include: {
-                    subItems: { orderBy: { order: "asc" } },
-                },
-            },
-        },
+    // Rewired through the schedule-core generator (PB-pipeline-002): one
+    // shared precondition/idempotency path for estimate — schedule.
+    // Merge mode skips already task-linked items. Response shape preserved
+    // for existing callers: the created task rows.
+    const result = await generateScheduleFromEstimate({
+        estimateId,
+        mode: "merge",
+        actor: { type: "TEAM", name: "Team" },
     });
-    if (!estimate || estimate.items.length === 0) return [];
-
-    const maxOrder = await prisma.scheduleTask.aggregate({
-        where: { projectId },
-        _max: { order: true },
-    });
-    let order = (maxOrder._max.order ?? -1) + 1;
-
-    const TYPE_COLORS: Record<string, string> = {
-        Material: "#3b82f6",
-        Labor: "#f59e0b",
-        Subcontractor: "#8b5cf6",
-    };
-
-    const today = new Date();
-    const created = [];
-    let dayOffset = 0;
-
-    for (const item of estimate.items) {
-        // Calculate estimated hours from labor items
-        let estimatedHours: number | null = null;
-        if (item.type === "Labor") {
-            // Top-level is labor — use its quantity as hours
-            estimatedHours = item.quantity || null;
-        } else if (item.subItems && item.subItems.length > 0) {
-            // Parent group — sum labor sub-item quantities as hours
-            const laborHours = item.subItems
-                .filter((si: any) => si.type === "Labor")
-                .reduce((sum: number, si: any) => sum + (si.quantity || 0), 0);
-            if (laborHours > 0) estimatedHours = laborHours;
-        }
-
-        const duration = item.type === "Labor" ? 7 : item.type === "Subcontractor" ? 10 : 5;
-        const startDate = new Date(today.getTime() + dayOffset * 86400000);
-        const endDate = new Date(today.getTime() + (dayOffset + duration) * 86400000);
-        dayOffset += Math.ceil(duration * 0.7);
-
-        const alreadyLinked = await prisma.scheduleTask.findFirst({
-            where: { estimateItemId: item.id }, select: { id: true },
-        });
-        const task = await prisma.scheduleTask.create({
-            data: {
-                projectId,
-                name: item.name,
-                startDate,
-                endDate,
-                color: getDefaultColorForTaskName(item.name) || TYPE_COLORS[item.type] || "#4c9a2a",
-                order: order++,
-                status: "Not Started",
-                estimatedHours,
-                estimateItemId: alreadyLinked ? null : item.id,
-            },
-        });
-        created.push(task);
-    }
-
     revalidatePath(`/projects/${projectId}/schedule`);
-    return created;
+    return result.created;
 }
-
 
 // ========== TASK COMMENTS ==========
 
@@ -7155,6 +7095,49 @@ export async function updateProjectStartDateAction(projectId: string, startDateI
     });
     revalidatePath("/company-dashboard");
     revalidatePath("/projects");
+    return result;
+}
+
+// Generate a project's schedule from its most recent qualifying estimate
+// (the same deterministic selection contractValue uses). ADMIN/MANAGER only.
+export async function generateProjectScheduleAction(projectId: string) {
+    const session = await getServerSession(authOptions);
+    const caller = session?.user?.email
+        ? await prisma.user.findUnique({ where: { email: session.user.email }, select: { role: true, name: true, email: true } })
+        : null;
+    if (!caller || !["ADMIN", "MANAGER"].includes(caller.role)) throw new Error("Forbidden");
+
+    const estimate = await prisma.estimate.findFirst({
+        where: { projectId, status: { in: CONTRACT_ESTIMATE_STATUSES } },
+        orderBy: { createdAt: "desc" },
+        select: { id: true },
+    });
+    if (!estimate) throw new Error("No Approved, Invoiced, Partially Paid, or Paid estimate on this project yet — approve an estimate first.");
+
+    const result = await generateScheduleFromEstimate({
+        estimateId: estimate.id,
+        mode: "merge",
+        actor: { type: "TEAM", name: caller.name || caller.email },
+    });
+    revalidatePath("/company-dashboard");
+    revalidatePath(`/projects/${projectId}/schedule`);
+    return result;
+}
+
+// Replace a project's crew from the dashboard picker. ADMIN/MANAGER only;
+// the core validates every id is an ACTIVATED user.
+export async function updateProjectCrewAction(projectId: string, userIds: string[]) {
+    const session = await getServerSession(authOptions);
+    const caller = session?.user?.email
+        ? await prisma.user.findUnique({ where: { email: session.user.email }, select: { role: true, name: true, email: true } })
+        : null;
+    if (!caller || !["ADMIN", "MANAGER"].includes(caller.role)) throw new Error("Forbidden");
+    const result = await setProjectCrew({
+        projectId,
+        userIds,
+        actor: { type: "TEAM", name: caller.name || caller.email },
+    });
+    revalidatePath("/company-dashboard");
     return result;
 }
 

--- a/src/lib/schedule-core.ts
+++ b/src/lib/schedule-core.ts
@@ -3,7 +3,7 @@ import { Prisma } from "@prisma/client";
 import { withTxRetry } from "./tx-retry";
 import { OPEN_PROJECT_STATUSES } from "./project-status";
 import { CLOSED_PROJECT_STATUSES, CLOSED_LEAD_STAGES } from "./gpt-estimate";
-import { formatDate, parseUTCDate } from "@/app/projects/[id]/schedule/schedule-utils";
+import { formatDate, parseUTCDate, addDays, getMonthGrid, getDefaultColorForTaskName } from "@/app/projects/[id]/schedule/schedule-utils";
 
 // Session-free core of the company pipeline dashboard + start-calendar flows
 // (.specs/PB-pipeline-001-company-dashboard.md), shared by the permission-gated
@@ -18,8 +18,9 @@ import { formatDate, parseUTCDate } from "@/app/projects/[id]/schedule/schedule-
 // partial shift of a QB-pushed mirror group.
 
 // Estimate statuses that count as the project's contract value (plan R1 fix 10,
-// R2 fix 4): the job is sold and the number is real.
-const CONTRACT_ESTIMATE_STATUSES = ["Approved", "Invoiced", "Partially Paid", "Paid"];
+// R2 fix 4): the job is sold and the number is real. Also the qualifying set
+// for schedule generation (same selection rule, PB-pipeline-002 R1 fix 6).
+export const CONTRACT_ESTIMATE_STATUSES = ["Approved", "Invoiced", "Partially Paid", "Paid"];
 
 export type ScheduleActor = { type: "TEAM" | "SYSTEM"; name: string };
 
@@ -40,6 +41,14 @@ export function parseStartDateInput(raw: string): Date {
     return parsed;
 }
 
+export interface PipelineCrewMember {
+    id: string;
+    name: string;
+    // User status (PENDING/ACTIVATED/DISABLED) — the dashboard picker renders
+    // assigned non-ACTIVATED members as removable "(inactive)" entries.
+    status: string;
+}
+
 export interface PipelineProject {
     id: string;
     name: string;
@@ -49,6 +58,8 @@ export interface PipelineProject {
     // totalAmount of the project's most recent Approved/Invoiced/Partially
     // Paid/Paid estimate; null when none exists.
     contractValue: number | null;
+    // Project.crew (the same relation the dashboard picker writes).
+    crew: PipelineCrewMember[];
 }
 
 export interface PipelineLead {
@@ -96,6 +107,7 @@ export async function getCompanyPipeline(): Promise<CompanyPipeline> {
             select: {
                 id: true, name: true, status: true, startDate: true,
                 client: { select: { name: true } },
+                crew: { select: { id: true, name: true, email: true, status: true } },
                 estimates: {
                     where: { status: { in: CONTRACT_ESTIMATE_STATUSES } },
                     orderBy: { createdAt: "desc" },
@@ -113,6 +125,7 @@ export async function getCompanyPipeline(): Promise<CompanyPipeline> {
         status: p.status,
         startDate: p.startDate ? p.startDate.toISOString() : null,
         contractValue: p.estimates[0] ? Number(p.estimates[0].totalAmount) : null,
+        crew: p.crew.map(u => ({ id: u.id, name: u.name || u.email, status: u.status })),
     });
 
     const waitingToStart: PipelineProject[] = [];
@@ -593,4 +606,1036 @@ export async function getCashflowOutlook(): Promise<CashflowOutlook> {
     out.days31to60.total = round2(out.days31to60.total);
     out.days61to90.total = round2(out.days61to90.total);
     return out;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Workstream A — Estimate → schedule generation (PB-pipeline-002)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function utcDay(d: Date): Date {
+    return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+// Labor classification (R1 fix 5 — EstimateItem has NO `unit` field): a line
+// counts as Labor when costType?.name ?? type equals "Labor", case-insensitive.
+function isLaborLine(line: { type: string; costTypeName: string | null }): boolean {
+    return (line.costTypeName ?? line.type ?? "").toLowerCase() === "labor";
+}
+
+const HOUR_LIKE_BUDGET_UNITS = new Set(["hr", "hrs", "hour", "hours"]);
+function isHourLikeBudgetUnit(budgetUnit: string | null): boolean {
+    return !!budgetUnit && HOUR_LIKE_BUDGET_UNITS.has(budgetUnit.toLowerCase());
+}
+
+interface EstimateLine {
+    id: string;
+    name: string;
+    type: string;
+    quantity: number;
+    budgetUnit: string | null;
+    total: number;
+    parentId: string | null;
+    costTypeName: string | null;
+}
+
+export interface GeneratedTaskRow {
+    id: string;
+    name: string;
+    startDate: string;
+    endDate: string;
+    type: string;
+    color: string;
+    order: number;
+    status: string;
+    progress: number;
+    estimatedHours: number | null;
+    estimateItemId: string | null;
+    parentId: string | null;
+}
+
+export interface GenerateScheduleResult {
+    estimateCode: string;
+    created: GeneratedTaskRow[];
+    skipped: number;
+    milestonesLinked: number;
+    notes: string[];
+}
+
+/**
+ * Generate a project's schedule from its completed estimate: phase parent
+ * tasks with children, flat tasks for phase-less estimates, and milestone
+ * tasks for the payment schedule — then link the milestone mirrors and
+ * initialize null dueDates. EVERYTHING runs in ONE transaction (withTxRetry;
+ * Project row FOR UPDATE first, same lock family as P1).
+ *
+ * Phase windows: window = startDate → endDate if set, else startDate + 42d,
+ * extended to phaseCount days when phases exceed it. Reserve 1 day per phase,
+ * then distribute the remainder proportionally by labor-dollar share
+ * (Hamilton/largest-remainder: floor each ideal share, leftover days to the
+ * largest fractional remainders, ties by estimate order) — slices sum exactly
+ * to the window. Bounds [start, end) end-exclusive as in P1.
+ *
+ * Milestones — ONE canonical date rule: EPS rows ordered by (order, id),
+ * percentages accumulated → the cumulative-percentage point of the window
+ * (fixed-amount/unordered rows at window end); the milestone task date =
+ * EPS.dueDate if set, else that derived point. dueDate is initialized from
+ * that date ONLY on rows that are Pending AND null-dated AND not QB-pushed;
+ * linking (scheduleTaskId on the EPS row AND every unpaid clone) happens
+ * regardless of qbInvoiceId — linking is not a QBO mutation.
+ *
+ * mode "merge" (default) skips items already task-linked. mode "regenerate"
+ * deletes generated tasks first, where deletable means the FULL eligibility
+ * predicate (provenance + progress 0 + Not Started + no timeEntries/comments/
+ * punchItems/assignments/subAssignments/dependency rows), evaluated per phase
+ * SUBTREE — a protected descendant keeps the whole subtree (never a cascade
+ * through protected work).
+ */
+export async function generateScheduleFromEstimate(input: {
+    estimateId: string;
+    mode?: "merge" | "regenerate";
+    actor: ScheduleActor;
+}): Promise<GenerateScheduleResult> {
+    const mode = input.mode ?? "merge";
+    if (mode !== "merge" && mode !== "regenerate") throw new Error(`Unknown generation mode "${mode}"`);
+
+    return withTxRetry(() => prisma.$transaction(async (tx) => {
+        // Lock-then-read, mirroring setProjectStartDate exactly: resolve the
+        // project id with a minimal read, take the Project row lock, and ONLY
+        // THEN re-read the full estimate (items, paymentSchedules — clones are
+        // read under their own FOR UPDATE below) — so a concurrent start-date
+        // move can't shift dueDates between the read and the lock.
+        const estimateRef = await tx.estimate.findUnique({
+            where: { id: input.estimateId },
+            select: { id: true, code: true, status: true, projectId: true },
+        });
+        if (!estimateRef) throw new Error("Estimate not found");
+        if (!CONTRACT_ESTIMATE_STATUSES.includes(estimateRef.status)) {
+            throw new Error(`Estimate ${estimateRef.code} is "${estimateRef.status}" — only Approved, Invoiced, Partially Paid, or Paid estimates can generate a schedule.`);
+        }
+        if (!estimateRef.projectId) {
+            throw new Error(`Estimate ${estimateRef.code} is attached to a lead, not a project — convert the lead to a project first.`);
+        }
+        const projectId = estimateRef.projectId;
+
+        // Same lock family as P1 start-date moves and invoice cloning:
+        // serialize generation against both on this project.
+        await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${projectId} FOR UPDATE`;
+        const project = await tx.project.findUnique({
+            where: { id: projectId },
+            select: { id: true, name: true, startDate: true, endDate: true },
+        });
+        if (!project) throw new Error("Project not found");
+        if (!project.startDate) {
+            throw new Error(`Project "${project.name}" has no start date yet — set one on the company dashboard before generating its schedule.`);
+        }
+
+        // Full estimate read INSIDE the lock.
+        const estimate = await tx.estimate.findUniqueOrThrow({
+            where: { id: input.estimateId },
+            include: {
+                items: {
+                    orderBy: { order: "asc" },
+                    include: { costType: { select: { name: true } } },
+                },
+                paymentSchedules: {
+                    orderBy: [{ order: "asc" }, { id: "asc" }],
+                    select: { id: true, name: true, percentage: true, dueDate: true, status: true, scheduleTaskId: true, order: true },
+                },
+            },
+        });
+
+        const notes: string[] = [];
+        const start = utcDay(project.startDate);
+        const windowEndBase = project.endDate ? utcDay(project.endDate) : addDays(start, 42);
+
+        // Split top-level lines into phases (have children) and flat lines.
+        const lines: EstimateLine[] = estimate.items.map(i => ({
+            id: i.id,
+            name: i.name,
+            type: i.type,
+            quantity: i.quantity,
+            budgetUnit: i.budgetUnit,
+            total: Number(i.total),
+            parentId: i.parentId,
+            costTypeName: i.costType?.name ?? null,
+        }));
+        const topLevel = lines.filter(l => !l.parentId);
+        const childrenOf = new Map<string, EstimateLine[]>();
+        for (const l of lines) {
+            if (!l.parentId) continue;
+            const arr = childrenOf.get(l.parentId) ?? [];
+            arr.push(l);
+            childrenOf.set(l.parentId, arr);
+        }
+        const hasPhases = topLevel.some(l => (childrenOf.get(l.id) ?? []).length > 0);
+        // Allocation units (estimate order): every top-level line when phases
+        // exist (childless top-levels become single-task phases); the flat
+        // lines otherwise.
+        const units = topLevel;
+        const unitCount = units.length;
+
+        let windowDays = Math.max(1, Math.round((windowEndBase.getTime() - start.getTime()) / 86_400_000));
+        // Phases extend the window to fit; flat placement packs instead.
+        if (hasPhases && unitCount > windowDays) windowDays = unitCount;
+
+        // Reserve 1 day per unit, then distribute the remaining
+        // windowDays − unitCount days by labor-dollar share (floor each ideal;
+        // leftover to largest fractional remainders, ties by estimate order).
+        const laborDollarsOf = (line: EstimateLine): number => {
+            const own = isLaborLine(line) ? line.total : 0;
+            return own + (childrenOf.get(line.id) ?? []).reduce((s, k) => s + (isLaborLine(k) ? k.total : 0), 0);
+        };
+        const allocateWindow = (count: number, laborDollars: number[]): number[] => {
+            const remainder = windowDays - count;
+            if (remainder <= 0) return laborDollars.map(() => 1);
+            const totalLabor = laborDollars.reduce((s, n) => s + n, 0);
+            const ideals = laborDollars.map(d => (totalLabor > 0 ? (remainder * d) / totalLabor : remainder / count));
+            const days = ideals.map(x => 1 + Math.floor(x));
+            let leftover = windowDays - days.reduce((s, n) => s + n, 0);
+            const byFraction = ideals
+                .map((x, i) => ({ i, frac: x - Math.floor(x) }))
+                .sort((a, b) => b.frac - a.frac || a.i - b.i);
+            for (let k = 0; leftover > 0 && byFraction.length > 0; k++) {
+                days[byFraction[k % byFraction.length].i]++;
+                leftover--;
+            }
+            return days;
+        };
+
+        // ── regenerate: delete eligible generated subtrees first ──
+        if (mode === "regenerate") {
+            const allTasks = await tx.scheduleTask.findMany({
+                where: { projectId },
+                select: {
+                    id: true, parentId: true, generatedFromEstimateId: true, progress: true, status: true,
+                    _count: {
+                        select: {
+                            timeEntries: true, comments: true, punchItems: true,
+                            assignments: true, subAssignments: true,
+                            dependencies: true, dependents: true,
+                        },
+                    },
+                },
+            });
+            const byParent = new Map<string | null, typeof allTasks>();
+            for (const t of allTasks) {
+                const arr = byParent.get(t.parentId) ?? [];
+                arr.push(t);
+                byParent.set(t.parentId, arr);
+            }
+            const generatedIds = new Set(allTasks.filter(t => t.generatedFromEstimateId === estimate.id).map(t => t.id));
+            // The FULL eligibility predicate, evaluated at delete time.
+            const isDeletable = (t: (typeof allTasks)[number]) =>
+                t.generatedFromEstimateId === estimate.id &&
+                t.progress === 0 &&
+                t.status === "Not Started" &&
+                t._count.timeEntries === 0 &&
+                t._count.comments === 0 &&
+                t._count.punchItems === 0 &&
+                t._count.assignments === 0 &&
+                t._count.subAssignments === 0 &&
+                t._count.dependencies === 0 &&
+                t._count.dependents === 0;
+            // Subtree roots: generated tasks whose parent is not generated from
+            // this estimate. Delete a subtree only when EVERY descendant is
+            // deletable — the parent delete cascades, so anything less would
+            // cut through protected work.
+            const roots = allTasks.filter(t => generatedIds.has(t.id) && (!t.parentId || !generatedIds.has(t.parentId)));
+            let keptSubtrees = 0;
+            for (const root of roots) {
+                const subtree: typeof allTasks = [];
+                const stack = [root];
+                while (stack.length) {
+                    const cur = stack.pop()!;
+                    subtree.push(cur);
+                    for (const child of byParent.get(cur.id) ?? []) stack.push(child);
+                }
+                if (subtree.every(isDeletable)) {
+                    await tx.scheduleTask.delete({ where: { id: root.id } });
+                } else {
+                    keptSubtrees++;
+                }
+            }
+            if (keptSubtrees > 0) {
+                notes.push(`Kept ${keptSubtrees} generated subtree${keptSubtrees === 1 ? "" : "s"} untouched — work was logged or edits made (progress, status, time, comments, punch items, assignments, or dependencies).`);
+            }
+        }
+
+        const maxOrder = await tx.scheduleTask.aggregate({ where: { projectId }, _max: { order: true } });
+        let nextOrder = (maxOrder._max.order ?? -1) + 1;
+
+        // Link state for merge-skip — read AFTER any regenerate deletion:
+        // deleting a generated task drops its estimateItemId link and SetNulls
+        // the EPS scheduleTaskId, so pre-delete reads would be stale here.
+        const itemIds = lines.map(l => l.id);
+        const existingLinked = itemIds.length
+            ? await tx.scheduleTask.findMany({
+                where: { estimateItemId: { in: itemIds } },
+                select: { id: true, estimateItemId: true },
+            })
+            : [];
+        const taskIdByItemId = new Map(existingLinked.map(t => [t.estimateItemId!, t.id]));
+        const freshEpsLinks = await tx.estimatePaymentSchedule.findMany({
+            where: { estimateId: estimate.id },
+            select: { id: true, scheduleTaskId: true },
+        });
+        const freshTaskIdByEps = new Map(freshEpsLinks.map(e => [e.id, e.scheduleTaskId]));
+
+        const createdRows: GeneratedTaskRow[] = [];
+        let skipped = 0;
+
+        const TYPE_COLORS: Record<string, string> = { Material: "#3b82f6", Labor: "#f59e0b", Subcontractor: "#8b5cf6" };
+        const colorFor = (line: EstimateLine) =>
+            getDefaultColorForTaskName(line.name) || TYPE_COLORS[line.costTypeName ?? line.type] || "#4c9a2a";
+
+        const createTask = async (data: {
+            name: string; startDate: Date; endDate: Date; color: string; order: number;
+            type: string; estimatedHours: number | null; estimateItemId: string | null; parentId: string | null;
+        }) => {
+            const row = await tx.scheduleTask.create({
+                data: {
+                    projectId,
+                    status: "Not Started",
+                    progress: 0,
+                    generatedFromEstimateId: estimate.id,
+                    ...data,
+                },
+            });
+            createdRows.push({
+                id: row.id,
+                name: row.name,
+                startDate: row.startDate.toISOString(),
+                endDate: row.endDate.toISOString(),
+                type: row.type,
+                color: row.color,
+                order: row.order,
+                status: row.status,
+                progress: row.progress,
+                estimatedHours: row.estimatedHours,
+                estimateItemId: row.estimateItemId,
+                parentId: row.parentId,
+            });
+            return row;
+        };
+
+        // Flat/leaf placement: sequential in estimate order, each task's
+        // [start, end) computed from proportional boundaries —
+        // start_i = windowStart + floor(i × windowDays / n),
+        // end_i   = windowStart + floor((i+1) × windowDays / n) —
+        // so the slices cover the window EXACTLY (no flooring shortfall) and
+        // the last task ends at the window end. When taskCount > windowDays
+        // the proportional endpoints can coincide, so the end becomes
+        // start + 1 day instead — the spec's one-day minimum always holds
+        // (multiple tasks share a start day, order preserved via `order`).
+        const placeLeaves = async (leafLines: EstimateLine[], winStart: Date, winDays: number, parentTaskId: string | null) => {
+            const pending = leafLines.filter(l => !taskIdByItemId.has(l.id));
+            skipped += leafLines.length - pending.length;
+            const n = pending.length;
+            if (n === 0) return;
+            const days = Math.max(1, winDays);
+            const packed = n > days;
+            for (let k = 0; k < n; k++) {
+                const line = pending[k];
+                const tStart = addDays(winStart, Math.floor((k * days) / n));
+                const tEnd = packed
+                    ? addDays(tStart, 1)
+                    : addDays(winStart, Math.floor(((k + 1) * days) / n));
+                await createTask({
+                    name: line.name,
+                    startDate: tStart,
+                    endDate: tEnd,
+                    color: colorFor(line),
+                    order: nextOrder++,
+                    type: "task",
+                    estimatedHours: isHourLikeBudgetUnit(line.budgetUnit) ? line.quantity : null,
+                    estimateItemId: line.id,
+                    parentId: parentTaskId,
+                });
+            }
+        };
+
+        if (hasPhases) {
+            const sliceDays = allocateWindow(unitCount, units.map(laborDollarsOf));
+            let cursor = start;
+            for (let u = 0; u < unitCount; u++) {
+                const unit = units[u];
+                const sliceStart = cursor;
+                const sliceEnd = addDays(sliceStart, sliceDays[u]);
+                cursor = sliceEnd;
+                const kids = childrenOf.get(unit.id) ?? [];
+                if (kids.length === 0) {
+                    // Childless top-level inside a phased estimate: single-task slice.
+                    await placeLeaves([unit], sliceStart, sliceDays[u], null);
+                    continue;
+                }
+                let parentTaskId = taskIdByItemId.get(unit.id) ?? null;
+                if (parentTaskId) {
+                    skipped++;
+                } else {
+                    const parent = await createTask({
+                        name: unit.name,
+                        startDate: sliceStart,
+                        endDate: sliceEnd,
+                        color: colorFor(unit),
+                        order: nextOrder++,
+                        type: "task",
+                        estimatedHours: null,
+                        estimateItemId: unit.id,
+                        parentId: null,
+                    });
+                    parentTaskId = parent.id;
+                }
+                // Children split the phase window by the flat-placement rule.
+                await placeLeaves(kids, sliceStart, sliceDays[u], parentTaskId);
+            }
+        } else {
+            await placeLeaves(units, start, windowDays, null);
+        }
+
+        // ── Milestones — ONE canonical date rule ──
+        const epsRows = estimate.paymentSchedules; // already ordered by (order, id)
+        const canonicalByEps = new Map<string, Date>();
+        const milestoneTaskIdByEps = new Map<string, string>();
+        let cumPct = 0;
+        for (const eps of epsRows) {
+            const pct = eps.percentage != null ? Number(eps.percentage) : null;
+            if (pct != null) cumPct += pct;
+            const derived = pct != null
+                ? addDays(start, Math.round((Math.min(cumPct, 100) / 100) * windowDays))
+                : addDays(start, windowDays); // fixed-amount/unordered → window end
+            const canonical = eps.dueDate ? utcDay(eps.dueDate) : derived;
+            canonicalByEps.set(eps.id, canonical);
+
+            const existingTaskId = freshTaskIdByEps.get(eps.id);
+            if (existingTaskId) {
+                // Already task-linked (kept subtree / prior run): merge-skip,
+                // but remember the link so later-created clones still attach.
+                milestoneTaskIdByEps.set(eps.id, existingTaskId);
+                skipped++;
+                continue;
+            }
+            const mTask = await createTask({
+                name: eps.name,
+                startDate: canonical,
+                endDate: addDays(canonical, 1),
+                color: "#f59e0b",
+                order: nextOrder++,
+                type: "milestone",
+                estimatedHours: null,
+                estimateItemId: null,
+                parentId: null,
+            });
+            milestoneTaskIdByEps.set(eps.id, mTask.id);
+        }
+
+        // Link EPS rows AND every unpaid clone in their sourceScheduleId groups
+        // — regardless of qbInvoiceId (linking is not a QBO mutation; the QB
+        // whole-group skip applies ONLY to due-date WRITES, per P1). dueDate is
+        // initialized from the canonical date ONLY on rows that are Pending AND
+        // null-dated AND not QB-pushed — paid/settled rows are never rewritten,
+        // QB-pushed clones keep their QB-visible date and are noted. All under
+        // FOR UPDATE row locks on the decision set (P1 family).
+        let milestonesLinked = 0;
+        const epsIds = epsRows.map(e => e.id);
+        if (epsIds.length > 0) {
+            const lockedEps = await tx.$queryRaw<{ id: string; status: string; dueDate: Date | null }[]>`
+                SELECT e."id", e."status", e."dueDate"
+                FROM "EstimatePaymentSchedule" e
+                WHERE e."id" IN (${Prisma.join(epsIds)})
+                FOR UPDATE
+            `;
+            const lockedClones = await tx.$queryRaw<{ id: string; name: string; status: string; dueDate: Date | null; qbInvoiceId: string | null; sourceScheduleId: string | null }[]>`
+                SELECT p."id", p."name", p."status", p."dueDate", p."qbInvoiceId", p."sourceScheduleId"
+                FROM "PaymentSchedule" p
+                WHERE p."sourceScheduleId" IN (${Prisma.join(epsIds)})
+                FOR UPDATE
+            `;
+            const clonesByEps = new Map<string, typeof lockedClones>();
+            for (const c of lockedClones) {
+                if (!c.sourceScheduleId) continue;
+                const arr = clonesByEps.get(c.sourceScheduleId) ?? [];
+                arr.push(c);
+                clonesByEps.set(c.sourceScheduleId, arr);
+            }
+
+            for (const eps of lockedEps) {
+                const taskId = milestoneTaskIdByEps.get(eps.id);
+                const canonical = canonicalByEps.get(eps.id);
+                if (!taskId || !canonical) continue;
+
+                // Upsert-style link (skip where already set).
+                milestonesLinked += await tx.$executeRaw`
+                    UPDATE "EstimatePaymentSchedule"
+                    SET "scheduleTaskId" = ${taskId}
+                    WHERE "id" = ${eps.id} AND "scheduleTaskId" IS NULL
+                `;
+                // Initialize the dueDate ONLY on Pending null-dated rows.
+                if (eps.status === "Pending" && !eps.dueDate) {
+                    await tx.$executeRaw`
+                        UPDATE "EstimatePaymentSchedule"
+                        SET "dueDate" = ${canonical}
+                        WHERE "id" = ${eps.id} AND "status" = 'Pending' AND "dueDate" IS NULL
+                    `;
+                }
+
+                // Every unpaid clone in the group — link regardless of QB state.
+                milestonesLinked += await tx.$executeRaw`
+                    UPDATE "PaymentSchedule"
+                    SET "scheduleTaskId" = ${taskId}
+                    WHERE "sourceScheduleId" = ${eps.id} AND "scheduleTaskId" IS NULL AND "status" <> 'Paid'
+                `;
+                // Pending null-dated non-QB clones get the canonical date.
+                await tx.$executeRaw`
+                    UPDATE "PaymentSchedule"
+                    SET "dueDate" = ${canonical}
+                    WHERE "sourceScheduleId" = ${eps.id} AND "status" = 'Pending' AND "dueDate" IS NULL AND "qbInvoiceId" IS NULL
+                `;
+                // QB-pushed null-date clones keep their QB-visible date (empty);
+                // the income overlay projects them on their linked task date.
+                for (const c of clonesByEps.get(eps.id) ?? []) {
+                    if (c.qbInvoiceId && c.status === "Pending" && !c.dueDate) {
+                        notes.push(`Milestone "${c.name}" is already pushed to QuickBooks — its due date was left unset locally; it appears as projected income on its linked task date.`);
+                    }
+                }
+            }
+        }
+
+        await tx.activityLog.create({
+            data: {
+                projectId,
+                actorType: input.actor.type,
+                actorName: input.actor.name,
+                action: "generated_schedule",
+                entityType: "project",
+                entityId: projectId,
+                entityName: project.name,
+                metadata: JSON.stringify({
+                    estimateId: estimate.id,
+                    estimateCode: estimate.code,
+                    mode,
+                    created: createdRows.length,
+                    skipped,
+                    milestonesLinked,
+                }),
+            },
+        });
+
+        return { estimateCode: estimate.code, created: createdRows, skipped, milestonesLinked, notes };
+    }));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Workstream B — Crew on the company calendar (PB-pipeline-002)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ProjectCrewMember {
+    id: string;
+    name: string;
+}
+
+/**
+ * Replace a project's crew (Project.crew — the same relation the dashboard
+ * picker writes and getCrewConflicts reads) via a connect/disconnect diff.
+ * Every id must be an ACTIVATED user. Idempotent; writes a "set_project_crew"
+ * ActivityLog row.
+ */
+export async function setProjectCrew(input: {
+    projectId: string;
+    userIds: string[];
+    actor: ScheduleActor;
+}): Promise<{ projectId: string; crew: ProjectCrewMember[] }> {
+    return withTxRetry(() => prisma.$transaction(async (tx) => {
+        await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${input.projectId} FOR UPDATE`;
+        const project = await tx.project.findUnique({
+            where: { id: input.projectId },
+            select: { id: true, name: true, crew: { select: { id: true, name: true, email: true } } },
+        });
+        if (!project) throw new Error("Project not found");
+
+        const wanted = [...new Set(input.userIds)];
+        const users = wanted.length
+            ? await tx.user.findMany({
+                where: { id: { in: wanted } },
+                select: { id: true, name: true, email: true, status: true },
+            })
+            : [];
+        const byId = new Map(users.map(u => [u.id, u]));
+        const missing = wanted.filter(id => !byId.has(id));
+        if (missing.length > 0) throw new Error(`Unknown user id(s): ${missing.join(", ")}`);
+        const notActivated = users.filter(u => u.status !== "ACTIVATED");
+        if (notActivated.length > 0) {
+            throw new Error(`Crew members must be ACTIVATED users: ${notActivated.map(u => u.name || u.email).join(", ")}`);
+        }
+
+        const current = project.crew.map(u => u.id);
+        const toConnect = wanted.filter(id => !current.includes(id));
+        const toDisconnect = current.filter(id => !wanted.includes(id));
+        await tx.project.update({
+            where: { id: input.projectId },
+            data: {
+                crew: {
+                    connect: toConnect.map(id => ({ id })),
+                    disconnect: toDisconnect.map(id => ({ id })),
+                },
+            },
+        });
+
+        await tx.activityLog.create({
+            data: {
+                projectId: input.projectId,
+                actorType: input.actor.type,
+                actorName: input.actor.name,
+                action: "set_project_crew",
+                entityType: "project",
+                entityId: input.projectId,
+                entityName: project.name,
+                metadata: JSON.stringify({ added: toConnect, removed: toDisconnect, crewIds: wanted }),
+            },
+        });
+
+        return {
+            projectId: input.projectId,
+            crew: wanted.map(id => ({ id, name: byId.get(id)!.name || byId.get(id)!.email })),
+        };
+    }));
+}
+
+export interface CrewConflictPair {
+    projectA: { id: string; name: string };
+    projectB: { id: string; name: string };
+    overlapStart: string;
+    overlapEnd: string;
+}
+
+export interface CrewConflict {
+    userId: string;
+    name: string;
+    pairs: CrewConflictPair[];
+}
+
+/**
+ * Crew double-bookings within [from, to): a conflict = one user in the crew of
+ * two different projects whose windows overlap within the range. Window =
+ * startDate → (endDate ?? latest task endDate ?? startDate + 1 day) — the
+ * 1-day fallback means two crews booked on the same day DO conflict; overlaps
+ * use half-open [start, end) bounds. Bounded queries; overlap computed in
+ * memory. (TaskAssignment-level precision is Phase 3.)
+ */
+export async function getCrewConflicts(from: Date, to: Date): Promise<CrewConflict[]> {
+    const projects = await prisma.project.findMany({
+        where: { startDate: { not: null }, crew: { some: {} } },
+        select: {
+            id: true, name: true, startDate: true, endDate: true,
+            crew: { select: { id: true, name: true, email: true } },
+            scheduleTasks: { orderBy: { endDate: "desc" }, take: 1, select: { endDate: true } },
+        },
+    });
+
+    const windows = projects.map(p => {
+        const start = utcDay(p.startDate!);
+        const rawEnd = p.endDate
+            ? utcDay(p.endDate)
+            : p.scheduleTasks[0]
+                ? utcDay(p.scheduleTasks[0].endDate)
+                : addDays(start, 1);
+        return {
+            id: p.id,
+            name: p.name,
+            start,
+            end: rawEnd > start ? rawEnd : addDays(start, 1),
+            crew: p.crew,
+        };
+    });
+
+    // Group windows by crew user, then check each pair of that user's projects.
+    const byUser = new Map<string, { name: string; windows: typeof windows }>();
+    for (const w of windows) {
+        for (const u of w.crew) {
+            const entry = byUser.get(u.id) ?? { name: u.name || u.email, windows: [] };
+            entry.windows.push(w);
+            byUser.set(u.id, entry);
+        }
+    }
+
+    const conflicts: CrewConflict[] = [];
+    for (const [userId, { name, windows: userWindows }] of byUser) {
+        if (userWindows.length < 2) continue;
+        const pairs: CrewConflictPair[] = [];
+        for (let i = 0; i < userWindows.length; i++) {
+            for (let j = i + 1; j < userWindows.length; j++) {
+                const a = userWindows[i];
+                const b = userWindows[j];
+                const oStart = a.start > b.start ? a.start : b.start;
+                const oEnd = a.end < b.end ? a.end : b.end;
+                if (oStart >= oEnd) continue; // half-open: no overlap
+                // The overlap must intersect the visible range.
+                if (oEnd <= from || oStart >= to) continue;
+                pairs.push({
+                    projectA: { id: a.id, name: a.name },
+                    projectB: { id: b.id, name: b.name },
+                    overlapStart: oStart.toISOString(),
+                    overlapEnd: oEnd.toISOString(),
+                });
+            }
+        }
+        if (pairs.length > 0) conflicts.push({ userId, name, pairs });
+    }
+    return conflicts;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Workstream C — Money/hours overlays (ADMIN-only, data-layer enforced as P1)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface OverlayIncomeItem {
+    id: string;
+    name: string;
+    amount: number;
+    dueDate: string | null;
+    // Shared rule: dueDate ?? linked milestone task's startDate. Used by BOTH
+    // the calendar income layer and the project strip's "Income due", so
+    // overlays and tasks agree by construction.
+    effectiveDueDate: string;
+    invoiceId: string;
+    invoiceCode: string;
+    projectId: string | null;
+    projectName: string | null;
+    anchoredToTask: boolean;
+    inQuickBooks: boolean;
+}
+
+export interface OverlayExpenseItem {
+    id: string;
+    amount: number;
+    vendor: string | null;
+    date: string;
+    projectId: string | null;
+    projectName: string | null;
+}
+
+export interface OverlayHoursItem {
+    id: string;
+    userId: string;
+    userName: string;
+    projectId: string;
+    projectName: string | null;
+    startTime: string;
+    durationHours: number;
+}
+
+export interface CalendarOverlays {
+    income: OverlayIncomeItem[];
+    expenses: OverlayExpenseItem[];
+    hours: OverlayHoursItem[];
+}
+
+/**
+ * ADMIN-path calendar overlays: income (Pending milestones by the shared
+ * effectiveDueDate rule), expenses (Expense.date in range, project via
+ * estimate), hours (TimeEntry.startTime date in range). Read-only.
+ */
+export async function getCalendarOverlays(from: Date, to: Date): Promise<CalendarOverlays> {
+    const [milestones, expenses, hours] = await Promise.all([
+        prisma.paymentSchedule.findMany({
+            where: {
+                status: "Pending",
+                OR: [
+                    { dueDate: { gte: from, lt: to } },
+                    { dueDate: null, scheduleTask: { startDate: { gte: from, lt: to } } },
+                ],
+            },
+            orderBy: { createdAt: "asc" },
+            select: {
+                id: true, name: true, amount: true, dueDate: true, scheduleTaskId: true, qbInvoiceId: true,
+                scheduleTask: { select: { startDate: true } },
+                invoice: { select: { id: true, code: true, project: { select: { id: true, name: true } } } },
+            },
+        }),
+        prisma.expense.findMany({
+            where: { date: { gte: from, lt: to } },
+            orderBy: { date: "asc" },
+            select: {
+                id: true, amount: true, vendor: true, date: true,
+                estimate: { select: { projectId: true, project: { select: { id: true, name: true } } } },
+            },
+        }),
+        prisma.timeEntry.findMany({
+            where: { startTime: { gte: from, lt: to } },
+            orderBy: { startTime: "asc" },
+            select: {
+                id: true, userId: true, startTime: true, durationHours: true,
+                user: { select: { name: true, email: true } },
+                project: { select: { id: true, name: true } },
+            },
+        }),
+    ]);
+
+    return {
+        income: milestones.map(m => {
+            const effective = m.dueDate ?? m.scheduleTask?.startDate ?? null;
+            return {
+                id: m.id,
+                name: m.name,
+                amount: Number(m.amount),
+                dueDate: m.dueDate ? m.dueDate.toISOString() : null,
+                effectiveDueDate: effective!.toISOString(),
+                invoiceId: m.invoice.id,
+                invoiceCode: m.invoice.code,
+                projectId: m.invoice.project?.id ?? null,
+                projectName: m.invoice.project?.name ?? null,
+                anchoredToTask: !!m.scheduleTaskId,
+                inQuickBooks: !!m.qbInvoiceId,
+            };
+        }),
+        expenses: expenses.map(e => ({
+            id: e.id,
+            amount: Number(e.amount),
+            vendor: e.vendor,
+            date: e.date!.toISOString(),
+            projectId: e.estimate?.project?.id ?? null,
+            projectName: e.estimate?.project?.name ?? null,
+        })),
+        hours: hours.map(h => ({
+            id: h.id,
+            userId: h.userId,
+            userName: h.user.name || h.user.email,
+            projectId: h.project.id,
+            projectName: h.project.name ?? null,
+            startTime: h.startTime.toISOString(),
+            durationHours: h.durationHours ?? 0,
+        })),
+    };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dashboard page assembly (PB-pipeline-002, R1 fix 10 — directly testable)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface DashboardProjectRow extends PipelineProject {
+    taskCount: number;
+    hasQualifyingEstimate: boolean;
+}
+
+export interface ProjectMonthStripRow {
+    projectId: string;
+    projectName: string;
+    incomeDue: number;
+    received: number;
+    expenses: number;
+    laborBurdened: number;
+    hoursActual: number;
+    hoursEstimated: number;
+    net: number;
+}
+
+export interface CompanyDashboardData {
+    month: string;
+    role: string;
+    canEdit: boolean;
+    isAdmin: boolean;
+    pipeline: {
+        estimating: CompanyPipeline["estimating"];
+        waitingToStart: DashboardProjectRow[];
+        scheduled: DashboardProjectRow[];
+        inProgress: DashboardProjectRow[];
+        substantialCompletion: CompanyPipeline["substantialCompletion"];
+    };
+    calendar: StartCalendar;
+    cashflow: CashflowOutlook | null;
+    teamMembers: { id: string; name: string; email: string }[] | null;
+    crewConflicts: CrewConflict[] | null;
+    overlays: CalendarOverlays | null;
+    strip: ProjectMonthStripRow[] | null;
+}
+
+/**
+ * Per-project month strip (ADMIN only). Exact semantics:
+ *   Income due = Pending milestone sums by effectiveDueDate
+ *   Received   = Paid milestone sums by COALESCE(paymentDate, paidAt)
+ *   Expenses   = sum by Expense.date
+ *   Labor (actual, burdened) = laborCost + burdenCost sums
+ *   Hours      = actual TimeEntry hours vs estimatedHours of month-overlapping tasks
+ *   Net        = Received − Expenses − burdened Labor (profitability convention)
+ */
+async function getProjectMonthStrip(from: Date, to: Date): Promise<ProjectMonthStripRow[]> {
+    const openProjects = await prisma.project.findMany({
+        where: { status: { in: OPEN_PROJECT_STATUSES } },
+        select: { id: true, name: true },
+    });
+    if (openProjects.length === 0) return [];
+    const nameOf = new Map(openProjects.map(p => [p.id, p.name]));
+
+    const [pendingMilestones, paidMilestones, expenseRows, timeRows, overlappingTasks] = await Promise.all([
+        // Income due: effectiveDueDate = dueDate ?? linkedTask.startDate.
+        prisma.paymentSchedule.findMany({
+            where: { status: "Pending" },
+            select: {
+                amount: true, dueDate: true,
+                scheduleTask: { select: { startDate: true } },
+                invoice: { select: { projectId: true } },
+            },
+        }),
+        // Received: bucketed by COALESCE(paymentDate, paidAt) — never dueDate.
+        prisma.paymentSchedule.findMany({
+            where: {
+                status: "Paid",
+                OR: [
+                    { paymentDate: { gte: from, lt: to } },
+                    { paymentDate: null, paidAt: { gte: from, lt: to } },
+                ],
+            },
+            select: { amount: true, paymentDate: true, paidAt: true, invoice: { select: { projectId: true } } },
+        }),
+        prisma.expense.findMany({
+            where: { date: { gte: from, lt: to } },
+            select: { amount: true, estimate: { select: { projectId: true } } },
+        }),
+        prisma.timeEntry.findMany({
+            where: { startTime: { gte: from, lt: to } },
+            select: { projectId: true, durationHours: true, laborCost: true, burdenCost: true },
+        }),
+        prisma.scheduleTask.findMany({
+            where: { startDate: { lt: to }, endDate: { gt: from }, estimatedHours: { not: null } },
+            select: { projectId: true, estimatedHours: true },
+        }),
+    ]);
+
+    const sums = new Map<string, ProjectMonthStripRow>();
+    const row = (projectId: string): ProjectMonthStripRow => {
+        let r = sums.get(projectId);
+        if (!r) {
+            r = {
+                projectId,
+                projectName: nameOf.get(projectId) ?? "Unknown",
+                incomeDue: 0, received: 0, expenses: 0,
+                laborBurdened: 0, hoursActual: 0, hoursEstimated: 0, net: 0,
+            };
+            sums.set(projectId, r);
+        }
+        return r;
+    };
+
+    for (const m of pendingMilestones) {
+        const pid = m.invoice.projectId;
+        if (!pid || !nameOf.has(pid)) continue;
+        const effective = m.dueDate ?? m.scheduleTask?.startDate ?? null;
+        if (!effective || effective < from || effective >= to) continue;
+        row(pid).incomeDue += Number(m.amount);
+    }
+    for (const m of paidMilestones) {
+        const pid = m.invoice.projectId;
+        if (!pid || !nameOf.has(pid)) continue;
+        row(pid).received += Number(m.amount);
+    }
+    for (const e of expenseRows) {
+        const pid = e.estimate?.projectId;
+        if (!pid || !nameOf.has(pid)) continue;
+        row(pid).expenses += Number(e.amount);
+    }
+    for (const t of timeRows) {
+        if (!nameOf.has(t.projectId)) continue;
+        const r = row(t.projectId);
+        r.hoursActual += t.durationHours ?? 0;
+        r.laborBurdened += Number(t.laborCost ?? 0) + Number(t.burdenCost ?? 0);
+    }
+    for (const t of overlappingTasks) {
+        if (!t.projectId || !nameOf.has(t.projectId)) continue;
+        row(t.projectId).hoursEstimated += t.estimatedHours ?? 0;
+    }
+
+    const round2 = (n: number) => Math.round(n * 100) / 100;
+    return [...sums.values()]
+        .map(r => ({
+            ...r,
+            incomeDue: round2(r.incomeDue),
+            received: round2(r.received),
+            expenses: round2(r.expenses),
+            laborBurdened: round2(r.laborBurdened),
+            hoursActual: round2(r.hoursActual),
+            hoursEstimated: round2(r.hoursEstimated),
+            net: round2(r.received - r.expenses - r.laborBurdened),
+        }))
+        .filter(r => r.incomeDue !== 0 || r.received !== 0 || r.expenses !== 0 || r.laborBurdened !== 0 || r.hoursActual !== 0 || r.hoursEstimated !== 0)
+        .sort((a, b) => a.projectName.localeCompare(b.projectName));
+}
+
+/**
+ * All data the company dashboard page needs, assembled in one place so the
+ * page stays thin and the role matrix is directly testable: overlays + the
+ * per-project strip are ONLY queried and serialized when role === "ADMIN";
+ * crew conflicts and the picker list only for ADMIN/MANAGER (canEdit).
+ * `month` must be a validated "YYYY-MM" string (the page validates).
+ */
+export async function getCompanyDashboardData(
+    userLike: { role: string },
+    month: string,
+): Promise<CompanyDashboardData> {
+    const role = userLike.role;
+    const isAdmin = role === "ADMIN";
+    const canEdit = role === "ADMIN" || role === "MANAGER";
+
+    // Same 42-day grid as the calendar; `to` exclusive (getStartCalendar rule).
+    const grid = getMonthGrid(parseUTCDate(`${month}-01`));
+    const from = grid[0];
+    const to = new Date(grid[grid.length - 1].getTime() + 86_400_000);
+
+    const [pipeline, calendar, cashflow, crewConflicts, overlays, strip] = await Promise.all([
+        getCompanyPipeline(),
+        // The income layer comes from overlays (effectiveDueDate) for ADMIN, so
+        // the calendar fetch stays financial-free here.
+        getStartCalendar(from, to, { includeFinancials: false }),
+        isAdmin ? getCashflowOutlook() : Promise.resolve(null),
+        canEdit ? getCrewConflicts(from, to) : Promise.resolve(null),
+        isAdmin ? getCalendarOverlays(from, to) : Promise.resolve(null),
+        isAdmin ? getProjectMonthStrip(from, to) : Promise.resolve(null),
+    ]);
+
+    // Button data for "Generate schedule": Waiting/Scheduled rows show it only
+    // when the project has a qualifying estimate AND zero schedule tasks.
+    const rowIds = [
+        ...pipeline.waitingToStart.map(p => p.id),
+        ...pipeline.scheduled.map(p => p.id),
+        ...pipeline.inProgress.map(p => p.id),
+    ];
+    const [taskCounts, qualifying] = await Promise.all([
+        prisma.scheduleTask.groupBy({ by: ["projectId"], where: { projectId: { in: rowIds } }, _count: { id: true } }),
+        prisma.estimate.groupBy({ by: ["projectId"], where: { projectId: { in: rowIds }, status: { in: CONTRACT_ESTIMATE_STATUSES } }, _count: { id: true } }),
+    ]);
+    const taskCountOf = new Map(taskCounts.map(t => [t.projectId, t._count.id]));
+    const hasQualifying = new Set(qualifying.map(q => q.projectId));
+    const enrich = (p: PipelineProject): DashboardProjectRow => ({
+        ...p,
+        taskCount: taskCountOf.get(p.id) ?? 0,
+        hasQualifyingEstimate: hasQualifying.has(p.id),
+    });
+
+    // Picker list is pre-filtered to ACTIVATED (getTeamMembers stays unchanged
+    // for other callers) and only sent to roles that can edit.
+    const teamMembers = canEdit
+        ? (await prisma.user.findMany({
+            where: { status: "ACTIVATED" },
+            orderBy: { name: "asc" },
+            select: { id: true, name: true, email: true },
+        })).map(u => ({ id: u.id, name: u.name || u.email, email: u.email }))
+        : null;
+
+    return {
+        month,
+        role,
+        canEdit,
+        isAdmin,
+        pipeline: {
+            estimating: pipeline.estimating,
+            waitingToStart: pipeline.waitingToStart.map(enrich),
+            scheduled: pipeline.scheduled.map(enrich),
+            inProgress: pipeline.inProgress.map(enrich),
+            substantialCompletion: pipeline.substantialCompletion,
+        },
+        calendar,
+        cashflow,
+        teamMembers,
+        crewConflicts,
+        overlays,
+        strip,
+    };
 }


### PR DESCRIPTION
## What

Phase 2 of the company dashboard (stacked on #214). Completes the owner's original sentence: *tasks from the completed estimate, crew on the company calendar, and cashflow/expense/hours/income overlays — admin-only.*

**Estimate → schedule** (`generateScheduleFromEstimate`, MCP `generate_project_schedule`, dashboard button on zero-task Waiting/Scheduled rows, and the rewired `importEstimateToSchedule`):
- Phase/child tasks from the most recent qualifying estimate (Approved/Invoiced/Partially Paid/Paid); windows = reserve-1-day-per-phase then largest-remainder apportionment over the project window; leaf placement by proportional boundaries (exact coverage, 1-day minimum even when tasks > days)
- Milestone tasks by the canonical rule (existing dueDate > `(EPS.order, EPS.id)` cumulative percentage); Pending-only null-dueDate initialization — settled and QB-pushed rows are never rewritten
- `scheduleTaskId` linked on EPS + ALL unpaid clones regardless of QB state (linking ≠ QBO mutation); regenerate deletes only provenance-tagged (`generatedFromEstimateId`) tasks whose ENTIRE phase subtree is untouched
- Single transaction; Project row `FOR UPDATE` before any full estimate read (P1 lock discipline)

**Crew** (`setProjectCrew`, MCP `assign_project_crew`): ACTIVATED-validated connect/disconnect replace; dashboard picker including removable "(inactive)" assigned members; crew initials on calendar chips; **conflict panel** from Project.crew project windows (half-open overlap, startDate+1d fallback).

**Admin money/hours overlays** (queried + serialized only for `role === "ADMIN"`, via `getCompanyDashboardData`): calendar layer toggles — income (shared `effectiveDueDate = dueDate ?? linkedTask.startDate`, so QBO-pushed null-date clones appear as projected income), expenses by `Expense.date`, hours by `TimeEntry.startTime`; per-project month strip: Income due / Received (by paymentDate) / Expenses / burdened Labor / Hours actual vs estimated / **Net** (profitability convention).

## Gates

- **TRIP-1** plan review: APPROVED (5 rounds) — `.specs/PB-pipeline-002-crew-money-overlays.md`
- **TRIP-2** code review: APPROVED (3 rounds) — `.specs/PB-pipeline-002-code-review.md`
- `tsc --noEmit`: 0 errors · `scripts/verify-crew-overlays.ts`: **66/66 PASS** (apportionment edge cases, canonical-date rules, subtree regenerate eligibility, QB/projected income, role matrix, conflict detection, importer delegation)
- Dev smoke: `/company-dashboard` 200 OK with Schedule & crew card, conflict panel, overlay toggles

## Deploy notes

1. `node scripts/apply-schedule-provenance-schema.mjs` (additive — already run against the dev DB)
2. `npx prisma generate`
3. Deploy. ChatGPT connector URL unchanged (server v1.8.0 — new tools appear automatically).

## Stacked-branch note

Base is `feat/company-pipeline-dashboard` (#214). Once #214 lands on main, retarget this PR to `main`.