### PR TITLE
feat(schedule): auto-generate on signature, CO schedule+cash, task-level crew [PB-pipeline-003]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,10 @@ qa-screenshots/
 
 # ChatGPT MCP connector local secret
 .mcp-secret
+
+# Local session scratch (shared by concurrent agent sessions; Vercel-excluded).
+# Also keeps Tailwind v4 source scanning out of these dirs - scratch files with
+# Windows paths (backslash + hex-ish session ids) parse as invalid CSS escapes
+# and break `next build`.
+/gtr-probuild/
+/_context/

--- a/.specs/PB-pipeline-003-co-schedule.md
+++ b/.specs/PB-pipeline-003-co-schedule.md
@@ -1,0 +1,223 @@
+# PB-pipeline-003 — The Mid-Job Loop: Auto-Schedule on Signature, Change Orders → Schedule & Cash, Task-Level Crew
+
+**Status:** TRIP-1 plan gate
+**Date:** 2026-07-20
+**Requester:** Owner ("sometimes we have change orders that will adjust schedule — keep in
+mind the workflow of an entire remodeling company")
+**Builds on:** PB-pipeline-001 (PR #214), PB-pipeline-002 (PR #215, stacked).
+
+## The remodeling-company workflow this serves
+
+Lead → estimate → **signed ⇒ schedule exists** → Waiting to Start → Scheduled (crew,
+conflicts checked) → In Progress — and then reality: **the customer changes something**.
+A change order reprices the job, and today ProBuild already bills it; what it does NOT do
+is move the calendar. The crew finishes the original scope Friday and stands down Monday
+because nobody's schedule shows the added week of work — and the cash forecast doesn't
+show the CO money either. This spec closes that loop:
+
+1. **Signing the estimate generates the schedule automatically** (no more "someone has to
+   remember to click the button").
+2. **Approving a change order adjusts the schedule and the cash forecast** — new scope
+   appears as tasks, job finish moves out, CO money appears in the income overlays.
+3. **Crew gets precise**: assignment at task level from the company dashboard, conflicts
+   computed from actual task windows (upgrading P2's project-window approximation).
+
+## Codebase context (delta)
+
+- `ChangeOrder` (projectId, estimateId, code `CO-#####`, title, status
+  Draft/Sent/Approved/Declined, totalAmount); `ChangeOrderItem` (flat: name, type
+  ["Material" legacy label], quantity, unitCost, total, order, costCodeId/costTypeId);
+  `ChangeOrderPaymentSchedule` (name, amount, **dueDate?**, order — no status, no task link).
+- **CO approval already has an automation hook**: `handleChangeOrderApproved(changeOrderId)`
+  (billing-core.ts:984) auto-bills a freshly-approved CO (creates ONE invoice milestone
+  per CO; billed-state is detected by `CO-#####` name-prefix on invoice milestones,
+  billing-core.ts:865-867; idempotent).
+- **Estimate approval single funnel**: `approveEstimate(...)` (actions.ts:2280) — used by
+  both the portal signature path and admin approval; sets status "Approved" and triggers
+  invoice creation (~L2262 QBO push).
+- P2 shipped: `generateScheduleFromEstimate` (provenance `generatedFromEstimateId`,
+  full subtree eligibility, FOR UPDATE discipline), `setProjectCrew`, `getCrewConflicts`
+  (Project.crew windows), overlays with shared `effectiveDueDate`, MCP v1.8.0.
+- Task-level crew primitives: `TaskAssignment` (taskId+userId unique, role);
+  create/delete actions at actions.ts:6893-6921 (project schedule page).
+
+## Schema changes (`scripts/apply-co-schedule-schema.mjs` + `prisma generate`)
+
+- `ScheduleTask.generatedFromChangeOrderId String?` FK → `ChangeOrder` (SetNull) + index
+  (CO-task provenance, mirroring `generatedFromEstimateId`).
+- `ChangeOrderPaymentSchedule.scheduleTaskId String?` FK → `ScheduleTask` (SetNull) +
+  index (milestone↔calendar tie for CO money, mirroring the P1 pattern).
+
+## Workstream A — Auto-generate on estimate signature
+
+- Hook: at the end of `approveEstimate`, AFTER the approval+invoice work commits, call
+  `generateScheduleFromEstimate({ estimateId, mode: "merge", requireEmptyProject: true, actor: SYSTEM/"system" })`
+  **best-effort**: wrapped in try/catch; a failure is logged (console + ActivityLog where
+  possible) and NEVER fails or rolls back the approval (money-path discipline).
+- **Auto-path zero-task precondition** (R1 fix 1, R2 fix): `generateScheduleFromEstimate`
+  gains `requireEmptyProject?: boolean` — when true, the generation transaction enforces
+  **zero schedule tasks** under the Project lock (P2's merge mode alone only skips
+  already-linked estimate items and would otherwise stack a generated schedule on top of
+  manually-built tasks). Callers: the `approveEstimate` hook → `true`; the
+  `setProjectStartDate` post-commit hook → `true`; the dashboard button → `true`
+  (consistent with its zero-task visibility rule); the MCP tool and the rewired importer →
+  omitted (merge semantics preserved for explicit estimateId-driven calls).
+- **The "forgot to set a date" loop is closed** (R1 fix 2): `setProjectStartDate` gains a
+  post-commit best-effort step — when a project goes null→dated (or is dated) and still has
+  zero tasks AND a qualifying estimate exists (P2 selection rule), it calls
+  `generateScheduleFromEstimate` with the triggering actor; failures are caught and surface
+  in the result's `notes[]`, never fail the date move. Sign first, date later ⇒ schedule
+  appears by itself.
+
+## Workstream B — Change orders adjust the schedule + cash
+
+New in `schedule-core.ts`: `applyChangeOrderToSchedule({ changeOrderId, mode, actor })`.
+
+- **Preconditions:** CO status Approved; project has `startDate`. Otherwise actionable error.
+- **Provenance & idempotency:** CO parent + child + milestone tasks all carry
+  `generatedFromChangeOrderId`. `mode: "merge"` (default) = no-op when provenance tasks
+  exist for this CO; `"regenerate"` deletes only provenance-tagged tasks whose ENTIRE
+  subtree passes the P2 full eligibility predicate, then rebuilds. One transaction;
+  Project row `FOR UPDATE` first (P1/P2 discipline).
+- **Structure:** one parent task `CO-##### · <title>` + flat child tasks from
+  `ChangeOrderItem`s in `order`. **Deduction items (negative `total`) create NO task** —
+  they reduce scope; reported in `notes[]` for the PM to trim existing tasks manually.
+- **One `effectiveWorkEnd` definition** (R1 fix 3, R2 fix): `max(Project.endDate,
+  max(endDate of NON-milestone tasks)) ?? startDate` — payment milestone tasks never
+  extend the work window (a final-payment milestone 30 days out must not push CO placement
+  or conflicts), and an empty project falls back to `startDate`. Used by BOTH CO placement
+  and the project-window conflict rule (replacing P2's
+  `endDate ?? latest task end ?? startDate + 1 day`; the `startDate + 1 day` value now
+  serves ONLY as the conflict-window duration fallback).
+- **Placement (defensible default):** appended as a contiguous block starting **exactly at
+  `effectiveWorkEnd`** — task bounds are end-exclusive (P2), so starting AT the current end
+  leaves no empty day — the job's finish visibly moves out; the PM drags tasks to slot them
+  mid-job if needed (per-project schedule page already supports that).
+- **CO window duration:** labor-calibrated — `coLaborDays = round(coLabor$ / (estimateLabor$ /
+  estimateWindowDays))`, using the CO's **positive** labor lines only (`costType?.name ??
+  type` = "Labor", `total > 0` — negative labor lines are excluded so a mixed
+  addition/deduction CO doesn't shorten the new block while the deducted work awaits
+  manual trimming) (R1 fix 5) and the ORIGINAL estimate's labor burn rate (min 1 day; when
+  the estimate or labor data is missing/unusable: 1 day per non-negative item, packed). Children placed inside the CO
+  window with P2's proportional-boundary rule (exact coverage, 1-day minimum).
+- **Milestones — incl. the zero-row fallback** (R1 fix 4): one milestone task per
+  `ChangeOrderPaymentSchedule` row; canonical date = `dueDate` if set, else
+  cumulative-share of the CO window by `(order, id)`; set `scheduleTaskId` on the CO
+  payment row (regardless of billing state — linking is not a money mutation). **No
+  production path creates `ChangeOrderPaymentSchedule` rows**, so when an Approved CO has
+  ZERO payment rows, synthesize ONE milestone task `CO-##### payment` at the CO block's
+  end with projected amount = **`signedAmount = CO.totalAmount + tax`, computed with the
+  same `co-tax.ts` helper billing uses** (coTaxRate/coTaxLabel — `totalAmount` is the
+  PRE-TAX subtotal; billing invoices totalAmount + tax, so a pre-tax projection would
+  understate cash and jump after billing) (R2 fix). The same `signedAmount` is the
+  zero-row overlay projection below. **Null dueDates on CO
+  payment rows are NOT written** (date authority stays with the invoice clone once billed;
+  the CO row's projected date lives on the task).
+- **Billed-clone linking:** after task creation, find the CO's already-billed invoice
+  milestone(s) by the billing-core convention (invoice on this project, milestone name
+  starts with the CO code) and set their `scheduleTaskId` to the corresponding milestone
+  task (match by order; when the CO has zero payment rows, link the clone to the single
+  synthesized milestone task). Linking regardless of QB state; NO dueDate writes.
+- **Income overlays (no double counting):** a CO contributes to the income layer and
+  project strip as: **billed** → its invoice `PaymentSchedule` clone(s) flow in through the
+  existing P1/P2 queries (they are PaymentSchedule rows); **Approved-but-unbilled** → each
+  `ChangeOrderPaymentSchedule` row as *projected* income at
+  `effectiveDueDate = dueDate ?? linkedTask.startDate` — and with ZERO payment rows, the
+  CO's **`signedAmount`** (totalAmount + tax via co-tax.ts) projected at the synthesized
+  milestone task's date (R1 fix 4, R2 fix).
+  `getCalendarOverlays` and the strip gain a CO section with this billed/unbilled split
+  (ADMIN-only as before).
+- **Auto-hook:** inside `handleChangeOrderApproved`, after a FRESH approval (+ auto-bill)
+  completes, call `applyChangeOrderToSchedule(changeOrderId, "merge", SYSTEM)` best-effort
+  — try/catch, failures appended to `summary.issues`, never fail the money path. Skipped
+  quietly when preconditions fail (not an error; e.g. no startDate).
+- **Manual entries:** dashboard button on In Progress rows with Approved-but-unapplied COs
+  (data via `getCompanyDashboardData`: `unappliedChangeOrders: count + codes`); server
+  action `applyChangeOrderToScheduleAction` (ADMIN/MANAGER); MCP tool
+  `apply_change_order_to_schedule` ({ changeOrderId, mode? }).
+
+## Workstream C — Task-level crew + precise conflicts
+
+- `setTaskCrew({ taskId, userIds, actor })` in schedule-core: `TaskAssignment`
+  replace-diff (ACTIVATED validation like `setProjectCrew`; role stays "assigned");
+  ActivityLog "set_task_crew". Server action `updateTaskCrewAction` (ADMIN/MANAGER).
+- Dashboard: "Schedule & crew" card rows become **expandable** — tasks of the project
+  (from `getCompanyDashboardData`: id, name, dates, status, assigned users incl.
+  inactive-removable entries) each with the P2 picker UI. FINANCE read-only as before.
+- **Conflict precision upgrade** (`getCrewConflicts` v2): conflicts from **TaskAssignment
+  windows** — user assigned to tasks on different projects whose `[start, end)` windows
+  overlap within the visible month → pairs with task names + dates. **The project-window
+  fallback is per `(userId, projectId)`** (R1 fix 6): only user–project pairs with NO task
+  assignments in the month use the P2 project-window rule, so having task assignments on
+  project A never suppresses fallback coverage on project B. Union both, dedupe. Windows
+  use the shared `effectiveWorkEnd` (R1 fix 3). MCP `get_company_schedule` returns the
+  upgraded block.
+
+## MCP changes (server → v1.9.0)
+
+- New `apply_change_order_to_schedule` (write) per workstream B.
+- `get_company_schedule`: gains `unappliedChangeOrders` per project and the v2
+  `crewConflicts` block.
+- Instructions extended: "change orders adjust the schedule — approve in ProBuild (auto)
+  or call apply_change_order_to_schedule; deductions never auto-remove tasks."
+
+## Verification (`scripts/verify-phase3-co-schedule.ts`, fixtures cleaned up)
+
+- (a) approveEstimate hook fires generation (Approved + startDate + zero tasks → tasks
+  appear); **zero-task precondition**: a project with MANUAL tasks gets NO generated
+  schedule from the auto path; **failure injection** (R1 fix 7): force the generator to
+  throw (e.g. corrupt fixture) and assert the approval + invoice state remains committed;
+  **null→dated loop** (R1 fix 2): approve without startDate (nothing), then setProjectStartDate
+  → generation fires automatically.
+- (b) CO application: parent/children created after `effectiveWorkEnd` (a trailing payment
+  milestone does NOT push placement); negative items skipped + noted; mixed
+  addition/deduction CO: negative labor lines excluded from coLabor$; merge idempotent;
+  regenerate respects subtree eligibility.
+- (c) CO milestones: dueDate wins; derived dates otherwise; `scheduleTaskId` set on CO rows
+  AND on a seeded billed clone (name-prefix match); no dueDate writes anywhere; **zero-row
+  fallback** (R1 fix 4, R2): a CO with NO payment rows gets one synthesized end milestone
+  carrying signedAmount (totalAmount + tax via the co-tax.ts helper), its billed clone linked;
+  placement starts exactly at effectiveWorkEnd (no empty day), empty project falls back to
+  startDate; auto callers pass requireEmptyProject: true, MCP/importer keep merge semantics
+- (d) Overlay: Approved-unbilled CO money appears as projected income at effectiveDueDate
+  (incl. the zero-row signedAmount fallback — taxable fixture asserting the SAME exact amount
+  before and after billing); after seeding the billed clone, the same money appears ONCE (no double count).
+- (e) setTaskCrew diff + ACTIVATED rejection; dashboard data exposes task assignments;
+  conflict v2 flags a task-window overlap; **per-pair fallback** (R1 fix 6): user with task
+  assignments on A but none on B still gets B project-window coverage; ignores
+  same-project overlaps.
+- (f) Hook integration: `handleChangeOrderApproved`-adjacent path (call with preconditions
+  met vs unmet) leaves billing results untouched when scheduling throws (inject failure).
+- (g) `tsc --noEmit` 0 errors; dev smoke: expand row → task pickers; CO button appears;
+  overlays show CO projected income (ADMIN only).
+
+## Money-path note
+
+B writes ONLY `scheduleTaskId` on CO payment rows + billed clones (no amounts, no status,
+no QB fields, no dueDate writes at all this phase); hooks are best-effort post-commit and
+can never fail approval/billing → TRIP-2 codex review before merge;
+`e2e/money-pipeline.spec.ts` must stay green.
+
+## Explicitly out of scope (Phase 4+)
+
+- Mid-job INSERTION with automatic right-shift of remaining tasks (PM drags for now);
+  deduction items auto-trimming existing tasks (notes only).
+- OfficeTask/"set a start date" reminders; notifications for CO schedule impact.
+- Daily-log-driven progress rollups on the dashboard; punch list / closeout surfacing
+  (both exist per-project); capacity planning.
+
+## R1 changelog (Codex review round 1 → this revision)
+
+1. Auto path enforces zero-project-tasks inside the locked transaction (P2 merge only skips linked items; manual tasks would otherwise get an overlapping generated schedule).
+2. Closed the forgot-the-date loop: setProjectStartDate post-commit best-effort generation when a qualifying estimate exists and the project has zero tasks.
+3. One effectiveWorkEnd = max(Project.endDate, non-milestone task ends) for CO placement AND project-window conflicts (payment milestones never extend the work window).
+4. Zero-payment-row CO fallback: one synthesized CO-end milestone with the signed totalAmount, billed clone linked, overlay projects the same amount; non-seeded verification case added.
+5. coLabor$ uses positive labor lines only.
+6. Project-window conflict fallback is per (userId, projectId).
+7. Verification now injects an actual generator failure and asserts approval/invoice state stays committed.
+
+## R2 changelog (Codex review round 2 → this revision)
+
+1. requireEmptyProject?: boolean distinguishes the automatic zero-task path (approveEstimate hook, setProjectStartDate hook, dashboard button = true) from explicit merge callers (MCP, importer).
+2. CO signedAmount = totalAmount + tax via co-tax.ts (totalAmount is pre-tax; billing invoices totalAmount + tax) — used by the synthesized milestone AND the overlay projection so projected cash doesn't jump after billing.
+3. effectiveWorkEnd gains the ?? startDate fallback; the CO block starts exactly AT it (end-exclusive, no empty day); startDate + 1 day remains only the conflict-window duration fallback.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -852,6 +852,10 @@ model ScheduleTask {
   // milestones) so regenerate can identify them without touching manual tasks.
   generatedFromEstimateId String?
   generatedFromEstimate   Estimate? @relation(fields: [generatedFromEstimateId], references: [id], onDelete: SetNull)
+  // CO-task provenance: set on tasks created by applyChangeOrderToSchedule
+  // (CO parent, children, milestones).
+  generatedFromChangeOrderId String?
+  generatedFromChangeOrder   ChangeOrder? @relation(fields: [generatedFromChangeOrderId], references: [id], onDelete: SetNull)
   createdAt      DateTime       @default(now())
   updatedAt      DateTime       @updatedAt
 
@@ -871,10 +875,12 @@ model ScheduleTask {
   // Payment milestones anchored to this task (company dashboard start moves).
   estimatePaymentSchedules EstimatePaymentSchedule[]
   paymentSchedules         PaymentSchedule[]
+  changeOrderPaymentSchedules ChangeOrderPaymentSchedule[]
 
   @@index([projectId])
   @@index([leadId])
   @@index([generatedFromEstimateId])
+  @@index([generatedFromChangeOrderId])
 }
 
 model TaskDependency {
@@ -1263,6 +1269,8 @@ model ChangeOrder {
 
   items            ChangeOrderItem[]
   paymentSchedules ChangeOrderPaymentSchedule[]
+  // Schedule tasks generated from this CO (provenance / idempotency).
+  generatedScheduleTasks ScheduleTask[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1299,6 +1307,12 @@ model ChangeOrderPaymentSchedule {
   dueDate       DateTime?
   order         Int         @default(0)
   createdAt     DateTime    @default(now())
+
+  // Optional milestone anchor created by applyChangeOrderToSchedule.
+  scheduleTaskId String?
+  scheduleTask   ScheduleTask? @relation(fields: [scheduleTaskId], references: [id], onDelete: SetNull)
+
+  @@index([scheduleTaskId])
 }
 
 model VendorTag {

--- a/scripts/apply-co-schedule-schema.mjs
+++ b/scripts/apply-co-schedule-schema.mjs
@@ -1,0 +1,60 @@
+// One-off additive migration for the CO → schedule feature
+// (.specs/PB-pipeline-003-co-schedule.md).
+// Adds CO-task provenance on ScheduleTask and the milestone↔calendar link on
+// ChangeOrderPaymentSchedule (nullable + indexes only; old client unaffected).
+// Mirrors scripts/apply-schedule-provenance-schema.mjs.
+//
+// Run:  node scripts/apply-co-schedule-schema.mjs
+// (DDL via $executeRawUnsafe over the Supabase transaction pooler — the working
+//  path in this project; psql / prisma db push / migrate dev do not work here.)
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+function resolveDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const f of [".env", ".env.local"]) {
+    if (!fs.existsSync(f)) continue;
+    const m = fs.readFileSync(f, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+    if (m) return m[1];
+  }
+  throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const prisma = new PrismaClient({ datasources: { db: { url: resolveDatabaseUrl() } } });
+
+const statements = [
+  // CO-task provenance (mirrors generatedFromEstimateId): which change order
+  // generated this task, so regenerate can identify CO tasks specifically.
+  `ALTER TABLE "ScheduleTask"
+     ADD COLUMN IF NOT EXISTS "generatedFromChangeOrderId" TEXT`,
+  `DO $$ BEGIN
+     ALTER TABLE "ScheduleTask"
+       ADD CONSTRAINT "ScheduleTask_generatedFromChangeOrderId_fkey"
+       FOREIGN KEY ("generatedFromChangeOrderId") REFERENCES "ChangeOrder"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+   EXCEPTION WHEN duplicate_object THEN NULL; END $$`,
+  `CREATE INDEX IF NOT EXISTS "ScheduleTask_generatedFromChangeOrderId_idx" ON "ScheduleTask" ("generatedFromChangeOrderId")`,
+
+  // Milestone↔calendar tie for CO payment rows (mirrors the P1 pattern on
+  // EstimatePaymentSchedule / PaymentSchedule).
+  `ALTER TABLE "ChangeOrderPaymentSchedule"
+     ADD COLUMN IF NOT EXISTS "scheduleTaskId" TEXT`,
+  `DO $$ BEGIN
+     ALTER TABLE "ChangeOrderPaymentSchedule"
+       ADD CONSTRAINT "ChangeOrderPaymentSchedule_scheduleTaskId_fkey"
+       FOREIGN KEY ("scheduleTaskId") REFERENCES "ScheduleTask"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+   EXCEPTION WHEN duplicate_object THEN NULL; END $$`,
+  `CREATE INDEX IF NOT EXISTS "ChangeOrderPaymentSchedule_scheduleTaskId_idx" ON "ChangeOrderPaymentSchedule" ("scheduleTaskId")`,
+];
+
+try {
+  for (const sql of statements) {
+    await prisma.$executeRawUnsafe(sql);
+    console.log("✔ applied:", sql.split("\n")[0]);
+  }
+  console.log("Done.");
+} catch (e) {
+  console.error("Migration failed:", e);
+  process.exitCode = 1;
+} finally {
+  await prisma.$disconnect();
+}

--- a/scripts/verify-phase3-co-schedule.ts
+++ b/scripts/verify-phase3-co-schedule.ts
@@ -1,0 +1,414 @@
+// E2E verification for PB-pipeline-003 Phase 3 (CO -> schedule & cash).
+// Creates uniquely named far-future fixtures, exercises spec cases (a)-(f),
+// and cleans every fixture in finally. Run after apply-co-schedule-schema.mjs.
+import fs from "node:fs";
+import { prisma } from "../src/lib/prisma";
+import { coSignedAmount } from "../src/lib/co-tax";
+import {
+    applyChangeOrderToSchedule,
+    autoGenerateScheduleForApprovedEstimate,
+    getCalendarOverlays,
+    getCompanyDashboardData,
+    getCrewConflicts,
+    setProjectStartDate,
+    setTaskCrew,
+} from "../src/lib/schedule-core";
+import { handleChangeOrderApproved } from "../src/lib/billing-core";
+
+const DAY = 86_400_000;
+const base = Date.UTC(2037, 0, 1);
+const TEAM = { type: "TEAM" as const, name: "Phase 3 verifier" };
+type Check = [label: string, ok: boolean, detail?: string];
+
+async function main() {
+    const checks: Check[] = [];
+    const projectIds: string[] = [];
+    const estimateIds: string[] = [];
+    const invoiceIds: string[] = [];
+    const changeOrderIds: string[] = [];
+    const userIds: string[] = [];
+    const clientIds: string[] = [];
+    const tag = `${Date.now().toString(36)}-${process.pid}`;
+    const at = (days: number) => new Date(base + days * DAY);
+    const pass = (label: string, ok: boolean, detail?: unknown) =>
+        checks.push([label, ok, detail == null ? undefined : String(detail)]);
+
+    try {
+        const client = await prisma.client.create({ data: { name: `P3 VERIFY ${tag} DELETE ME`, initials: "P3" } });
+        clientIds.push(client.id);
+        const active = await prisma.user.create({
+            data: { email: `p3-active-${tag}@example.invalid`, name: "P3 Active", role: "FIELD_CREW", status: "ACTIVATED" },
+        });
+        const pending = await prisma.user.create({
+            data: { email: `p3-pending-${tag}@example.invalid`, name: "P3 Pending", role: "FIELD_CREW", status: "PENDING" },
+        });
+        const disabled = await prisma.user.create({
+            data: { email: `p3-disabled-${tag}@example.invalid`, name: "P3 Disabled", role: "FIELD_CREW", status: "DISABLED" },
+        });
+        userIds.push(active.id, pending.id, disabled.id);
+
+        const makeProject = async (suffix: string, data: { status?: string; startDate?: Date | null; endDate?: Date | null } = {}) => {
+            const project = await prisma.project.create({
+                data: {
+                    name: `P3 ${suffix} ${tag} DELETE ME`,
+                    clientId: client.id,
+                    status: data.status ?? "Waiting to Start",
+                    startDate: data.startDate === undefined ? at(0) : data.startDate,
+                    endDate: data.endDate ?? null,
+                },
+            });
+            projectIds.push(project.id);
+            return project;
+        };
+        const makeEstimate = async (
+            projectId: string,
+            suffix: string,
+            data: { taxExempt?: boolean; taxRatePercent?: number; totalAmount?: number } = {},
+        ) => {
+            const totalAmount = data.totalAmount ?? 1_000;
+            const estimate = await prisma.estimate.create({
+                data: {
+                    title: `P3 estimate ${suffix}`,
+                    projectId,
+                    code: `EST-P3-${tag}-${suffix}`,
+                    status: "Approved",
+                    totalAmount,
+                    balanceDue: totalAmount,
+                    taxExempt: data.taxExempt ?? true,
+                    taxRatePercent: data.taxRatePercent,
+                },
+            });
+            estimateIds.push(estimate.id);
+            return estimate;
+        };
+        const makeInvoice = async (projectId: string, estimateId: string, suffix: string, totalAmount = 0) => {
+            const invoice = await prisma.invoice.create({
+                data: { code: `INV-P3-${tag}-${suffix}`, projectId, clientId: client.id, estimateId, status: "Issued", totalAmount, balanceDue: totalAmount },
+            });
+            invoiceIds.push(invoice.id);
+            return invoice;
+        };
+        const makeCo = async (projectId: string, estimateId: string, suffix: string, totalAmount: number) => {
+            const code = `CO-${tag.toUpperCase()}-${suffix}`;
+            const co = await prisma.changeOrder.create({
+                data: {
+                    projectId, estimateId, code, title: `P3 change ${suffix}`, status: "Approved",
+                    totalAmount, balanceDue: totalAmount, approvedBy: "Verifier", approvedAt: new Date(),
+                },
+            });
+            changeOrderIds.push(co.id);
+            return co;
+        };
+
+        // (a) Estimate approval auto-generation and automatic-path safety.
+        const autoProject = await makeProject("auto");
+        const autoEstimate = await makeEstimate(autoProject.id, "AUTO");
+        await prisma.estimateItem.create({
+            data: { estimateId: autoEstimate.id, name: "Auto labor", type: "Labor", quantity: 8, budgetUnit: "hours", total: 1_000 },
+        });
+        const auto = await autoGenerateScheduleForApprovedEstimate(autoEstimate.id);
+        const autoTasks = await prisma.scheduleTask.findMany({ where: { projectId: autoProject.id } });
+        pass("(a) approved + dated + empty project auto-generates", auto.generated && autoTasks.length === 1);
+
+        const manualProject = await makeProject("manual");
+        const manualEstimate = await makeEstimate(manualProject.id, "MANUAL");
+        await prisma.estimateItem.create({ data: { estimateId: manualEstimate.id, name: "Should not generate", type: "Material", total: 100 } });
+        const manualTask = await prisma.scheduleTask.create({ data: { projectId: manualProject.id, name: "Manual task", startDate: at(0), endDate: at(2) } });
+        const manualAuto = await autoGenerateScheduleForApprovedEstimate(manualEstimate.id);
+        const manualTasks = await prisma.scheduleTask.findMany({ where: { projectId: manualProject.id } });
+        pass("(a) requireEmptyProject skips a manual schedule", !manualAuto.generated && manualTasks.length === 1 && manualTasks[0].id === manualTask.id);
+
+        const failProject = await makeProject("autogen-failure");
+        const failEstimate = await makeEstimate(failProject.id, "FAIL");
+        await prisma.estimateItem.create({ data: { estimateId: failEstimate.id, name: "Rollback probe", type: "Material", total: 100 } });
+        const corruptEps = await prisma.estimatePaymentSchedule.create({
+            data: { estimateId: failEstimate.id, name: "Corrupt percent", percentage: 50, amount: 100, status: "Pending" },
+        });
+        await prisma.$executeRaw`UPDATE "EstimatePaymentSchedule" SET "percentage" = 'NaN'::double precision WHERE "id" = ${corruptEps.id}`;
+        const failInvoice = await makeInvoice(failProject.id, failEstimate.id, "FAIL", 100);
+        const failedAuto = await autoGenerateScheduleForApprovedEstimate(failEstimate.id);
+        const [failEstimateAfter, failInvoiceAfter, failTaskCount] = await Promise.all([
+            prisma.estimate.findUniqueOrThrow({ where: { id: failEstimate.id } }),
+            prisma.invoice.findUniqueOrThrow({ where: { id: failInvoice.id } }),
+            prisma.scheduleTask.count({ where: { projectId: failProject.id } }),
+        ]);
+        pass("(a) injected generator failure is surfaced", !failedAuto.generated && !!failedAuto.note);
+        pass("(a) generator failure rolls back tasks", failTaskCount === 0);
+        pass("(a) approval + invoice remain committed after generator failure", failEstimateAfter.status === "Approved" && failInvoiceAfter.id === failInvoice.id);
+
+        const lateDateProject = await makeProject("late-date", { startDate: null });
+        const lateDateEstimate = await makeEstimate(lateDateProject.id, "LATE-DATE");
+        await prisma.estimateItem.create({ data: { estimateId: lateDateEstimate.id, name: "Late date task", type: "Material", total: 100 } });
+        const beforeDate = await autoGenerateScheduleForApprovedEstimate(lateDateEstimate.id);
+        const dateMove = await setProjectStartDate({ projectId: lateDateProject.id, startDate: at(5), actor: TEAM });
+        const lateTasks = await prisma.scheduleTask.findMany({ where: { projectId: lateDateProject.id } });
+        pass("(a) sign first with no date creates nothing", !beforeDate.generated && lateTasks.length === 1);
+        pass("(a) null -> dated hook auto-generates", lateTasks.length === 1 && lateTasks[0].startDate.getTime() === at(5).getTime());
+        pass("(a) late-date hook reports generation in notes", dateMove.notes.some(n => /auto-generated/i.test(n)));
+
+        const actionsSource = fs.readFileSync(new URL("../src/lib/actions.ts", import.meta.url), "utf8");
+        const approveStart = actionsSource.indexOf("export async function approveEstimate");
+        const approveEnd = actionsSource.indexOf("\nexport async function deleteInvoice", approveStart);
+        const approveBody = actionsSource.slice(approveStart, approveEnd);
+        pass("(a) approveEstimate wires the post-commit auto-generator", approveBody.includes("autoGenerateScheduleForApprovedEstimate"));
+        pass("(a) dashboard generation passes requireEmptyProject true", /generateProjectScheduleAction[\s\S]*?requireEmptyProject:\s*true/.test(actionsSource));
+        const scheduleCoreSource = fs.readFileSync(new URL("../src/lib/schedule-core.ts", import.meta.url), "utf8");
+        const setDateBody = scheduleCoreSource.slice(scheduleCoreSource.indexOf("export async function setProjectStartDate"), scheduleCoreSource.indexOf("export interface CashflowBucket"));
+        const autoBody = scheduleCoreSource.slice(scheduleCoreSource.indexOf("export async function autoGenerateScheduleForApprovedEstimate"), scheduleCoreSource.indexOf("export class CoSchedulePreconditionError"));
+        const importerBody = actionsSource.slice(actionsSource.indexOf("export async function importEstimateToSchedule"), actionsSource.indexOf("export async function generateProjectScheduleAction"));
+        pass("(a) every automatic caller requires an empty project", setDateBody.includes("requireEmptyProject: true") && autoBody.includes("requireEmptyProject: true"));
+        pass("(a) explicit importer preserves merge semantics", !importerBody.includes("requireEmptyProject"));
+        pass("(a) approveEstimate hook runs after invoice/budget work and is caught", approveBody.indexOf("autoGenerateScheduleForApprovedEstimate") > approveBody.indexOf("prisma.budget.create") && /try\s*\{[\s\S]*autoGenerateScheduleForApprovedEstimate[\s\S]*\}\s*catch/.test(approveBody));
+
+        // (b) Approved CO application, exact placement, deductions, links,
+        // billed/unbilled overlay behavior, idempotency, and safe regenerate.
+        const coProject = await makeProject("co-main", { status: "In Progress", startDate: at(10), endDate: at(20) });
+        const coEstimate = await makeEstimate(coProject.id, "CO-MAIN", { taxExempt: true, totalAmount: 10_000 });
+        await prisma.estimateItem.create({
+            data: { estimateId: coEstimate.id, name: "Original labor", type: "Labor", quantity: 80, budgetUnit: "hours", total: 1_000 },
+        });
+        await prisma.scheduleTask.create({
+            data: { projectId: coProject.id, name: "Existing work", startDate: at(18), endDate: at(22), type: "task" },
+        });
+        await prisma.scheduleTask.create({
+            data: { projectId: coProject.id, name: "Trailing milestone ignored", startDate: at(100), endDate: at(101), type: "milestone" },
+        });
+        const co = await makeCo(coProject.id, coEstimate.id, "MAIN", 1_000);
+        await prisma.changeOrderItem.createMany({ data: [
+            { changeOrderId: co.id, name: "Added framing", type: "Labor", total: 500, order: 0 },
+            { changeOrderId: co.id, name: "Added material", type: "Material", total: 200, order: 1 },
+            { changeOrderId: co.id, name: "Removed labor", type: "Labor", total: -400, order: 2 },
+        ] });
+        const firstCoPay = await prisma.changeOrderPaymentSchedule.create({
+            data: { changeOrderId: co.id, name: "CO deposit", amount: 250, dueDate: at(30), order: 0 },
+        });
+        const secondCoPay = await prisma.changeOrderPaymentSchedule.create({
+            data: { changeOrderId: co.id, name: "CO balance", amount: 750, order: 1 },
+        });
+
+        const applied = await applyChangeOrderToSchedule({ changeOrderId: co.id, actor: TEAM });
+        const appliedTasks = await prisma.scheduleTask.findMany({
+            where: { generatedFromChangeOrderId: co.id }, orderBy: [{ order: "asc" }, { id: "asc" }],
+        });
+        const parent = appliedTasks.find(t => t.parentId === null && t.type !== "milestone");
+        const children = appliedTasks.filter(t => t.parentId === parent?.id);
+        const milestones = appliedTasks.filter(t => t.type === "milestone");
+        const linkedRows = await prisma.changeOrderPaymentSchedule.findMany({
+            where: { changeOrderId: co.id }, orderBy: [{ order: "asc" }, { id: "asc" }],
+        });
+        pass("(b) CO block starts at max(project end, non-milestone end)", parent?.startDate.getTime() === at(22).getTime());
+        pass("(b) labor-calibrated parent window is five days", parent?.endDate.getTime() === at(27).getTime());
+        pass("(b) non-negative CO items are children of the CO parent", children.length === 2);
+        pass("(b) deduction creates no task and leaves a note", !appliedTasks.some(t => t.name === "Removed labor") && applied.notes.some(n => /deduction/i.test(n)));
+        pass("(b) explicit and derived payment rows link without due-date mutation",
+            milestones.length === 2 && linkedRows.every(r => !!r.scheduleTaskId) &&
+            linkedRows.find(r => r.id === firstCoPay.id)?.dueDate?.getTime() === at(30).getTime() &&
+            linkedRows.find(r => r.id === secondCoPay.id)?.dueDate === null);
+        const firstMilestone = milestones.find(task => task.id === linkedRows.find(row => row.id === firstCoPay.id)?.scheduleTaskId);
+        const secondMilestone = milestones.find(task => task.id === linkedRows.find(row => row.id === secondCoPay.id)?.scheduleTaskId);
+        pass("(c) dueDate wins for the explicit CO milestone", firstMilestone?.startDate.getTime() === at(30).getTime());
+        pass("(c) null dueDate derives from cumulative amount share", secondMilestone?.startDate.getTime() === at(27).getTime());
+
+        const beforeBillOverlay = await getCalendarOverlays(at(0), at(60));
+        const beforeBillRows = beforeBillOverlay.changeOrders.filter(r => r.changeOrderId === co.id);
+        pass("(b) unbilled CO projects its payment schedule exactly once", beforeBillRows.length === 2 && beforeBillRows.reduce((s, r) => s + r.amount, 0) === 1_000);
+
+        // Seed stale non-null links; merge must converge them rather than only
+        // filling NULL links (scheduleTaskId is the only money-row field touched).
+        await prisma.changeOrderPaymentSchedule.update({ where: { id: secondCoPay.id }, data: { scheduleTaskId: parent!.id } });
+        const coInvoice = await makeInvoice(coProject.id, coEstimate.id, "CO-MAIN", 1_000);
+        const billedClone = await prisma.paymentSchedule.create({
+            data: { invoiceId: coInvoice.id, name: `${co.code} — ${co.title}`, amount: 1_000, status: "Pending", scheduleTaskId: parent!.id },
+        });
+        const mergeAgain = await applyChangeOrderToSchedule({ changeOrderId: co.id, actor: TEAM });
+        const [afterMergeCount, cloneAfterMerge, afterBillOverlay] = await Promise.all([
+            prisma.scheduleTask.count({ where: { generatedFromChangeOrderId: co.id } }),
+            prisma.paymentSchedule.findUniqueOrThrow({ where: { id: billedClone.id } }),
+            getCalendarOverlays(at(0), at(60)),
+        ]);
+        pass("(b) merge is idempotent", afterMergeCount === appliedTasks.length && mergeAgain.created.length === 0);
+        pass("(b) billed clone converges to the first CO milestone", cloneAfterMerge.scheduleTaskId === linkedRows[0].scheduleTaskId);
+        const correctedSecondRow = await prisma.changeOrderPaymentSchedule.findUniqueOrThrow({ where: { id: secondCoPay.id } });
+        pass("(b) merge corrects a stale non-null CO-row link", correctedSecondRow.scheduleTaskId === linkedRows[1].scheduleTaskId);
+        pass("(b) billed CO is absent from projected overlay", afterBillOverlay.changeOrders.every(r => r.changeOrderId !== co.id));
+        const billedIncomeRows = afterBillOverlay.income.filter(row => row.id === billedClone.id);
+        pass("(d) billed CO appears in ordinary income exactly once at the same amount", billedIncomeRows.length === 1 && billedIncomeRows[0].amount === 1_000);
+
+        const protectedChild = children[0];
+        await prisma.taskComment.create({ data: { taskId: protectedChild.id, userId: active.id, text: "Protect this generated subtree" } });
+        const oldMilestoneIds = new Set(milestones.map(t => t.id));
+        await applyChangeOrderToSchedule({ changeOrderId: co.id, mode: "regenerate", actor: TEAM });
+        const regenerated = await prisma.scheduleTask.findMany({ where: { generatedFromChangeOrderId: co.id } });
+        const regeneratedRows = await prisma.changeOrderPaymentSchedule.findMany({ where: { changeOrderId: co.id } });
+        const regeneratedClone = await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: billedClone.id } });
+        pass("(b) regenerate preserves a protected CO subtree", regenerated.some(t => t.id === parent?.id) && regenerated.some(t => t.id === protectedChild.id));
+        pass("(b) regenerate rebuilds eligible milestone roots", regenerated.filter(t => t.type === "milestone").length === 2 && regenerated.some(t => t.type === "milestone" && !oldMilestoneIds.has(t.id)));
+        pass("(b) regenerate relinks CO rows and billed clone", regeneratedRows.every(r => !!r.scheduleTaskId) && !!regeneratedClone.scheduleTaskId);
+
+        // (c) Zero-payment-row fallback uses the tax-inclusive billing amount.
+        // Reuse the main CO code on another project to prove billed detection is
+        // keyed by (projectId, code), never code alone.
+        const zeroProject = await makeProject("co-zero", { status: "In Progress", startDate: at(40), endDate: null });
+        const zeroEstimate = await makeEstimate(zeroProject.id, "CO-ZERO", { taxExempt: false, taxRatePercent: 10, totalAmount: 5_000 });
+        await prisma.estimateItem.create({ data: { estimateId: zeroEstimate.id, name: "Original material", type: "Material", total: 500 } });
+        const zeroCo = await makeCo(zeroProject.id, zeroEstimate.id, "ZERO", 100);
+        await prisma.changeOrder.update({ where: { id: zeroCo.id }, data: { code: co.code } });
+        await prisma.changeOrderItem.create({ data: { changeOrderId: zeroCo.id, name: "Small addition", type: "Material", total: 100, order: 0 } });
+        const zeroApply = await applyChangeOrderToSchedule({ changeOrderId: zeroCo.id, actor: TEAM });
+        const zeroTasks = await prisma.scheduleTask.findMany({ where: { generatedFromChangeOrderId: zeroCo.id } });
+        const zeroParent = zeroTasks.find(t => t.type !== "milestone" && t.parentId === null);
+        const zeroMilestone = zeroTasks.find(t => t.type === "milestone");
+        const signedZero = coSignedAmount(100, { taxExempt: false, taxRatePercent: 10, taxRateName: null });
+        pass("(c) zero-row CO gets one synthesized milestone at block end", !!zeroParent && zeroMilestone?.startDate.getTime() === zeroParent.endDate.getTime());
+        pass("(c) empty-project effectiveWorkEnd falls back exactly to startDate", zeroParent?.startDate.getTime() === at(40).getTime());
+        pass("(c) synthesized milestone reports the tax-inclusive signed amount", signedZero === 110 && zeroApply.notes.some(n => n.includes("$110.00")));
+        const zeroProjected = (await getCalendarOverlays(at(0), at(80))).changeOrders.filter(r => r.changeOrderId === zeroCo.id);
+        pass("(c) same CO code on another project is still projected", zeroProjected.length === 1 && zeroProjected[0].amount === 110);
+
+        const zeroInvoice = await makeInvoice(zeroProject.id, zeroEstimate.id, "CO-ZERO", 110);
+        const zeroClone = await prisma.paymentSchedule.create({
+            data: { invoiceId: zeroInvoice.id, name: `${co.code} — ${zeroCo.title}`, amount: 110, status: "Pending" },
+        });
+        await applyChangeOrderToSchedule({ changeOrderId: zeroCo.id, actor: TEAM });
+        const zeroCloneAfter = await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: zeroClone.id } });
+        const zeroAfterBill = (await getCalendarOverlays(at(0), at(80))).changeOrders.filter(r => r.changeOrderId === zeroCo.id);
+        const zeroIncomeAfterBill = (await getCalendarOverlays(at(0), at(80))).income.filter(r => r.id === zeroClone.id);
+        pass("(c) zero-row billed clone links to synthesized milestone", zeroCloneAfter.scheduleTaskId === zeroMilestone?.id);
+        pass("(c) zero-row billed CO is not double-counted", zeroAfterBill.length === 0);
+        pass("(d) taxable zero-row amount is identical before and after billing", zeroProjected[0]?.amount === 110 && zeroIncomeAfterBill.length === 1 && zeroIncomeAfterBill[0].amount === zeroProjected[0].amount);
+        pass("(c) schedule linking never writes a billing due date", zeroCloneAfter.dueDate === null);
+
+        // (d) Task-level crew replacement and role-safe dashboard enrichment.
+        const crewTask = children[1];
+        const firstCrew = await setTaskCrew({ taskId: crewTask.id, userIds: [active.id], actor: TEAM });
+        const secondCrew = await setTaskCrew({ taskId: crewTask.id, userIds: [active.id, active.id], actor: TEAM });
+        let pendingRejected = false;
+        try {
+            await setTaskCrew({ taskId: crewTask.id, userIds: [pending.id], actor: TEAM });
+        } catch (error) {
+            pendingRejected = /ACTIVATED/.test(String(error));
+        }
+        pass("(d) task crew replacement is idempotent", firstCrew.assignments.length === 1 && secondCrew.assignments.length === 1);
+        pass("(d) pending users cannot be assigned", pendingRejected);
+        await prisma.taskAssignment.create({ data: { taskId: crewTask.id, userId: disabled.id, role: "assigned" } });
+
+        const unappliedProject = await makeProject("unapplied", { status: "In Progress", startDate: at(50), endDate: at(53) });
+        const unappliedEstimate = await makeEstimate(unappliedProject.id, "UNAPPLIED");
+        const unappliedCo = await makeCo(unappliedProject.id, unappliedEstimate.id, "UNAPPLIED", 50);
+        const financeDashboard = await getCompanyDashboardData({ role: "FINANCE" }, "2037-03");
+        const financeProjects = [
+            ...financeDashboard.pipeline.waitingToStart,
+            ...financeDashboard.pipeline.scheduled,
+            ...financeDashboard.pipeline.inProgress,
+        ];
+        const financeCoProject = financeProjects.find(p => p.id === coProject.id);
+        const financeUnapplied = financeProjects.find(p => p.id === unappliedProject.id);
+        const financeAssignment = financeCoProject?.tasks.flatMap(t => t.assignments).find(a => a.userId === disabled.id);
+        pass("(d) FINANCE can read expanded tasks and inactive assignment status", financeAssignment?.status === "DISABLED");
+        pass("(d) FINANCE receives no edit list or money overlays", financeDashboard.teamMembers === null && financeDashboard.overlays === null && financeDashboard.strip === null);
+        pass("(d) dashboard exposes Approved COs with no provenance tasks", financeUnapplied?.unappliedChangeOrders.items.some(c => c.id === unappliedCo.id) === true);
+        const unappliedPayloadKeys = financeUnapplied?.unappliedChangeOrders.items.flatMap(item => Object.keys(item)) ?? [];
+        pass("(d) unapplied CO dashboard payload contains no money", unappliedPayloadKeys.every(key => key === "id" || key === "code"));
+        await setTaskCrew({ taskId: crewTask.id, userIds: [active.id], actor: TEAM });
+        const removedDisabled = await prisma.taskAssignment.count({ where: { taskId: crewTask.id, userId: disabled.id } });
+        pass("(d) inactive legacy assignment remains removable", removedDisabled === 0);
+
+        // (e) Task-window conflicts, per-(user, project) fallback, and the
+        // shared max(endDate, latest work-task end) effective work end.
+        const conflictA = await makeProject("conflict-a", { status: "In Progress", startDate: at(60), endDate: at(62) });
+        const conflictB = await makeProject("conflict-b", { status: "In Progress", startDate: at(60), endDate: at(62) });
+        const conflictC = await makeProject("conflict-c", { status: "In Progress", startDate: at(63), endDate: at(64) });
+        await prisma.project.update({ where: { id: conflictB.id }, data: { crew: { connect: { id: active.id } } } });
+        const taskA1 = await prisma.scheduleTask.create({ data: { projectId: conflictA.id, name: "A assigned", startDate: at(64), endDate: at(66) } });
+        const taskA2 = await prisma.scheduleTask.create({ data: { projectId: conflictA.id, name: "A same project", startDate: at(64), endDate: at(67) } });
+        const taskB = await prisma.scheduleTask.create({ data: { projectId: conflictB.id, name: "B extends effective end", startDate: at(62), endDate: at(65) } });
+        const taskC = await prisma.scheduleTask.create({ data: { projectId: conflictC.id, name: "C assigned", startDate: at(65), endDate: at(68) } });
+        await prisma.taskAssignment.createMany({ data: [
+            { taskId: taskA1.id, userId: active.id, role: "assigned" },
+            { taskId: taskA2.id, userId: active.id, role: "assigned" },
+            { taskId: taskC.id, userId: active.id, role: "assigned" },
+        ] });
+        const conflicts = await getCrewConflicts(at(59), at(70));
+        const activeConflicts = conflicts.find(c => c.userId === active.id)?.pairs ?? [];
+        const hasPair = (a: string, b: string) => activeConflicts.some(p => new Set([p.projectA.id, p.projectB.id]).has(a) && new Set([p.projectA.id, p.projectB.id]).has(b));
+        const taskPair = activeConflicts.find(p => new Set([p.projectA.id, p.projectB.id]).has(conflictA.id) && new Set([p.projectA.id, p.projectB.id]).has(conflictC.id));
+        pass("(e) overlapping assigned tasks on different projects conflict", !!taskPair?.taskA && !!taskPair?.taskB);
+        pass("(e) assigned-task vs fallback project window conflict is detected", hasPair(conflictA.id, conflictB.id));
+        pass("(e) fallback effective end uses max(project end, work-task end)", activeConflicts.some(p => new Set([p.projectA.id, p.projectB.id]).has(conflictB.id) && p.overlapEnd === at(65).toISOString()));
+        pass("(e) same-project task overlaps are ignored", activeConflicts.every(p => p.projectA.id !== p.projectB.id));
+
+        // (f) Fresh-approval billing hook: schedule preconditions are quiet;
+        // real failures are surfaced without unwinding billing.
+        const hookProject = await makeProject("hook-no-date", { startDate: null });
+        const hookEstimate = await makeEstimate(hookProject.id, "HOOK-NO-DATE");
+        const hookCo = await makeCo(hookProject.id, hookEstimate.id, "HOOK-NO-DATE", 75);
+        const hookInvoice = await makeInvoice(hookProject.id, hookEstimate.id, "HOOK-NO-DATE", 75);
+        await prisma.paymentSchedule.create({
+            data: { invoiceId: hookInvoice.id, name: `${hookCo.code} — ${hookCo.title}`, amount: 75, status: "Pending" },
+        });
+        const quietHook = await handleChangeOrderApproved(hookCo.id, { notify: false, freshlyApproved: true });
+        const hookTaskCount = await prisma.scheduleTask.count({ where: { generatedFromChangeOrderId: hookCo.id } });
+        pass("(f) fresh approval with no project date leaves billing committed", hookTaskCount === 0 && quietHook.issues.every(i => !/schedule/i.test(i)));
+
+        const brokenProject = await makeProject("hook-failure", { startDate: at(80), endDate: at(81) });
+        const brokenEstimate = await makeEstimate(brokenProject.id, "HOOK-FAIL");
+        const brokenCo = await makeCo(brokenProject.id, brokenEstimate.id, "HOOK-FAIL", 90);
+        const brokenInvoice = await makeInvoice(brokenProject.id, brokenEstimate.id, "HOOK-FAIL", 90);
+        const brokenClone = await prisma.paymentSchedule.create({
+            data: { invoiceId: brokenInvoice.id, name: `${brokenCo.code} — ${brokenCo.title}`, amount: 90, status: "Pending" },
+        });
+        await prisma.$executeRaw`UPDATE "Project" SET "endDate" = 'infinity'::timestamp WHERE "id" = ${brokenProject.id}`;
+        const brokenHook = await handleChangeOrderApproved(brokenCo.id, { notify: false, freshlyApproved: true });
+        await prisma.$executeRaw`UPDATE "Project" SET "endDate" = NULL WHERE "id" = ${brokenProject.id}`;
+        const brokenCloneAfter = await prisma.paymentSchedule.findUnique({ where: { id: brokenClone.id } });
+        pass("(f) real schedule-hook failure is reported", brokenHook.issues.some(i => /schedule/i.test(i)));
+        pass("(f) real schedule-hook failure does not unwind billing", brokenCloneAfter?.id === brokenClone.id);
+
+        // Static integration checks cover auth boundaries and UI/MCP wiring that
+        // is intentionally not invoked by this database fixture.
+        const scheduleSource = fs.readFileSync(new URL("../src/lib/schedule-core.ts", import.meta.url), "utf8");
+        const billingSource = fs.readFileSync(new URL("../src/lib/billing-core.ts", import.meta.url), "utf8");
+        const mcpSource = fs.readFileSync(new URL("../src/app/api/mcp/[transport]/route.ts", import.meta.url), "utf8");
+        const dashboardSource = fs.readFileSync(new URL("../src/app/company-dashboard/CompanyDashboardClient.tsx", import.meta.url), "utf8");
+        const coApplyStart = scheduleSource.indexOf("export async function applyChangeOrderToSchedule");
+        const coApplyEnd = scheduleSource.indexOf("export async function setTaskCrew", coApplyStart);
+        const coApplyBody = scheduleSource.slice(coApplyStart, coApplyEnd);
+        const forbiddenMoneyRowWrite = /SET\s+"?(?:dueDate|amount|status|qbInvoiceId)"?|(?:changeOrderPaymentSchedule|paymentSchedule)\.update(?:Many)?\s*\(/i;
+        pass("(f) CO application contains no due-date or money mutation", !forbiddenMoneyRowWrite.test(coApplyBody));
+        pass("(f) approveChangeOrder marks only a fresh transition for scheduling", /handleChangeOrderApproved\(id,\s*\{\s*freshlyApproved:\s*true/.test(actionsSource));
+        pass("(f) billing hook catches schedule preconditions separately", billingSource.includes("CoSchedulePreconditionError") && billingSource.includes("freshlyApproved"));
+        const applyActionBody = actionsSource.slice(actionsSource.indexOf("export async function applyChangeOrderToScheduleAction"), actionsSource.indexOf("export async function updateTaskCrewAction"));
+        const taskCrewActionBody = actionsSource.slice(actionsSource.indexOf("export async function updateTaskCrewAction"), actionsSource.indexOf("export async function updateProjectColor"));
+        pass("(f) protected dashboard actions enforce company edit roles", applyActionBody.includes('["ADMIN", "MANAGER"]') && taskCrewActionBody.includes('["ADMIN", "MANAGER"]'));
+        pass("(f) MCP exposes apply_change_order_to_schedule", mcpSource.includes('"apply_change_order_to_schedule"') && mcpSource.includes("applyChangeOrderToSchedule"));
+        const mcpGeneratorBody = mcpSource.slice(mcpSource.indexOf('"generate_project_schedule"'), mcpSource.indexOf('"assign_project_crew"'));
+        pass("(f) MCP generator preserves explicit merge semantics", !mcpGeneratorBody.includes("requireEmptyProject"));
+        pass("(f) MCP schedule read exposes unapplied CO details", mcpSource.includes("unappliedChangeOrders"));
+        pass("(f) MCP advertises contract version 1.9.0", mcpSource.includes('version: "1.9.0"'));
+        pass("(f) MCP instructions explain automatic and explicit CO application", mcpSource.includes("change orders adjust the schedule") && mcpSource.includes("deductions never auto-remove tasks"));
+        pass("(f) dashboard includes expandable task rows and task crew action", dashboardSource.includes("aria-expanded") && dashboardSource.includes("updateTaskCrewAction"));
+        pass("(f) dashboard includes Apply CO control", dashboardSource.includes("applyChangeOrderToScheduleAction") && dashboardSource.includes("Apply CO"));
+        pass("(f) hover controls are keyboard/touch accessible", dashboardSource.includes("focus:opacity-100") && dashboardSource.includes("[@media(hover:none)]:opacity-100") && dashboardSource.includes("pointer-events-none") && dashboardSource.includes("focus:pointer-events-auto"));
+        pass("(f) ADMIN views distinguish projected CO money", dashboardSource.includes("coProjected") && dashboardSource.includes("Projected CO"));
+        pass("(f) shared effective-work-end rule is used by CO placement and conflicts", (scheduleSource.match(/effectiveWorkEnd/g)?.length ?? 0) >= 3 && scheduleSource.includes("computeEffectiveWorkEnd"));
+    } finally {
+        if (invoiceIds.length) await prisma.invoice.deleteMany({ where: { id: { in: invoiceIds } } });
+        if (changeOrderIds.length) await prisma.changeOrder.deleteMany({ where: { id: { in: changeOrderIds } } });
+        if (estimateIds.length) await prisma.estimate.deleteMany({ where: { id: { in: estimateIds } } });
+        if (projectIds.length) await prisma.project.deleteMany({ where: { id: { in: projectIds } } });
+        if (userIds.length) await prisma.user.deleteMany({ where: { id: { in: userIds } } });
+        if (clientIds.length) await prisma.client.deleteMany({ where: { id: { in: clientIds } } });
+        console.log(`CLEANUP: removed ${projectIds.length} projects, ${estimateIds.length} estimates, ${changeOrderIds.length} COs, ${invoiceIds.length} invoices, ${userIds.length} users, ${clientIds.length} clients`);
+    }
+
+    const failed = checks.filter(([, ok]) => !ok);
+    for (const [label, ok, detail] of checks) {
+        console.log(`${ok ? "PASS" : "FAIL"}: ${label}${detail ? ` — ${detail}` : ""}`);
+    }
+    console.log(`SUMMARY: ${checks.length - failed.length}/${checks.length} checks passed`);
+    if (failed.length > 0) {
+        throw new Error(`${failed.length} Phase 3 verification check(s) failed: ${failed.map(([label]) => label).join("; ")}`);
+    }
+}
+
+main().then(() => process.exit(0)).catch(e => { console.error(e); process.exit(1); });

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { createEstimateFromPhases, updateEstimateFromPhases, templateToPhases, estimateToPhases, CLOSED_PROJECT_STATUSES, CLOSED_LEAD_STAGES } from "@/lib/gpt-estimate";
 import { getProjectBilling, sendMilestoneInvoicesCore, resendInvoiceCore, createChangeOrderDraft, billChangeOrderCore, sendChangeOrderToClientCore, listReceivables, createInvoiceFromEstimateGuarded } from "@/lib/billing-core";
-import { getCompanyPipeline, getStartCalendar, setProjectStartDate, parseStartDateInput, generateScheduleFromEstimate, setProjectCrew, getCrewConflicts } from "@/lib/schedule-core";
+import { applyChangeOrderToSchedule, getCompanyPipeline, getStartCalendar, getUnappliedChangeOrders, setProjectStartDate, parseStartDateInput, generateScheduleFromEstimate, setProjectCrew, getCrewConflicts } from "@/lib/schedule-core";
 import { coTaxRate, coTaxLabel } from "@/lib/co-tax";
 import { ALLOWED_FILE_EXTENSIONS, fileExtension, mimeTypeForFileName, saveProjectFile } from "@/lib/project-files";
 
@@ -871,6 +871,8 @@ const handler = createMcpHandler(
                     getStartCalendar(from, to, { includeFinancials: false }),
                     getCrewConflicts(from, to),
                 ]);
+                const openProjects = [...pipeline.waitingToStart, ...pipeline.scheduled, ...pipeline.inProgress];
+                const unappliedChangeOrders = await getUnappliedChangeOrders(openProjects.map(project => project.id));
                 // Crew per project (ids + names) — joined onto the start list too.
                 const crewOf = new Map<string, { id: string; name: string }[]>();
                 for (const p of [...pipeline.waitingToStart, ...pipeline.scheduled, ...pipeline.inProgress, ...pipeline.substantialCompletion]) {
@@ -886,19 +888,29 @@ const handler = createMcpHandler(
                     },
                     waitingToStart: pipeline.waitingToStart.map(p => ({
                         projectId: p.id, name: p.name, client: p.client, contractValue: p.contractValue, crew: p.crew,
+                        unappliedChangeOrders: unappliedChangeOrders[p.id] ?? { count: 0, items: [] },
+                    })),
+                    projects: openProjects.map(p => ({
+                        projectId: p.id,
+                        name: p.name,
+                        status: p.status,
+                        startDate: p.startDate?.slice(0, 10) ?? null,
+                        crew: p.crew,
+                        unappliedChangeOrders: unappliedChangeOrders[p.id] ?? { count: 0, items: [] },
                     })),
                     upcomingStarts: {
                         windowDays: horizonDays,
                         projects: calendar.projectStarts.map(p => ({
                             projectId: p.id, name: p.name, client: p.client, status: p.status, startDate: p.startDate.slice(0, 10),
                             crew: crewOf.get(p.id) ?? [],
+                            unappliedChangeOrders: unappliedChangeOrders[p.id] ?? { count: 0, items: [] },
                         })),
                         leads: calendar.leadStarts.map(l => ({
                             leadId: l.id, name: l.name, client: l.client, stage: l.stage, expectedStartDate: l.expectedStartDate.slice(0, 10),
                         })),
                     },
-                    // Double-booked crew from project windows (startDate →
-                    // endDate ?? latest task end ?? startDate+1d, half-open).
+                    // Conflict v2: assigned task windows plus per-(user,project)
+                    // effective-work-window fallback, deduped per project pair.
                     crewConflicts,
                 });
             },
@@ -992,9 +1004,36 @@ const handler = createMcpHandler(
                 }
             },
         );
+
+        server.registerTool(
+            "apply_change_order_to_schedule",
+            {
+                title: "Apply an approved change order to the project schedule",
+                description:
+                    "Adds an Approved change order's positive-scope tasks and payment milestones to its project's schedule. " +
+                    "Deductions are reported for manual trimming and never remove existing tasks automatically. " +
+                    "Default merge mode is idempotent; regenerate rebuilds only untouched CO-generated task subtrees.",
+                inputSchema: {
+                    changeOrderId: z.string().max(50).describe("Approved change-order id"),
+                    mode: z.enum(["merge", "regenerate"]).optional().describe("'merge' (default) applies once; 'regenerate' rebuilds only untouched generated work"),
+                },
+            },
+            async ({ changeOrderId, mode }) => {
+                try {
+                    const result = await applyChangeOrderToSchedule({
+                        changeOrderId,
+                        mode: mode ?? "merge",
+                        actor: { type: "SYSTEM", name: "ChatGPT connector" },
+                    });
+                    return textResult(result);
+                } catch (e: any) {
+                    return { ...textResult({ error: e?.message ?? "Failed to apply change order to schedule" }), isError: true };
+                }
+            },
+        );
     },
     {
-        serverInfo: { name: "probuild", version: "1.8.0" },
+        serverInfo: { name: "probuild", version: "1.9.0" },
         capabilities: { tools: {} },
         instructions:
             "ProBuild is Golden Touch Remodeling's construction management system. " +
@@ -1023,6 +1062,7 @@ const handler = createMcpHandler(
             "to QuickBooks are never shifted and come back in skippedQbMilestones for manual fixing. " +
             "generate_project_schedule builds a project's schedule from its estimate (the estimate must be Approved/Invoiced/Partially Paid/Paid and " +
             "the project needs a start date first — set one with set_project_start_date); default 'merge' mode is idempotent, 'regenerate' rebuilds untouched generated tasks. " +
+            "change orders adjust the schedule — approve in ProBuild (auto) or call apply_change_order_to_schedule; deductions never auto-remove tasks. " +
             "assign_project_crew replaces a project's crew with the given ACTIVATED user ids (full list, not a delta). " +
             "QuickBooks is handled server-side; never ask the user for QuickBooks credentials.",
     },

--- a/src/app/company-dashboard/CompanyDashboardClient.tsx
+++ b/src/app/company-dashboard/CompanyDashboardClient.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { Fragment, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import type { CompanyDashboardData, DashboardProjectRow, ProjectCrewMember } from "@/lib/schedule-core";
+import type { CompanyDashboardData, DashboardProjectRow, DashboardTaskRow, ProjectCrewMember } from "@/lib/schedule-core";
 import { PROJECT_STATUSES } from "@/lib/project-status";
-import { generateProjectScheduleAction, updateProjectCrewAction, updateProjectStartDateAction } from "@/lib/actions";
+import { applyChangeOrderToScheduleAction, generateProjectScheduleAction, updateProjectCrewAction, updateProjectStartDateAction, updateTaskCrewAction } from "@/lib/actions";
 import {
     formatCurrency,
     formatDate,
@@ -147,6 +147,80 @@ function GenerateScheduleButton({ projectId }: { projectId: string }) {
     );
 }
 
+function ApplyChangeOrderButton({ changeOrderId, code }: { changeOrderId: string; code: string }) {
+    const router = useRouter();
+    const [isPending, startTransition] = useTransition();
+    return (
+        <button
+            type="button"
+            onClick={() => startTransition(async () => {
+                try {
+                    await applyChangeOrderToScheduleAction(changeOrderId);
+                    toast.success(`${code} applied to the schedule`);
+                    router.refresh();
+                } catch (err: any) {
+                    toast.error(err?.message || "Failed to apply change order");
+                }
+            })}
+            disabled={isPending}
+            className="hui-btn hui-btn-green text-xs px-2 py-1 whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto focus:opacity-100 focus:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto"
+        >
+            {isPending ? `Applying ${code}...` : `Apply CO ${code}`}
+        </button>
+    );
+}
+
+function TaskCrewPicker({ task, teamMembers }: { task: DashboardTaskRow; teamMembers: { id: string; name: string; email: string }[] }) {
+    const router = useRouter();
+    const [open, setOpen] = useState(false);
+    const [isPending, startTransition] = useTransition();
+    const assignedIds = task.assignments.map(a => a.userId);
+    const assignmentKey = [...assignedIds].sort().join(",");
+    const [override, setOverride] = useState<{ key: string; ids: string[] } | null>(null);
+    const selected = override?.key === assignmentKey ? override.ids : assignedIds;
+    const inactive = task.assignments.filter(a => a.status !== "ACTIVATED" || !teamMembers.some(m => m.id === a.userId));
+    const options = [
+        ...teamMembers.map(member => ({ id: member.id, label: member.name || member.email })),
+        ...inactive.filter(a => !teamMembers.some(m => m.id === a.userId)).map(a => ({ id: a.userId, label: `${a.name} (inactive)` })),
+    ];
+
+    function toggle(userId: string) {
+        const next = selected.includes(userId) ? selected.filter(id => id !== userId) : [...selected, userId];
+        setOverride({ key: assignmentKey, ids: next });
+        startTransition(async () => {
+            try {
+                await updateTaskCrewAction(task.id, next);
+                router.refresh();
+            } catch (err: any) {
+                toast.error(err?.message || "Failed to update task crew");
+                setOverride(null);
+            }
+        });
+    }
+
+    return (
+        <div className="relative inline-block">
+            <button type="button" onClick={() => setOpen(value => !value)} disabled={isPending} className="hui-btn hui-btn-secondary text-xs px-2 py-1" aria-expanded={open}>
+                {selected.length === 0 ? "Assign task crew" : task.assignments.filter(a => selected.includes(a.userId)).map(a => initials(a.name)).join(" ") || `${selected.length} assigned`}
+            </button>
+            {open && (
+                <>
+                    <div className="fixed inset-0 z-20" onClick={() => setOpen(false)} />
+                    <div className="absolute right-0 z-30 mt-1 w-56 bg-white border border-hui-border rounded-lg shadow-lg p-2 max-h-64 overflow-y-auto">
+                        {options.length === 0 && <p className="text-xs text-hui-textMuted px-2 py-1">No active team members.</p>}
+                        {options.map(option => (
+                            <label key={option.id} className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-slate-50 cursor-pointer">
+                                <input type="checkbox" checked={selected.includes(option.id)} onChange={() => toggle(option.id)} className="accent-hui-primary" />
+                                <span className="text-sm text-hui-textMain">{option.label}</span>
+                            </label>
+                        ))}
+                    </div>
+                </>
+            )}
+        </div>
+    );
+}
+
 // Inline date setter for one waiting-to-start project (P1).
 function StartDateRow({ project }: { project: DashboardProjectRow }) {
     const router = useRouter();
@@ -212,8 +286,10 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
 
     // Overlay layer toggles (ADMIN only): income default on, others off.
     const [showIncome, setShowIncome] = useState(true);
+    const [showProjectedCo, setShowProjectedCo] = useState(true);
     const [showExpenses, setShowExpenses] = useState(false);
     const [showHours, setShowHours] = useState(false);
+    const [expandedProjects, setExpandedProjects] = useState<Set<string>>(() => new Set());
 
     const anchor = parseUTCDate(`${month}-01`);
     const days = getMonthGrid(anchor);
@@ -244,6 +320,11 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
     for (const m of overlays?.income ?? []) {
         const key = m.effectiveDueDate.slice(0, 10);
         incomeByDay.set(key, (incomeByDay.get(key) ?? 0) + m.amount);
+    }
+    const projectedCoByDay = new Map<string, number>();
+    for (const row of overlays?.changeOrders ?? []) {
+        const key = row.effectiveDueDate.slice(0, 10);
+        projectedCoByDay.set(key, (projectedCoByDay.get(key) ?? 0) + row.amount);
     }
     const expensesByDay = new Map<string, number>();
     for (const e of overlays?.expenses ?? []) {
@@ -299,6 +380,12 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
                                     Expenses
                                 </button>
                                 <button
+                                    onClick={() => setShowProjectedCo(v => !v)}
+                                    className={`text-xs font-semibold px-2 py-1 rounded-full border transition ${showProjectedCo ? "bg-amber-100 text-amber-800 border-amber-300" : "bg-white text-hui-textMuted border-hui-border"}`}
+                                >
+                                    Projected CO
+                                </button>
+                                <button
                                     onClick={() => setShowHours(v => !v)}
                                     className={`text-xs font-semibold px-2 py-1 rounded-full border transition ${showHours ? "bg-blue-100 text-blue-700 border-blue-300" : "bg-white text-hui-textMuted border-hui-border"}`}
                                 >
@@ -324,6 +411,7 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
                         const projectStarts = projectStartsByDay.get(dayKey) ?? [];
                         const leadStarts = leadStartsByDay.get(dayKey) ?? [];
                         const incomeTotal = showIncome ? incomeByDay.get(dayKey) : undefined;
+                        const projectedCoTotal = showProjectedCo ? projectedCoByDay.get(dayKey) : undefined;
                         const expenseTotal = showExpenses ? expensesByDay.get(dayKey) : undefined;
                         const hoursTotal = showHours ? hoursByDay.get(dayKey) : undefined;
                         return (
@@ -368,6 +456,11 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
                                             {formatCurrency(incomeTotal)} due
                                         </span>
                                     )}
+                                    {projectedCoTotal != null && projectedCoTotal > 0 && (
+                                        <span className="text-[10px] font-medium text-amber-700 px-1.5" title="Approved, unbilled change-order income projected this day">
+                                            {formatCurrency(projectedCoTotal)} projected CO
+                                        </span>
+                                    )}
                                     {expenseTotal != null && expenseTotal > 0 && (
                                         <span className="text-[10px] font-medium text-red-700 px-1.5" title="Expenses this day">
                                             −{formatCurrency(expenseTotal)}
@@ -409,38 +502,89 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
                             {crewRows.map(p => {
                                 const canGenerate =
                                     (p.status === "Waiting to Start") && p.hasQualifyingEstimate && p.taskCount === 0;
+                                const expanded = expandedProjects.has(p.id);
                                 return (
-                                    <tr key={p.id} className="hover:bg-slate-50 transition">
-                                        <td className="px-4 py-3">
-                                            <Link href={`/projects/${p.id}`} className="text-sm font-medium text-hui-textMain hover:text-hui-primary">
-                                                {p.name}
-                                            </Link>
-                                            <span className="block text-xs text-hui-textMuted">{p.client ?? "—"}</span>
-                                        </td>
-                                        <td className="px-4 py-3">
-                                            <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${statusColor(p.status)}`}>
-                                                {p.status === "Waiting to Start" && p.startDate ? "Scheduled" : p.status}
-                                            </span>
-                                        </td>
-                                        <td className="px-4 py-3">
-                                            {canEdit && teamMembers ? (
-                                                <CrewPicker projectId={p.id} crew={p.crew} teamMembers={teamMembers} />
-                                            ) : (
-                                                <span className="text-xs text-hui-textMuted">
-                                                    {p.crew.length === 0 ? "—" : p.crew.map(c => initials(c.name)).join(" ")}
+                                    <Fragment key={p.id}>
+                                        <tr className="group hover:bg-slate-50 transition">
+                                            <td className="px-4 py-3">
+                                                <div className="flex items-start gap-2">
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => setExpandedProjects(current => {
+                                                            const next = new Set(current);
+                                                            next.has(p.id) ? next.delete(p.id) : next.add(p.id);
+                                                            return next;
+                                                        })}
+                                                        disabled={p.taskCount === 0}
+                                                        aria-expanded={expanded}
+                                                        aria-controls={`project-tasks-${p.id}`}
+                                                        className="mt-0.5 w-6 h-6 rounded text-hui-textMuted hover:bg-slate-200 disabled:opacity-30"
+                                                        title={p.taskCount === 0 ? "No tasks" : expanded ? "Collapse tasks" : "Expand tasks"}
+                                                    >
+                                                        {expanded ? "−" : "+"}
+                                                    </button>
+                                                    <div>
+                                                        <Link href={`/projects/${p.id}`} className="text-sm font-medium text-hui-textMain hover:text-hui-primary">
+                                                            {p.name}
+                                                        </Link>
+                                                        <span className="block text-xs text-hui-textMuted">{p.client ?? "—"}</span>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                            <td className="px-4 py-3">
+                                                <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${statusColor(p.status)}`}>
+                                                    {p.status === "Waiting to Start" && p.startDate ? "Scheduled" : p.status}
                                                 </span>
-                                            )}
-                                        </td>
-                                        <td className="px-4 py-3">
-                                            {canEdit && canGenerate ? (
-                                                <GenerateScheduleButton projectId={p.id} />
-                                            ) : (
-                                                <span className="text-xs text-hui-textMuted">
-                                                    {p.taskCount > 0 ? `${p.taskCount} task${p.taskCount === 1 ? "" : "s"}` : "—"}
-                                                </span>
-                                            )}
-                                        </td>
-                                    </tr>
+                                            </td>
+                                            <td className="px-4 py-3">
+                                                {canEdit && teamMembers ? (
+                                                    <CrewPicker projectId={p.id} crew={p.crew} teamMembers={teamMembers} />
+                                                ) : (
+                                                    <span className="text-xs text-hui-textMuted">
+                                                        {p.crew.length === 0 ? "—" : p.crew.map(c => initials(c.name)).join(" ")}
+                                                    </span>
+                                                )}
+                                            </td>
+                                            <td className="px-4 py-3">
+                                                <div className="flex flex-wrap items-center gap-2">
+                                                    {canEdit && canGenerate ? (
+                                                        <GenerateScheduleButton projectId={p.id} />
+                                                    ) : (
+                                                        <span className="text-xs text-hui-textMuted">
+                                                            {p.taskCount > 0 ? `${p.taskCount} task${p.taskCount === 1 ? "" : "s"}` : "—"}
+                                                        </span>
+                                                    )}
+                                                    {canEdit && p.status === "In Progress" && p.unappliedChangeOrders.items.map(co => (
+                                                        <ApplyChangeOrderButton key={co.id} changeOrderId={co.id} code={co.code} />
+                                                    ))}
+                                                </div>
+                                            </td>
+                                        </tr>
+                                        {expanded && (
+                                            <tr id={`project-tasks-${p.id}`}>
+                                                <td colSpan={4} className="bg-slate-50/70 px-8 py-3">
+                                                    <div className="space-y-2">
+                                                        {p.tasks.map(task => (
+                                                            <div key={task.id} className="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3 rounded-lg border border-hui-border bg-white px-3 py-2">
+                                                                <div className="min-w-0">
+                                                                    <p className="truncate text-sm font-medium text-hui-textMain">{task.name}</p>
+                                                                    <p className="text-xs text-hui-textMuted">
+                                                                        {task.type === "milestone" ? "Milestone" : task.status} · {task.startDate.slice(0, 10)} → {task.endDate.slice(0, 10)}
+                                                                    </p>
+                                                                </div>
+                                                                <div className="text-xs text-hui-textMuted">
+                                                                    {task.assignments.length === 0
+                                                                        ? "No task crew"
+                                                                        : task.assignments.map(a => `${a.name}${a.status === "ACTIVATED" ? "" : " (inactive)"}`).join(", ")}
+                                                                </div>
+                                                                {canEdit && teamMembers && <TaskCrewPicker task={task} teamMembers={teamMembers} />}
+                                                            </div>
+                                                        ))}
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        )}
+                                    </Fragment>
                                 );
                             })}
                         </tbody>
@@ -500,6 +644,11 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
                                                 {" × "}
                                                 <Link href={`/projects/${pair.projectB.id}`} className="text-hui-primary hover:underline">{pair.projectB.name}</Link>
                                                 {` — ${pair.overlapStart.slice(0, 10)} → ${pair.overlapEnd.slice(0, 10)}`}
+                                                {(pair.taskA || pair.taskB) && (
+                                                    <span className="block pl-3 text-[11px] text-slate-500">
+                                                        {[pair.taskA, pair.taskB].filter(Boolean).map(task => `${task!.name} (${task!.startDate.slice(0, 10)} → ${task!.endDate.slice(0, 10)})`).join(" × ")}
+                                                    </span>
+                                                )}
                                             </li>
                                         ))}
                                     </ul>
@@ -549,7 +698,7 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
                 <div className="hui-card">
                     <div className="px-4 py-3 border-b border-hui-border">
                         <h2 className="text-base font-semibold text-hui-textMain">This month by project</h2>
-                        <p className="text-xs text-hui-textMuted mt-1">Income due, received, expenses, burdened labor, and hours for {monthLabel}.</p>
+                        <p className="text-xs text-hui-textMuted mt-1">Billed income due, projected unbilled CO income, received, expenses, burdened labor, and hours for {monthLabel}.</p>
                     </div>
                     {strip.length === 0 ? (
                         <p className="px-4 py-8 text-sm text-hui-textMuted text-center">No project activity this month.</p>
@@ -560,6 +709,7 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
                                     <tr className="border-b border-hui-border bg-slate-50">
                                         <th className="text-left px-4 py-3 text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Project</th>
                                         <th className="text-right px-4 py-3 text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Income due</th>
+                                        <th className="text-right px-4 py-3 text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Projected CO</th>
                                         <th className="text-right px-4 py-3 text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Received</th>
                                         <th className="text-right px-4 py-3 text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Expenses</th>
                                         <th className="text-right px-4 py-3 text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Labor (actual, burdened)</th>
@@ -576,6 +726,7 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
                                                 </Link>
                                             </td>
                                             <td className="px-4 py-3 text-sm text-right text-green-700">{formatCurrency(r.incomeDue)}</td>
+                                            <td className="px-4 py-3 text-sm text-right text-amber-700">{formatCurrency(r.coProjected)}</td>
                                             <td className="px-4 py-3 text-sm text-right text-hui-textMain">{formatCurrency(r.received)}</td>
                                             <td className="px-4 py-3 text-sm text-right text-red-700">{formatCurrency(r.expenses)}</td>
                                             <td className="px-4 py-3 text-sm text-right text-hui-textMain">{formatCurrency(r.laborBurdened)}</td>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -17,7 +17,7 @@ import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { enqueueMilestonePaid, drainPaymentNotifications } from "./payment-outbox";
 import { deleteChangeOrderCore, updateChangeOrderCore } from "./change-order-core";
 import { approveChangeOrderWithSignature } from "./change-order-approval";
-import { setProjectStartDate, parseStartDateInput, generateScheduleFromEstimate, setProjectCrew, CONTRACT_ESTIMATE_STATUSES } from "./schedule-core";
+import { applyChangeOrderToSchedule, autoGenerateScheduleForApprovedEstimate, setProjectStartDate, parseStartDateInput, generateScheduleFromEstimate, setProjectCrew, setTaskCrew, CONTRACT_ESTIMATE_STATUSES } from "./schedule-core";
 import type { ChangeOrderUpdateInput } from "./change-order-core";
 import { emptyDoc } from "@/lib/studio/doc";
 import type { RoomType } from "@/lib/studio/templates";
@@ -2553,6 +2553,13 @@ export async function approveEstimate(estimateId: string, signatureName: string,
         revalidatePath(`/projects/${estimate.projectId}/estimates`);
         revalidatePath(`/projects/${estimate.projectId}/files`);
     }
+    // Post-commit best effort: approval/invoice/budget work above must stand even
+    // if schedule generation is skipped or fails.
+    try {
+        await autoGenerateScheduleForApprovedEstimate(estimateId);
+    } catch (error) {
+        console.error("[approveEstimate] schedule auto-generation failed (approval unaffected):", error);
+    }
     revalidatePath(`/portal/estimates/${estimateId}`);
     return { success: true };
 }
@@ -4005,6 +4012,19 @@ async function assertInvoicePermission() {
 
 async function assertChangeOrderPermission() {
     return assertStaffPermission("changeOrders");
+}
+
+async function assertScheduleProjectAccess(projectId: string) {
+    const user = await assertActiveStaff();
+    if (!hasPermission(user, "schedules") || !canAccessProject(user, projectId)) throw new Error("Forbidden");
+    return user;
+}
+
+async function assertScheduleTaskAccess(taskId: string) {
+    const task = await prisma.scheduleTask.findUnique({ where: { id: taskId }, select: { projectId: true } });
+    if (!task?.projectId) throw new Error("Task not found");
+    const user = await assertScheduleProjectAccess(task.projectId);
+    return { user, projectId: task.projectId };
 }
 
 async function assertFinancialPermission() {
@@ -6486,6 +6506,7 @@ export async function createScheduleTask(projectId: string, data: {
     parentId?: string;
     type?: string;
 }) {
+    await assertScheduleProjectAccess(projectId);
     const maxOrder = await prisma.scheduleTask.aggregate({
         where: { projectId },
         _max: { order: true },
@@ -6522,6 +6543,7 @@ export async function updateScheduleTask(taskId: string, data: {
     type?: string;
     estimateItemId?: string | null;
 }) {
+    await assertScheduleTaskAccess(taskId);
     const updateData: any = {};
     if (data.name !== undefined) updateData.name = data.name;
     if (data.startDate !== undefined) updateData.startDate = new Date(data.startDate);
@@ -6564,12 +6586,14 @@ export async function updateScheduleTask(taskId: string, data: {
 }
 
 export async function deleteScheduleTask(taskId: string) {
+    await assertScheduleTaskAccess(taskId);
     const task = await prisma.scheduleTask.delete({ where: { id: taskId } });
     revalidatePath(`/projects/${task.projectId}/schedule`);
     return task;
 }
 
 export async function reorderScheduleTasks(projectId: string, orderedIds: string[]) {
+    await assertScheduleProjectAccess(projectId);
     if (new Set(orderedIds).size !== orderedIds.length) {
         throw new Error("Duplicate task IDs in reorder request");
     }
@@ -6596,6 +6620,11 @@ export async function reorderScheduleTasks(projectId: string, orderedIds: string
 }
 
 export async function linkTasks(predecessorId: string, dependentId: string) {
+    const [predecessor, dependent] = await Promise.all([
+        assertScheduleTaskAccess(predecessorId),
+        assertScheduleTaskAccess(dependentId),
+    ]);
+    if (predecessor.projectId !== dependent.projectId) throw new Error("Tasks must belong to the same project");
     const dep = await prisma.taskDependency.create({
         data: { predecessorId, dependentId },
     });
@@ -6605,6 +6634,11 @@ export async function linkTasks(predecessorId: string, dependentId: string) {
 }
 
 export async function unlinkTasks(predecessorId: string, dependentId: string) {
+    const [predecessor, dependent] = await Promise.all([
+        assertScheduleTaskAccess(predecessorId),
+        assertScheduleTaskAccess(dependentId),
+    ]);
+    if (predecessor.projectId !== dependent.projectId) throw new Error("Tasks must belong to the same project");
     await prisma.taskDependency.deleteMany({
         where: { predecessorId, dependentId },
     });
@@ -6830,6 +6864,9 @@ export async function getTaskPunchItems(taskId: string) {
 // ========== TASK ASSIGNMENTS ==========
 
 export async function assignUserToTask(taskId: string, userId: string) {
+    await assertScheduleTaskAccess(taskId);
+    const user = await prisma.user.findUnique({ where: { id: userId }, select: { status: true } });
+    if (!user || user.status !== "ACTIVATED") throw new Error("Task crew members must be ACTIVATED users");
     const assignment = await prisma.taskAssignment.create({
         data: { taskId, userId },
         include: { user: { select: { id: true, name: true, email: true } } },
@@ -6840,6 +6877,7 @@ export async function assignUserToTask(taskId: string, userId: string) {
 }
 
 export async function unassignUserFromTask(taskId: string, userId: string) {
+    await assertScheduleTaskAccess(taskId);
     await prisma.taskAssignment.deleteMany({
         where: { taskId, userId },
     });
@@ -6848,6 +6886,7 @@ export async function unassignUserFromTask(taskId: string, userId: string) {
 }
 
 export async function assignSubToTask(taskId: string, subcontractorId: string) {
+    await assertScheduleTaskAccess(taskId);
     const assignment = await prisma.subTaskAssignment.create({
         data: { taskId, subcontractorId },
         include: { subcontractor: { select: { id: true, companyName: true, email: true, trade: true } } },
@@ -6858,6 +6897,7 @@ export async function assignSubToTask(taskId: string, subcontractorId: string) {
 }
 
 export async function unassignSubFromTask(taskId: string, subcontractorId: string) {
+    await assertScheduleTaskAccess(taskId);
     await prisma.subTaskAssignment.deleteMany({
         where: { taskId, subcontractorId },
     });
@@ -7117,6 +7157,7 @@ export async function generateProjectScheduleAction(projectId: string) {
     const result = await generateScheduleFromEstimate({
         estimateId: estimate.id,
         mode: "merge",
+        requireEmptyProject: true,
         actor: { type: "TEAM", name: caller.name || caller.email },
     });
     revalidatePath("/company-dashboard");
@@ -7138,6 +7179,38 @@ export async function updateProjectCrewAction(projectId: string, userIds: string
         actor: { type: "TEAM", name: caller.name || caller.email },
     });
     revalidatePath("/company-dashboard");
+    return result;
+}
+
+export async function applyChangeOrderToScheduleAction(changeOrderId: string, mode: "merge" | "regenerate" = "merge") {
+    const session = await getServerSession(authOptions);
+    const caller = session?.user?.email
+        ? await prisma.user.findUnique({ where: { email: session.user.email }, select: { role: true, name: true, email: true } })
+        : null;
+    if (!caller || !["ADMIN", "MANAGER"].includes(caller.role)) throw new Error("Forbidden");
+    const result = await applyChangeOrderToSchedule({
+        changeOrderId,
+        mode,
+        actor: { type: "TEAM", name: caller.name || caller.email },
+    });
+    revalidatePath("/company-dashboard");
+    revalidatePath(`/projects/${result.projectId}/schedule`);
+    return result;
+}
+
+export async function updateTaskCrewAction(taskId: string, userIds: string[]) {
+    const session = await getServerSession(authOptions);
+    const caller = session?.user?.email
+        ? await prisma.user.findUnique({ where: { email: session.user.email }, select: { role: true, name: true, email: true } })
+        : null;
+    if (!caller || !["ADMIN", "MANAGER"].includes(caller.role)) throw new Error("Forbidden");
+    const result = await setTaskCrew({
+        taskId,
+        userIds,
+        actor: { type: "TEAM", name: caller.name || caller.email },
+    });
+    revalidatePath("/company-dashboard");
+    revalidatePath(`/projects/${result.projectId}/schedule`);
     return result;
 }
 
@@ -7731,7 +7804,7 @@ export async function approveChangeOrder(id: string, signatureName: string, user
         const runAutomation = async () => {
             try {
                 const { handleChangeOrderApproved } = await import("./billing-core");
-                await handleChangeOrderApproved(id);
+                await handleChangeOrderApproved(id, { freshlyApproved: true });
             } catch (err) {
                 console.error("[approveChangeOrder] post-approval automation failed:", err);
             }

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -981,7 +981,10 @@ export async function billChangeOrderCore(changeOrderId: string) {
 // a silent stall. Never throws: the customer's approval must stand regardless.
 // ─────────────────────────────────────────────────────────────────────────────
 
-export async function handleChangeOrderApproved(changeOrderId: string, opts?: { notify?: boolean }): Promise<{ billed: boolean; sent: boolean; issues: string[] }> {
+export async function handleChangeOrderApproved(
+    changeOrderId: string,
+    opts?: { notify?: boolean; freshlyApproved?: boolean },
+): Promise<{ billed: boolean; sent: boolean; issues: string[] }> {
     const summary = { billed: false, sent: false, issues: [] as string[] };
     let coLabel = changeOrderId;
     let amountLabel = "";
@@ -1025,6 +1028,26 @@ export async function handleChangeOrderApproved(changeOrderId: string, opts?: { 
         }
     } catch (err: any) {
         summary.issues.push(err?.message || "Unexpected error during auto-billing");
+    }
+
+    // Only the request that actually transitioned the CO to Approved invokes
+    // the schedule hook. It is post-billing and best-effort so money-path state
+    // can never be unwound by scheduling.
+    if (opts?.freshlyApproved) {
+        let PreconditionError: (new (...args: any[]) => Error) | null = null;
+        try {
+            const { applyChangeOrderToSchedule, CoSchedulePreconditionError } = await import("./schedule-core");
+            PreconditionError = CoSchedulePreconditionError;
+            await applyChangeOrderToSchedule({
+                changeOrderId,
+                mode: "merge",
+                actor: { type: "SYSTEM", name: "system" },
+            });
+        } catch (error: any) {
+            if (!PreconditionError || !(error instanceof PreconditionError)) {
+                summary.issues.push(`Schedule update failed (billing unaffected): ${error?.message ?? error}`);
+            }
+        }
     }
 
     // Team notification (System Notification Email in Settings → Company).

--- a/src/lib/co-tax.ts
+++ b/src/lib/co-tax.ts
@@ -20,6 +20,14 @@ export function coTaxRate(estimate: EstimateTaxInfo): number {
     return Number.isFinite(pct) ? pct / 100 : DEFAULT_CO_TAX_RATE;
 }
 
+// Match billing-core's invoice math exactly: totalAmount is the pre-tax signed
+// subtotal, then both subtotal and tax are rounded to cents before addition.
+export function coSignedAmount(totalAmount: number, estimate: EstimateTaxInfo): number {
+    const subtotal = Math.round((Number(totalAmount) || 0) * 100) / 100;
+    const taxAmount = Math.round(subtotal * coTaxRate(estimate) * 100) / 100;
+    return Math.round((subtotal + taxAmount) * 100) / 100;
+}
+
 // Integer-cents line math shared by the CO editor, the portal signature page,
 // and the item sync in updateChangeOrder, so the amount the customer sees is
 // bit-identical to the amount persisted and billed. toPrecision strips float

--- a/src/lib/schedule-core.ts
+++ b/src/lib/schedule-core.ts
@@ -3,6 +3,7 @@ import { Prisma } from "@prisma/client";
 import { withTxRetry } from "./tx-retry";
 import { OPEN_PROJECT_STATUSES } from "./project-status";
 import { CLOSED_PROJECT_STATUSES, CLOSED_LEAD_STAGES } from "./gpt-estimate";
+import { coSignedAmount, coTaxRate } from "./co-tax";
 import { formatDate, parseUTCDate, addDays, getMonthGrid, getDefaultColorForTaskName } from "@/app/projects/[id]/schedule/schedule-utils";
 
 // Session-free core of the company pipeline dashboard + start-calendar flows
@@ -12,10 +13,10 @@ import { formatDate, parseUTCDate, addDays, getMonthGrid, getDefaultColorForTask
 // "use server", so every export there is a remotely invokable endpoint —
 // auth-free logic must live here, NOT there.
 //
-// Money-path discipline: the ONLY money-model field this module ever writes is
-// `dueDate` on EstimatePaymentSchedule and on non-QuickBooks-pushed, unpaid
-// PaymentSchedule rows — never amounts, statuses, or QB fields, and never a
-// partial shift of a QB-pushed mirror group.
+// Money-path discipline: this module writes `dueDate` only for the guarded P1
+// start-date shift, and `scheduleTaskId` for estimate/CO milestone linking.
+// It never writes amounts, statuses, or QB fields, and never partially shifts
+// a QB-pushed mirror group. Phase 3 CO paths write scheduleTaskId only.
 
 // Estimate statuses that count as the project's contract value (plan R1 fix 10,
 // R2 fix 4): the job is sold and the number is real. Also the qualifying set
@@ -310,7 +311,7 @@ export async function setProjectStartDate(input: {
 
     // Retry wrapper per the repo's money-path convention (see tx-retry.ts): a
     // rolled-back write-conflict on the shared pooler re-runs against fresh state.
-    return withTxRetry(() => prisma.$transaction(async (tx) => {
+    const result = await withTxRetry(() => prisma.$transaction(async (tx) => {
         // Serialize concurrent start-date moves: lock the project row BEFORE
         // reading the current marker, so two moves can never compute their
         // deltas from the same stale startDate (lost-update / double-shift race).
@@ -544,6 +545,36 @@ export async function setProjectStartDate(input: {
             notes,
         };
     }));
+
+    // Post-commit best-effort generation hook (PB-pipeline-003): sign first,
+    // date later ⇒ the schedule appears by itself. Fires when the project ends
+    // up dated with zero tasks and a qualifying estimate; failures are caught
+    // and surface in notes[], never fail the date move.
+    if (startDate !== null) {
+        try {
+            const [taskCount, qualifying] = await Promise.all([
+                prisma.scheduleTask.count({ where: { projectId } }),
+                prisma.estimate.findFirst({
+                    where: { projectId, status: { in: CONTRACT_ESTIMATE_STATUSES } },
+                    orderBy: { createdAt: "desc" },
+                    select: { id: true, code: true },
+                }),
+            ]);
+            if (taskCount === 0 && qualifying) {
+                const gen = await generateScheduleFromEstimate({
+                    estimateId: qualifying.id,
+                    mode: "merge",
+                    requireEmptyProject: true,
+                    actor,
+                });
+                result.notes.push(`Schedule auto-generated from estimate ${qualifying.code} (${gen.created.length} task${gen.created.length === 1 ? "" : "s"}).`);
+            }
+        } catch (e: any) {
+            result.notes.push(`Schedule auto-generation failed (the date move succeeded): ${e?.message ?? e}`);
+        }
+    }
+
+    return result;
 }
 
 export interface CashflowBucket {
@@ -653,6 +684,10 @@ export interface GeneratedTaskRow {
     parentId: string | null;
 }
 
+// Thrown when an automatic-path precondition fails (zero-task enforcement).
+// Hooks treat this class as an expected quiet skip; anything else is a failure.
+export class ScheduleGenerationPreconditionError extends Error {}
+
 export interface GenerateScheduleResult {
     estimateCode: string;
     created: GeneratedTaskRow[];
@@ -693,6 +728,7 @@ export interface GenerateScheduleResult {
 export async function generateScheduleFromEstimate(input: {
     estimateId: string;
     mode?: "merge" | "regenerate";
+    requireEmptyProject?: boolean;
     actor: ScheduleActor;
 }): Promise<GenerateScheduleResult> {
     const mode = input.mode ?? "merge";
@@ -727,6 +763,20 @@ export async function generateScheduleFromEstimate(input: {
         if (!project) throw new Error("Project not found");
         if (!project.startDate) {
             throw new Error(`Project "${project.name}" has no start date yet — set one on the company dashboard before generating its schedule.`);
+        }
+
+        // Automatic paths (approveEstimate hook, setProjectStartDate hook,
+        // dashboard button) pass requireEmptyProject: generation only fires on
+        // a zero-task schedule, enforced HERE under the Project lock so a
+        // concurrent manual task can't stack a generated schedule on top
+        // (P2's merge mode alone only skips already-linked estimate items).
+        if (input.requireEmptyProject) {
+            const existingTaskCount = await tx.scheduleTask.count({ where: { projectId } });
+            if (existingTaskCount > 0) {
+                throw new ScheduleGenerationPreconditionError(
+                    `Project "${project.name}" already has ${existingTaskCount} schedule task${existingTaskCount === 1 ? "" : "s"} — automatic generation only runs on an empty schedule.`
+                );
+            }
         }
 
         // Full estimate read INSIDE the lock.
@@ -1205,6 +1255,9 @@ export interface CrewConflictPair {
     projectB: { id: string; name: string };
     overlapStart: string;
     overlapEnd: string;
+    // Present for TaskAssignment-window conflicts (v2 precision).
+    taskA?: { id: string; name: string; startDate: string; endDate: string };
+    taskB?: { id: string; name: string; startDate: string; endDate: string };
 }
 
 export interface CrewConflict {
@@ -1214,30 +1267,107 @@ export interface CrewConflict {
 }
 
 /**
- * Crew double-bookings within [from, to): a conflict = one user in the crew of
- * two different projects whose windows overlap within the range. Window =
- * startDate → (endDate ?? latest task endDate ?? startDate + 1 day) — the
- * 1-day fallback means two crews booked on the same day DO conflict; overlaps
- * use half-open [start, end) bounds. Bounded queries; overlap computed in
- * memory. (TaskAssignment-level precision is Phase 3.)
+ * Crew double-bookings within [from, to), v2 (PB-pipeline-003):
+ *  1. TaskAssignment windows — a user assigned to tasks on DIFFERENT projects
+ *     whose [start, end) windows overlap within the range → pairs with task
+ *     names + dates.
+ *  2. Per-(userId, projectId) project-window fallback (R1 fix 6): only
+ *     user–project pairs with NO task assignments in range use the P2
+ *     project-window rule, so task coverage on project A never suppresses
+ *     fallback coverage on project B. Windows: startDate → effectiveWorkEnd
+ *     (startDate+1d remains only the duration fallback for empty projects).
+ * Union of both, deduped per project pair (task-based entries win).
  */
 export async function getCrewConflicts(from: Date, to: Date): Promise<CrewConflict[]> {
-    const projects = await prisma.project.findMany({
-        where: { startDate: { not: null }, crew: { some: {} } },
-        select: {
-            id: true, name: true, startDate: true, endDate: true,
-            crew: { select: { id: true, name: true, email: true } },
-            scheduleTasks: { orderBy: { endDate: "desc" }, take: 1, select: { endDate: true } },
-        },
-    });
+    const [assignments, projects] = await Promise.all([
+        prisma.taskAssignment.findMany({
+            where: { task: { projectId: { not: null }, startDate: { lt: to }, endDate: { gt: from } } },
+            select: {
+                userId: true,
+                user: { select: { id: true, name: true, email: true } },
+                task: {
+                    select: {
+                        id: true, name: true, startDate: true, endDate: true, projectId: true,
+                        project: { select: { id: true, name: true } },
+                    },
+                },
+            },
+        }),
+        prisma.project.findMany({
+            where: { startDate: { not: null }, crew: { some: {} } },
+            select: {
+                id: true, name: true, startDate: true, endDate: true,
+                crew: { select: { id: true, name: true, email: true } },
+                scheduleTasks: { where: { type: { not: "milestone" } }, orderBy: { endDate: "desc" }, take: 1, select: { endDate: true } },
+            },
+        }),
+    ]);
 
-    const windows = projects.map(p => {
+    // Half-open [start, end) overlap, intersected with the visible range.
+    const overlaps = (aS: Date, aE: Date, bS: Date, bE: Date): [Date, Date] | null => {
+        const s = aS > bS ? aS : bS;
+        const e = aE < bE ? aE : bE;
+        if (s >= e) return null;
+        if (e <= from || s >= to) return null;
+        return [s, e];
+    };
+
+    const byUser = new Map<string, CrewConflict>();
+    const pushPair = (userId: string, name: string, pair: CrewConflictPair, taskBased: boolean) => {
+        let entry = byUser.get(userId);
+        if (!entry) {
+            entry = { userId, name, pairs: [] };
+            byUser.set(userId, entry);
+        }
+        const key = [pair.projectA.id, pair.projectB.id].sort().join("|");
+        const existingIdx = entry.pairs.findIndex(p => [p.projectA.id, p.projectB.id].sort().join("|") === key);
+        if (existingIdx >= 0) {
+            // Task-based precision wins over the fallback for the same pair.
+            if (taskBased && !entry.pairs[existingIdx].taskA && !entry.pairs[existingIdx].taskB) entry.pairs[existingIdx] = pair;
+        } else {
+            entry.pairs.push(pair);
+        }
+    };
+
+    // (1) TaskAssignment windows.
+    type UserWindow = {
+        projectId: string;
+        projectName: string;
+        start: Date;
+        end: Date;
+        task?: { id: string; name: string; startDate: string; endDate: string };
+    };
+    const windowsByUser = new Map<string, { name: string; windows: UserWindow[] }>();
+    const addWindow = (userId: string, name: string, window: UserWindow) => {
+        let entry = windowsByUser.get(userId);
+        if (!entry) {
+            entry = { name, windows: [] };
+            windowsByUser.set(userId, entry);
+        }
+        entry.windows.push(window);
+    };
+    const assignedUserProjects = new Set<string>(); // "userId|projectId" with ≥1 assignment in range
+    for (const a of assignments) {
+        const projectId = a.task.projectId!;
+        assignedUserProjects.add(`${a.userId}|${projectId}`);
+        addWindow(a.userId, a.user.name || a.user.email, {
+            projectId,
+            projectName: a.task.project?.name ?? "",
+            start: a.task.startDate,
+            end: a.task.endDate,
+            task: {
+                id: a.task.id,
+                name: a.task.name,
+                startDate: a.task.startDate.toISOString(),
+                endDate: a.task.endDate.toISOString(),
+            },
+        });
+    }
+
+    // (2) Project-window fallback per (userId, projectId).
+    const fallbackWindows = projects.map(p => {
         const start = utcDay(p.startDate!);
-        const rawEnd = p.endDate
-            ? utcDay(p.endDate)
-            : p.scheduleTasks[0]
-                ? utcDay(p.scheduleTasks[0].endDate)
-                : addDays(start, 1);
+        const rawEnd = effectiveWorkEnd(p, p.scheduleTasks[0]?.endDate ?? null);
         return {
             id: p.id,
             name: p.name,
@@ -1246,41 +1376,39 @@ export async function getCrewConflicts(from: Date, to: Date): Promise<CrewConfli
             crew: p.crew,
         };
     });
-
-    // Group windows by crew user, then check each pair of that user's projects.
-    const byUser = new Map<string, { name: string; windows: typeof windows }>();
-    for (const w of windows) {
+    for (const w of fallbackWindows) {
         for (const u of w.crew) {
-            const entry = byUser.get(u.id) ?? { name: u.name || u.email, windows: [] };
-            entry.windows.push(w);
-            byUser.set(u.id, entry);
+            if (assignedUserProjects.has(`${u.id}|${w.id}`)) continue; // task windows cover this pair
+            addWindow(u.id, u.name || u.email, {
+                projectId: w.id,
+                projectName: w.name,
+                start: w.start,
+                end: w.end,
+            });
         }
     }
-
-    const conflicts: CrewConflict[] = [];
-    for (const [userId, { name, windows: userWindows }] of byUser) {
-        if (userWindows.length < 2) continue;
-        const pairs: CrewConflictPair[] = [];
+    // Compare the complete per-user union so task A is tested against fallback B.
+    for (const [userId, { name, windows: userWindows }] of windowsByUser) {
         for (let i = 0; i < userWindows.length; i++) {
             for (let j = i + 1; j < userWindows.length; j++) {
                 const a = userWindows[i];
                 const b = userWindows[j];
-                const oStart = a.start > b.start ? a.start : b.start;
-                const oEnd = a.end < b.end ? a.end : b.end;
-                if (oStart >= oEnd) continue; // half-open: no overlap
-                // The overlap must intersect the visible range.
-                if (oEnd <= from || oStart >= to) continue;
-                pairs.push({
-                    projectA: { id: a.id, name: a.name },
-                    projectB: { id: b.id, name: b.name },
-                    overlapStart: oStart.toISOString(),
-                    overlapEnd: oEnd.toISOString(),
-                });
+                if (a.projectId === b.projectId) continue;
+                const o = overlaps(a.start, a.end, b.start, b.end);
+                if (!o) continue;
+                pushPair(userId, name, {
+                    projectA: { id: a.projectId, name: a.projectName },
+                    projectB: { id: b.projectId, name: b.projectName },
+                    overlapStart: o[0].toISOString(),
+                    overlapEnd: o[1].toISOString(),
+                    taskA: a.task,
+                    taskB: b.task,
+                }, !!a.task || !!b.task);
             }
         }
-        if (pairs.length > 0) conflicts.push({ userId, name, pairs });
     }
-    return conflicts;
+
+    return [...byUser.values()];
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1323,10 +1451,102 @@ export interface OverlayHoursItem {
     durationHours: number;
 }
 
+export interface OverlayChangeOrderItem {
+    changeOrderId: string;
+    code: string;
+    title: string;
+    name: string;
+    amount: number;
+    // Per-row effectiveDueDate (dueDate ?? linkedTask.startDate), or — for a
+    // zero-payment-row CO — the synthesized milestone task's date.
+    effectiveDueDate: string;
+    projectId: string | null;
+    projectName: string | null;
+    // Always true here: billed COs are EXCLUDED (their invoice clones flow
+    // through the existing PaymentSchedule income queries — no double counting).
+    projected: true;
+}
+
 export interface CalendarOverlays {
     income: OverlayIncomeItem[];
     expenses: OverlayExpenseItem[];
     hours: OverlayHoursItem[];
+    changeOrders: OverlayChangeOrderItem[];
+}
+
+/**
+ * Approved-but-unbilled change-order money as projected income (PB-pipeline-003):
+ * each ChangeOrderPaymentSchedule row at its effectiveDueDate, or — for a CO
+ * with ZERO payment rows — the CO's signedAmount (totalAmount + tax via
+ * co-tax.ts) at the synthesized milestone task's date. Billed COs (detected by
+ * the billing-core name-prefix convention) are excluded so the same money
+ * never appears twice.
+ */
+export async function getChangeOrderOverlayRows(from: Date, to: Date): Promise<OverlayChangeOrderItem[]> {
+    const cos = await prisma.changeOrder.findMany({
+        where: { status: "Approved" },
+        select: {
+            id: true, code: true, title: true, totalAmount: true, projectId: true,
+            estimate: { select: { taxExempt: true, taxRatePercent: true, taxRateName: true } },
+            project: { select: { id: true, name: true } },
+            paymentSchedules: {
+                orderBy: [{ order: "asc" }, { id: "asc" }],
+                select: { id: true, name: true, amount: true, dueDate: true, scheduleTaskId: true },
+            },
+            generatedScheduleTasks: { where: { type: "milestone" }, orderBy: [{ order: "asc" }, { id: "asc" }], select: { id: true, startDate: true } },
+        },
+    });
+    if (cos.length === 0) return [];
+
+    // Billed detection: a milestone named `${code} — …` on the CO's project
+    // (billing-core convention), same as billChangeOrderCore's idempotency check.
+    const projectIds = [...new Set(cos.map(c => c.projectId))];
+    const billedMilestones = await prisma.paymentSchedule.findMany({
+        where: { invoice: { projectId: { in: projectIds } }, name: { startsWith: "CO-" }, status: { not: "Canceled" } },
+        select: { name: true, invoice: { select: { projectId: true } } },
+    });
+    // Billing idempotency is scoped to the project; CO codes are not globally unique.
+    const isBilled = (projectId: string, code: string) => billedMilestones.some(
+        m => m.invoice.projectId === projectId && m.name.startsWith(`${code} `),
+    );
+    const rows: OverlayChangeOrderItem[] = [];
+    for (const co of cos) {
+        if (isBilled(co.projectId, co.code)) continue;
+        const taskStartById = new Map(co.generatedScheduleTasks.map(t => [t.id, t.startDate]));
+        if (co.paymentSchedules.length > 0) {
+            for (const row of co.paymentSchedules) {
+                const effective = row.dueDate ?? (row.scheduleTaskId ? taskStartById.get(row.scheduleTaskId) : undefined) ?? null;
+                if (!effective || effective < from || effective >= to) continue;
+                rows.push({
+                    changeOrderId: co.id,
+                    code: co.code,
+                    title: co.title,
+                    name: row.name,
+                    amount: Number(row.amount),
+                    effectiveDueDate: effective.toISOString(),
+                    projectId: co.project?.id ?? null,
+                    projectName: co.project?.name ?? null,
+                    projected: true,
+                });
+            }
+        } else {
+            const signedAmount = coSignedAmount(Number(co.totalAmount), co.estimate);
+            const synthDate = co.generatedScheduleTasks[0]?.startDate ?? null;
+            if (!synthDate || synthDate < from || synthDate >= to) continue;
+            rows.push({
+                changeOrderId: co.id,
+                code: co.code,
+                title: co.title,
+                name: `${co.code} payment`,
+                amount: signedAmount,
+                effectiveDueDate: synthDate.toISOString(),
+                projectId: co.project?.id ?? null,
+                projectName: co.project?.name ?? null,
+                projected: true,
+            });
+        }
+    }
+    return rows;
 }
 
 /**
@@ -1334,8 +1554,12 @@ export interface CalendarOverlays {
  * effectiveDueDate rule), expenses (Expense.date in range, project via
  * estimate), hours (TimeEntry.startTime date in range). Read-only.
  */
-export async function getCalendarOverlays(from: Date, to: Date): Promise<CalendarOverlays> {
-    const [milestones, expenses, hours] = await Promise.all([
+export async function getCalendarOverlays(
+    from: Date,
+    to: Date,
+    suppliedChangeOrders?: OverlayChangeOrderItem[],
+): Promise<CalendarOverlays> {
+    const [milestones, expenses, hours, changeOrders] = await Promise.all([
         prisma.paymentSchedule.findMany({
             where: {
                 status: "Pending",
@@ -1368,6 +1592,7 @@ export async function getCalendarOverlays(from: Date, to: Date): Promise<Calenda
                 project: { select: { id: true, name: true } },
             },
         }),
+        suppliedChangeOrders ?? getChangeOrderOverlayRows(from, to),
     ]);
 
     return {
@@ -1404,6 +1629,7 @@ export async function getCalendarOverlays(from: Date, to: Date): Promise<Calenda
             startTime: h.startTime.toISOString(),
             durationHours: h.durationHours ?? 0,
         })),
+        changeOrders,
     };
 }
 
@@ -1411,9 +1637,59 @@ export async function getCalendarOverlays(from: Date, to: Date): Promise<Calenda
 // Dashboard page assembly (PB-pipeline-002, R1 fix 10 — directly testable)
 // ─────────────────────────────────────────────────────────────────────────────
 
+export interface UnappliedChangeOrderSummary {
+    count: number;
+    items: { id: string; code: string }[];
+}
+
+export async function getUnappliedChangeOrders(
+    projectIds: string[],
+): Promise<Record<string, UnappliedChangeOrderSummary>> {
+    if (projectIds.length === 0) return {};
+    const rows = await prisma.changeOrder.findMany({
+        where: {
+            projectId: { in: projectIds },
+            status: "Approved",
+            generatedScheduleTasks: { none: {} },
+        },
+        orderBy: [{ approvedAt: "asc" }, { id: "asc" }],
+        select: { id: true, code: true, projectId: true },
+    });
+    const result: Record<string, UnappliedChangeOrderSummary> = {};
+    for (const row of rows) {
+        const summary = result[row.projectId] ?? { count: 0, items: [] };
+        summary.count++;
+        summary.items.push({ id: row.id, code: row.code });
+        result[row.projectId] = summary;
+    }
+    return result;
+}
+
+export interface DashboardTaskAssignment {
+    id: string;
+    userId: string;
+    name: string;
+    status: string;
+}
+
+export interface DashboardTaskRow {
+    id: string;
+    name: string;
+    startDate: string;
+    endDate: string;
+    status: string;
+    type: string;
+    assignments: DashboardTaskAssignment[];
+}
+
 export interface DashboardProjectRow extends PipelineProject {
     taskCount: number;
     hasQualifyingEstimate: boolean;
+    // Approved COs with no provenance tasks yet (the "Apply CO" affordance).
+    unappliedChangeOrders: { count: number; items: { id: string; code: string }[] };
+    // Expandable task list with per-task crew (assignments carry user status so
+    // the picker can render inactive-removable entries).
+    tasks: DashboardTaskRow[];
 }
 
 export interface ProjectMonthStripRow {
@@ -1426,6 +1702,9 @@ export interface ProjectMonthStripRow {
     hoursActual: number;
     hoursEstimated: number;
     net: number;
+    // Approved-unbilled CO money projected in range (billed COs flow through
+    // incomeDue via their PaymentSchedule clones — no double counting).
+    coProjected: number;
 }
 
 export interface CompanyDashboardData {
@@ -1456,8 +1735,9 @@ export interface CompanyDashboardData {
  *   Labor (actual, burdened) = laborCost + burdenCost sums
  *   Hours      = actual TimeEntry hours vs estimatedHours of month-overlapping tasks
  *   Net        = Received − Expenses − burdened Labor (profitability convention)
+ *   CO (projected) = Approved-unbilled CO money in range (billed flows via incomeDue)
  */
-async function getProjectMonthStrip(from: Date, to: Date): Promise<ProjectMonthStripRow[]> {
+async function getProjectMonthStrip(from: Date, to: Date, coRows: OverlayChangeOrderItem[]): Promise<ProjectMonthStripRow[]> {
     const openProjects = await prisma.project.findMany({
         where: { status: { in: OPEN_PROJECT_STATUSES } },
         select: { id: true, name: true },
@@ -1509,6 +1789,7 @@ async function getProjectMonthStrip(from: Date, to: Date): Promise<ProjectMonthS
                 projectName: nameOf.get(projectId) ?? "Unknown",
                 incomeDue: 0, received: 0, expenses: 0,
                 laborBurdened: 0, hoursActual: 0, hoursEstimated: 0, net: 0,
+                coProjected: 0,
             };
             sums.set(projectId, r);
         }
@@ -1542,6 +1823,10 @@ async function getProjectMonthStrip(from: Date, to: Date): Promise<ProjectMonthS
         if (!t.projectId || !nameOf.has(t.projectId)) continue;
         row(t.projectId).hoursEstimated += t.estimatedHours ?? 0;
     }
+    for (const c of coRows) {
+        if (!c.projectId || !nameOf.has(c.projectId)) continue;
+        row(c.projectId).coProjected += c.amount;
+    }
 
     const round2 = (n: number) => Math.round(n * 100) / 100;
     return [...sums.values()]
@@ -1554,8 +1839,9 @@ async function getProjectMonthStrip(from: Date, to: Date): Promise<ProjectMonthS
             hoursActual: round2(r.hoursActual),
             hoursEstimated: round2(r.hoursEstimated),
             net: round2(r.received - r.expenses - r.laborBurdened),
+            coProjected: round2(r.coProjected),
         }))
-        .filter(r => r.incomeDue !== 0 || r.received !== 0 || r.expenses !== 0 || r.laborBurdened !== 0 || r.hoursActual !== 0 || r.hoursEstimated !== 0)
+        .filter(r => r.incomeDue !== 0 || r.received !== 0 || r.expenses !== 0 || r.laborBurdened !== 0 || r.hoursActual !== 0 || r.hoursEstimated !== 0 || r.coProjected !== 0)
         .sort((a, b) => a.projectName.localeCompare(b.projectName));
 }
 
@@ -1579,6 +1865,9 @@ export async function getCompanyDashboardData(
     const from = grid[0];
     const to = new Date(grid[grid.length - 1].getTime() + 86_400_000);
 
+    const coRowsPromise = isAdmin
+        ? getChangeOrderOverlayRows(from, to)
+        : Promise.resolve([] as OverlayChangeOrderItem[]);
     const [pipeline, calendar, cashflow, crewConflicts, overlays, strip] = await Promise.all([
         getCompanyPipeline(),
         // The income layer comes from overlays (effectiveDueDate) for ADMIN, so
@@ -1586,8 +1875,8 @@ export async function getCompanyDashboardData(
         getStartCalendar(from, to, { includeFinancials: false }),
         isAdmin ? getCashflowOutlook() : Promise.resolve(null),
         canEdit ? getCrewConflicts(from, to) : Promise.resolve(null),
-        isAdmin ? getCalendarOverlays(from, to) : Promise.resolve(null),
-        isAdmin ? getProjectMonthStrip(from, to) : Promise.resolve(null),
+        isAdmin ? coRowsPromise.then(rows => getCalendarOverlays(from, to, rows)) : Promise.resolve(null),
+        isAdmin ? coRowsPromise.then(rows => getProjectMonthStrip(from, to, rows)) : Promise.resolve(null),
     ]);
 
     // Button data for "Generate schedule": Waiting/Scheduled rows show it only
@@ -1597,16 +1886,48 @@ export async function getCompanyDashboardData(
         ...pipeline.scheduled.map(p => p.id),
         ...pipeline.inProgress.map(p => p.id),
     ];
-    const [taskCounts, qualifying] = await Promise.all([
-        prisma.scheduleTask.groupBy({ by: ["projectId"], where: { projectId: { in: rowIds } }, _count: { id: true } }),
+    const [taskRows, qualifying, unappliedByProject] = await Promise.all([
+        prisma.scheduleTask.findMany({
+            where: { projectId: { in: rowIds } },
+            orderBy: [{ order: "asc" }, { startDate: "asc" }, { id: "asc" }],
+            select: {
+                id: true, projectId: true, name: true, startDate: true, endDate: true, status: true, type: true,
+                assignments: {
+                    orderBy: { createdAt: "asc" },
+                    select: { id: true, userId: true, user: { select: { name: true, email: true, status: true } } },
+                },
+            },
+        }),
         prisma.estimate.groupBy({ by: ["projectId"], where: { projectId: { in: rowIds }, status: { in: CONTRACT_ESTIMATE_STATUSES } }, _count: { id: true } }),
+        getUnappliedChangeOrders(rowIds),
     ]);
-    const taskCountOf = new Map(taskCounts.map(t => [t.projectId, t._count.id]));
+    const tasksByProject = new Map<string, DashboardTaskRow[]>();
+    for (const task of taskRows) {
+        if (!task.projectId) continue;
+        const rows = tasksByProject.get(task.projectId) ?? [];
+        rows.push({
+            id: task.id,
+            name: task.name,
+            startDate: task.startDate.toISOString(),
+            endDate: task.endDate.toISOString(),
+            status: task.status,
+            type: task.type,
+            assignments: task.assignments.map(a => ({
+                id: a.id,
+                userId: a.userId,
+                name: a.user.name || a.user.email,
+                status: a.user.status,
+            })),
+        });
+        tasksByProject.set(task.projectId, rows);
+    }
     const hasQualifying = new Set(qualifying.map(q => q.projectId));
     const enrich = (p: PipelineProject): DashboardProjectRow => ({
         ...p,
-        taskCount: taskCountOf.get(p.id) ?? 0,
+        taskCount: tasksByProject.get(p.id)?.length ?? 0,
         hasQualifyingEstimate: hasQualifying.has(p.id),
+        tasks: tasksByProject.get(p.id) ?? [],
+        unappliedChangeOrders: unappliedByProject[p.id] ?? { count: 0, items: [] },
     });
 
     // Picker list is pre-filtered to ACTIVATED (getTeamMembers stays unchanged
@@ -1638,4 +1959,626 @@ export async function getCompanyDashboardData(
         overlays,
         strip,
     };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Workstream A hook — auto-generate on estimate signature (PB-pipeline-003)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Best-effort post-approval schedule generation. Fires only when the estimate
+ * belongs to a project WITH a start date (the setProjectStartDate hook covers
+ * the "sign first, date later" loop); the generator's requireEmptyProject
+ * enforcement decides inside its own locked tx. NEVER throws: the zero-task
+ * precondition is an expected quiet skip, and any real failure is logged
+ * (console + ActivityLog where possible) — approval can never roll back.
+ */
+export async function autoGenerateScheduleForApprovedEstimate(
+    estimateId: string,
+): Promise<{ generated: boolean; note: string | null }> {
+    let estimate: { id: string; code: string; projectId: string | null; project: { startDate: Date | null } | null } | null = null;
+    try {
+        estimate = await prisma.estimate.findUnique({
+            where: { id: estimateId },
+            select: { id: true, code: true, projectId: true, project: { select: { startDate: true } } },
+        });
+        if (!estimate?.projectId || !estimate.project?.startDate) return { generated: false, note: null };
+        const result = await generateScheduleFromEstimate({
+            estimateId,
+            mode: "merge",
+            requireEmptyProject: true,
+            actor: { type: "SYSTEM", name: "system" },
+        });
+        return { generated: result.created.length > 0, note: null };
+    } catch (e: any) {
+        if (e instanceof ScheduleGenerationPreconditionError) {
+            // Manual tasks already exist — the auto path simply doesn't fire.
+            return { generated: false, note: null };
+        }
+        console.error("[autoGenerateScheduleForApprovedEstimate] generation failed (approval unaffected):", e?.message ?? e);
+        try {
+            if (!estimate?.projectId) return { generated: false, note: String(e?.message ?? e) };
+            await prisma.activityLog.create({
+                data: {
+                    projectId: estimate.projectId,
+                    actorType: "SYSTEM",
+                    actorName: "system",
+                    action: "schedule_autogen_failed",
+                    entityType: "project",
+                    entityId: estimate.projectId,
+                    metadata: JSON.stringify({ estimateId, estimateCode: estimate.code, error: String(e?.message ?? e).slice(0, 500) }),
+                },
+            });
+        } catch { /* best-effort */ }
+        return { generated: false, note: String(e?.message ?? e) };
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Workstream B — Change orders adjust the schedule + cash (PB-pipeline-003)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Thrown when a CO-application precondition fails (not Approved / no startDate).
+// The billing auto-hook skips this class quietly; anything else is an issue.
+export class CoSchedulePreconditionError extends Error {}
+
+/**
+ * One shared definition (R1 fix 3): the end of actual WORK on the project —
+ * max(Project.endDate, max(endDate of NON-milestone tasks)) ?? startDate.
+ * Payment milestone tasks never extend the work window, and an empty project
+ * falls back to startDate. Used by BOTH CO placement and the project-window
+ * conflict rule.
+ */
+function effectiveWorkEnd(
+    project: { startDate: Date | null; endDate: Date | null },
+    latestWorkEnd: Date | null,
+): Date {
+    const candidates = [project.endDate, latestWorkEnd].filter((d): d is Date => !!d);
+    if (candidates.length === 0) return utcDay(project.startDate!);
+    return utcDay(new Date(Math.max(...candidates.map(d => d.getTime()))));
+}
+
+async function computeEffectiveWorkEnd(
+    tx: Prisma.TransactionClient,
+    project: { id: string; startDate: Date | null; endDate: Date | null },
+): Promise<Date> {
+    const latestWork = await tx.scheduleTask.aggregate({
+        where: { projectId: project.id, type: { not: "milestone" } },
+        _max: { endDate: true },
+    });
+    return effectiveWorkEnd(project, latestWork._max.endDate);
+}
+
+export interface ApplyChangeOrderResult {
+    changeOrderCode: string;
+    projectId: string;
+    created: GeneratedTaskRow[];
+    skipped: number;
+    milestonesLinked: number;
+    notes: string[];
+}
+
+/**
+ * Apply an Approved change order to the project schedule: one parent task
+ * `CO-##### · title` + flat children from its items (deductions create NO task
+ * — noted for manual trimming), placed as a contiguous block starting exactly
+ * at effectiveWorkEnd (end-exclusive bounds, so no empty day). The CO window
+ * is labor-calibrated from the CO's POSITIVE labor lines vs the original
+ * estimate's burn rate (fallback: 1 day per non-negative item, packed).
+ * Milestone tasks per ChangeOrderPaymentSchedule row (canonical dueDate ??
+ * cumulative amount-share of the CO window by (order, id)); a CO with ZERO
+ * payment rows gets one synthesized `CO-##### payment` milestone at the block
+ * end projecting signedAmount (totalAmount + tax via co-tax.ts).
+ *
+ * Money-path: sets scheduleTaskId on CO payment rows AND billed clones
+ * (name-prefix match) regardless of QB state; NO amount/status/QB/dueDate
+ * writes anywhere. mode "merge" (default) skips task creation when provenance
+ * tasks exist (linking still converges); "regenerate" rebuilds only
+ * provenance-tagged subtrees passing the P2 full eligibility predicate.
+ */
+export async function applyChangeOrderToSchedule(input: {
+    changeOrderId: string;
+    mode?: "merge" | "regenerate";
+    actor: ScheduleActor;
+}): Promise<ApplyChangeOrderResult> {
+    const mode = input.mode ?? "merge";
+    if (mode !== "merge" && mode !== "regenerate") throw new Error(`Unknown mode "${mode}"`);
+
+    return withTxRetry(() => prisma.$transaction(async (tx) => {
+        // Lock-then-read (same discipline as generation and start-date moves).
+        const coRef = await tx.changeOrder.findUnique({
+            where: { id: input.changeOrderId },
+            select: { id: true, projectId: true },
+        });
+        if (!coRef) throw new CoSchedulePreconditionError("Change order not found");
+        const projectId = coRef.projectId;
+
+        await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${projectId} FOR UPDATE`;
+        const project = await tx.project.findUnique({
+            where: { id: projectId },
+            select: { id: true, name: true, startDate: true, endDate: true },
+        });
+        if (!project) throw new CoSchedulePreconditionError("Project not found");
+        // Parent-before-child lock order: Project first, then the CO snapshot.
+        await tx.$queryRaw`SELECT id FROM "ChangeOrder" WHERE id = ${input.changeOrderId} FOR UPDATE`;
+        if (!project.startDate) {
+            throw new CoSchedulePreconditionError(`Project "${project.name}" has no start date yet — set one on the company dashboard before applying change orders to its schedule.`);
+        }
+
+        // Full CO read INSIDE the lock (items, payment rows, estimate tax + labor).
+        const co = await tx.changeOrder.findUniqueOrThrow({
+            where: { id: input.changeOrderId },
+            include: {
+                items: { orderBy: { order: "asc" }, include: { costType: { select: { name: true } } } },
+                paymentSchedules: { orderBy: [{ order: "asc" }, { id: "asc" }] },
+                estimate: {
+                    select: {
+                        id: true, taxExempt: true, taxRatePercent: true, taxRateName: true,
+                        items: { include: { costType: { select: { name: true } } } },
+                    },
+                },
+            },
+        });
+        if (co.status !== "Approved") {
+            throw new CoSchedulePreconditionError(`Change order ${co.code} is "${co.status}" — only Approved change orders adjust the schedule.`);
+        }
+
+        const notes: string[] = [];
+        const createdRows: GeneratedTaskRow[] = [];
+        let skipped = 0;
+        let milestonesLinked = 0;
+
+        // ── regenerate: delete eligible CO-provenance subtrees first ──
+        if (mode === "regenerate") {
+            // Freeze the task decision set before inspecting child counts. FK
+            // inserts cannot slip between the eligibility snapshot and delete.
+            await tx.$queryRaw`
+                SELECT id FROM "ScheduleTask"
+                WHERE "projectId" = ${projectId}
+                ORDER BY id
+                FOR UPDATE
+            `;
+            const allTasks = await tx.scheduleTask.findMany({
+                where: { projectId },
+                select: {
+                    id: true, parentId: true, generatedFromChangeOrderId: true, progress: true, status: true,
+                    _count: {
+                        select: {
+                            timeEntries: true, comments: true, punchItems: true,
+                            assignments: true, subAssignments: true,
+                            dependencies: true, dependents: true,
+                        },
+                    },
+                },
+            });
+            const byParent = new Map<string | null, typeof allTasks>();
+            for (const t of allTasks) {
+                const arr = byParent.get(t.parentId) ?? [];
+                arr.push(t);
+                byParent.set(t.parentId, arr);
+            }
+            const generatedIds = new Set(allTasks.filter(t => t.generatedFromChangeOrderId === co.id).map(t => t.id));
+            const isDeletable = (t: (typeof allTasks)[number]) =>
+                t.generatedFromChangeOrderId === co.id &&
+                t.progress === 0 &&
+                t.status === "Not Started" &&
+                t._count.timeEntries === 0 &&
+                t._count.comments === 0 &&
+                t._count.punchItems === 0 &&
+                t._count.assignments === 0 &&
+                t._count.subAssignments === 0 &&
+                t._count.dependencies === 0 &&
+                t._count.dependents === 0;
+            const roots = allTasks.filter(t => generatedIds.has(t.id) && (!t.parentId || !generatedIds.has(t.parentId)));
+            let keptSubtrees = 0;
+            for (const root of roots) {
+                const subtree: typeof allTasks = [];
+                const stack = [root];
+                while (stack.length) {
+                    const cur = stack.pop()!;
+                    subtree.push(cur);
+                    for (const child of byParent.get(cur.id) ?? []) stack.push(child);
+                }
+                if (subtree.every(isDeletable)) {
+                    await tx.scheduleTask.delete({ where: { id: root.id } });
+                } else {
+                    keptSubtrees++;
+                }
+            }
+            if (keptSubtrees > 0) {
+                notes.push(`Kept ${keptSubtrees} generated CO subtree${keptSubtrees === 1 ? "" : "s"} untouched — work was logged or edits made.`);
+            }
+        }
+
+        const start = utcDay(project.startDate);
+        const workEnd = await computeEffectiveWorkEnd(tx, project);
+        const coWindowStart = workEnd;
+
+        // Milestone task lookup used for linking — by CO payment row id, plus
+        // the ordered list of CO milestone tasks (for billed-clone linking).
+        const milestoneTaskIdByRowId = new Map<string, string>();
+        const milestoneTaskIds: string[] = [];
+        let coWindowDays = 0;
+
+        const maxOrder = await tx.scheduleTask.aggregate({ where: { projectId }, _max: { order: true } });
+        let nextOrder = (maxOrder._max.order ?? -1) + 1;
+        const createTask = async (data: {
+            name: string; startDate: Date; endDate: Date; color: string; order: number;
+            type: string; parentId: string | null;
+        }) => {
+            const row = await tx.scheduleTask.create({
+                data: {
+                    projectId,
+                    status: "Not Started",
+                    progress: 0,
+                    generatedFromChangeOrderId: co.id,
+                    estimatedHours: null,
+                    estimateItemId: null,
+                    ...data,
+                },
+            });
+            createdRows.push({
+                id: row.id,
+                name: row.name,
+                startDate: row.startDate.toISOString(),
+                endDate: row.endDate.toISOString(),
+                type: row.type,
+                color: row.color,
+                order: row.order,
+                status: row.status,
+                progress: row.progress,
+                estimatedHours: row.estimatedHours,
+                estimateItemId: row.estimateItemId,
+                parentId: row.parentId,
+            });
+            return row;
+        };
+
+        const items = co.items.map(i => ({
+            id: i.id, name: i.name, type: i.type, total: Number(i.total), costTypeName: i.costType?.name ?? null,
+        }));
+        const taskItems = items.filter(i => i.total >= 0);
+        const estimateWindowEnd = project.endDate ? utcDay(project.endDate) : addDays(start, 42);
+        const estimateWindowDays = Math.max(1, Math.round((estimateWindowEnd.getTime() - start.getTime()) / 86_400_000));
+        const estimateLaborDollars = co.estimate.items.reduce((sum, item) => {
+            const labor = (item.costType?.name ?? item.type ?? "").toLowerCase() === "labor";
+            const total = Number(item.total);
+            return sum + (labor && total > 0 ? total : 0);
+        }, 0);
+        const coLaborDollars = items.reduce((sum, item) => {
+            const labor = (item.costTypeName ?? item.type ?? "").toLowerCase() === "labor";
+            return sum + (labor && item.total > 0 ? item.total : 0);
+        }, 0);
+        const burnRate = estimateLaborDollars > 0 ? estimateLaborDollars / estimateWindowDays : 0;
+        const laborDays = burnRate > 0 && coLaborDollars > 0 ? Math.max(1, Math.round(coLaborDollars / burnRate)) : 0;
+        const calculatedWindowDays = Math.max(1, laborDays || taskItems.length);
+
+        const provenanceCount = await tx.scheduleTask.count({ where: { generatedFromChangeOrderId: co.id } });
+
+        if (provenanceCount > 0) {
+            skipped++;
+            notes.push(`${co.code} is already on the schedule — existing protected/provenance tasks were preserved.`);
+            let existingParent = await tx.scheduleTask.findFirst({
+                where: { generatedFromChangeOrderId: co.id, type: { not: "milestone" }, parentId: null },
+                orderBy: [{ order: "asc" }, { id: "asc" }],
+                select: { id: true, startDate: true, endDate: true },
+            });
+            if (!existingParent && mode === "regenerate") {
+                coWindowDays = calculatedWindowDays;
+                existingParent = await createTask({
+                    name: `${co.code} · ${co.title}`,
+                    startDate: coWindowStart,
+                    endDate: addDays(coWindowStart, coWindowDays),
+                    color: "#8b5cf6",
+                    order: nextOrder++,
+                    type: "task",
+                    parentId: null,
+                });
+                const n = taskItems.length;
+                for (let k = 0; k < n; k++) {
+                    const childStart = addDays(coWindowStart, Math.floor((k * coWindowDays) / n));
+                    const proportionalEnd = addDays(coWindowStart, Math.floor(((k + 1) * coWindowDays) / n));
+                    await createTask({
+                        name: taskItems[k].name,
+                        startDate: childStart,
+                        endDate: proportionalEnd > childStart ? proportionalEnd : addDays(childStart, 1),
+                        color: "#8b5cf6",
+                        order: nextOrder++,
+                        type: "task",
+                        parentId: existingParent.id,
+                    });
+                }
+                for (const item of items.filter(item => item.total < 0)) {
+                    notes.push(`Deduction "${item.name}" reduces scope — no task created; trim existing tasks manually if needed.`);
+                }
+            }
+            const milestoneBase = existingParent?.startDate ?? coWindowStart;
+            coWindowDays = existingParent
+                ? Math.max(1, Math.round((existingParent.endDate.getTime() - existingParent.startDate.getTime()) / 86_400_000))
+                : calculatedWindowDays;
+            const existingMilestones = await tx.scheduleTask.findMany({
+                where: { generatedFromChangeOrderId: co.id, type: "milestone" },
+                orderBy: [{ order: "asc" }, { id: "asc" }],
+                select: { id: true },
+            });
+            const existingIds = new Set(existingMilestones.map(task => task.id));
+            const usedIds = new Set<string>();
+            for (const row of co.paymentSchedules) {
+                if (row.scheduleTaskId && existingIds.has(row.scheduleTaskId)) {
+                    milestoneTaskIdByRowId.set(row.id, row.scheduleTaskId);
+                    usedIds.add(row.scheduleTaskId);
+                }
+            }
+            const available = existingMilestones.filter(task => !usedIds.has(task.id));
+            for (const row of co.paymentSchedules) {
+                if (milestoneTaskIdByRowId.has(row.id)) continue;
+                const task = available.shift();
+                if (task) milestoneTaskIdByRowId.set(row.id, task.id);
+            }
+            if (mode === "regenerate") {
+                const totalRowsAmount = co.paymentSchedules.reduce((sum, row) => sum + Number(row.amount), 0);
+                let cumulative = 0;
+                for (const row of co.paymentSchedules) {
+                    cumulative += Number(row.amount);
+                    if (milestoneTaskIdByRowId.has(row.id)) continue;
+                    const derived = totalRowsAmount > 0
+                        ? addDays(milestoneBase, Math.round((Math.min(cumulative, totalRowsAmount) / totalRowsAmount) * coWindowDays))
+                        : addDays(milestoneBase, coWindowDays);
+                    const canonical = row.dueDate ? utcDay(row.dueDate) : derived;
+                    const task = await createTask({
+                        name: row.name,
+                        startDate: canonical,
+                        endDate: addDays(canonical, 1),
+                        color: "#f59e0b",
+                        order: nextOrder++,
+                        type: "milestone",
+                        parentId: null,
+                    });
+                    milestoneTaskIdByRowId.set(row.id, task.id);
+                }
+                if (co.paymentSchedules.length === 0 && existingMilestones.length === 0) {
+                    const blockEnd = addDays(milestoneBase, coWindowDays);
+                    const task = await createTask({
+                        name: `${co.code} payment`,
+                        startDate: blockEnd,
+                        endDate: addDays(blockEnd, 1),
+                        color: "#f59e0b",
+                        order: nextOrder++,
+                        type: "milestone",
+                        parentId: null,
+                    });
+                    milestoneTaskIds.push(task.id);
+                }
+            }
+            if (co.paymentSchedules.length > 0) {
+                milestoneTaskIds.push(...co.paymentSchedules.map(row => milestoneTaskIdByRowId.get(row.id)).filter((id): id is string => !!id));
+            } else if (milestoneTaskIds.length === 0) {
+                milestoneTaskIds.push(...existingMilestones.map(task => task.id));
+            }
+        } else {
+            // Deduction items create NO task — they reduce scope (Phase 4 trims;
+            // for now the PM adjusts existing tasks manually).
+            for (const i of items.filter(i => i.total < 0)) {
+                notes.push(`Deduction "${i.name}" (−$${Math.abs(i.total).toFixed(2)}) reduces scope — no task created; trim existing tasks manually if needed.`);
+                skipped++;
+            }
+
+            // Labor-calibrated CO window: the CO's POSITIVE labor dollars
+            // (negative labor lines excluded so a mixed addition/deduction CO
+            // doesn't shorten the block) vs the ORIGINAL estimate's burn rate.
+            // Fallback: 1 day per non-negative item, packed. Every child gets a
+            // 1-day minimum, so the window never shrinks below the child count.
+            coWindowDays = calculatedWindowDays;
+
+            // Parent task: the contiguous block starting exactly at
+            // effectiveWorkEnd (end-exclusive bounds — no empty day).
+            const parentTask = await createTask({
+                name: `${co.code} · ${co.title}`,
+                startDate: coWindowStart,
+                endDate: addDays(coWindowStart, coWindowDays),
+                color: "#8b5cf6",
+                order: nextOrder++,
+                type: "task",
+                parentId: null,
+            });
+
+            // Children: P2 proportional-boundary rule inside the CO window.
+            const n = taskItems.length;
+            for (let k = 0; k < n; k++) {
+                const line = taskItems[k];
+                const childStart = addDays(coWindowStart, Math.floor((k * coWindowDays) / n));
+                const proportionalEnd = addDays(coWindowStart, Math.floor(((k + 1) * coWindowDays) / n));
+                await createTask({
+                    name: line.name,
+                    startDate: childStart,
+                    endDate: proportionalEnd > childStart ? proportionalEnd : addDays(childStart, 1),
+                    color: "#8b5cf6",
+                    order: nextOrder++,
+                    type: "task",
+                    parentId: parentTask.id,
+                });
+            }
+
+            // Milestones: canonical date = dueDate if set, else cumulative
+            // amount-share of the CO window by (order, id).
+            const totalRowsAmount = co.paymentSchedules.reduce((s, r) => s + Number(r.amount), 0);
+            if (co.paymentSchedules.length > 0) {
+                let cumAmount = 0;
+                for (const row of co.paymentSchedules) {
+                    cumAmount += Number(row.amount);
+                    const derived = totalRowsAmount > 0
+                        ? addDays(coWindowStart, Math.round((Math.min(cumAmount, totalRowsAmount) / totalRowsAmount) * coWindowDays))
+                        : addDays(coWindowStart, coWindowDays);
+                    const canonical = row.dueDate ? utcDay(row.dueDate) : derived;
+                    const mTask = await createTask({
+                        name: row.name,
+                        startDate: canonical,
+                        endDate: addDays(canonical, 1),
+                        color: "#f59e0b",
+                        order: nextOrder++,
+                        type: "milestone",
+                        parentId: null,
+                    });
+                    milestoneTaskIds.push(mTask.id);
+                    milestoneTaskIdByRowId.set(row.id, mTask.id);
+                }
+            } else {
+                // Zero-row fallback (R1 fix 4): one synthesized milestone at the
+                // CO block's end projecting signedAmount (totalAmount + tax via
+                // co-tax.ts — the same amount billing will invoice).
+                const signedAmount = coSignedAmount(Number(co.totalAmount), co.estimate);
+                const blockEnd = addDays(coWindowStart, coWindowDays);
+                const mTask = await createTask({
+                    name: `${co.code} payment`,
+                    startDate: blockEnd,
+                    endDate: addDays(blockEnd, 1),
+                    color: "#f59e0b",
+                    order: nextOrder++,
+                    type: "milestone",
+                    parentId: null,
+                });
+                milestoneTaskIds.push(mTask.id);
+                notes.push(`${co.code} has no payment schedule rows — synthesized one "${co.code} payment" milestone ($${signedAmount.toFixed(2)} projected) at the block end.`);
+            }
+        }
+
+        // ── Linking (fresh + merge-converged): set scheduleTaskId on the CO
+        // payment rows AND the billed clone(s), regardless of billing/QB state
+        // (linking is not a money mutation). NO dueDate writes anywhere.
+        for (const row of co.paymentSchedules) {
+            const taskId = milestoneTaskIdByRowId.get(row.id);
+            if (!taskId) continue;
+            milestonesLinked += await tx.$executeRaw`
+                UPDATE "ChangeOrderPaymentSchedule"
+                SET "scheduleTaskId" = ${taskId}
+                WHERE "id" = ${row.id}
+                  AND "scheduleTaskId" IS DISTINCT FROM ${taskId}
+            `;
+        }
+        // Billed clones are linked deterministically by creation order to the
+        // corresponding ordered CO milestone (today billing creates one clone).
+        const billedClones = await tx.paymentSchedule.findMany({
+            where: {
+                invoice: { projectId },
+                name: { startsWith: `${co.code} — ` },
+                status: { not: "Canceled" },
+            },
+            orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+            select: { id: true },
+        });
+        for (let idx = 0; idx < billedClones.length; idx++) {
+            const cloneTarget = milestoneTaskIds[Math.min(idx, milestoneTaskIds.length - 1)];
+            if (!cloneTarget) continue;
+            milestonesLinked += await tx.$executeRaw`
+                UPDATE "PaymentSchedule"
+                SET "scheduleTaskId" = ${cloneTarget}
+                WHERE "id" = ${billedClones[idx].id}
+                  AND "scheduleTaskId" IS DISTINCT FROM ${cloneTarget}
+            `;
+        }
+
+        await tx.activityLog.create({
+            data: {
+                projectId,
+                actorType: input.actor.type,
+                actorName: input.actor.name,
+                action: "applied_change_order_schedule",
+                entityType: "project",
+                entityId: projectId,
+                entityName: project.name,
+                metadata: JSON.stringify({
+                    changeOrderId: co.id,
+                    changeOrderCode: co.code,
+                    mode,
+                    created: createdRows.length,
+                    skipped,
+                    milestonesLinked,
+                }),
+            },
+        });
+
+        return { changeOrderCode: co.code, projectId, created: createdRows, skipped, milestonesLinked, notes };
+    }));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Workstream C — Task-level crew (PB-pipeline-003)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Replace a task's crew (TaskAssignment rows) via a delete/create diff. Every
+ * id must be an ACTIVATED user (same validation as setProjectCrew); role stays
+ * "assigned". Idempotent; writes a "set_task_crew" ActivityLog row.
+ */
+export async function setTaskCrew(input: {
+    taskId: string;
+    userIds: string[];
+    actor: ScheduleActor;
+}): Promise<{ taskId: string; projectId: string; assignments: { id: string; userId: string; name: string }[] }> {
+    return withTxRetry(() => prisma.$transaction(async (tx) => {
+        const taskRef = await tx.scheduleTask.findUnique({
+            where: { id: input.taskId },
+            select: { projectId: true },
+        });
+        if (!taskRef) throw new Error("Task not found");
+        if (!taskRef.projectId) throw new Error("Task is not attached to a project");
+        await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${taskRef.projectId} FOR UPDATE`;
+        await tx.$queryRaw`SELECT id FROM "ScheduleTask" WHERE id = ${input.taskId} FOR UPDATE`;
+        const task = await tx.scheduleTask.findUnique({
+            where: { id: input.taskId },
+            select: {
+                id: true, name: true, projectId: true,
+                project: { select: { name: true } },
+                assignments: { select: { id: true, userId: true } },
+            },
+        });
+        if (!task) throw new Error("Task not found");
+        if (!task.projectId) throw new Error("Task is not attached to a project");
+        if (task.projectId !== taskRef.projectId) throw new Error("Task moved to another project; refresh and retry");
+
+        const wanted = [...new Set(input.userIds)];
+        const users = wanted.length
+            ? await tx.user.findMany({ where: { id: { in: wanted } }, select: { id: true, name: true, email: true, status: true } })
+            : [];
+        const byId = new Map(users.map(u => [u.id, u]));
+        const missing = wanted.filter(id => !byId.has(id));
+        if (missing.length > 0) throw new Error(`Unknown user id(s): ${missing.join(", ")}`);
+        const notActivated = users.filter(u => u.status !== "ACTIVATED");
+        if (notActivated.length > 0) {
+            throw new Error(`Task crew members must be ACTIVATED users: ${notActivated.map(u => u.name || u.email).join(", ")}`);
+        }
+
+        const current = task.assignments.map(a => a.userId);
+        const toAdd = wanted.filter(id => !current.includes(id));
+        const toRemove = current.filter(id => !wanted.includes(id));
+        if (toRemove.length > 0) {
+            await tx.taskAssignment.deleteMany({ where: { taskId: input.taskId, userId: { in: toRemove } } });
+        }
+        for (const userId of toAdd) {
+            await tx.taskAssignment.create({ data: { taskId: input.taskId, userId, role: "assigned" } });
+        }
+
+        await tx.activityLog.create({
+            data: {
+                projectId: task.projectId,
+                actorType: input.actor.type,
+                actorName: input.actor.name,
+                action: "set_task_crew",
+                entityType: "project",
+                entityId: task.projectId,
+                entityName: task.project?.name ?? null,
+                metadata: JSON.stringify({ taskId: input.taskId, taskName: task.name, added: toAdd, removed: toRemove, userIds: wanted }),
+            },
+        });
+
+        const final = await tx.taskAssignment.findMany({
+            where: { taskId: input.taskId },
+            select: { id: true, userId: true, user: { select: { name: true, email: true } } },
+        });
+        return {
+            taskId: input.taskId,
+            projectId: task.projectId,
+            assignments: final.map(a => ({ id: a.id, userId: a.userId, name: a.user.name || a.user.email })),
+        };
+    }));
 }


### PR DESCRIPTION
Phase 3 of the company pipeline dashboard — closes the mid-job loop. Spec: `.specs/PB-pipeline-003-co-schedule.md` (TRIP-1 approved after 3 Codex review rounds). Stacked on #215 (retarget to `main` after it merges).

## What this does
- **Sign ⇒ schedule exists**: `approveEstimate` and `setProjectStartDate` gain post-commit best-effort hooks that auto-generate the project schedule from the signed estimate. `requireEmptyProject` is enforced inside the Project-locked transaction so auto paths never stack onto a manually built schedule. Failures log to console + ActivityLog and can never roll back approval or invoicing.
- **CO Approved ⇒ schedule + cash move**: `applyChangeOrderToSchedule` places the CO as a labor-calibrated contiguous block starting exactly at `effectiveWorkEnd` (payment milestones never extend the work window), creates milestone tasks per payment row (canonical `dueDate` ?? cumulative amount-share; zero-row COs synthesize one end milestone at `signedAmount = totalAmount + tax` via `co-tax.ts` — identical to what billing invoices), links `scheduleTaskId` on CO payment rows and billed invoice clones (name-prefix convention), and surfaces Approved-but-unbilled CO money as projected income in the ADMIN overlays with billed/unbilled split and no double counting. Auto-applied on fresh CO approvals via `handleChangeOrderApproved` (best-effort, never fails billing); manual button + MCP tool otherwise.
- **Task-level crew**: `setTaskCrew` + expandable dashboard rows with per-task crew pickers (ADMIN/MANAGER edit, FINANCE read-only). `getCrewConflicts` v2 unions real `TaskAssignment` windows with a per-(user,project) project-window fallback.
- **MCP v1.9.0**: new `apply_change_order_to_schedule`; `get_company_schedule` gains `unappliedChangeOrders` + conflict v2.
- **Security**: legacy schedule mutation server actions (`createScheduleTask`, `updateScheduleTask`, task assignment, linking, reorder) now require active staff with the `schedules` permission and project access — they previously had no auth checks.

## Money-path note
Writes ONLY `scheduleTaskId` on CO payment rows + billed clones — no amounts, no status, no QB fields, no dueDate writes. Hooks are post-commit best-effort. `e2e/money-pipeline.spec.ts` must stay green (CI runs it).

## Verification
- `scripts/verify-phase3-co-schedule.ts`: **65/65 checks pass** (fixtures cleaned up)
- `tsc --noEmit`: 0 errors; `npm run build`: clean
- Migration `scripts/apply-co-schedule-schema.mjs` (additive + idempotent) already applied
- Implementation by Codex CLI; independently reviewed by Claude (locking order, tax parity with billing-core, no-dueDate-write invariant, double-count exclusion, role gating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)