### PR TITLE
fix(billing): milestone-scoped payment-request send [Berg INV-00177]

### DIFF
--- a/e2e/milestone-payment-request.spec.ts
+++ b/e2e/milestone-payment-request.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from "@playwright/test";
+import { PrismaClient } from "@prisma/client";
+import { buildMilestoneRequestEmail, sendMilestoneInvoicesCore } from "../src/lib/billing-core";
+
+/**
+ * Milestone payment-request regression net — born from the July 2026 Berg ADU
+ * confusion: the client opened the portal and saw the WHOLE invoice balance
+ * ($21,590) when the office only meant to request the $10k progress payment.
+ *
+ * Guards:
+ *  1. The request email asks for EXACTLY the selected milestones — the
+ *     whole-invoice total/balance never appears in subject or body.
+ *  2. Multiple milestones in one send are summed into a single Amount Due Now.
+ *  3. Customer-controlled values (milestone/client/project/company names) are
+ *     HTML-escaped in the body, and the subject is newline-stripped against
+ *     header injection.
+ *  4. sendMilestoneInvoicesCore fails CLOSED when the QuickBooks money rail is
+ *     unavailable: no email, no sent stamps, no activity rows.
+ *
+ * The DB test runs against the throwaway CI Postgres (data.setup.ts guards
+ * prod). No CompanySettings row + the dummy RESEND_API_KEY means no real email
+ * can leave; the QBO path has no Integration row here, which is exactly what
+ * test 4 relies on.
+ */
+
+const prisma = new PrismaClient();
+
+test.describe("Milestone payment request email (composition)", () => {
+    test("asks for exactly the selected milestone, never the whole balance", () => {
+        const { subject, html } = buildMilestoneRequestEmail({
+            companyName: "Golden Touch Remodeling",
+            clientName: "Dixie Berg",
+            projectName: "Berg ADU",
+            invoiceCode: "INV-00177",
+            milestones: [{ name: "Drywall Complete", amount: 10000 }],
+            portalUrl: "https://app.example.com/portal/invoices/inv1?milestone=ms1",
+        });
+
+        expect(subject).toContain("$10,000.00");
+        expect(subject).toContain("Drywall Complete");
+        expect(html).toContain("Amount Due Now");
+        expect(html).toContain("$10,000.00");
+        expect(html).toContain("Drywall Complete");
+        expect(html).toContain("Only the payment above is due now");
+        // The whole-invoice figures (Berg: total $36,590 / balance $21,590)
+        // must never leak into a milestone-scoped request.
+        expect(html).not.toContain("36,590");
+        expect(html).not.toContain("21,590");
+        // The portal link carries the milestone focus.
+        expect(html).toContain("milestone=ms1");
+    });
+
+    test("sums multiple milestones into one Amount Due Now", () => {
+        const { subject, html } = buildMilestoneRequestEmail({
+            companyName: "GTR",
+            clientName: "Dixie",
+            projectName: "Berg ADU",
+            invoiceCode: "INV-00177",
+            milestones: [
+                { name: "Drywall Complete", amount: 10000 },
+                { name: "Progress Payment", amount: 11590 },
+            ],
+            portalUrl: "https://app.example.com/portal/invoices/inv1?milestone=ms1,ms2",
+        });
+
+        expect(html).toContain("$21,590.00");
+        expect(html).toContain("Only the payments above are due now");
+        expect(subject).toContain("$21,590.00");
+        // Multi-milestone sends must not name a single milestone in the subject.
+        expect(subject).not.toContain("for Drywall");
+    });
+
+    test("escapes customer-controlled HTML and strips subject newlines", () => {
+        const evilName = '<img src=x onerror=alert(1)>\nBCC: attacker@evil.com';
+        const { subject, html } = buildMilestoneRequestEmail({
+            companyName: 'GTR <b>"HQ"</b>',
+            clientName: evilName,
+            projectName: "<script>alert(1)</script>",
+            invoiceCode: "INV-<b>1</b>",
+            milestones: [{ name: evilName, amount: 10000 }],
+            portalUrl: "https://app.example.com/portal/invoices/inv1?milestone=ms1",
+        });
+
+        expect(html).not.toContain("<img src=x");
+        expect(html).not.toContain("<script>alert(1)</script>");
+        expect(html).not.toContain('GTR <b>"HQ"</b>');
+        expect(html).toContain("&lt;img src=x");
+        expect(html).toContain("&lt;script&gt;");
+        // Header injection requires CRLF — the subject must contain neither.
+        expect(subject).not.toMatch(/[\r\n]/);
+    });
+});
+
+const FIX = {
+    client: "msr-e2e-client",
+    project: "msr-e2e-project",
+    invoice: "msr-e2e-invoice",
+    milestone: "msr-e2e-milestone",
+};
+
+test.describe("sendMilestoneInvoicesCore fail-closed (no QuickBooks connection)", () => {
+    test.beforeAll(async () => {
+        await prisma.client.create({ data: { id: FIX.client, name: "Milestone Send Drill", initials: "MSD" } });
+        await prisma.project.create({ data: { id: FIX.project, name: "Milestone Send Drill Project", clientId: FIX.client } });
+        await prisma.invoice.create({
+            data: {
+                id: FIX.invoice,
+                code: "INV-E2E-MSR-001",
+                projectId: FIX.project,
+                clientId: FIX.client,
+                totalAmount: 10000,
+                balanceDue: 10000,
+                status: "Issued",
+            },
+        });
+        await prisma.paymentSchedule.create({
+            data: { id: FIX.milestone, invoiceId: FIX.invoice, name: "Drywall Complete", amount: 10000 },
+        });
+    });
+
+    test.afterAll(async () => {
+        await prisma.paymentSchedule.deleteMany({ where: { invoiceId: FIX.invoice } });
+        await prisma.invoice.deleteMany({ where: { id: FIX.invoice } });
+        await prisma.project.deleteMany({ where: { id: FIX.project } });
+        await prisma.client.deleteMany({ where: { id: FIX.client } });
+        await prisma.$disconnect();
+    });
+
+    test("nothing is sent, stamped, or logged when the money rail is down", async () => {
+        const res = await sendMilestoneInvoicesCore(FIX.invoice, [FIX.milestone], "drill@example.com", undefined, "E2E Drill");
+
+        expect(res.success).toBe(false);
+        expect(res.sent).toBe(0);
+        expect(res.error || "").toBeTruthy();
+
+        const ms = await prisma.paymentSchedule.findUnique({ where: { id: FIX.milestone } });
+        expect(ms?.qbInvoiceSentAt).toBeNull();
+
+        const logs = await prisma.activityLog.count({ where: { entityId: FIX.invoice, action: "sent_invoice" } });
+        expect(logs).toBe(0);
+    });
+});

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -337,9 +337,11 @@ const handler = createMcpHandler(
         server.registerTool(
             "send_milestone_invoice",
             {
-                title: "Send payment milestone(s) to the customer via QuickBooks",
+                title: "Send payment milestone(s) to the customer",
                 description:
-                    "Emails the customer a QuickBooks invoice with a payment link for each selected milestone. TWO-STEP: call without confirmToken to get a preview " +
+                    "Emails the customer a payment request listing ONLY the selected milestones (name + amount, never the whole invoice balance), with a portal link " +
+                    "that opens their invoice focused on exactly those payments and a Pay Now button. QuickBooks is still the money rail: each milestone is pushed/verified " +
+                    "against QBO before anything is emailed. TWO-STEP: call without confirmToken to get a preview " +
                     "(what will be sent, to whom, amounts) plus a confirmToken; show the preview to the user, then call again with the confirmToken only after they approve. " +
                     "The token is bound to the exact milestones/recipient/amounts and expires in ~5 minutes. " +
                     "If QuickBooks amounts have drifted, the result returns needsReview + driftReview — show the user the amounts and, if they approve reconciling, " +

--- a/src/app/portal/invoices/[id]/PortalInvoiceClient.tsx
+++ b/src/app/portal/invoices/[id]/PortalInvoiceClient.tsx
@@ -30,7 +30,7 @@ class PaymentSectionErrorBoundary extends React.Component<{ children: React.Reac
     }
 }
 
-export default function PortalInvoiceClient({ initialInvoice, companySettings, paymentSuccess }: { initialInvoice: any, companySettings?: any, paymentSuccess?: boolean }) {
+export default function PortalInvoiceClient({ initialInvoice, companySettings, paymentSuccess, focusMilestoneParam }: { initialInvoice: any, companySettings?: any, paymentSuccess?: boolean, focusMilestoneParam?: string | null }) {
     const [isPayingId, setIsPayingId] = useState<string | null>(null);
 
     useEffect(() => {
@@ -78,6 +78,18 @@ export default function PortalInvoiceClient({ initialInvoice, companySettings, p
     const companyLicense = companySettings?.licenseNumber || "";
     const isPaid = initialInvoice.status === "Paid";
     const totalPaid = Number(initialInvoice.totalAmount || 0) - Number(initialInvoice.balanceDue || 0);
+
+    // Milestone focus mode: the payment-request email links here with
+    // ?milestone=<ids> so the client sees a clear "amount due now" for exactly
+    // the requested payment(s), with the full-invoice figures demoted to a
+    // secondary reference line. Paid/unknown ids fall out; if nothing valid
+    // remains the page renders as the normal full invoice.
+    const focusIds = (focusMilestoneParam || "").split(",").map(s => s.trim()).filter(Boolean);
+    const focusedPayments = focusIds.length > 0
+        ? (initialInvoice.payments || []).filter((p: any) => focusIds.includes(p.id) && p.status !== "Paid")
+        : [];
+    const hasFocus = focusedPayments.length > 0;
+    const focusTotal = focusedPayments.reduce((sum: number, p: any) => sum + Number(p.amount), 0);
 
     return (
         <div className="min-h-screen bg-slate-100 font-sans">
@@ -155,7 +167,36 @@ export default function PortalInvoiceClient({ initialInvoice, companySettings, p
                         </div>
                     </div>
 
-                    {/* Amount Summary */}
+                    {/* Focused payment request — the amount the client is being asked to pay right now */}
+                    {hasFocus && (
+                        <div className="px-10 py-8 bg-emerald-50 border-b border-emerald-200">
+                            <p className="text-xs font-semibold text-emerald-700 uppercase tracking-wider mb-1">Payment Requested</p>
+                            <p className="text-sm text-emerald-900 mb-3">{focusedPayments.map((p: any) => p.name).join(" · ")}</p>
+                            <div className="flex items-center justify-between flex-wrap gap-4">
+                                <p className="text-3xl font-bold text-emerald-700">{formatCurrency(focusTotal)}</p>
+                                {focusedPayments.length === 1 && (
+                                    <PortalPayButton
+                                        invoiceId={initialInvoice.id}
+                                        paymentScheduleId={focusedPayments[0].id}
+                                        amount={Number(focusedPayments[0].amount)}
+                                        label="Pay Now"
+                                        settings={companySettings}
+                                        qbPayLink={focusedPayments[0].status === "Pending" && !focusedPayments[0].qbSyncError ? (focusedPayments[0].qbInvoiceLink || null) : null}
+                                    />
+                                )}
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Amount Summary — full-width when there's no focus; a compact
+                        reference line when a specific payment is being requested */}
+                    {hasFocus ? (
+                        <div className="px-10 py-4 bg-slate-50 border-b border-slate-200">
+                            <p className="text-xs text-slate-500 text-center">
+                                Full invoice {initialInvoice.code}: total {formatCurrency(initialInvoice.totalAmount)} · paid to date {formatCurrency(totalPaid)} · remaining balance {formatCurrency(initialInvoice.balanceDue)}
+                            </p>
+                        </div>
+                    ) : (
                     <div className="px-10 py-8 bg-slate-50 border-b border-slate-200">
                         <div className="flex justify-between items-center">
                             <div>
@@ -174,6 +215,7 @@ export default function PortalInvoiceClient({ initialInvoice, companySettings, p
                             </div>
                         </div>
                     </div>
+                    )}
 
                     {/* Notes */}
                     {initialInvoice.notes && (
@@ -192,6 +234,7 @@ export default function PortalInvoiceClient({ initialInvoice, companySettings, p
                                 {initialInvoice.payments.map((payment: any) => {
                                     const isPaidItem = payment.status === "Paid";
                                     const isPastDue = payment.dueDate && new Date(payment.dueDate) < new Date() && !isPaidItem;
+                                    const isFocused = !isPaidItem && focusIds.includes(payment.id);
 
                                     return (
                                         <div
@@ -199,16 +242,21 @@ export default function PortalInvoiceClient({ initialInvoice, companySettings, p
                                             className={`flex items-center justify-between px-5 py-4 rounded-lg border ${
                                                 isPaidItem
                                                     ? 'bg-green-50 border-green-200'
+                                                    : isFocused
+                                                    ? 'bg-white border-emerald-300 ring-2 ring-emerald-200'
                                                     : isPastDue
                                                     ? 'bg-red-50 border-red-200'
                                                     : 'bg-white border-slate-200'
-                                            }`}
+                                            }${hasFocus && !isFocused && !isPaidItem ? ' opacity-60' : ''}`}
                                         >
                                             <div className="flex-1">
                                                 <div className="flex items-center gap-2">
                                                     <span className="font-medium text-slate-800">{payment.name}</span>
                                                     {isPaidItem && (
                                                         <span className="text-[10px] font-bold uppercase text-green-700 bg-green-100 px-1.5 py-0.5 rounded">Paid</span>
+                                                    )}
+                                                    {isFocused && (
+                                                        <span className="text-[10px] font-bold uppercase text-emerald-700 bg-emerald-100 px-1.5 py-0.5 rounded">Requested</span>
                                                     )}
                                                     {isPastDue && (
                                                         <span className="text-[10px] font-bold uppercase text-red-700 bg-red-100 px-1.5 py-0.5 rounded">Overdue</span>

--- a/src/app/portal/invoices/[id]/page.tsx
+++ b/src/app/portal/invoices/[id]/page.tsx
@@ -92,7 +92,7 @@ export default async function PortalInvoicePage({
     searchParams,
 }: {
     params: Promise<{ id: string }>;
-    searchParams: Promise<{ payment?: string; session_id?: string }>;
+    searchParams: Promise<{ payment?: string; session_id?: string; milestone?: string }>;
 }) {
     const resolvedParams = await params;
     const resolvedSearch = await searchParams;
@@ -105,8 +105,11 @@ export default async function PortalInvoicePage({
             select: { id: true }
         });
         if (inv) {
-            const queryParams = resolvedSearch.session_id ? `?session_id=${resolvedSearch.session_id}` : '';
-            redirect(`/portal/invoices/${inv.id}${queryParams}`);
+            const qp = new URLSearchParams();
+            if (resolvedSearch.session_id) qp.set("session_id", resolvedSearch.session_id);
+            if (resolvedSearch.milestone) qp.set("milestone", resolvedSearch.milestone);
+            const qs = qp.toString();
+            redirect(`/portal/invoices/${inv.id}${qs ? `?${qs}` : ''}`);
         } else {
             return notFound();
         }
@@ -147,6 +150,7 @@ export default async function PortalInvoicePage({
             initialInvoice={invoice}
             companySettings={settings}
             paymentSuccess={resolvedSearch.payment === "success"}
+            focusMilestoneParam={resolvedSearch.milestone || null}
         />
     );
 }

--- a/src/app/projects/[id]/invoices/[invoiceId]/InvoiceEditor.tsx
+++ b/src/app/projects/[id]/invoices/[invoiceId]/InvoiceEditor.tsx
@@ -747,7 +747,7 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                                                                     setShowSendMilestonesModal(true);
                                                                 }}
                                                                 className="hui-btn hui-btn-secondary py-1 px-3 text-xs w-auto h-8 flex items-center justify-center whitespace-nowrap"
-                                                                title={payment.qbInvoiceSentAt ? "Resend invoice email via QuickBooks" : "Send invoice email via QuickBooks"}
+                                                                title={payment.qbInvoiceSentAt ? "Resend the payment request email for just this milestone" : "Email the client a payment request for just this milestone"}
                                                             >
                                                                 {payment.qbInvoiceSentAt ? "Resend" : "Send"}
                                                             </button>

--- a/src/components/SendMilestonesModal.tsx
+++ b/src/components/SendMilestonesModal.tsx
@@ -74,6 +74,13 @@ export default function SendMilestonesModal({
                         ? `Sent ${result.sent} invoice(s) to ${email} (${reconciledCount} reconciled to QuickBooks)`
                         : `Successfully sent ${result.sent} invoice(s) to ${email}`
                 );
+                // Delivered-but-not-recorded must be loud: the milestone will still
+                // show "Send" because the stamp failed, and a blind resend would
+                // email the client twice.
+                const recordingIssues = result.results.filter(r => (r.status === "sent" || r.status === "reconciled") && r.error);
+                if (recordingIssues.length > 0) {
+                    toast.warning(`The email went out, but recording it failed — verify in QuickBooks before resending (${recordingIssues[0].error})`);
+                }
                 if (result.failed > 0 || result.skipped > 0) {
                     toast.warning(`Failed: ${result.failed}, Skipped: ${result.skipped}`);
                 }
@@ -103,7 +110,7 @@ export default function SendMilestonesModal({
                         <p className="text-xs text-hui-textMuted mt-0.5">
                             {phase === "review"
                                 ? "Review the differences below before sending."
-                                : "The client will receive official QuickBooks Online invoice emails to review and pay."}
+                                : "The client will receive one email from your company listing only these milestones, with a link to view and pay online."}
                         </p>
                     </div>
                     <button onClick={onClose} className="text-hui-textMuted hover:text-hui-textMain transition">
@@ -149,9 +156,9 @@ export default function SendMilestonesModal({
                         <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-4 space-y-2">
                             <h3 className="text-sm font-semibold text-emerald-800">What happens when you send:</h3>
                             <ul className="text-xs text-emerald-700 space-y-1.5 list-disc pl-4">
-                                <li>Each milestone will be synced to QuickBooks if not already pushed.</li>
-                                <li>Client receives official QuickBooks Online invoice emails (with {"Review & Pay"} links).</li>
-                                <li>QuickBooks invoice status will be marked as emailed.</li>
+                                <li>Each milestone is synced to QuickBooks and its amount verified before anything goes out.</li>
+                                <li>Client receives one email requesting only the milestone(s) above — never the full invoice balance.</li>
+                                <li>The email opens their client portal focused on these payments, with a Pay Now button.</li>
                                 <li>Parent invoice status will change to {"Issued"} if currently a Draft.</li>
                             </ul>
                         </div>

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -544,8 +544,142 @@ export async function resendInvoiceCore(invoiceId: string, overrideEmail?: strin
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Milestone send via QuickBooks. Moved verbatim from actions.ts; the actor's
-// display name is a parameter instead of coming from the session.
+// Milestone-scoped payment request email. The client is asked for EXACTLY the
+// listed milestones — the whole-invoice total/balance never appears in the
+// email — and the portal link opens the invoice focused on just those payments
+// (/portal/invoices/<id>?milestone=<ids>), where views are first-class events.
+//
+// Composition (buildMilestoneRequestEmail) is a pure exported function so the
+// e2e regression net can pin the milestone-only totals, HTML escaping, and
+// header sanitization without a mail provider.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Header-injection guard for values that end up in the Subject/From headers.
+function sanitizeHeaderValue(s: string): string {
+    return s.replace(/[\r\n]+/g, " ").trim();
+}
+
+export function buildMilestoneRequestEmail(input: {
+    companyName: string;
+    clientName: string | null | undefined;
+    projectName: string | null | undefined;
+    invoiceCode: string;
+    milestones: Array<{ name: string; amount: number }>;
+    portalUrl: string;
+}): { subject: string; html: string } {
+    const company = escapeHtml(input.companyName);
+    const total = input.milestones.reduce((sum, m) => sum + m.amount, 0);
+    const single = input.milestones.length === 1;
+    const projectName = input.projectName || "project";
+    const milestoneRows = input.milestones.map(m => `
+                    <tr>
+                        <td style="padding: 10px 0; color: #333; border-bottom: 1px solid #f0f0f0;">${escapeHtml(m.name)}</td>
+                        <td style="padding: 10px 0; color: #111; font-weight: 600; text-align: right; border-bottom: 1px solid #f0f0f0;">${formatCurrency(m.amount)}</td>
+                    </tr>`).join("");
+
+    const subject = sanitizeHeaderValue(
+        `${input.companyName} — payment request: ${formatCurrency(total)} due${single ? ` for ${input.milestones[0].name}` : ""}`
+    );
+
+    const html = `<!DOCTYPE html>
+        <html>
+        <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 40px 20px; color: #333;">
+            <div style="text-align: center; margin-bottom: 32px;">
+                <h1 style="font-size: 24px; font-weight: 700; margin: 0;">${company}</h1>
+            </div>
+            <div style="background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; padding: 32px;">
+                <h2 style="font-size: 20px; margin: 0 0 8px;">Payment Requested</h2>
+                <p style="color: #666; margin: 0 0 24px;">Hi ${escapeHtml(input.clientName || 'there')},</p>
+                <p style="color: #666; line-height: 1.6;">
+                    ${company} is requesting ${single ? "a progress payment" : "payment"} for your ${escapeHtml(projectName)}:
+                </p>
+                <table style="width: 100%; border-collapse: collapse; margin: 8px 0 0;">
+                    ${milestoneRows}
+                </table>
+                <div style="background: #f9fafb; border-radius: 8px; padding: 16px; text-align: center; margin-top: 24px;">
+                    <div style="color: #666; font-size: 13px; margin-bottom: 4px;">Amount Due Now</div>
+                    <div style="font-size: 24px; font-weight: 700; color: #111;">${formatCurrency(total)}</div>
+                </div>
+                <div style="text-align: center; margin: 32px 0;">
+                    <a href="${escapeHtml(input.portalUrl)}" style="display: inline-block; background: #059669; color: #fff; text-decoration: none; padding: 14px 32px; border-radius: 8px; font-weight: 600; font-size: 15px;">
+                        View &amp; Pay ${formatCurrency(total)}
+                    </a>
+                </div>
+                <p style="color: #999; font-size: 13px; text-align: center; margin-top: 16px;">
+                    Reference: Invoice ${escapeHtml(input.invoiceCode)}. Only the payment${single ? "" : "s"} above ${single ? "is" : "are"} due now — your full invoice is available at the same link for reference.
+                </p>
+                <p style="color: #999; font-size: 13px; text-align: center; margin-top: 8px;">
+                    Or copy this link: ${escapeHtml(input.portalUrl)}
+                </p>
+            </div>
+            <p style="text-align: center; color: #aaa; font-size: 12px; margin-top: 32px;">
+                Sent via ProBuild • ${company}
+            </p>
+        </body>
+        </html>`;
+
+    return { subject, html };
+}
+
+async function sendMilestoneRequestEmail(
+    invoice: {
+        id: string;
+        code: string;
+        clientId: string | null;
+        client: { name: string | null; email: string | null; additionalEmail: string | null } | null;
+        project: { name: string; clientId: string | null; client: { additionalEmail: string | null } | null } | null;
+    },
+    milestones: Array<{ id: string; name: string; amount: number }>,
+    recipient: string,
+    companyName: string,
+): Promise<void> {
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+    const clientId = invoice.clientId || invoice.project?.clientId;
+    const nextPath = `/portal/invoices/${invoice.id}?milestone=${milestones.map(m => m.id).join(",")}`;
+    let portalUrl: string;
+    if (clientId) {
+        const { signClientPortalToken } = await import("./client-portal-auth");
+        const token = await signClientPortalToken(clientId, recipient.toLowerCase());
+        portalUrl = `${appUrl}/api/portal/verify?token=${encodeURIComponent(token)}&next=${encodeURIComponent(nextPath)}`;
+    } else {
+        portalUrl = `${appUrl}${nextPath}`;
+    }
+
+    const settings = await prisma.companySettings.findUnique({ where: { id: "singleton" } });
+    const { subject, html } = buildMilestoneRequestEmail({
+        companyName,
+        clientName: invoice.client?.name,
+        projectName: invoice.project?.name,
+        invoiceCode: invoice.code,
+        milestones,
+        portalUrl,
+    });
+
+    const result = await sendNotification(
+        recipient,
+        subject,
+        html,
+        undefined,
+        {
+            fromName: sanitizeHeaderValue(companyName),
+            replyTo: settings?.email || undefined,
+            cc: buildCc(recipient, invoice.client?.additionalEmail || invoice.project?.client?.additionalEmail || null),
+            copyToInternal: true,
+        }
+    );
+    // sendNotification reports provider/network failure as { success: false }
+    // rather than throwing — escalate it so no milestone is stamped "sent"
+    // when no email actually left.
+    if (!result.success) {
+        throw new Error("Email provider failed to send the payment request");
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Milestone send: QBO stays the money rail (push + Drift Guard per milestone),
+// but the client-facing email is ProBuild's milestone-scoped request above.
+// Moved from actions.ts; the actor's display name is a parameter instead of
+// coming from the session.
 // ─────────────────────────────────────────────────────────────────────────────
 
 export async function sendMilestoneInvoicesCore(
@@ -587,7 +721,7 @@ export async function sendMilestoneInvoicesCore(
         }
 
         const { getFreshQBTokens, pushMilestoneToQuickBooks, reconcileMilestoneToQbo } = await import("./quickbooks-payments");
-        const { sendQBInvoice, getQBInvoiceStatus } = await import("./quickbooks");
+        const { getQBInvoiceStatus, getQBInvoicePaymentLink } = await import("./quickbooks");
 
         let tokens;
         try {
@@ -612,6 +746,11 @@ export async function sendMilestoneInvoicesCore(
         let reconciledEstimate = false;
         const results: Array<{ id: string; name: string; status: "sent" | "skipped" | "failed" | "reconciled"; error?: string; sentTo?: string }> = [];
         const driftReview: Array<{ id: string; name: string; probuildAmount: number; qbTotal: number; direction: "higher" | "lower" }> = [];
+        // Milestones that cleared every guard, queued for the single request email
+        // that goes out after the loop (one email per batch, not one per milestone).
+        // effectiveAmount is the verified QuickBooks total — after a reconcile this
+        // is the NEW amount, so the email never quotes the stale pre-reconcile one.
+        const sendable: Array<{ schedule: (typeof selectedPayments)[number]; wasReconciled: boolean; effectiveAmount: number }> = [];
 
         for (const schedule of selectedPayments) {
             if (schedule.status === "Paid" || schedule.status === "Canceled") {
@@ -719,48 +858,116 @@ export async function sendMilestoneInvoicesCore(
                     && approvedTotal != null
                     && Math.abs(approvedTotal - qbTotal) <= 0.005;
 
-                // Send QBO invoice
-                const sendRes = await sendQBInvoice(tokens, qbInvoiceId, recipient);
-                if (!sendRes.ok) {
-                    failedCount++;
-                    results.push({ id: schedule.id, name: schedule.name, status: "failed", error: sendRes.error || "QuickBooks send failed" });
-                    continue;
-                }
-
-                // Success -> update sent status
-                await prisma.paymentSchedule.update({
-                    where: { id: schedule.id },
-                    data: { qbInvoiceSentAt: new Date() },
-                });
-
-                sentCount++;
-                results.push({ id: schedule.id, name: schedule.name, status: wasReconciled ? "reconciled" : "sent", sentTo: recipient });
-
-                // Log activity per sent milestone
-                if (invoice.projectId) {
-                    await logActivityLazy({
-                        projectId: invoice.projectId,
-                        actorType: "TEAM",
-                        actorName: companyName,
-                        action: "sent_invoice",
-                        entityType: "invoice",
-                        entityId: invoiceId,
-                        entityName: `Invoice ${invoice.code}`,
-                        metadata: { milestone: schedule.name, sentTo: recipient },
-                    });
-                }
+                // Amount verified. Queue for the ProBuild-branded request email sent
+                // after the loop, instead of Intuit's own invoice email — the client
+                // is asked for exactly these milestone amounts (never the whole
+                // invoice balance) and the view is tracked on the ProBuild portal.
+                sendable.push({ schedule, wasReconciled, effectiveAmount: qbTotal });
             } catch (err: any) {
                 failedCount++;
                 results.push({ id: schedule.id, name: schedule.name, status: "failed", error: err?.message || "Unexpected error during send" });
             }
         }
 
-        // If >= 1 successfully sent and invoice is Draft, flip to Issued
+        // One client email per send batch, listing only the milestones that passed
+        // the guards, with a portal link focused on them. If the email itself fails,
+        // every queued milestone is marked failed (nothing was communicated), and
+        // nothing is stamped as sent.
+        if (sendable.length > 0) {
+            const recipient = (overrideEmail || invoice.client?.email || invoice.project?.client?.email || "").trim();
+
+            // Refresh each milestone's live QBO pay link so the portal Pay Now
+            // never hands the client a stale link (best-effort — the portal
+            // still works when a link can't be fetched).
+            for (const { schedule } of sendable) {
+                if (!schedule.qbInvoiceId) continue;
+                try {
+                    const liveLink = await getQBInvoicePaymentLink(tokens, schedule.qbInvoiceId);
+                    if (liveLink && liveLink !== schedule.qbInvoiceLink) {
+                        await prisma.paymentSchedule.update({ where: { id: schedule.id }, data: { qbInvoiceLink: liveLink } });
+                    }
+                } catch { /* link refresh is best-effort */ }
+            }
+
+            let emailFailed = false;
+            try {
+                await sendMilestoneRequestEmail(
+                    invoice,
+                    sendable.map(s => ({ id: s.schedule.id, name: s.schedule.name, amount: s.effectiveAmount })),
+                    recipient,
+                    companyName,
+                );
+            } catch (emailErr: any) {
+                emailFailed = true;
+                for (const { schedule } of sendable) {
+                    failedCount++;
+                    results.push({ id: schedule.id, name: schedule.name, status: "failed", error: emailErr?.message || "Failed to send request email" });
+                }
+            }
+
+            // The email left — from here on a failure is a BOOKKEEPING failure and
+            // must never be reported as a send failure (that would invite a
+            // duplicate resend to the client). Stamp the batch atomically; if the
+            // stamp fails, milestones still report "sent" with the recording error
+            // attached so staff know to verify, not resend.
+            if (!emailFailed) {
+                const stampedAt = new Date();
+                let stampError: string | null = null;
+                try {
+                    await prisma.$transaction(
+                        sendable.map(({ schedule }) =>
+                            prisma.paymentSchedule.update({ where: { id: schedule.id }, data: { qbInvoiceSentAt: stampedAt } })
+                        )
+                    );
+                } catch (e: any) {
+                    stampError = e?.message || "unknown error";
+                    console.error("[sendMilestoneInvoices] email delivered but recording the send failed:", e);
+                }
+                for (const { schedule, wasReconciled } of sendable) {
+                    sentCount++;
+                    results.push({
+                        id: schedule.id,
+                        name: schedule.name,
+                        status: wasReconciled ? "reconciled" : "sent",
+                        sentTo: recipient,
+                        ...(stampError ? { error: `Email delivered, but recording the send failed (${stampError}) — verify in QuickBooks before resending` } : {}),
+                    });
+
+                    // Log activity per sent milestone (best-effort — never flips a
+                    // delivered send to "failed")
+                    if (invoice.projectId) {
+                        try {
+                            await logActivityLazy({
+                                projectId: invoice.projectId,
+                                actorType: "TEAM",
+                                actorName: companyName,
+                                action: "sent_invoice",
+                                entityType: "invoice",
+                                entityId: invoiceId,
+                                entityName: `Invoice ${invoice.code}`,
+                                metadata: { milestone: schedule.name, sentTo: recipient },
+                            });
+                        } catch (e) {
+                            console.error("[sendMilestoneInvoices] activity log failed for", schedule.name, e);
+                        }
+                    }
+                }
+            }
+        }
+
+        // If >= 1 successfully sent and invoice is Draft, flip to Issued.
+        // Post-delivery bookkeeping: a failure here must NOT fall into the
+        // global catch and report success:false for an email the client
+        // already received — log it and let the sent results stand.
         if (sentCount > 0 && invoice.status === "Draft") {
-            await prisma.invoice.update({
-                where: { id: invoiceId },
-                data: { status: "Issued", issueDate: new Date() },
-            });
+            try {
+                await prisma.invoice.update({
+                    where: { id: invoiceId },
+                    data: { status: "Issued", issueDate: new Date() },
+                });
+            } catch (e) {
+                console.error("[sendMilestoneInvoices] email delivered but Draft→Issued flip failed:", e);
+            }
         }
 
         if (invoice.projectId) {


### PR DESCRIPTION
## Summary
- Milestone-row **Send** now emails a payment request for **only the selected milestones** (Amount Due Now = their sum), instead of surfacing the whole invoice balance. Replaces Intuit's `sendQBInvoice` email with a ProBuild-composed email; QBO remains the money rail (per-milestone push + Drift Guard + reconcile unchanged).
- New pure `buildMilestoneRequestEmail` (all values HTML-escaped, subject/From newline-sanitized); send fails closed on `sendNotification` `{success:false}`; queue carries `effectiveAmount` = verified post-reconcile QBO total.
- Portal invoice page gets milestone focus mode via `?milestone=<ids>`: "Payment Requested — $X" banner with Pay Now, whole-invoice totals demoted to a reference line; invalid/paid focus ids degrade to the normal view.
- Post-delivery bookkeeping (batch `qbInvoiceSentAt` stamp, activity, Draft→Issued) is separated so a recording failure never misreports a delivered send as failed; modal surfaces "delivered but not stamped" warnings.
- New `e2e/milestone-payment-request.spec.ts` (direct-core pattern): milestone-only totals, no whole-balance leakage, HTML escaping, subject CRLF sanitization, and a fail-closed no-Integration-row test.

## Context
Berg ADU INV-00177: client saw the full $21,590 balance in the portal when only a $10k progress payment was intended. No invoice email had ever been sent; the alert was an internal view notification. This makes the milestone Send button unambiguous for the client.

## Review
- Codex TRIP-2 (gpt-5.6-sol xhigh, 3 rounds): all six content findings addressed; final blocker was worktree scope only.
- Isolated cherry-pick verified byte-identical to the reviewed patch (`git patch-id` match), tsc clean, no schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)