### PR TITLE
feat(schedule): interactive company schedule board — drag/drop calendar, bars, milestones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "jspdf": "^4.2.1",
         "lucide-react": "^0.577.0",
         "mcp-handler": "^1.1.0",
-        "next": "16.1.6",
+        "next": "16.2.11",
         "next-auth": "^4.24.13",
         "next-safe-action": "^8.3.0",
         "nodemailer": "^7.0.13",
@@ -2709,9 +2709,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
-      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.11.tgz",
+      "integrity": "sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2725,9 +2725,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
-      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.11.tgz",
+      "integrity": "sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==",
       "cpu": [
         "arm64"
       ],
@@ -2741,9 +2741,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
-      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.11.tgz",
+      "integrity": "sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg==",
       "cpu": [
         "x64"
       ],
@@ -2757,11 +2757,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
-      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.11.tgz",
+      "integrity": "sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2773,11 +2776,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
-      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.11.tgz",
+      "integrity": "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2789,11 +2795,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
-      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.11.tgz",
+      "integrity": "sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2805,11 +2814,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
-      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.11.tgz",
+      "integrity": "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2821,9 +2833,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
-      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.11.tgz",
+      "integrity": "sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==",
       "cpu": [
         "arm64"
       ],
@@ -2837,9 +2849,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
-      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.11.tgz",
+      "integrity": "sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w==",
       "cpu": [
         "x64"
       ],
@@ -12738,14 +12750,14 @@
       }
     },
     "node_modules/next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
-      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.11.tgz",
+      "integrity": "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.6",
+        "@next/env": "16.2.11",
         "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.8.3",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -12757,15 +12769,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.6",
-        "@next/swc-darwin-x64": "16.1.6",
-        "@next/swc-linux-arm64-gnu": "16.1.6",
-        "@next/swc-linux-arm64-musl": "16.1.6",
-        "@next/swc-linux-x64-gnu": "16.1.6",
-        "@next/swc-linux-x64-musl": "16.1.6",
-        "@next/swc-win32-arm64-msvc": "16.1.6",
-        "@next/swc-win32-x64-msvc": "16.1.6",
-        "sharp": "^0.34.4"
+        "@next/swc-darwin-arm64": "16.2.11",
+        "@next/swc-darwin-x64": "16.2.11",
+        "@next/swc-linux-arm64-gnu": "16.2.11",
+        "@next/swc-linux-arm64-musl": "16.2.11",
+        "@next/swc-linux-x64-gnu": "16.2.11",
+        "@next/swc-linux-x64-musl": "16.2.11",
+        "@next/swc-win32-arm64-msvc": "16.2.11",
+        "@next/swc-win32-x64-msvc": "16.2.11",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "jspdf": "^4.2.1",
     "lucide-react": "^0.577.0",
     "mcp-handler": "^1.1.0",
-    "next": "16.1.6",
+    "next": "16.2.11",
     "next-auth": "^4.24.13",
     "next-safe-action": "^8.3.0",
     "nodemailer": "^7.0.13",

--- a/scripts/verify-schedule-board-layout.ts
+++ b/scripts/verify-schedule-board-layout.ts
@@ -24,9 +24,11 @@ assert.deepEqual(getEffectiveProjectRange(project), {
     start: new Date("2037-01-03T00:00:00.000Z"),
     end: new Date("2037-01-06T00:00:00.000Z"),
 });
+// Marker-only moves (In Progress) leave tasks in place: the bar must span
+// BOTH the existing work and the marker day — neither may clip out of view.
 const markerPrecedenceProject = { ...project, id: "p-marker", startDate: "2037-01-10T00:00:00.000Z" };
 assert.deepEqual(getEffectiveProjectRange(markerPrecedenceProject), {
-    start: new Date("2037-01-10T00:00:00.000Z"),
+    start: new Date("2037-01-03T00:00:00.000Z"),
     end: new Date("2037-01-11T00:00:00.000Z"),
 });
 const markerOnlyProject = { ...project, id: "p-marker-only", startDate: "2037-01-10T00:00:00.000Z", taskCount: 0, tasks: [] };

--- a/scripts/verify-schedule-board-layout.ts
+++ b/scripts/verify-schedule-board-layout.ts
@@ -1,0 +1,368 @@
+import assert from "node:assert/strict";
+import {
+    assignMonthProjectLanes,
+    assignProjectLanes,
+    clipRange,
+    getEffectiveProjectRange,
+    segmentProjectRange,
+    toTimelineRect,
+} from "../src/app/company-dashboard/schedule-board/useBarLayout";
+import * as barLayout from "../src/app/company-dashboard/schedule-board/useBarLayout";
+import { addDays, formatDate, parseUTCDate } from "../src/app/projects/[id]/schedule/schedule-utils";
+
+const project = {
+    id: "p1", name: "Shop", client: null, status: "In Progress",
+    startDate: null, color: "#123456", contractValue: null, crew: [],
+    taskCount: 2, hasQualifyingEstimate: false, unappliedChangeOrders: { count: 0, items: [] },
+    tasks: [
+        { id: "t1", name: "Frame", startDate: "2037-01-03T00:00:00.000Z", endDate: "2037-01-06T00:00:00.000Z", color: "#111111", parentId: null, progress: 0, status: "Not Started", type: "task", assignments: [] },
+        { id: "t2", name: "Billing", startDate: "2037-01-20T00:00:00.000Z", endDate: "2037-01-20T00:00:00.000Z", color: "#222222", parentId: null, progress: 0, status: "Not Started", type: "milestone", assignments: [] },
+    ],
+};
+
+assert.deepEqual(getEffectiveProjectRange(project), {
+    start: new Date("2037-01-03T00:00:00.000Z"),
+    end: new Date("2037-01-06T00:00:00.000Z"),
+});
+const markerPrecedenceProject = { ...project, id: "p-marker", startDate: "2037-01-10T00:00:00.000Z" };
+assert.deepEqual(getEffectiveProjectRange(markerPrecedenceProject), {
+    start: new Date("2037-01-10T00:00:00.000Z"),
+    end: new Date("2037-01-11T00:00:00.000Z"),
+});
+const markerOnlyProject = { ...project, id: "p-marker-only", startDate: "2037-01-10T00:00:00.000Z", taskCount: 0, tasks: [] };
+assert.deepEqual(getEffectiveProjectRange(markerOnlyProject), {
+    start: new Date("2037-01-10T00:00:00.000Z"),
+    end: new Date("2037-01-11T00:00:00.000Z"),
+});
+const taskDerivedProject = { ...project, id: "p-task-derived", startDate: null };
+assert.deepEqual(getEffectiveProjectRange(taskDerivedProject), {
+    start: new Date("2037-01-03T00:00:00.000Z"),
+    end: new Date("2037-01-06T00:00:00.000Z"),
+});
+
+assert.equal(typeof (barLayout as Record<string, unknown>).createProjectDropIntent, "function", "createProjectDropIntent must be exported");
+assert.equal(typeof (barLayout as Record<string, unknown>).previewProjectMove, "function", "previewProjectMove must be exported");
+const createProjectDropIntent = (barLayout as unknown as {
+    createProjectDropIntent: (candidate: typeof project, targetStart: string) => {
+        project: typeof project;
+        originalStart: string;
+        targetStart: string;
+        deltaDays: number;
+    } | null;
+}).createProjectDropIntent;
+const previewProjectMove = (barLayout as unknown as {
+    previewProjectMove: (candidate: typeof project, targetStart: string) => typeof project;
+}).previewProjectMove;
+const moveIntent = createProjectDropIntent(project, "2037-03-15");
+assert.deepEqual(moveIntent, {
+    project,
+    originalStart: "2037-01-03",
+    targetStart: "2037-03-15",
+    deltaDays: 71,
+});
+assert.equal(createProjectDropIntent(project, "2037-01-03")?.deltaDays, 0);
+const firstSetPreview = previewProjectMove(project, "2037-03-15");
+assert.equal(firstSetPreview.startDate, "2037-03-15");
+assert.deepEqual(firstSetPreview.tasks, project.tasks);
+const scheduledProject = { ...project, status: "Waiting to Start", startDate: "2037-01-03T00:00:00.000Z" };
+const preview = previewProjectMove(scheduledProject, "2037-03-15");
+assert.equal(preview.startDate, "2037-03-15");
+assert.deepEqual(preview.tasks.map(task => [task.startDate, task.endDate]), [
+    ["2037-03-15", "2037-03-18"],
+    ["2037-04-01", "2037-04-01"],
+]);
+assert.equal(new Date(preview.tasks[0].endDate).getTime() - new Date(preview.tasks[0].startDate).getTime(), 3 * 86_400_000);
+const unscheduledPreview = previewProjectMove({ ...project, id: "p-unscheduled", startDate: null, tasks: [] }, "2037-03-15");
+assert.equal(unscheduledPreview.startDate, "2037-03-15");
+
+type TaskEditMode = import("../src/app/company-dashboard/schedule-board/useBarLayout").TaskEditMode;
+const taskEditModes: TaskEditMode[] = ["move", "resize-left", "resize-right"];
+assert.deepEqual(taskEditModes, ["move", "resize-left", "resize-right"]);
+assert.equal(typeof (barLayout as Record<string, unknown>).previewTaskDates, "function", "previewTaskDates must be exported");
+const previewTaskDates = (barLayout as unknown as {
+    previewTaskDates: (
+        candidate: typeof project.tasks[number],
+        mode: TaskEditMode,
+        deltaDays: number,
+    ) => { startDate: string; endDate: string } | null;
+}).previewTaskDates;
+const task = project.tasks[0];
+const milestoneTask = project.tasks[1];
+assert.deepEqual(previewTaskDates(task, "move", 2), { startDate: "2037-01-05", endDate: "2037-01-08" });
+assert.deepEqual(previewTaskDates(task, "resize-left", 2), { startDate: "2037-01-05", endDate: "2037-01-06" });
+assert.deepEqual(previewTaskDates(task, "resize-right", -2), { startDate: "2037-01-03", endDate: "2037-01-04" });
+assert.equal(previewTaskDates(task, "resize-left", 3), null, "left resize must preserve a positive end-exclusive duration");
+assert.equal(previewTaskDates(task, "resize-right", -3), null, "right resize must preserve a positive end-exclusive duration");
+assert.deepEqual(previewTaskDates(milestoneTask, "move", 3), { startDate: "2037-01-23", endDate: "2037-01-23" });
+assert.equal(previewTaskDates(milestoneTask, "resize-left", 1), null, "milestones cannot resize");
+assert.equal(previewTaskDates({ ...task, endDate: task.startDate }, "move", 1), null, "invalid non-milestone durations cannot be previewed");
+assert.equal(typeof (barLayout as Record<string, unknown>).taskDatesMatch, "function", "taskDatesMatch must be exported");
+const taskDatesMatch = (barLayout as unknown as {
+    taskDatesMatch: (
+        candidate: typeof task,
+        dates: { startDate: string; endDate: string },
+    ) => boolean;
+}).taskDatesMatch;
+const savedDates = { startDate: "2037-01-05", endDate: "2037-01-08" };
+assert.equal(taskDatesMatch(task, savedDates), false, "slow-refresh canonical dates must not acknowledge the saved override");
+const refreshedTask = { ...task, startDate: "2037-01-05T00:00:00.000Z", endDate: "2037-01-08T00:00:00.000Z" };
+assert.equal(taskDatesMatch(refreshedTask, savedDates), true, "matching refreshed props acknowledge the saved override");
+assert.deepEqual(previewTaskDates(refreshedTask, "move", 1), { startDate: "2037-01-06", endDate: "2037-01-09" }, "a sequential edit derives from refreshed canonical dates");
+assert.equal(typeof (barLayout as Record<string, unknown>).getEffectivePendingProjectIds, "function", "pending child tasks must block their parent project");
+const getEffectivePendingProjectIds = (barLayout as unknown as {
+    getEffectivePendingProjectIds: (
+        pendingProjects: Iterable<string>,
+        pendingTasks: Iterable<string>,
+        taskProjectById: ReadonlyMap<string, string>,
+    ) => Set<string>;
+}).getEffectivePendingProjectIds;
+const reversePending = getEffectivePendingProjectIds(
+    ["project-operation"],
+    ["t1", "awaiting-task"],
+    new Map([["t1", "p1"], ["awaiting-task", "p-awaiting"]]),
+);
+assert.deepEqual([...reversePending].sort(), ["p-awaiting", "p1", "project-operation"], "task mutation and task refresh states both close the reverse project race");
+assert.equal(typeof (barLayout as Record<string, unknown>).mergeProjectPendingIds, "function", "page siblings need one rendered project lock set");
+const mergeProjectPendingIds = (barLayout as unknown as {
+    mergeProjectPendingIds: (...sources: Iterable<string>[]) => Set<string>;
+}).mergeProjectPendingIds;
+const pagePending = mergeProjectPendingIds(reversePending, ["legacy-project"]);
+assert.deepEqual([...pagePending].sort(), ["legacy-project", "p-awaiting", "p1", "project-operation"], "board locks disable the legacy row and legacy locks disable the board");
+assert.equal(typeof (barLayout as Record<string, unknown>).projectIdSetsEqual, "function", "stable publications must compare Set contents");
+const projectIdSetsEqual = (barLayout as unknown as {
+    projectIdSetsEqual: (left: ReadonlySet<string>, right: ReadonlySet<string>) => boolean;
+}).projectIdSetsEqual;
+assert.equal(projectIdSetsEqual(new Set(["p1", "p2"]), new Set(["p2", "p1"])), true);
+assert.equal(projectIdSetsEqual(new Set(["p1"]), new Set(["p1", "p2"])), false);
+assert.equal(typeof (barLayout as Record<string, unknown>).getNewlyPendingProjectIds, "function", "external lock transitions need a rising-edge selector");
+const getNewlyPendingProjectIds = (barLayout as unknown as {
+    getNewlyPendingProjectIds: (previous: ReadonlySet<string>, current: ReadonlySet<string>) => Set<string>;
+}).getNewlyPendingProjectIds;
+assert.deepEqual(
+    [...getNewlyPendingProjectIds(new Set(["p-existing", "p-unlocked"]), new Set(["p-existing", "p-locked"]))].sort(),
+    ["p-locked"],
+    "only newly locked projects cancel their active editors",
+);
+assert.deepEqual(
+    [...getNewlyPendingProjectIds(new Set(["p-existing"]), new Set(["p-existing"]))],
+    [],
+    "an unchanged lock set must not wipe active drafts again",
+);
+assert.deepEqual(
+    [...getNewlyPendingProjectIds(new Set(["p-unlocked"]), new Set())],
+    [],
+    "unlocking must not cancel unrelated newly opened drafts",
+);
+
+assert.equal(typeof (barLayout as Record<string, unknown>).projectRefreshMatches, "function", "project refresh reconciliation must be exported");
+const projectRefreshMatches = (barLayout as unknown as {
+    projectRefreshMatches: (
+        canonical: typeof project | undefined,
+        expected: { projectStartDate?: string | null; taskDates: Array<{ id: string; startDate: string; endDate: string }> },
+    ) => boolean;
+}).projectRefreshMatches;
+assert.equal(typeof (barLayout as Record<string, unknown>).previewProjectWithPersistedTaskDates, "function", "server-returned task dates must drive the saved preview");
+const previewProjectWithPersistedTaskDates = (barLayout as unknown as {
+    previewProjectWithPersistedTaskDates: (
+        candidate: typeof project,
+        projectStartDate: string | null,
+        taskDates: Array<{ id: string; startDate: string; endDate: string }>,
+    ) => typeof project;
+}).previewProjectWithPersistedTaskDates;
+
+const concurrentTask = { ...task, id: "t-concurrent", name: "Concurrent", startDate: "2037-02-01T00:00:00.000Z", endDate: "2037-02-04T00:00:00.000Z" };
+const projectWithConcurrentTask = { ...project, startDate: "2037-01-03T00:00:00.000Z", tasks: [...project.tasks, concurrentTask] };
+const markerExpectation = { projectStartDate: "2037-01-05", taskDates: [] };
+const markerCanonical = {
+    ...projectWithConcurrentTask,
+    startDate: "2037-01-05T00:00:00.000Z",
+    tasks: projectWithConcurrentTask.tasks.map(candidate => candidate.id === concurrentTask.id
+        ? { ...candidate, startDate: "2037-02-10T00:00:00.000Z", endDate: "2037-02-13T00:00:00.000Z" }
+        : candidate),
+};
+assert.equal(projectRefreshMatches(undefined, markerExpectation), false, "an absent canonical project keeps its optimistic preview");
+assert.equal(projectRefreshMatches(projectWithConcurrentTask, markerExpectation), false, "marker-only reconciliation waits for the saved project start");
+assert.equal(projectRefreshMatches(markerCanonical, markerExpectation), true, "marker-only reconciliation ignores every unrelated concurrent task edit");
+
+const selectiveTaskDates = [{ id: task.id, startDate: "2037-01-05", endDate: "2037-01-08" }];
+const selectiveExpectation = { taskDates: selectiveTaskDates };
+const selectiveCanonical = {
+    ...projectWithConcurrentTask,
+    tasks: projectWithConcurrentTask.tasks.map(candidate => {
+        if (candidate.id === task.id) return { ...candidate, startDate: "2037-01-05T00:00:00.000Z", endDate: "2037-01-08T00:00:00.000Z" };
+        if (candidate.id === concurrentTask.id) return { ...candidate, startDate: "2037-02-10T00:00:00.000Z", endDate: "2037-02-13T00:00:00.000Z" };
+        return candidate;
+    }),
+};
+assert.equal(projectRefreshMatches(projectWithConcurrentTask, selectiveExpectation), false, "selective reconciliation waits for each affected task date");
+assert.equal(projectRefreshMatches(selectiveCanonical, selectiveExpectation), true, "shift-Not-Started reconciliation ignores unrelated task changes");
+
+const fullShiftDates = project.tasks.map(candidate => ({
+    id: candidate.id,
+    startDate: formatDate(addDays(parseUTCDate(candidate.startDate.slice(0, 10)), 2)),
+    endDate: formatDate(addDays(parseUTCDate(candidate.endDate.slice(0, 10)), 2)),
+}));
+const fullShiftPreview = previewProjectWithPersistedTaskDates(projectWithConcurrentTask, "2037-01-05", fullShiftDates);
+const fullShiftCanonical = {
+    ...fullShiftPreview,
+    startDate: "2037-01-05T00:00:00.000Z",
+    tasks: fullShiftPreview.tasks.map(candidate => candidate.id === concurrentTask.id
+        ? { ...candidate, startDate: "2037-02-11T00:00:00.000Z", endDate: "2037-02-14T00:00:00.000Z" }
+        : candidate),
+};
+assert.equal(projectRefreshMatches(fullShiftCanonical, { projectStartDate: "2037-01-05", taskDates: fullShiftDates }), true, "Waiting full-shift reconciliation uses only server-returned affected task IDs/dates");
+assert.equal(projectRefreshMatches(markerCanonical, { projectStartDate: "2037-01-05", taskDates: [] }), true, "first-time tray scheduling with no shifted task result ignores concurrent task truth");
+
+const overlayRefreshEdgeCases = [
+    "null-dated QuickBooks row resolves to a different effective date",
+    "shifted income row leaves the requested date range",
+    "mixed-QuickBooks mirror group keeps a sibling fixed",
+    "unrelated overlay row disappears during refresh",
+];
+for (const scenario of overlayRefreshEdgeCases) {
+    assert.equal(
+        projectRefreshMatches(markerCanonical, markerExpectation),
+        true,
+        `${scenario} cannot keep a canonically reconciled project in a retry loop`,
+    );
+}
+assert.equal(typeof (barLayout as Record<string, unknown>).previewTaskPointerCandidate, "function", "previewTaskPointerCandidate must be exported");
+const previewTaskPointerCandidate = (barLayout as unknown as {
+    previewTaskPointerCandidate: (
+        candidate: typeof task,
+        mode: TaskEditMode,
+        deltaDays: number | null,
+    ) => { startDate: string; endDate: string } | null;
+}).previewTaskPointerCandidate;
+assert.equal(previewTaskPointerCandidate(task, "move", null), null, "an outside-grid release has no committable candidate");
+assert.equal(previewTaskPointerCandidate(task, "resize-left", 3), null, "an invalid resize boundary has no committable candidate");
+assert.deepEqual(previewTaskPointerCandidate(task, "move", 1), { startDate: "2037-01-04", endDate: "2037-01-07" });
+
+const incomeRows = [
+    { id: "eligible-explicit", name: "Deposit", amount: 100, dueDate: "2037-01-05T00:00:00.000Z", effectiveDueDate: "2037-01-05T00:00:00.000Z", invoiceId: "i1", invoiceCode: "INV-1", projectId: "p1", projectName: "Shop", scheduleTaskId: "t1", anchoredToTask: true, inQuickBooks: false },
+    { id: "eligible-fallback", name: "Progress", amount: 200, dueDate: null, effectiveDueDate: "2037-01-06T00:00:00.000Z", invoiceId: "i2", invoiceCode: "INV-2", projectId: "p1", projectName: "Shop", scheduleTaskId: "t2", anchoredToTask: true, inQuickBooks: false },
+    { id: "projectless", name: "General", amount: 300, dueDate: "2037-01-07T00:00:00.000Z", effectiveDueDate: "2037-01-07T00:00:00.000Z", invoiceId: "i3", invoiceCode: "INV-3", projectId: null, projectName: null, scheduleTaskId: "t3", anchoredToTask: true, inQuickBooks: false },
+    { id: "unanchored", name: "Fixed", amount: 400, dueDate: "2037-01-08T00:00:00.000Z", effectiveDueDate: "2037-01-08T00:00:00.000Z", invoiceId: "i4", invoiceCode: "INV-4", projectId: "p1", projectName: "Shop", scheduleTaskId: null, anchoredToTask: false, inQuickBooks: false },
+    { id: "quickbooks", name: "QB", amount: 500, dueDate: "2037-01-09T00:00:00.000Z", effectiveDueDate: "2037-01-09T00:00:00.000Z", invoiceId: "i5", invoiceCode: "INV-5", projectId: "p1", projectName: "Shop", scheduleTaskId: "t1", anchoredToTask: true, inQuickBooks: true },
+    { id: "other-project", name: "Other", amount: 600, dueDate: "2037-01-10T00:00:00.000Z", effectiveDueDate: "2037-01-10T00:00:00.000Z", invoiceId: "i6", invoiceCode: "INV-6", projectId: "p2", projectName: "Other", scheduleTaskId: "t1", anchoredToTask: true, inQuickBooks: false },
+];
+assert.equal(typeof (barLayout as Record<string, unknown>).previewProjectIncomeOverlays, "function", "previewProjectIncomeOverlays must be exported");
+const previewProjectIncomeOverlays = (barLayout as unknown as {
+    previewProjectIncomeOverlays: (rows: typeof incomeRows, projectId: string, deltaDays: number) => typeof incomeRows;
+}).previewProjectIncomeOverlays;
+const incomePreview = previewProjectIncomeOverlays(incomeRows, "p1", 3);
+assert.deepEqual([incomePreview[0].dueDate, incomePreview[0].effectiveDueDate], ["2037-01-08", "2037-01-08"]);
+assert.deepEqual([incomePreview[1].dueDate, incomePreview[1].effectiveDueDate], [null, "2037-01-09"]);
+assert.deepEqual(incomePreview.map(row => row.amount), incomeRows.map(row => row.amount));
+for (const index of [2, 3, 4, 5]) assert.strictEqual(incomePreview[index], incomeRows[index]);
+assert.equal(typeof (barLayout as Record<string, unknown>).previewShiftedTaskIncomeOverlays, "function", "shift-task overlay reconciliation must be exported");
+const previewShiftedTaskIncomeOverlays = (barLayout as unknown as {
+    previewShiftedTaskIncomeOverlays: (rows: typeof incomeRows, projectId: string, deltaDays: number, eligibleTaskIds: ReadonlySet<string>) => typeof incomeRows;
+}).previewShiftedTaskIncomeOverlays;
+const selectiveIncomePreview = previewShiftedTaskIncomeOverlays(incomeRows, "p1", 3, new Set(["t1", "t2"]));
+assert.strictEqual(selectiveIncomePreview[0], incomeRows[0], "explicit due dates remain fixed when only tasks shift");
+assert.deepEqual([selectiveIncomePreview[1].dueDate, selectiveIncomePreview[1].effectiveDueDate], [null, "2037-01-09"]);
+for (const index of [2, 3, 4, 5]) assert.strictEqual(selectiveIncomePreview[index], incomeRows[index]);
+assert.equal(typeof (barLayout as Record<string, unknown>).previewProjectOverlays, "function", "previewProjectOverlays must be exported");
+const overlayFixture = {
+    income: incomeRows,
+    changeOrders: [{ probe: "change-order" }],
+    expenses: [{ probe: "expense" }],
+    hours: [{ probe: "hours" }],
+};
+const previewProjectOverlays = (barLayout as unknown as {
+    previewProjectOverlays: (overlays: typeof overlayFixture, projectId: string, deltaDays: number) => typeof overlayFixture;
+}).previewProjectOverlays;
+const overlayPreview = previewProjectOverlays(overlayFixture, "p1", 3);
+assert.strictEqual(overlayPreview.changeOrders, overlayFixture.changeOrders);
+assert.strictEqual(overlayPreview.expenses, overlayFixture.expenses);
+assert.strictEqual(overlayPreview.hours, overlayFixture.hours);
+assert.deepEqual(overlayPreview.income.map(row => row.amount), overlayFixture.income.map(row => row.amount));
+const segments = segmentProjectRange("p1", getEffectiveProjectRange(project)!, new Date("2036-12-29T00:00:00.000Z"), new Date("2037-02-09T00:00:00.000Z"));
+assert.equal(segments.length, 2);
+assert.deepEqual(segments.map(s => [s.weekIndex, s.startColumn, s.spanDays, s.continuesBefore, s.continuesAfter]), [
+    [0, 5, 2, false, true],
+    [1, 0, 1, true, false],
+]);
+assert.deepEqual(toTimelineRect({ start: new Date("2037-01-03Z"), end: new Date("2037-01-06Z") }, new Date("2037-01-01Z"), 20), { left: 40, width: 60 });
+const timelineOriginX = 240;
+const timelineClientX = 271;
+const timelineDayWidth = 20;
+const timelineDeltaDays = Math.round((timelineClientX - timelineOriginX) / timelineDayWidth);
+assert.equal(timelineDeltaDays, 2);
+assert.equal(formatDate(addDays(parseUTCDate(moveIntent!.originalStart), timelineDeltaDays)), "2037-01-05");
+assert.equal(typeof (barLayout as Record<string, unknown>).getTimelinePointerDelta, "function", "getTimelinePointerDelta must be exported");
+const getTimelinePointerDelta = (barLayout as unknown as {
+    getTimelinePointerDelta: (_clientX: number, _originX: number, _dayWidth: number) => number;
+}).getTimelinePointerDelta;
+assert.equal(getTimelinePointerDelta(timelineClientX, timelineOriginX, timelineDayWidth), 2);
+assert.equal(formatDate(addDays(parseUTCDate(moveIntent!.originalStart), getTimelinePointerDelta(timelineClientX, timelineOriginX, timelineDayWidth))), "2037-01-05");
+assert.equal(typeof (barLayout as Record<string, unknown>).getTimelineAutoscrollStep, "function", "getTimelineAutoscrollStep must be exported");
+const getTimelineAutoscrollStep = (barLayout as unknown as {
+    getTimelineAutoscrollStep: (_input: {
+        clientX: number;
+        containerLeft: number;
+        containerRight: number;
+        timelineLeftInset: number;
+        scrollLeft: number;
+        scrollWidth: number;
+        clientWidth: number;
+        threshold: number;
+        maxStep: number;
+    }) => number;
+}).getTimelineAutoscrollStep;
+const autoscrollFixture = {
+    containerLeft: 100,
+    containerRight: 900,
+    timelineLeftInset: 240,
+    scrollLeft: 100,
+    scrollWidth: 1600,
+    clientWidth: 800,
+    threshold: 48,
+    maxStep: 16,
+};
+assert.equal(getTimelineAutoscrollStep({ ...autoscrollFixture, clientX: 291 }), 0);
+assert.equal(getTimelineAutoscrollStep({ ...autoscrollFixture, clientX: 292 }), 0);
+assert.equal(getTimelineAutoscrollStep({ ...autoscrollFixture, clientX: 293 }), -1);
+assert.equal(getTimelineAutoscrollStep({ ...autoscrollFixture, clientX: 340 }), -16);
+assert.equal(getTimelineAutoscrollStep({ ...autoscrollFixture, clientX: 387 }), -1);
+assert.equal(getTimelineAutoscrollStep({ ...autoscrollFixture, clientX: 388 }), 0);
+assert.equal(getTimelineAutoscrollStep({ ...autoscrollFixture, clientX: 851 }), 0);
+assert.equal(getTimelineAutoscrollStep({ ...autoscrollFixture, clientX: 853 }), 1);
+assert.equal(getTimelineAutoscrollStep({ ...autoscrollFixture, clientX: 900 }), 16);
+assert.equal(getTimelineAutoscrollStep({ ...autoscrollFixture, clientX: 947 }), 1);
+assert.equal(getTimelineAutoscrollStep({ ...autoscrollFixture, clientX: 948 }), 0);
+assert.equal(getTimelineAutoscrollStep({ ...autoscrollFixture, clientX: 340, scrollLeft: 0 }), 0);
+assert.equal(getTimelineAutoscrollStep({ ...autoscrollFixture, clientX: 900, scrollLeft: 800 }), 0);
+assert.equal(clipRange({ start: new Date("2036-12-01Z"), end: new Date("2036-12-02Z") }, { start: new Date("2037-01-01Z"), end: new Date("2037-02-01Z") }), null);
+
+const crowded = new Map(Array.from({ length: 6 }, (_, index) => [`p${index}`, [{ ...segments[0], projectId: `p${index}` }]]));
+const lanes = assignProjectLanes(crowded);
+assert.equal(lanes.visible.filter(s => s.weekIndex === 0).length, 4);
+assert.equal(lanes.hiddenByWeek.get(0), 2);
+
+const laneGridStart = new Date("2037-01-01T00:00:00.000Z");
+const laneGridEnd = new Date("2037-02-12T00:00:00.000Z");
+const occupiedWork = new Map([
+    ["occupier", segmentProjectRange("occupier", { start: new Date("2037-01-03Z"), end: new Date("2037-01-04Z") }, laneGridStart, laneGridEnd)],
+    ["milestoned", segmentProjectRange("milestoned", { start: new Date("2037-01-10Z"), end: new Date("2037-01-12Z") }, laneGridStart, laneGridEnd)],
+]);
+const milestoneDays = new Map([
+    ["milestoned", [new Date("2037-01-03Z"), new Date("2037-01-11Z"), new Date("2037-01-20Z")]],
+]);
+const monthLanes = assignMonthProjectLanes(occupiedWork, milestoneDays, laneGridStart, laneGridEnd);
+assert.deepEqual(monthLanes.visibleWork.map(segment => [segment.projectId, segment.lane]), [
+    ["occupier", 0],
+    ["milestoned", 1],
+]);
+assert.deepEqual(monthLanes.visibleMilestoneHosts.map(host => [host.projectId, host.dateKey, host.lane]), [
+    ["milestoned", "2037-01-03", 1],
+    ["milestoned", "2037-01-20", 1],
+]);
+assert.equal(monthLanes.visibleMilestoneHosts.some(host => host.dateKey === "2037-01-11"), false);
+
+const milestoneOnlyDays = new Map(Array.from({ length: 5 }, (_, index) => [`m${index}`, [new Date("2037-01-25Z")]]));
+const milestoneOnlyLanes = assignMonthProjectLanes(new Map(), milestoneOnlyDays, laneGridStart, laneGridEnd);
+assert.equal(milestoneOnlyLanes.visibleMilestoneHosts.length, 4);
+assert.deepEqual(milestoneOnlyLanes.hiddenProjectIdsByWeek.get(3), ["m4"]);
+console.log("schedule-board layout verification: PASS");

--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -1,0 +1,446 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const monthSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/MonthBarsView.tsx", import.meta.url), "utf8");
+const taskSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/TaskBlockSegment.tsx", import.meta.url), "utf8");
+const boardSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/ScheduleBoard.tsx", import.meta.url), "utf8");
+const projectSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/ProjectBar.tsx", import.meta.url), "utf8");
+function optionalSource(path: string): string {
+    try {
+        return readFileSync(new URL(path, import.meta.url), "utf8");
+    } catch {
+        return "";
+    }
+}
+const traySource = optionalSource("../src/app/company-dashboard/schedule-board/UnscheduledTray.tsx");
+const dialogSource = optionalSource("../src/app/company-dashboard/schedule-board/ShiftConfirmDialog.tsx");
+const timelineSource = optionalSource("../src/app/company-dashboard/schedule-board/TimelineView.tsx");
+const milestoneSource = optionalSource("../src/app/company-dashboard/schedule-board/MilestoneMarker.tsx");
+const layoutSource = optionalSource("../src/app/company-dashboard/schedule-board/useBarLayout.ts");
+const actionsSource = optionalSource("../src/lib/actions.ts");
+const coreSource = optionalSource("../src/lib/schedule-core.ts");
+const pageSource = optionalSource("../src/app/company-dashboard/page.tsx");
+const navSource = optionalSource("../src/components/nav/navItems.tsx");
+const companyDashboardSource = optionalSource("../src/app/company-dashboard/CompanyDashboardClient.tsx");
+
+assert.match(monthSource, /showIncome\s*\?\s*adminOverlays\.income\s*:\s*EMPTY_INCOME/);
+assert.match(monthSource, /showProjectedCo\s*\?\s*adminOverlays\.changeOrders\s*:\s*EMPTY_CHANGE_ORDERS/);
+assert.match(monthSource, /visibleMilestoneHosts/);
+assert.match(taskSource, /task\.assignments\.slice\(0,\s*2\).*initials\(assignment\.name\)/s);
+assert.match(taskSource, /ref=\{setMeasuredElement\}/);
+assert.match(traySource, /application\/x-gtr-project-id/);
+assert.match(traySource, /dataTransfer\.setData/);
+assert.match(traySource, /aria-disabled="true"/);
+assert.match(traySource, /type="date"/);
+assert.match(traySource, /\[@media\(hover:none\)\]:opacity-100/);
+assert.match(traySource, /canEdit\s*\?\s*"Drag a Waiting-to-Start project onto a day or use Project actions\."\s*:\s*"Unscheduled projects are read-only for your role\."/);
+assert.match(monthSource, /data-schedule-date=\{dayKey\}/);
+assert.match(monthSource, /if \(!data\.canEdit \|\| !hasProjectDragPayload\(event\)\) return;[\s\S]*?preventDefault\(\)/);
+assert.match(monthSource, /dragOverDate/);
+assert.match(monthSource, /dataTransfer\.types\.includes\(PROJECT_DRAG_MIME\)/);
+assert.equal((monthSource.match(/!hasProjectDragPayload\(event\)/g) ?? []).length, 2);
+assert.doesNotMatch(projectSource, /window\.addEventListener\("pointermove"|requestAnimationFrame|elementsFromPoint/);
+assert.match(boardSource, /activeProjectPointerRef/);
+assert.match(boardSource, /window\.addEventListener\("pointermove"/);
+assert.match(boardSource, /hitTestTimelineScheduleGrid/);
+assert.match(projectSource, /type="date"/);
+assert.match(projectSource, /\[@media\(hover:none\)\]:opacity-100/);
+assert.match(projectSource, /onProjectPointerEditStart/);
+assert.match(dialogSource, /Dialog\.Title/);
+assert.match(dialogSource, /Dialog\.Description/);
+assert.match(dialogSource, /Move start marker only/);
+assert.match(dialogSource, /Also shift all Not Started tasks by/);
+assert.match(boardSource, /updateProjectStartDateAction\(intent\.project\.id, intent\.targetStart, false\)/);
+assert.match(boardSource, /shiftNotStartedTasksAction\(intent\.project\.id, intent\.deltaDays\)/);
+assert.match(boardSource, /toast\.success\("Project scheduled"/);
+assert.match(boardSource, /router\.refresh\(\)/);
+assert.match(boardSource, /previewProjectIncomeOverlays/);
+assert.match(boardSource, /project\.status === "Waiting to Start" && project\.startDate/);
+assert.match(boardSource, /overlays:\s*data\.overlays\s*\?/);
+
+assert.match(timelineSource, /export function TimelineView/);
+assert.match(boardSource, /export type BoardView\s*=\s*"month"\s*\|\s*"timeline"/);
+assert.match(boardSource, /gtr-company-schedule-board-view/);
+assert.match(boardSource, /useState<BoardView>\("month"\)/);
+assert.match(boardSource, /useEffect\(\(\)\s*=>\s*\{[\s\S]*?localStorage\.getItem\([\s\S]*?stored\s*===\s*"month"\s*\|\|\s*stored\s*===\s*"timeline"[\s\S]*?setBoardView\(stored\)/);
+assert.match(boardSource, /localStorage\.setItem\([\s\S]*?gtr-company-schedule-board-view|localStorage\.setItem\(BOARD_VIEW_STORAGE_KEY/);
+assert.equal((boardSource.match(/aria-pressed=\{boardView === /g) ?? []).length, 2);
+assert.match(boardSource, /boardView\s*===\s*"month"[\s\S]*?<MonthBarsView[\s\S]*?\)\s*:\s*\(\s*<TimelineView/);
+
+assert.match(timelineSource, /DAY_WIDTH\s*=\s*20/);
+assert.match(timelineSource, /TIMELINE_DAYS\s*=\s*42/);
+assert.match(timelineSource, /toTimelineRect\([\s\S]*?DAY_WIDTH/);
+assert.match(timelineSource, /getMonthGrid/);
+assert.match(timelineSource, /position:\s*"sticky"|sticky left-0/);
+assert.match(timelineSource, /overflow-x-auto/);
+assert.match(timelineSource, /isWeekend/);
+assert.match(timelineSource, /isSameUTCDay/);
+assert.match(timelineSource, /ProjectBar/);
+assert.match(timelineSource, /MilestoneMarker/);
+assert.match(timelineSource, /timelineOrigin=\{gridStart\}/);
+assert.match(timelineSource, /dayWidth=\{DAY_WIDTH\}/);
+assert.match(milestoneSource, /timelineOrigin\?:\s*Date/);
+assert.match(milestoneSource, /dayWidth\?:\s*number/);
+assert.match(milestoneSource, /toTimelineRect/);
+assert.match(timelineSource, /adminOverlays\.income/);
+assert.match(timelineSource, /adminOverlays\.changeOrders/);
+assert.match(timelineSource, /showIncome/);
+assert.match(timelineSource, /showProjectedCo/);
+assert.match(timelineSource, /showExpenses/);
+assert.match(timelineSource, /showHours/);
+assert.match(timelineSource, /onMoveCommit=\{onProjectMoveCommit\}/);
+assert.match(timelineSource, /onProjectPointerEditStart=\{onProjectPointerEditStart\}/);
+assert.match(timelineSource, /LABEL_WIDTH\s*=\s*240/);
+assert.match(timelineSource, /timelineLeftInset=\{LABEL_WIDTH\}/);
+assert.match(timelineSource, /tabIndex=\{labels\.length\s*>\s*0\s*\?\s*0\s*:\s*undefined\}/);
+assert.match(timelineSource, /aria-label=\{labels\.length\s*>\s*0/);
+assert.match(timelineSource, /focus-visible:ring-2/);
+assert.match(timelineSource, /group\/overlay/);
+assert.match(timelineSource, /group-focus\/overlay:block/);
+assert.match(timelineSource, /labels\.join\(", "\)/);
+
+// Task 7 Timeline release regression: only the date body is a valid pointer-up target.
+assert.match(timelineSource, /data-timeline-schedule-grid="true"/);
+assert.match(timelineSource, /data-timeline-sticky-label="true"/);
+assert.match(boardSource, /function hitTestTimelineScheduleGrid\(clientX: number, clientY: number\): boolean/);
+const timelineGridHitTestStart = boardSource.indexOf("function hitTestTimelineScheduleGrid");
+const timelineGridHitTestEnd = boardSource.indexOf("function isInteractiveTaskFallbackTarget", timelineGridHitTestStart);
+const timelineGridHitTestBody = boardSource.slice(timelineGridHitTestStart, timelineGridHitTestEnd);
+assert.match(timelineGridHitTestBody, /document\.elementsFromPoint\(clientX, clientY\)/);
+assert.match(timelineGridHitTestBody, /data-timeline-sticky-label/);
+assert.match(timelineGridHitTestBody, /data-timeline-schedule-grid/);
+assert.match(timelineGridHitTestBody, /getBoundingClientRect\(\)/);
+const taskPointerStart = boardSource.indexOf("function handleTaskPointerEditStart");
+const taskPointerEnd = boardSource.indexOf("function handleTaskKeyboardStart", taskPointerStart);
+const taskPointerBody = boardSource.slice(taskPointerStart, taskPointerEnd);
+assert.match(taskPointerBody, /if \(start\.timelineDayWidth\) \{\s*if \(hitTestTimelineScheduleGrid\(drag\.latestClientX, drag\.latestClientY\)\) \{\s*deltaDays = getTimelinePointerDelta/);
+
+assert.match(boardSource, /getTimelineAutoscrollStep\(/);
+assert.match(boardSource, /timelineScrollContainerRef/);
+assert.match(boardSource, /drag\.latestClientX\s*=\s*event\.clientX;[\s\S]*?drag\.latestClientY\s*=\s*event\.clientY;[\s\S]*?calculateProjectPointerCandidate/);
+assert.match(boardSource, /cancelActiveProjectEdit\(\);[\s\S]*?cancelActiveTaskEdit\(\);[\s\S]*?setBoardView\(nextView\)/);
+
+// Task 7: task movement, resize, accessible fallbacks, and stable controller ownership.
+assert.match(layoutSource, /export type TaskEditMode\s*=\s*"move"\s*\|\s*"resize-left"\s*\|\s*"resize-right"/);
+assert.match(layoutSource, /export interface TaskDateOverride\s*\{[\s\S]*?startDate:\s*string;[\s\S]*?endDate:\s*string;/);
+assert.match(boardSource, /const \[taskDateOverrides, setTaskDateOverrides\]\s*=\s*useState<Record<string, TaskDateOverride>>/);
+assert.match(boardSource, /canonicalTaskById/);
+assert.match(boardSource, /previewTaskDates\(canonicalTask/);
+assert.equal((boardSource.match(/updateCompanyScheduleTaskDatesAction\(taskId,\s*\{\s*startDate:\s*dates\.startDate,\s*endDate:\s*dates\.endDate\s*\}\)/g) ?? []).length, 1);
+assert.match(boardSource, /toast\.success\("Task dates updated"\);[\s\S]*?router\.refresh\(\)/);
+assert.match(boardSource, /catch \(error\)\s*\{[\s\S]*?clearTaskPreview\(taskId\)[\s\S]*?toast\.error/);
+assert.match(boardSource, /pendingTaskIds/);
+assert.match(boardSource, /TASK_MOUSE_DRAG_THRESHOLD_PX\s*=\s*5/);
+assert.match(boardSource, /TASK_TOUCH_DRAG_THRESHOLD_PX\s*=\s*8/);
+assert.match(boardSource, /requestAnimationFrame/);
+assert.match(boardSource, /window\.addEventListener\("pointermove"/);
+assert.match(boardSource, /window\.removeEventListener\("pointermove"/);
+assert.match(boardSource, /window\.addEventListener\("keydown",\s*onWindowKeyDown\)/);
+assert.match(boardSource, /window\.removeEventListener\("keydown",\s*onWindowKeyDown\)/);
+assert.match(boardSource, /activeTaskPointerRef/);
+assert.match(boardSource, /cancelActiveTaskEdit\(\);[\s\S]*?setBoardView\(nextView\)/);
+assert.match(boardSource, /sourceElement\.style\.touchAction\s*=\s*"none"/);
+assert.match(boardSource, /sourceElement\.style\.touchAction\s*=\s*drag\.previousTouchAction/);
+assert.match(boardSource, /if \(!data\.canEdit \|\| isTaskOrProjectPending\(/);
+assert.match(taskSource, /timelineScrollContainerRef/);
+assert.match(taskSource, /timelineLeftInset/);
+assert.match(taskPointerBody, /getTaskAutoscrollStep/);
+assert.match(taskPointerBody, /timelineScrollContainerRef\?\.current/);
+assert.match(taskPointerBody, /timelineLeftInset/);
+assert.match(taskPointerBody, /MAX_AUTOSCROLL_PX_PER_FRAME/);
+assert.match(taskPointerBody, /container\.scrollLeft \+= scrollDelta/);
+assert.match(taskPointerBody, /drag\.originX -= container\.scrollLeft - before/);
+assert.match(taskPointerBody, /requestAnimationFrame\(runTaskPointerFrame\)/);
+
+assert.equal((monthSource.match(/onTaskPointerEditStart=\{onTaskPointerEditStart\}/g) ?? []).length, 2);
+assert.equal((timelineSource.match(/onTaskPointerEditStart=\{onTaskPointerEditStart\}/g) ?? []).length, 2);
+assert.match(projectSource, /onTaskPointerEditStart=\{onTaskPointerEditStart\}/);
+assert.match(projectSource, /isPending=\{isPending \|\| pendingTaskIds\.has\(task\.id\)\}/);
+assert.match(monthSource, /isPending=\{pendingProjectIds\.has\(project\.id\) \|\| pendingTaskIds\.has\(task\.id\)\}/);
+assert.match(timelineSource, /isPending=\{pendingProjectIds\.has\(project\.id\) \|\| pendingTaskIds\.has\(task\.id\)\}/);
+assert.match(taskSource, /onTaskPointerEditStart/);
+assert.match(taskSource, /if \(!canEdit \|\| isPending/);
+assert.match(taskSource, /w-2/);
+assert.equal((taskSource.match(/Resize (?:start|end) of/g) ?? []).length, 2);
+assert.match(taskSource, /task\.type\s*!==\s*"milestone"[\s\S]*?resize-left/);
+assert.match(taskSource, /task\.type\s*!==\s*"milestone"[\s\S]*?resize-right/);
+assert.match(taskSource, /touch-pan-y/);
+assert.match(taskSource, /tabIndex=\{0\}/);
+assert.match(taskSource, /data-task-edit-block="true"/);
+assert.match(taskSource, /event\.key === " " \|\| event\.key === "Enter"/);
+assert.match(taskSource, /event\.shiftKey \? 7 : 1/);
+assert.match(taskSource, /event\.key === "ArrowLeft" \|\| event\.key === "ArrowUp"/);
+assert.match(taskSource, /event\.key === "ArrowRight" \|\| event\.key === "ArrowDown"/);
+assert.match(taskSource, /event\.key === "Escape"/);
+assert.match(taskSource, /type="date"/);
+assert.match(taskSource, /Move Earlier/);
+assert.match(taskSource, /Move Later/);
+assert.match(taskSource, /\[@media\(hover:none\)\]:opacity-100/);
+assert.match(taskSource, /group-focus-within\/task:opacity-100/);
+assert.match(taskSource, /aria-disabled=\{!canEdit \|\| isPending\}/);
+
+// Task 8 focused re-review: the company board adds authorization only; the
+// established project schedule action remains the single mutation core.
+assert.doesNotMatch(coreSource, /export async function updateCompanyScheduleTaskDates/);
+const canonicalTaskActionStart = actionsSource.indexOf("export async function updateScheduleTask");
+const canonicalTaskActionEnd = actionsSource.indexOf("export async function deleteScheduleTask", canonicalTaskActionStart);
+const canonicalTaskActionBody = actionsSource.slice(canonicalTaskActionStart, canonicalTaskActionEnd);
+assert.match(canonicalTaskActionBody, /await assertScheduleTaskAccess\(taskId\)/);
+assert.doesNotMatch(canonicalTaskActionBody, /\["ADMIN",\s*"MANAGER"\]\.includes\((?:user|caller)\.role\)/);
+assert.match(canonicalTaskActionBody, /withTxRetry\(\(\)\s*=>\s*prisma\.\$transaction/);
+assert.match(canonicalTaskActionBody, /SELECT id FROM "Project"[\s\S]*?FOR UPDATE/);
+assert.match(canonicalTaskActionBody, /SELECT id FROM "ScheduleTask"[\s\S]*?FOR UPDATE/);
+assert.match(canonicalTaskActionBody, /parseStartDateInput/);
+assert.match(canonicalTaskActionBody, /persistedTask\.type === "milestone"/);
+assert.match(canonicalTaskActionBody, /endDate <= startDate/);
+assert.match(canonicalTaskActionBody, /activityLog\.create/);
+assert.match(canonicalTaskActionBody, /revalidatePath\("\/company-dashboard"\)/);
+const companyTaskAdapterStart = actionsSource.indexOf("export async function updateCompanyScheduleTaskDatesAction");
+const companyTaskAdapterEnd = actionsSource.indexOf("export async function updateProjectStatus", companyTaskAdapterStart);
+const companyTaskAdapterBody = actionsSource.slice(companyTaskAdapterStart, companyTaskAdapterEnd);
+assert.ok(companyTaskAdapterStart >= 0, "company schedule task-date authorization adapter must exist");
+assert.match(companyTaskAdapterBody, /\["ADMIN",\s*"MANAGER"\]\.includes\(caller\.role\)/);
+assert.equal((companyTaskAdapterBody.match(/updateScheduleTask\(/g) ?? []).length, 1, "adapter delegates exactly once to the canonical action");
+assert.doesNotMatch(companyTaskAdapterBody, /parseStartDateInput|withTxRetry|\$transaction|\$queryRaw|scheduleTask\.update|activityLog\.create|revalidatePath/);
+assert.match(boardSource, /import \{[^}]*updateCompanyScheduleTaskDatesAction[^}]*\} from "@\/lib\/actions"/s);
+assert.doesNotMatch(boardSource, /\bupdateScheduleTask\(/);
+
+assert.match(taskSource, /if \(event\.target !== event\.currentTarget\) return;/);
+assert.match(boardSource, /taskKeyboardSentinelRef/);
+assert.match(boardSource, /sourceElement\.isConnected/);
+assert.match(boardSource, /isInteractiveTaskFallbackTarget/);
+assert.match(boardSource, /document\.activeElement === taskKeyboardSentinelRef\.current/);
+assert.match(taskSource, /useId\(\)/);
+assert.match(taskSource, /task-start-\$\{task\.id\}-\$\{fragmentId\}/);
+assert.match(taskSource, /!mutationDisabled\s*&&\s*\(\s*<details/);
+
+assert.match(boardSource, /currentCandidate:\s*TaskDateOverride \| null/);
+assert.match(boardSource, /drag\.currentCandidate\s*=\s*null;[\s\S]*?clearTaskPreview\(task\.id\)/);
+assert.match(boardSource, /drag\.latestClientX\s*=\s*event\.clientX;[\s\S]*?drag\.latestClientY\s*=\s*event\.clientY;[\s\S]*?calculatePointerCandidate\(\)/);
+assert.match(boardSource, /if \(!candidate\)\s*\{[\s\S]*?clearTaskPreview\(task\.id\)[\s\S]*?return;/);
+
+assert.match(boardSource, /awaitingTaskRefreshIds/);
+assert.match(boardSource, /taskDatesMatch\(canonicalTask,\s*dates\)/);
+assert.match(boardSource, /setAwaitingTaskRefreshIds/);
+const taskCommitStart = boardSource.indexOf("async function commitTaskDates");
+const taskCommitEnd = boardSource.indexOf("function showSuccess", taskCommitStart);
+const taskCommitBody = boardSource.slice(taskCommitStart, taskCommitEnd);
+const taskSuccessStart = taskCommitBody.indexOf('toast.success("Task dates updated")');
+const taskSuccessEnd = taskCommitBody.indexOf("catch (error)", taskSuccessStart);
+const taskSuccessBody = taskCommitBody.slice(taskSuccessStart, taskSuccessEnd);
+assert.doesNotMatch(taskSuccessBody, /clearTaskPreview\(taskId\)|setTaskPending\(taskId, false\)/);
+assert.match(taskSuccessBody, /setAwaitingTaskRefreshIds/);
+assert.match(taskSuccessBody, /router\.refresh\(\)/);
+
+// Parent-project pending state blocks every child-task entry/commit path, and
+// project/task pointer + keyboard controllers cannot coexist.
+assert.match(boardSource, /canonicalTaskProjectById/);
+assert.match(boardSource, /const isTaskOrProjectPending = \(taskId: string\)/);
+assert.match(layoutSource, /export function getEffectivePendingProjectIds/);
+assert.match(boardSource, /getEffectivePendingProjectIds\([\s\S]*?effectivePendingTaskIds[\s\S]*?canonicalTaskProjectById/);
+assert.match(boardSource, /effectivePendingProjectIdsRef\.current = effectivePendingProjectIds/);
+assert.match(boardSource, /const isProjectPending = \(projectId: string\) =>[\s\S]*?effectivePendingProjectIdsRef\.current\.has\(projectId\)/);
+assert.match(taskCommitBody, /isTaskOrProjectPending\(taskId\)/);
+assert.match(taskPointerBody, /isTaskOrProjectPending\(task\.id\)/);
+assert.match(taskPointerBody, /cancelActiveProjectEdit\(\)/);
+const taskKeyboardStart = boardSource.indexOf("function handleTaskKeyboardStart");
+const taskKeyboardEnd = boardSource.indexOf("function handleTaskKeyboardAdjust", taskKeyboardStart);
+const taskKeyboardBody = boardSource.slice(taskKeyboardStart, taskKeyboardEnd);
+assert.match(taskKeyboardBody, /isTaskOrProjectPending\(task\.id\)/);
+assert.match(taskKeyboardBody, /cancelActiveProjectEdit\(\)/);
+const projectPointerStart = boardSource.indexOf("function handleProjectPointerEditStart");
+const projectPointerEnd = boardSource.indexOf("function handleProjectKeyboardStart", projectPointerStart);
+const projectPointerBody = boardSource.slice(projectPointerStart, projectPointerEnd);
+assert.match(projectPointerBody, /cancelActiveTaskEdit\(\)/);
+const projectKeyboardStart = boardSource.indexOf("function handleProjectKeyboardStart");
+const projectKeyboardEnd = boardSource.indexOf("function handleProjectKeyboardAdjust", projectKeyboardStart);
+assert.match(boardSource.slice(projectKeyboardStart, projectKeyboardEnd), /cancelActiveTaskEdit\(\)/);
+for (const [startMarker, endMarker] of [
+    ["function handleTaskKeyboardAdjust", "function handleTaskKeyboardCommit"],
+    ["function handleTaskKeyboardCommit", "function handleTaskKeyboardCancel"],
+    ["function handleTaskDatesCommit", "function handleTaskMoveBy"],
+    ["function handleTaskMoveBy", "return ("],
+] as const) {
+    const start = boardSource.indexOf(startMarker);
+    const end = boardSource.indexOf(endMarker, start);
+    assert.match(boardSource.slice(start, end), /isTaskOrProjectPending\(task\.id\)/, `${startMarker} must reject child work while the project is pending`);
+}
+
+// Reverse exclusion is live at every project start/preview/final-commit path,
+// including controllers whose listeners were created before a child save.
+for (const [startMarker, endMarker] of [
+    ["function scheduleUnscheduledProject", "function commitWaitingProjectMove"],
+    ["function commitWaitingProjectMove", "function handleProjectMovePreview"],
+    ["function handleProjectMovePreview", "function handleProjectMoveCommit"],
+    ["function handleProjectMoveCommit", "function handleMoveChoice"],
+    ["function handleMoveChoice", "function cancelConfirmedMove"],
+    ["function handleProjectPointerEditStart", "function handleProjectKeyboardStart"],
+    ["function handleProjectKeyboardStart", "function handleProjectKeyboardAdjust"],
+    ["function handleProjectKeyboardAdjust", "function handleProjectKeyboardCommit"],
+    ["function handleProjectKeyboardCommit", "function handleProjectKeyboardCancel"],
+] as const) {
+    const start = boardSource.indexOf(startMarker);
+    const end = boardSource.indexOf(endMarker, start);
+    assert.match(boardSource.slice(start, end), /isProjectPending\(/, `${startMarker} must read the live task-derived parent pending state`);
+}
+const projectCommitStart = boardSource.indexOf("function handleProjectMoveCommit");
+const projectCommitEnd = boardSource.indexOf("function handleMoveChoice", projectCommitStart);
+assert.match(boardSource.slice(projectCommitStart, projectCommitEnd), /isProjectPending\(project\.id\)[\s\S]*?clearProjectPreview\(project\.id\)/);
+assert.match(boardSource, /<UnscheduledTray[\s\S]*?pendingProjectIds=\{effectivePendingProjectIds\}/);
+assert.equal((boardSource.match(/pendingProjectIds=\{effectivePendingProjectIds\}/g) ?? []).length, 3, "tray and both views receive task-derived project pending state");
+
+// Task 8 final integration: page-wide project mutation exclusion coordinates
+// the sibling legacy StartDateRow and every board task/project entry point.
+assert.match(boardSource, /interface ScheduleBoardProps[\s\S]*?externallyPendingProjectIds:\s*ReadonlySet<string>[\s\S]*?isProjectExternallyPending:\s*\(projectId: string\) => boolean[\s\S]*?onEffectivePendingProjectIdsChange:\s*\(projectIds: ReadonlySet<string>\) => void/);
+assert.match(boardSource, /getEffectivePendingProjectIds\([\s\S]*?externallyPendingProjectIds[\s\S]*?effectivePendingTaskIds[\s\S]*?canonicalTaskProjectById/);
+assert.match(boardSource, /const isProjectPending = \(projectId: string\) =>[\s\S]*?effectivePendingProjectIdsRef\.current\.has\(projectId\)[\s\S]*?isProjectExternallyPending\(projectId\)/);
+assert.match(boardSource, /const publishEffectivePendingProjectIds = useCallback\([\s\S]*?onEffectivePendingProjectIdsChange\(next\)/);
+const projectPendingSetterStart = boardSource.indexOf("function setProjectPending");
+const taskPendingSetterStart = boardSource.indexOf("function setTaskPending", projectPendingSetterStart);
+const taskPendingSetterEnd = boardSource.indexOf("function setTaskKeyboardState", taskPendingSetterStart);
+assert.match(boardSource.slice(projectPendingSetterStart, taskPendingSetterStart), /if \(pending\)[\s\S]*?publishEffectivePendingProjectIds/);
+assert.match(boardSource.slice(taskPendingSetterStart, taskPendingSetterEnd), /if \(pending\)[\s\S]*?canonicalTaskProjectById\.get\(taskId\)[\s\S]*?publishEffectivePendingProjectIds/);
+assert.match(boardSource, /useEffect\(\(\) => \{\s*publishEffectivePendingProjectIds\(effectivePendingProjectIds\);\s*\}, \[effectivePendingProjectIds, publishEffectivePendingProjectIds\]\)/);
+assert.match(boardSource, /useEffect\(\(\) => \(\) => onEffectivePendingProjectIdsChange\(EMPTY_PROJECT_IDS\), \[onEffectivePendingProjectIdsChange\]\)/);
+
+assert.match(companyDashboardSource, /const boardPendingProjectIdsRef = useRef<Set<string>>/);
+assert.match(companyDashboardSource, /const legacyProjectMutationsRef = useRef<Map<string, LegacyProjectMutation>>/);
+assert.match(companyDashboardSource, /const isPageProjectPending = useCallback\(\(projectId: string\) =>[\s\S]*?boardPendingProjectIdsRef\.current\.has\(projectId\)[\s\S]*?legacyProjectMutationsRef\.current\.has\(projectId\)/);
+assert.match(companyDashboardSource, /const publishBoardPendingProjectIds = useCallback[\s\S]*?projectIdSetsEqual[\s\S]*?setBoardPendingProjectIds/);
+assert.match(companyDashboardSource, /<ScheduleBoard[\s\S]*?externallyPendingProjectIds=\{legacyPendingProjectIds\}[\s\S]*?isProjectExternallyPending=\{isPageProjectPending\}[\s\S]*?onEffectivePendingProjectIdsChange=\{publishBoardPendingProjectIds\}/);
+assert.match(companyDashboardSource, /<StartDateRow[\s\S]*?isProjectPending=\{pagePendingProjectIds\.has\(p\.id\)\}[\s\S]*?beginProjectMutation=\{beginLegacyProjectMutation\}[\s\S]*?awaitProjectRefresh=\{awaitLegacyProjectRefresh\}[\s\S]*?clearProjectMutation=\{clearLegacyProjectMutation\}/);
+
+const startDateRowStart = companyDashboardSource.indexOf("function StartDateRow");
+const startDateRowEnd = companyDashboardSource.indexOf("export default function CompanyDashboardClient", startDateRowStart);
+const startDateRowBody = companyDashboardSource.slice(startDateRowStart, startDateRowEnd);
+assert.equal((companyDashboardSource.match(/updateProjectStartDateAction\(/g) ?? []).length, 1, "the company dashboard has exactly one legacy project-start writer");
+assert.match(startDateRowBody, /if \(!beginProjectMutation\(project\.id\)\) return;/);
+assert.ok(startDateRowBody.indexOf("beginProjectMutation(project.id)") < startDateRowBody.indexOf("updateProjectStartDateAction(project.id"), "the live page lock must be acquired before the legacy action starts");
+assert.match(startDateRowBody, /awaitProjectRefresh\(project\.id,\s*\{[\s\S]*?projectStartDate:\s*result\.startDate[\s\S]*?taskDates:\s*result\.shiftedTaskDates/);
+const legacySuccessStart = startDateRowBody.indexOf("const result = await updateProjectStartDateAction");
+const legacySuccessEnd = startDateRowBody.indexOf("catch (error)", legacySuccessStart);
+assert.doesNotMatch(startDateRowBody.slice(legacySuccessStart, legacySuccessEnd), /clearProjectMutation/, "legacy success keeps the parent lock through canonical refresh");
+assert.match(startDateRowBody, /catch \(error\)[\s\S]*?clearProjectMutation\(project\.id\)/);
+assert.equal((startDateRowBody.match(/disabled=\{isPending \|\| isProjectPending\}/g) ?? []).length, 2, "legacy date input and button both render the shared page lock");
+assert.match(companyDashboardSource, /legacyRefreshCount > 0[\s\S]*?Refreshing start-date changes\.\.\.[\s\S]*?>Retry now<\/button>/);
+assert.match(companyDashboardSource, /window\.setInterval\(\(\) => router\.refresh\(\), 2_000\)/);
+assert.match(companyDashboardSource, /projectRefreshMatches\(canonicalProjectById\.get\(projectId\), mutation\.expectation\)/);
+assert.match(companyDashboardSource, /!canonicalProjectById\.has\(projectId\)/, "a canonical project removal must release a stale parent lock");
+assert.match(companyDashboardSource, /pageMountedRef\.current = false;[\s\S]*?boardPendingProjectIdsRef\.current = new Set\(\);[\s\S]*?legacyProjectMutationsRef\.current = new Map\(\)/);
+
+// A rising legacy lock is a cancellation boundary for pre-existing board
+// controllers and stable-key local menu drafts, not merely a disabled state.
+assert.match(layoutSource, /export function getNewlyPendingProjectIds/);
+assert.match(boardSource, /const previousExternallyPendingProjectIdsRef = useRef<ReadonlySet<string>>/);
+assert.match(boardSource, /interface TaskKeyboardEditState\s*\{[\s\S]*?taskId:\s*string;[\s\S]*?projectId:\s*string;/);
+assert.match(boardSource, /interface ActiveTaskPointerEdit\s*\{[\s\S]*?taskId:\s*string;[\s\S]*?projectId:\s*string;/);
+const scopedTaskCancelStart = boardSource.indexOf("function cancelTaskEditsForProjects");
+const scopedTaskCancelEnd = boardSource.indexOf("function cancelActiveTaskEdit", scopedTaskCancelStart);
+const scopedTaskCancelBody = boardSource.slice(scopedTaskCancelStart, scopedTaskCancelEnd);
+assert.match(scopedTaskCancelBody, /activeTaskPointerRef\.current/);
+assert.match(scopedTaskCancelBody, /projectIds\.has\(pointerEdit\.projectId\)/);
+assert.match(scopedTaskCancelBody, /pointerEdit\.cleanup\(\)[\s\S]*?clearTaskPreview\(pointerEdit\.taskId\)/);
+assert.match(scopedTaskCancelBody, /projectIds\.has\(keyboardEdit\.projectId\)/);
+assert.match(scopedTaskCancelBody, /clearTaskPreview\(keyboardEdit\.taskId\)[\s\S]*?taskKeyboardCleanupRef\.current\?\.\(\)[\s\S]*?setTaskKeyboardState\(null\)/);
+const scopedProjectCancelStart = boardSource.indexOf("function cancelProjectEditsForProjects");
+const scopedProjectCancelEnd = boardSource.indexOf("function cancelActiveProjectEdit", scopedProjectCancelStart);
+const scopedProjectCancelBody = boardSource.slice(scopedProjectCancelStart, scopedProjectCancelEnd);
+assert.match(scopedProjectCancelBody, /activeProjectPointerRef\.current/);
+assert.match(scopedProjectCancelBody, /projectIds\.has\(pointerEdit\.projectId\)[\s\S]*?pointerEdit\.cleanup\(\)[\s\S]*?clearProjectPreview\(pointerEdit\.projectId\)/);
+assert.match(scopedProjectCancelBody, /projectIds\.has\(keyboardEdit\.projectId\)[\s\S]*?clearProjectPreview\(keyboardEdit\.projectId\)[\s\S]*?projectKeyboardCleanupRef\.current\?\.\(\)[\s\S]*?setProjectKeyboardState\(null\)/);
+const externalLockEffectStart = boardSource.indexOf("const newlyPendingProjectIds = getNewlyPendingProjectIds");
+const externalLockEffectEnd = boardSource.indexOf("}, [externallyPendingProjectIds])", externalLockEffectStart);
+const externalLockEffectBody = boardSource.slice(externalLockEffectStart, externalLockEffectEnd);
+assert.match(externalLockEffectBody, /previousExternallyPendingProjectIdsRef\.current = new Set\(externallyPendingProjectIds\)/);
+assert.match(externalLockEffectBody, /cancelExternallyLockedProjectEdits\(newlyPendingProjectIds\)/);
+assert.match(boardSource, /const cancelExternallyLockedProjectEdits = useEffectEvent\([\s\S]*?cancelProjectEditsForProjects\(newlyPendingProjectIds\)[\s\S]*?cancelTaskEditsForProjects\(newlyPendingProjectIds\)[\s\S]*?confirmIntentRef\.current[\s\S]*?newlyPendingProjectIds\.has\(intent\.project\.id\)[\s\S]*?clearProjectPreview\(intent\.project\.id\)[\s\S]*?setConfirmIntent\(null\)/);
+assert.match(taskSource, /const actionDetailsRef = useRef<HTMLDetailsElement>\(null\)/);
+assert.match(taskSource, /const actionResetKey = `\$\{isPending \? "pending" : "ready"\}:\$\{task\.startDate\}:\$\{task\.endDate\}`/);
+assert.match(taskSource, /const menuDates = menuDraft\.resetKey === actionResetKey \? menuDraft\.dates : null/);
+assert.match(taskSource, /if \(menuDraft\.resetKey !== actionResetKey\) \{\s*setMenuDraft\(\{ resetKey: actionResetKey, dates: null \}\)/);
+assert.match(taskSource, /useEffect\(\(\) => \{\s*if \(actionDetailsRef\.current\) actionDetailsRef\.current\.open = false;\s*\}, \[actionResetKey\]\)/);
+assert.match(taskSource, /<details\s+ref=\{actionDetailsRef\}/);
+assert.match(projectSource, /const actionDetailsRef = useRef<HTMLDetailsElement>\(null\)/);
+assert.match(projectSource, /const actionResetKey = `\$\{isPending \? "pending" : "ready"\}:\$\{projectStart\}`/);
+assert.match(projectSource, /const targetStart = targetStartDraft\.resetKey === actionResetKey \? targetStartDraft\.value : projectStart/);
+assert.match(projectSource, /if \(targetStartDraft\.resetKey !== actionResetKey\) \{\s*setTargetStartDraft\(\{ resetKey: actionResetKey, value: projectStart \}\)/);
+assert.match(projectSource, /useEffect\(\(\) => \{\s*if \(actionDetailsRef\.current\) actionDetailsRef\.current\.open = false;\s*\}, \[actionResetKey\]\)/);
+assert.match(projectSource, /<details\s+ref=\{actionDetailsRef\}/);
+assert.equal((monthSource.match(/isPending=\{pendingProjectIds\.has\(project\.id\)\}/g) ?? []).length, 1, "Month project menus receive the external parent lock");
+assert.equal((timelineSource.match(/isPending=\{pendingProjectIds\.has\(project\.id\)\}/g) ?? []).length, 1, "Timeline project menus receive the external parent lock");
+assert.match(monthSource, /isPending=\{pendingProjectIds\.has\(project\.id\) \|\| pendingTaskIds\.has\(task\.id\)\}/);
+assert.match(timelineSource, /isPending=\{pendingProjectIds\.has\(project\.id\) \|\| pendingTaskIds\.has\(task\.id\)\}/);
+
+// Project reconciliation is based only on canonical Project/ScheduleTask truth.
+const refreshExpectationStart = layoutSource.indexOf("export interface ProjectRefreshExpectation");
+const refreshExpectationEnd = layoutSource.indexOf("function toUTCDay", refreshExpectationStart);
+const refreshExpectationBody = layoutSource.slice(refreshExpectationStart, refreshExpectationEnd);
+assert.match(refreshExpectationBody, /projectStartDate\?:\s*string \| null/);
+assert.match(refreshExpectationBody, /taskDates:\s*PersistedTaskDate\[\]/);
+assert.doesNotMatch(refreshExpectationBody, /project:\s*DashboardProjectRow|income|OverlayIncomeItem/);
+const projectReconciliationStart = boardSource.indexOf("const reconciledProjectIds");
+const projectReconciliationEnd = boardSource.indexOf("useEffect(() => {", projectReconciliationStart);
+const projectReconciliationBody = boardSource.slice(projectReconciliationStart, projectReconciliationEnd);
+assert.match(projectReconciliationBody, /projectRefreshMatches\(canonical, expectation\)/);
+assert.doesNotMatch(projectReconciliationBody, /income|data\.overlays|actualIncome/);
+assert.match(boardSource, /setProjectRefreshExpectations\(current => \(\{ \.\.\.current, \[project\.id\]: expectation \}\)\)/);
+assert.equal((boardSource.match(/awaitProjectRefresh\(/g) ?? []).length, 5, "all four project success paths retain a reconciliation-backed optimistic preview");
+assert.match(boardSource, /previewProjectIncomeOverlays/);
+assert.match(boardSource, /previewShiftedTaskIncomeOverlays/);
+assert.match(layoutSource, /export function previewProjectWithPersistedTaskDates/);
+assert.match(coreSource, /interface SetProjectStartDateResult[\s\S]*?shiftedTaskDates:\s*PersistedScheduleTaskDate\[\]/);
+assert.match(coreSource, /interface ShiftNotStartedTasksResult[\s\S]*?shiftedTaskDates:\s*PersistedScheduleTaskDate\[\]/);
+assert.match(coreSource, /UPDATE "ScheduleTask"[\s\S]*?RETURNING "id", "startDate", "endDate"/);
+const trayScheduleStart = boardSource.indexOf("function scheduleUnscheduledProject");
+const trayScheduleEnd = boardSource.indexOf("function commitWaitingProjectMove", trayScheduleStart);
+const waitingMoveStart = trayScheduleEnd;
+const waitingMoveEnd = boardSource.indexOf("function handleProjectMovePreview", waitingMoveStart);
+for (const body of [boardSource.slice(trayScheduleStart, trayScheduleEnd), boardSource.slice(waitingMoveStart, waitingMoveEnd)]) {
+    assert.match(body, /projectStartDate:\s*result\.startDate/);
+    assert.match(body, /taskDates:\s*result\.shiftedTaskDates/);
+    assert.match(body, /previewProjectWithPersistedTaskDates/);
+}
+const moveChoiceStart = boardSource.indexOf("function handleMoveChoice");
+const moveChoiceEnd = boardSource.indexOf("function cancelConfirmedMove", moveChoiceStart);
+const moveChoiceBody = boardSource.slice(moveChoiceStart, moveChoiceEnd);
+assert.match(moveChoiceBody, /choice === "marker-only"[\s\S]*?taskDates:\s*\[\]/);
+assert.match(moveChoiceBody, /shiftNotStartedTasksAction[\s\S]*?taskDates:\s*result\.shiftedTaskDates/);
+assert.doesNotMatch(moveChoiceBody, /intent\.project\.tasks\.map/);
+
+// A task-only reconciliation exposes the same visible/manual recovery path.
+assert.match(boardSource, /projectRefreshCount > 0 \|\| awaitingTaskRefreshIds\.size > 0/);
+assert.match(boardSource, /pendingRefreshKinds/);
+assert.match(boardSource, /Refreshing saved \{pendingRefreshKinds\.join\(" and "\)\} schedule changes\.\.\./);
+assert.doesNotMatch(boardSource, /Ã|Â|â€¦/);
+assert.match(boardSource, />Retry now<\/button>/);
+
+// Task 8 coverage/access/reconciliation/identity contracts.
+for (const source of [boardSource, monthSource, timelineSource]) assert.match(source, /substantialCompletion/);
+assert.match(coreSource, /substantialCompletion:\s*DashboardProjectRow\[\]/);
+assert.match(coreSource, /substantialCompletion:\s*pipeline\.substantialCompletion\.map\(enrich\)/);
+assert.match(pageSource, /hasPermission\(effectiveUser, "financialReports"\)[\s\S]*?hasPermission\(effectiveUser, "schedules"\)/);
+assert.match(navSource, /key:\s*"dashboard"[\s\S]*?can\("financialReports"\)\s*\|\|\s*can\("schedules"\)/);
+assert.match(coreSource, /paymentScheduleId:\s*string/);
+assert.match(coreSource, /paymentScheduleId:\s*row\.id/);
+assert.match(coreSource, /paymentScheduleId:\s*`synthetic:/);
+assert.match(projectSource, /item\.paymentScheduleId/);
+assert.match(monthSource, /item\.paymentScheduleId/);
+assert.match(timelineSource, /item\.paymentScheduleId/);
+assert.doesNotMatch([projectSource, monthSource, timelineSource].join("\n"), /co-\$\{item\.changeOrderId\}-\$\{item\.effectiveDueDate\}-\$\{item\.name\}/);
+const duplicateNameDateRows = [
+    { paymentScheduleId: "payment-row-a", changeOrderId: "co-1", name: "Progress", effectiveDueDate: "2037-01-10" },
+    { paymentScheduleId: "payment-row-b", changeOrderId: "co-1", name: "Progress", effectiveDueDate: "2037-01-10" },
+];
+assert.equal(new Set(duplicateNameDateRows.map(row => `co-${row.paymentScheduleId}`)).size, 2, "duplicate CO name/date rows retain distinct stable identities");
+assert.match(boardSource, /projectRefreshExpectations/);
+assert.match(boardSource, /window\.setInterval\([\s\S]*?router\.refresh\(\)/);
+assert.match(projectSource, /onProjectKeyboardStart/);
+assert.match(projectSource, /event\.key === " " \|\| event\.key === "Enter"/);
+assert.match(projectSource, /event\.shiftKey \? 7 : 1/);
+assert.match(boardSource, /projectKeyboardSentinelRef/);
+assert.match(boardSource, /aria-live="polite"/);
+const shiftActionStart = actionsSource.indexOf("export async function shiftNotStartedTasksAction");
+const shiftActionEnd = actionsSource.indexOf("export async function", shiftActionStart + 30);
+assert.match(actionsSource.slice(shiftActionStart, shiftActionEnd), /actor:\s*\{\s*type:\s*"TEAM",\s*name:\s*caller\.name\s*\|\|\s*caller\.email\s*\}/);
+
+console.log("schedule-board render contract verification: PASS");

--- a/scripts/verify-schedule-board.ts
+++ b/scripts/verify-schedule-board.ts
@@ -1,0 +1,515 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "../src/lib/prisma";
+import { getCompanyDashboardData, setProjectStartDate, shiftNotStartedTasks } from "../src/lib/schedule-core";
+import { canAccessProject, hasPermission } from "../src/lib/permissions";
+import { withTxRetry } from "../src/lib/tx-retry";
+
+type Check = [label: string, passed: boolean];
+
+function serializable(value: unknown): unknown {
+    if (value instanceof Date) return value.toISOString();
+    if (Prisma.Decimal.isDecimal(value)) return value.toString();
+    if (Array.isArray(value)) return value.map(serializable);
+    if (value && typeof value === "object") {
+        return Object.fromEntries(Object.entries(value).map(([key, nested]) => [key, serializable(nested)]));
+    }
+    return value;
+}
+
+function snapshot(value: unknown): string {
+    return JSON.stringify(serializable(value));
+}
+
+function withoutTaskDates(value: Record<string, unknown>): string {
+    const rest = { ...value };
+    delete rest.startDate;
+    delete rest.endDate;
+    return snapshot(rest);
+}
+
+async function main() {
+    const checks: Check[] = [];
+    const check = (label: string, passed: boolean) => checks.push([label, passed]);
+    const tag = randomUUID();
+    const DAY = 86_400_000;
+    const base = Date.UTC(2040, 4, 1);
+    const at = (day: number) => new Date(base + day * DAY);
+    const month = "2040-05";
+    const actor = { type: "TEAM" as const, name: `Board verifier ${tag}` };
+
+    const projectIds: string[] = [];
+    const estimateIds: string[] = [];
+    const invoiceIds: string[] = [];
+    let clientId: string | null = null;
+
+    try {
+        const client = await prisma.client.create({
+            data: {
+                name: `BOARD VERIFY ${tag} DELETE ME`,
+                initials: "BV",
+                email: `board-client-${tag}@example.invalid`,
+            },
+        });
+        clientId = client.id;
+
+        const project = await prisma.project.create({
+            data: {
+                name: `BOARD VERIFY ${tag} DELETE ME`,
+                clientId: client.id,
+                status: "In Progress",
+                startDate: at(0),
+                color: "#123456",
+            },
+        });
+        projectIds.push(project.id);
+
+        const notStarted = await prisma.scheduleTask.create({
+            data: {
+                projectId: project.id,
+                name: "Not started",
+                startDate: at(1),
+                endDate: at(4),
+                status: "Not Started",
+                color: "#abcdef",
+                progress: 15,
+            },
+        });
+        const active = await prisma.scheduleTask.create({
+            data: {
+                projectId: project.id,
+                name: "Active",
+                startDate: at(4),
+                endDate: at(7),
+                status: "In Progress",
+            },
+        });
+        const complete = await prisma.scheduleTask.create({
+            data: {
+                projectId: project.id,
+                name: "Complete",
+                startDate: at(7),
+                endDate: at(9),
+                status: "Completed",
+            },
+        });
+        const milestoneTask = await prisma.scheduleTask.create({
+            data: {
+                projectId: project.id,
+                name: "Billing anchor",
+                startDate: at(4),
+                endDate: at(4),
+                status: "Not Started",
+                type: "milestone",
+            },
+        });
+
+        const estimate = await prisma.estimate.create({
+            data: {
+                title: `Board verify estimate ${tag}`,
+                projectId: project.id,
+                code: `BOARD-EST-${tag}`,
+                status: "Approved",
+                totalAmount: 1000,
+                balanceDue: 1000,
+            },
+        });
+        estimateIds.push(estimate.id);
+
+        const invoice = await prisma.invoice.create({
+            data: {
+                code: `BOARD-INV-${tag}`,
+                projectId: project.id,
+                clientId: client.id,
+                estimateId: estimate.id,
+                status: "Issued",
+                totalAmount: 1000,
+                subtotal: 900,
+                taxRate: 10,
+                taxAmount: 100,
+                balanceDue: 1000,
+            },
+        });
+        invoiceIds.push(invoice.id);
+
+        const explicitEstimateMilestone = await prisma.estimatePaymentSchedule.create({
+            data: {
+                estimateId: estimate.id,
+                name: `Explicit estimate milestone ${tag}`,
+                amount: 300,
+                dueDate: at(12),
+                status: "Pending",
+                scheduleTaskId: notStarted.id,
+            },
+        });
+        const nullDatedPayment = await prisma.paymentSchedule.create({
+            data: {
+                invoiceId: invoice.id,
+                name: `Null-date invoice milestone ${tag}`,
+                amount: 300,
+                dueDate: null,
+                status: "Pending",
+                scheduleTaskId: notStarted.id,
+                qbInvoiceId: `QB-NULL-${tag}`,
+                qbInvoiceLink: `https://example.invalid/invoice/${tag}/null-date`,
+                qbPaymentId: `QB-PAY-NULL-${tag}`,
+                qbSyncedAt: at(-2),
+                qbInvoiceSentAt: at(-1),
+                qbSyncError: "verify-null-date",
+            },
+        });
+        const explicitPaymentMilestone = await prisma.paymentSchedule.create({
+            data: {
+                invoiceId: invoice.id,
+                name: `Explicit invoice milestone ${tag}`,
+                amount: 700,
+                dueDate: at(16),
+                status: "Pending",
+                scheduleTaskId: milestoneTask.id,
+                qbInvoiceId: `QB-EXPLICIT-${tag}`,
+                qbInvoiceLink: `https://example.invalid/invoice/${tag}/explicit`,
+                qbPaymentId: `QB-PAY-EXPLICIT-${tag}`,
+                qbSyncedAt: at(-2),
+                qbInvoiceSentAt: at(-1),
+                qbSyncError: "verify-explicit",
+            },
+        });
+
+        const waitingProject = await prisma.project.create({
+            data: {
+                name: `BOARD WAITING VERIFY ${tag} DELETE ME`,
+                clientId: client.id,
+                status: "Waiting to Start",
+                startDate: at(30),
+                color: "#654321",
+            },
+        });
+        projectIds.push(waitingProject.id);
+        const waitingTask = await prisma.scheduleTask.create({
+            data: {
+                projectId: waitingProject.id,
+                name: `Waiting task ${tag}`,
+                startDate: at(31),
+                endDate: at(33),
+                status: "Not Started",
+            },
+        });
+
+        const substantialProject = await prisma.project.create({
+            data: {
+                name: `BOARD SUBSTANTIAL VERIFY ${tag} DELETE ME`,
+                clientId: client.id,
+                status: "Substantial Completion",
+                startDate: at(34),
+                color: "#112233",
+            },
+        });
+        projectIds.push(substantialProject.id);
+        const substantialTask = await prisma.scheduleTask.create({
+            data: {
+                projectId: substantialProject.id,
+                name: `Substantial task ${tag}`,
+                startDate: at(35),
+                endDate: at(37),
+                status: "Not Started",
+            },
+        });
+
+        for (const role of ["ADMIN", "MANAGER", "FINANCE", "FIELD_CREW"] as const) {
+            const dashboard = await getCompanyDashboardData({ role }, month);
+            const row = dashboard.pipeline.inProgress.find(candidate => candidate.id === project.id);
+            const task = row?.tasks.find(candidate => candidate.id === notStarted.id);
+            const additiveFieldsPresent = !!row
+                && row.color === "#123456"
+                && !!task
+                && task.color === "#abcdef"
+                && Object.prototype.hasOwnProperty.call(task, "parentId")
+                && task.parentId === null
+                && task.progress === 15;
+            check(`${role} dashboard includes project/task color, parentId, and progress`, additiveFieldsPresent);
+            const substantialRow = dashboard.pipeline.substantialCompletion.find(candidate => candidate.id === substantialProject.id);
+            check(`${role} dashboard enriches Substantial Completion rows and tasks`, substantialRow?.tasks.some(task => task.id === substantialTask.id) === true);
+            if (role === "ADMIN") {
+                check("ADMIN dashboard includes overlays, cashflow, and strip", dashboard.overlays !== null && dashboard.cashflow !== null && dashboard.strip !== null);
+            } else {
+                check(`${role} dashboard omits overlays, cashflow, and strip`, dashboard.overlays === null && dashboard.cashflow === null && dashboard.strip === null);
+            }
+            // Pipeline money redaction: financialReports holders see dollars;
+            // schedules-only viewers (FIELD_CREW default) get nulls everywhere.
+            const expectFinancials = role !== "FIELD_CREW";
+            check(`${role} dashboard canSeeFinancials matches the role default`, dashboard.canSeeFinancials === expectFinancials);
+            if (expectFinancials) {
+                check(`${role} dashboard serializes the fixture contractValue`, row?.contractValue === 1000);
+            } else {
+                const everyPipelineProject = [
+                    ...dashboard.pipeline.waitingToStart,
+                    ...dashboard.pipeline.scheduled,
+                    ...dashboard.pipeline.inProgress,
+                    ...dashboard.pipeline.substantialCompletion,
+                ];
+                check(`${role} dashboard redacts contractValue in every pipeline bucket`, everyPipelineProject.length > 0
+                    && everyPipelineProject.every(candidate => candidate.contractValue === null));
+                check(`${role} dashboard redacts lead targetRevenue and latestEstimateTotal`, dashboard.pipeline.estimating.every(
+                    candidate => candidate.targetRevenue === null && candidate.latestEstimateTotal === null,
+                ));
+            }
+        }
+
+        // Explicit canSeeFinancials override wins over the role default (the page
+        // passes hasPermission(user, "financialReports"), honoring per-user overrides).
+        const overriddenManager = await getCompanyDashboardData({ role: "MANAGER", canSeeFinancials: false }, month);
+        check("explicit canSeeFinancials=false overrides the MANAGER role default", overriddenManager.canSeeFinancials === false
+            && overriddenManager.pipeline.inProgress.every(candidate => candidate.contractValue === null)
+            && overriddenManager.pipeline.estimating.every(candidate => candidate.targetRevenue === null && candidate.latestEstimateTotal === null));
+
+        const allTasksBeforeZero = snapshot(await prisma.scheduleTask.findMany({
+            where: { projectId: project.id },
+            orderBy: { id: "asc" },
+        }));
+        let zeroRejected = false;
+        try {
+            await shiftNotStartedTasks({ projectId: project.id, deltaDays: 0, actor });
+        } catch (error) {
+            zeroRejected = /nonzero whole integer/i.test(String((error as Error).message));
+        }
+        const allTasksAfterZero = snapshot(await prisma.scheduleTask.findMany({
+            where: { projectId: project.id },
+            orderBy: { id: "asc" },
+        }));
+        check("zero delta rejects before changing rows", zeroRejected && allTasksAfterZero === allTasksBeforeZero);
+
+        let fractionalRejected = false;
+        try {
+            await shiftNotStartedTasks({ projectId: project.id, deltaDays: 1.5, actor });
+        } catch (error) {
+            fractionalRejected = /nonzero whole integer/i.test(String((error as Error).message));
+        }
+        check("fractional delta rejects", fractionalRejected);
+
+        const projectBefore = snapshot(await prisma.project.findUniqueOrThrow({ where: { id: project.id } }));
+        const notStartedBefore = await prisma.scheduleTask.findUniqueOrThrow({ where: { id: notStarted.id } });
+        const milestoneTaskBefore = await prisma.scheduleTask.findUniqueOrThrow({ where: { id: milestoneTask.id } });
+        const activeBefore = snapshot(await prisma.scheduleTask.findUniqueOrThrow({ where: { id: active.id } }));
+        const completeBefore = snapshot(await prisma.scheduleTask.findUniqueOrThrow({ where: { id: complete.id } }));
+        const estimateMilestoneBefore = snapshot(await prisma.estimatePaymentSchedule.findUniqueOrThrow({ where: { id: explicitEstimateMilestone.id } }));
+        const nullPaymentBefore = snapshot(await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: nullDatedPayment.id } }));
+        const explicitPaymentBefore = snapshot(await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: explicitPaymentMilestone.id } }));
+
+        const result = await shiftNotStartedTasks({ projectId: project.id, deltaDays: 3, actor });
+
+        const projectAfter = snapshot(await prisma.project.findUniqueOrThrow({ where: { id: project.id } }));
+        const notStartedAfter = await prisma.scheduleTask.findUniqueOrThrow({ where: { id: notStarted.id } });
+        const milestoneTaskAfter = await prisma.scheduleTask.findUniqueOrThrow({ where: { id: milestoneTask.id } });
+        const activeAfter = snapshot(await prisma.scheduleTask.findUniqueOrThrow({ where: { id: active.id } }));
+        const completeAfter = snapshot(await prisma.scheduleTask.findUniqueOrThrow({ where: { id: complete.id } }));
+        const estimateMilestoneAfter = snapshot(await prisma.estimatePaymentSchedule.findUniqueOrThrow({ where: { id: explicitEstimateMilestone.id } }));
+        const nullPaymentAfter = snapshot(await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: nullDatedPayment.id } }));
+        const explicitPaymentAfter = snapshot(await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: explicitPaymentMilestone.id } }));
+
+        const expectedShiftedIds = [notStarted.id, milestoneTask.id].sort();
+        check("+3 shifts only exact Not Started tasks", result.shiftedTasks === 2 && snapshot(result.shiftedTaskIds) === snapshot(expectedShiftedIds));
+        check("Not Started shift returns exact persisted affected task dates", snapshot(result.shiftedTaskDates) === snapshot([
+            { id: notStarted.id, startDate: at(4).toISOString(), endDate: at(7).toISOString() },
+            { id: milestoneTask.id, startDate: at(7).toISOString(), endDate: at(7).toISOString() },
+        ].sort((a, b) => a.id.localeCompare(b.id))));
+        check("Not Started task retains duration and non-date fields", notStartedAfter.startDate.getTime() === at(4).getTime()
+            && notStartedAfter.endDate.getTime() === at(7).getTime()
+            && notStartedAfter.endDate.getTime() - notStartedAfter.startDate.getTime() === notStartedBefore.endDate.getTime() - notStartedBefore.startDate.getTime()
+            && withoutTaskDates(notStartedAfter as unknown as Record<string, unknown>) === withoutTaskDates(notStartedBefore as unknown as Record<string, unknown>));
+        check("Not Started milestone retains zero duration and non-date fields", milestoneTaskAfter.startDate.getTime() === at(7).getTime()
+            && milestoneTaskAfter.endDate.getTime() === at(7).getTime()
+            && milestoneTaskAfter.endDate.getTime() - milestoneTaskAfter.startDate.getTime() === milestoneTaskBefore.endDate.getTime() - milestoneTaskBefore.startDate.getTime()
+            && withoutTaskDates(milestoneTaskAfter as unknown as Record<string, unknown>) === withoutTaskDates(milestoneTaskBefore as unknown as Record<string, unknown>));
+        check("In Progress task row remains byte-identical", activeAfter === activeBefore);
+        check("Completed task row remains byte-identical", completeAfter === completeBefore);
+        check("Project row and startDate remain byte-identical", projectAfter === projectBefore);
+        check("Estimate milestone row remains byte-identical", estimateMilestoneAfter === estimateMilestoneBefore);
+        check("null-dated PaymentSchedule row including QB fields remains byte-identical", nullPaymentAfter === nullPaymentBefore);
+        check("explicit-dated PaymentSchedule row including QB fields remains byte-identical", explicitPaymentAfter === explicitPaymentBefore);
+        check("notes identify only explicit-due-date anchored milestones", result.notes.length === 2
+            && result.notes.some(note => note.includes(explicitEstimateMilestone.id) && note.includes(explicitEstimateMilestone.name))
+            && result.notes.some(note => note.includes(explicitPaymentMilestone.id) && note.includes(explicitPaymentMilestone.name))
+            && result.notes.every(note => !note.includes(nullDatedPayment.id)));
+
+        const logs = await prisma.activityLog.findMany({
+            where: { projectId: project.id, action: "shift_not_started_tasks" },
+            orderBy: { createdAt: "asc" },
+        });
+        const metadata = JSON.parse(logs[0]?.metadata ?? "{}");
+        check("one shift_not_started_tasks ActivityLog records actor and metadata", logs.length === 1
+            && logs[0]?.actorType === actor.type
+            && logs[0]?.actorName === actor.name
+            && logs[0]?.entityType === "project"
+            && logs[0]?.entityId === project.id
+            && metadata.deltaDays === 3
+            && metadata.shiftedTasks === 2
+            && snapshot(metadata.shiftedTaskIds) === snapshot(expectedShiftedIds)
+            && metadata.explicitDueDateMilestones === 2);
+
+        const waitingProjectBefore = snapshot(await prisma.project.findUniqueOrThrow({ where: { id: waitingProject.id } }));
+        const waitingTaskBefore = snapshot(await prisma.scheduleTask.findUniqueOrThrow({ where: { id: waitingTask.id } }));
+        let waitingRejected = false;
+        try {
+            await shiftNotStartedTasks({ projectId: waitingProject.id, deltaDays: 3, actor });
+        } catch (error) {
+            waitingRejected = /Only In Progress projects/i.test(String((error as Error).message));
+        }
+        const waitingProjectAfter = snapshot(await prisma.project.findUniqueOrThrow({ where: { id: waitingProject.id } }));
+        const waitingTaskAfter = snapshot(await prisma.scheduleTask.findUniqueOrThrow({ where: { id: waitingTask.id } }));
+        check("Waiting-to-Start fixture rejects and remains byte-identical", waitingRejected
+            && waitingProjectAfter === waitingProjectBefore
+            && waitingTaskAfter === waitingTaskBefore);
+
+        const waitingMoveResult = await setProjectStartDate({
+            projectId: waitingProject.id,
+            startDate: at(33),
+            shiftJobTasks: true,
+            actor,
+        });
+        const waitingTaskMoved = await prisma.scheduleTask.findUniqueOrThrow({ where: { id: waitingTask.id } });
+        check("Waiting full shift returns exact persisted affected task dates", waitingMoveResult.startDate === at(33).toISOString()
+            && waitingMoveResult.shiftedTasks === 1
+            && snapshot(waitingMoveResult.shiftedTaskDates) === snapshot([
+                { id: waitingTask.id, startDate: at(34).toISOString(), endDate: at(36).toISOString() },
+            ])
+            && waitingTaskMoved.startDate.getTime() === at(34).getTime()
+            && waitingTaskMoved.endDate.getTime() === at(36).getTime());
+
+        let retryAttempts = 0;
+        const retryProbe = await withTxRetry(async () => {
+            retryAttempts++;
+            if (retryAttempts === 1) {
+                throw new Prisma.PrismaClientKnownRequestError("schedule-board retry probe", {
+                    code: "P2034",
+                    clientVersion: Prisma.prismaVersion.client,
+                });
+            }
+            return "retried";
+        });
+        check("withTxRetry retries one P2034 conflict and succeeds on attempt two", retryProbe === "retried" && retryAttempts === 2);
+
+        const scheduleCoreSource = readFileSync(new URL("../src/lib/schedule-core.ts", import.meta.url), "utf8");
+        const shiftStart = scheduleCoreSource.indexOf("export async function shiftNotStartedTasks");
+        const shiftEnd = scheduleCoreSource.indexOf("export interface CashflowBucket", shiftStart);
+        const shiftBody = scheduleCoreSource.slice(shiftStart, shiftEnd);
+        const projectLockIndex = shiftBody.indexOf('SELECT id FROM "Project"');
+        const taskLockIndex = shiftBody.indexOf('FROM "ScheduleTask"');
+        check("source wraps shiftNotStartedTasks in withTxRetry", shiftStart >= 0 && shiftBody.includes("withTxRetry(() => prisma.$transaction"));
+        check("source locks Project before ordered Not Started task selection", projectLockIndex >= 0
+            && taskLockIndex > projectLockIndex
+            && shiftBody.includes('"status" = \'Not Started\'')
+            && shiftBody.includes('ORDER BY "id"')
+            && shiftBody.includes("FOR UPDATE"));
+        check("source has no project or payment-table update in shift core", !shiftBody.includes("tx.project.update")
+            && !/UPDATE\s+"(?:EstimatePaymentSchedule|PaymentSchedule|ChangeOrderPaymentSchedule)"/i.test(shiftBody)
+            && !/tx\.(?:estimatePaymentSchedule|paymentSchedule|changeOrderPaymentSchedule)\.(?:update|updateMany)/.test(shiftBody));
+        check("project and selective shift results expose exact persisted affected task dates",
+            /interface SetProjectStartDateResult[\s\S]*?shiftedTaskDates:\s*PersistedScheduleTaskDate\[\]/.test(scheduleCoreSource)
+            && /interface ShiftNotStartedTasksResult[\s\S]*?shiftedTaskDates:\s*PersistedScheduleTaskDate\[\]/.test(scheduleCoreSource)
+            && /UPDATE "ScheduleTask"[\s\S]*?RETURNING "id", "startDate", "endDate"/.test(scheduleCoreSource));
+
+        const actionsSource = readFileSync(new URL("../src/lib/actions.ts", import.meta.url), "utf8");
+        const actionStart = actionsSource.indexOf("export async function shiftNotStartedTasksAction");
+        const actionEnd = actionsSource.indexOf("export async function generateProjectScheduleAction", actionStart);
+        const actionBody = actionsSource.slice(actionStart, actionEnd);
+        check("action wrapper is ADMIN/MANAGER gated and revalidates both boards", actionStart >= 0
+            && actionBody.includes('["ADMIN", "MANAGER"].includes(caller.role)')
+            && actionBody.includes('revalidatePath("/company-dashboard")')
+            && actionBody.includes('revalidatePath("/projects")')
+            && actionBody.includes("shiftNotStartedTasks({")
+            && !actionBody.includes("sendNotification"));
+        const canonicalTaskActionStart = actionsSource.indexOf("export async function updateScheduleTask");
+        const canonicalTaskActionEnd = actionsSource.indexOf("export async function deleteScheduleTask", canonicalTaskActionStart);
+        const canonicalTaskActionBody = actionsSource.slice(canonicalTaskActionStart, canonicalTaskActionEnd);
+        check("canonical task action preserves schedule permission and project access for date mutations", canonicalTaskActionStart >= 0
+            && canonicalTaskActionBody.includes("await assertScheduleTaskAccess(taskId)")
+            && !canonicalTaskActionBody.includes('["ADMIN", "MANAGER"].includes(user.role)')
+            && canonicalTaskActionBody.includes("parseStartDateInput")
+            && canonicalTaskActionBody.includes('SELECT id FROM "Project"')
+            && canonicalTaskActionBody.includes('SELECT id FROM "ScheduleTask"')
+            && canonicalTaskActionBody.includes("persistedTask.type === \"milestone\"")
+            && canonicalTaskActionBody.includes('revalidatePath("/company-dashboard")'));
+        const companyTaskAdapterStart = actionsSource.indexOf("export async function updateCompanyScheduleTaskDatesAction");
+        const companyTaskAdapterEnd = actionsSource.indexOf("export async function updateProjectStatus", companyTaskAdapterStart);
+        const companyTaskAdapterBody = actionsSource.slice(companyTaskAdapterStart, companyTaskAdapterEnd);
+        check("company task-date adapter is exact-role authorization around the one canonical action", companyTaskAdapterStart >= 0
+            && companyTaskAdapterBody.includes('["ADMIN", "MANAGER"].includes(caller.role)')
+            && (companyTaskAdapterBody.match(/updateScheduleTask\(/g) ?? []).length === 1
+            && !/parseStartDateInput|withTxRetry|\$transaction|\$queryRaw|scheduleTask\.update|activityLog\.create|revalidatePath/.test(companyTaskAdapterBody)
+            && !scheduleCoreSource.includes("updateCompanyScheduleTaskDates"));
+        const authorizedFieldCrew = {
+            role: "FIELD_CREW",
+            permissions: null,
+            projectAccess: [{ projectId: project.id }],
+            assignedProjects: [],
+        };
+        check("authorized FIELD_CREW retains canonical schedule-task access but is outside the company-board adapter roles",
+            hasPermission(authorizedFieldCrew, "schedules")
+            && canAccessProject(authorizedFieldCrew, project.id)
+            && !["ADMIN", "MANAGER"].includes(authorizedFieldCrew.role));
+        check("TEAM actor expression stays pinned to the authenticated caller", actionBody.includes('actor: { type: "TEAM", name: caller.name || caller.email }'));
+
+        const boardSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/ScheduleBoard.tsx", import.meta.url), "utf8");
+        const monthSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/MonthBarsView.tsx", import.meta.url), "utf8");
+        const timelineSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/TimelineView.tsx", import.meta.url), "utf8");
+        const projectBarSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/ProjectBar.tsx", import.meta.url), "utf8");
+        const taskBlockSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/TaskBlockSegment.tsx", import.meta.url), "utf8");
+        const scheduleBoardSources = [boardSource, monthSource, timelineSource, projectBarSource, taskBlockSource];
+        check("source forwards canEdit through both views to ProjectBar", monthSource.includes("canEdit={data.canEdit}")
+            && timelineSource.includes("canEdit={data.canEdit}"));
+        check("source forwards canEdit from ProjectBar to TaskBlockSegment", projectBarSource.includes("<TaskBlockSegment")
+            && projectBarSource.includes("canEdit={canEdit}"));
+        check("source guards milestone inputs behind the ADMIN overlay payload", monthSource.includes("const adminOverlays = data.isAdmin ? data.overlays : null")
+            && timelineSource.includes("const adminOverlays = data.isAdmin ? data.overlays : null")
+            && monthSource.includes("const milestoneMaps = adminOverlays ?")
+            && timelineSource.includes("const visibleIncomeMilestones = adminOverlays && showIncome"));
+        check("source persists the board view with the exact storage key", boardSource.includes('const BOARD_VIEW_STORAGE_KEY = "gtr-company-schedule-board-view"')
+            && boardSource.includes("localStorage.getItem(BOARD_VIEW_STORAGE_KEY)")
+            && boardSource.includes("localStorage.setItem(BOARD_VIEW_STORAGE_KEY, nextView)"));
+        check("schedule-board components do not import or call money-fetch functions", scheduleBoardSources.every(source =>
+            !/\b(?:getCashflowOutlook|getChangeOrderOverlayRows|getCalendarOverlays|getCompanyDashboardData)\b/.test(source)
+            && !/\bfetch\s*\(/.test(source)));
+    } finally {
+        let cleanupPassed = false;
+        try {
+            if (estimateIds.length > 0) {
+                await prisma.estimate.deleteMany({ where: { id: { in: estimateIds } } });
+            }
+            if (projectIds.length > 0) {
+                await prisma.project.deleteMany({ where: { id: { in: projectIds } } });
+            }
+            if (clientId) {
+                await prisma.client.deleteMany({ where: { id: clientId } });
+            }
+
+            const [projectsLeft, estimatesLeft, invoicesLeft, clientLeft] = await Promise.all([
+                prisma.project.count({ where: { id: { in: projectIds } } }),
+                prisma.estimate.count({ where: { id: { in: estimateIds } } }),
+                prisma.invoice.count({ where: { id: { in: invoiceIds } } }),
+                clientId ? prisma.client.count({ where: { id: clientId } }) : Promise.resolve(0),
+            ]);
+            cleanupPassed = projectsLeft === 0 && estimatesLeft === 0 && invoicesLeft === 0 && clientLeft === 0;
+        } catch (error) {
+            console.error("Fixture cleanup error:", error);
+        }
+        check("fixture cleanup removed collected client/project/estimate/invoice IDs", cleanupPassed);
+    }
+
+    let failures = 0;
+    for (const [label, passed] of checks) {
+        console.log(`${passed ? "PASS" : "FAIL"}  ${label}`);
+        if (!passed) failures++;
+    }
+    if (failures > 0) throw new Error(`${failures} schedule-board verification check(s) failed`);
+    console.log("ALL SCHEDULE BOARD CHECKS PASSED");
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/scripts/verify-schedule-board.ts
+++ b/scripts/verify-schedule-board.ts
@@ -28,6 +28,9 @@ function withoutTaskDates(value: Record<string, unknown>): string {
     const rest = { ...value };
     delete rest.startDate;
     delete rest.endDate;
+    // updatedAt legitimately advances on a shift (raw UPDATE sets NOW() to
+    // preserve @updatedAt semantics) — asserted separately, not as identity.
+    delete rest.updatedAt;
     return snapshot(rest);
 }
 
@@ -289,6 +292,14 @@ async function main() {
         }
         check("fractional delta rejects", fractionalRejected);
 
+        let oversizedRejected = false;
+        try {
+            await shiftNotStartedTasks({ projectId: project.id, deltaDays: 366, actor });
+        } catch (error) {
+            oversizedRejected = /cannot exceed 365/i.test(String((error as Error).message));
+        }
+        check("delta beyond 365 days rejects", oversizedRejected);
+
         const projectBefore = snapshot(await prisma.project.findUniqueOrThrow({ where: { id: project.id } }));
         const notStartedBefore = await prisma.scheduleTask.findUniqueOrThrow({ where: { id: notStarted.id } });
         const milestoneTaskBefore = await prisma.scheduleTask.findUniqueOrThrow({ where: { id: milestoneTask.id } });
@@ -323,6 +334,8 @@ async function main() {
             && milestoneTaskAfter.endDate.getTime() === at(7).getTime()
             && milestoneTaskAfter.endDate.getTime() - milestoneTaskAfter.startDate.getTime() === milestoneTaskBefore.endDate.getTime() - milestoneTaskBefore.startDate.getTime()
             && withoutTaskDates(milestoneTaskAfter as unknown as Record<string, unknown>) === withoutTaskDates(milestoneTaskBefore as unknown as Record<string, unknown>));
+        check("shifted task updatedAt advances", new Date(String(notStartedAfter.updatedAt)).getTime() > new Date(String(notStartedBefore.updatedAt)).getTime()
+            && new Date(String(milestoneTaskAfter.updatedAt)).getTime() > new Date(String(milestoneTaskBefore.updatedAt)).getTime());
         check("In Progress task row remains byte-identical", activeAfter === activeBefore);
         check("Completed task row remains byte-identical", completeAfter === completeBefore);
         check("Project row and startDate remain byte-identical", projectAfter === projectBefore);

--- a/src/app/company-dashboard/CompanyDashboardClient.tsx
+++ b/src/app/company-dashboard/CompanyDashboardClient.tsx
@@ -1,23 +1,21 @@
 "use client";
 
-import { Fragment, useState, useTransition } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import type { CompanyDashboardData, DashboardProjectRow, DashboardTaskRow, ProjectCrewMember } from "@/lib/schedule-core";
 import { PROJECT_STATUSES } from "@/lib/project-status";
 import { applyChangeOrderToScheduleAction, generateProjectScheduleAction, updateProjectCrewAction, updateProjectStartDateAction, updateTaskCrewAction } from "@/lib/actions";
+import { formatCurrency, parseUTCDate } from "@/app/projects/[id]/schedule/schedule-utils";
+import { ScheduleBoard } from "./schedule-board/ScheduleBoard";
 import {
-    formatCurrency,
-    formatDate,
-    getMonthGrid,
-    isSameUTCDay,
-    isWeekend,
-    parseUTCDate,
-    todayUTC,
-} from "@/app/projects/[id]/schedule/schedule-utils";
+    mergeProjectPendingIds,
+    projectIdSetsEqual,
+    projectRefreshMatches,
+    type ProjectRefreshExpectation,
+} from "./schedule-board/useBarLayout";
 
-const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 const MONTH_LABELS = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
 
 function StatCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
@@ -28,12 +26,6 @@ function StatCard({ label, value, sub }: { label: string; value: string; sub?: s
             {sub && <p className="text-xs text-hui-textMuted mt-1">{sub}</p>}
         </div>
     );
-}
-
-function shiftMonth(month: string, delta: number): string {
-    const [y, m] = month.split("-").map(Number);
-    const d = new Date(Date.UTC(y, m - 1 + delta, 1));
-    return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
 }
 
 function initials(name: string): string {
@@ -221,8 +213,26 @@ function TaskCrewPicker({ task, teamMembers }: { task: DashboardTaskRow; teamMem
     );
 }
 
+interface LegacyProjectMutation {
+    expectation: ProjectRefreshExpectation | null;
+}
+
+interface StartDateRowProps {
+    project: DashboardProjectRow;
+    isProjectPending: boolean;
+    beginProjectMutation: (projectId: string) => boolean;
+    awaitProjectRefresh: (projectId: string, expectation: ProjectRefreshExpectation) => void;
+    clearProjectMutation: (projectId: string) => void;
+}
+
 // Inline date setter for one waiting-to-start project (P1).
-function StartDateRow({ project }: { project: DashboardProjectRow }) {
+function StartDateRow({
+    project,
+    isProjectPending,
+    beginProjectMutation,
+    awaitProjectRefresh,
+    clearProjectMutation,
+}: StartDateRowProps) {
     const router = useRouter();
     const [date, setDate] = useState("");
     const [isPending, startTransition] = useTransition();
@@ -232,17 +242,23 @@ function StartDateRow({ project }: { project: DashboardProjectRow }) {
             toast.error("Pick a start date first");
             return;
         }
+        if (!beginProjectMutation(project.id)) return;
         startTransition(async () => {
             try {
                 const result = await updateProjectStartDateAction(project.id, date, true);
+                awaitProjectRefresh(project.id, {
+                    projectStartDate: result.startDate,
+                    taskDates: result.shiftedTaskDates,
+                });
                 toast.success(
                     result.shiftedTasks > 0
                         ? `Start set — ${result.shiftedTasks} job task${result.shiftedTasks === 1 ? "" : "s"} shifted`
                         : "Start date set"
                 );
                 router.refresh();
-            } catch (err: any) {
-                toast.error(err?.message || "Failed to set start date");
+            } catch (error) {
+                clearProjectMutation(project.id);
+                toast.error(error instanceof Error ? error.message : "Failed to set start date");
             }
         });
     }
@@ -265,14 +281,14 @@ function StartDateRow({ project }: { project: DashboardProjectRow }) {
                         value={date}
                         onChange={e => setDate(e.target.value)}
                         className="hui-input text-sm"
-                        disabled={isPending}
+                        disabled={isPending || isProjectPending}
                     />
                     <button
                         onClick={handleSet}
-                        disabled={isPending}
+                        disabled={isPending || isProjectPending}
                         className="hui-btn hui-btn-green text-sm whitespace-nowrap"
                     >
-                        {isPending ? "Setting..." : "Set"}
+                        {isPending ? "Setting..." : isProjectPending ? "Refreshing..." : "Set"}
                     </button>
                 </div>
             </td>
@@ -282,65 +298,103 @@ function StartDateRow({ project }: { project: DashboardProjectRow }) {
 
 export default function CompanyDashboardClient({ data }: { data: CompanyDashboardData }) {
     const router = useRouter();
-    const { month, canEdit, isAdmin, pipeline, calendar, cashflow, teamMembers, crewConflicts, overlays, strip } = data;
+    const { month, canEdit, isAdmin, canSeeFinancials, pipeline, cashflow, teamMembers, crewConflicts, strip } = data;
 
-    // Overlay layer toggles (ADMIN only): income default on, others off.
-    const [showIncome, setShowIncome] = useState(true);
-    const [showProjectedCo, setShowProjectedCo] = useState(true);
-    const [showExpenses, setShowExpenses] = useState(false);
-    const [showHours, setShowHours] = useState(false);
     const [expandedProjects, setExpandedProjects] = useState<Set<string>>(() => new Set());
+    const pageMountedRef = useRef(true);
+    const boardPendingProjectIdsRef = useRef<Set<string>>(new Set());
+    const legacyProjectMutationsRef = useRef<Map<string, LegacyProjectMutation>>(new Map());
+    const [boardPendingProjectIds, setBoardPendingProjectIds] = useState<Set<string>>(() => new Set());
+    const [legacyProjectMutations, setLegacyProjectMutations] = useState<Map<string, LegacyProjectMutation>>(() => new Map());
+    const canonicalProjects = useMemo(() => [
+        ...pipeline.waitingToStart,
+        ...pipeline.scheduled,
+        ...pipeline.inProgress,
+        ...pipeline.substantialCompletion,
+    ], [pipeline]);
+    const canonicalProjectById = useMemo(() => new Map(canonicalProjects.map(project => [project.id, project])), [canonicalProjects]);
+    const legacyPendingProjectIds = useMemo(() => new Set(legacyProjectMutations.keys()), [legacyProjectMutations]);
+    const pagePendingProjectIds = useMemo(
+        () => mergeProjectPendingIds(boardPendingProjectIds, legacyPendingProjectIds),
+        [boardPendingProjectIds, legacyPendingProjectIds],
+    );
+    const legacyRefreshCount = useMemo(
+        () => [...legacyProjectMutations.values()].filter(mutation => mutation.expectation !== null).length,
+        [legacyProjectMutations],
+    );
 
+    const isPageProjectPending = useCallback((projectId: string) => (
+        boardPendingProjectIdsRef.current.has(projectId)
+        || legacyProjectMutationsRef.current.has(projectId)
+    ), []);
+
+    const publishBoardPendingProjectIds = useCallback((projectIds: ReadonlySet<string>) => {
+        const next = new Set(projectIds);
+        if (projectIdSetsEqual(boardPendingProjectIdsRef.current, next)) return;
+        boardPendingProjectIdsRef.current = next;
+        if (pageMountedRef.current) setBoardPendingProjectIds(next);
+    }, []);
+
+    const beginLegacyProjectMutation = useCallback((projectId: string) => {
+        if (!pageMountedRef.current || isPageProjectPending(projectId)) return false;
+        const next = new Map(legacyProjectMutationsRef.current);
+        next.set(projectId, { expectation: null });
+        legacyProjectMutationsRef.current = next;
+        setLegacyProjectMutations(next);
+        return true;
+    }, [isPageProjectPending]);
+
+    const awaitLegacyProjectRefresh = useCallback((projectId: string, expectation: ProjectRefreshExpectation) => {
+        if (!pageMountedRef.current || !legacyProjectMutationsRef.current.has(projectId)) return;
+        const next = new Map(legacyProjectMutationsRef.current);
+        next.set(projectId, { expectation });
+        legacyProjectMutationsRef.current = next;
+        setLegacyProjectMutations(next);
+    }, []);
+
+    const clearLegacyProjectMutation = useCallback((projectId: string) => {
+        if (!legacyProjectMutationsRef.current.has(projectId)) return;
+        const next = new Map(legacyProjectMutationsRef.current);
+        next.delete(projectId);
+        legacyProjectMutationsRef.current = next;
+        if (pageMountedRef.current) setLegacyProjectMutations(next);
+    }, []);
+
+    const reconciledLegacyProjectIds = useMemo(() => [...legacyProjectMutations].flatMap(([projectId, mutation]) => {
+        if (!mutation.expectation) return [];
+        if (!canonicalProjectById.has(projectId)) return [projectId];
+        return projectRefreshMatches(canonicalProjectById.get(projectId), mutation.expectation) ? [projectId] : [];
+    }), [canonicalProjectById, legacyProjectMutations]);
+
+    useEffect(() => {
+        if (reconciledLegacyProjectIds.length === 0) return;
+        const timeoutId = window.setTimeout(() => {
+            for (const projectId of reconciledLegacyProjectIds) clearLegacyProjectMutation(projectId);
+        }, 0);
+        return () => window.clearTimeout(timeoutId);
+    }, [clearLegacyProjectMutation, reconciledLegacyProjectIds]);
+
+    useEffect(() => {
+        if (legacyRefreshCount === 0) return;
+        const intervalId = window.setInterval(() => router.refresh(), 2_000);
+        return () => window.clearInterval(intervalId);
+    }, [legacyRefreshCount, router]);
+
+    useEffect(() => {
+        pageMountedRef.current = true;
+        return () => {
+            pageMountedRef.current = false;
+            boardPendingProjectIdsRef.current = new Set();
+            legacyProjectMutationsRef.current = new Map();
+        };
+    }, []);
     const anchor = parseUTCDate(`${month}-01`);
-    const days = getMonthGrid(anchor);
-    const today = todayUTC();
-    const currentMonth = anchor.getUTCMonth();
     const monthLabel = `${MONTH_LABELS[anchor.getUTCMonth()]} ${anchor.getUTCFullYear()}`;
-
-    // Bucket calendar entries by UTC day key (YYYY-MM-DD) for O(1) cell lookup.
-    const projectStartsByDay = new Map<string, typeof calendar.projectStarts>();
-    for (const p of calendar.projectStarts) {
-        const key = p.startDate.slice(0, 10);
-        projectStartsByDay.set(key, [...(projectStartsByDay.get(key) ?? []), p]);
-    }
-    const leadStartsByDay = new Map<string, typeof calendar.leadStarts>();
-    for (const l of calendar.leadStarts) {
-        const key = l.expectedStartDate.slice(0, 10);
-        leadStartsByDay.set(key, [...(leadStartsByDay.get(key) ?? []), l]);
-    }
-
-    // Crew per project (chips show up to 3 initials + overflow count).
-    const crewByProject = new Map<string, ProjectCrewMember[]>();
-    for (const row of [...pipeline.waitingToStart, ...pipeline.scheduled, ...pipeline.inProgress, ...pipeline.substantialCompletion]) {
-        crewByProject.set(row.id, row.crew);
-    }
-
-    // Overlay per-day totals (income uses the shared effectiveDueDate rule).
-    const incomeByDay = new Map<string, number>();
-    for (const m of overlays?.income ?? []) {
-        const key = m.effectiveDueDate.slice(0, 10);
-        incomeByDay.set(key, (incomeByDay.get(key) ?? 0) + m.amount);
-    }
-    const projectedCoByDay = new Map<string, number>();
-    for (const row of overlays?.changeOrders ?? []) {
-        const key = row.effectiveDueDate.slice(0, 10);
-        projectedCoByDay.set(key, (projectedCoByDay.get(key) ?? 0) + row.amount);
-    }
-    const expensesByDay = new Map<string, number>();
-    for (const e of overlays?.expenses ?? []) {
-        const key = e.date.slice(0, 10);
-        expensesByDay.set(key, (expensesByDay.get(key) ?? 0) + e.amount);
-    }
-    const hoursByDay = new Map<string, number>();
-    for (const h of overlays?.hours ?? []) {
-        const key = h.startTime.slice(0, 10);
-        hoursByDay.set(key, (hoursByDay.get(key) ?? 0) + h.durationHours);
-    }
 
     const sumContract = (rows: { contractValue: number | null }[]) => rows.reduce((s, r) => s + (r.contractValue ?? 0), 0);
     const estimatingTotal = pipeline.estimating.reduce((s, l) => s + (l.targetRevenue ?? 0), 0);
 
-    const crewRows = [...pipeline.waitingToStart, ...pipeline.scheduled, ...pipeline.inProgress];
+    const crewRows = [...pipeline.waitingToStart, ...pipeline.scheduled, ...pipeline.inProgress, ...pipeline.substantialCompletion];
 
     return (
         <div className="max-w-6xl mx-auto py-8 px-6">
@@ -354,129 +408,25 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
 
             {/* Funnel */}
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-                <StatCard label="Estimating" value={String(pipeline.estimating.length)} sub={`${formatCurrency(estimatingTotal)} pipeline`} />
-                <StatCard label="Waiting to Start" value={String(pipeline.waitingToStart.length)} sub={`${formatCurrency(sumContract(pipeline.waitingToStart))} contracted`} />
-                <StatCard label="Scheduled" value={String(pipeline.scheduled.length)} sub={`${formatCurrency(sumContract(pipeline.scheduled))} contracted`} />
-                <StatCard label="In Progress" value={String(pipeline.inProgress.length)} sub={`${formatCurrency(sumContract(pipeline.inProgress))} contracted`} />
+                <StatCard label="Estimating" value={String(pipeline.estimating.length)} sub={canSeeFinancials ? `${formatCurrency(estimatingTotal)} pipeline` : undefined} />
+                <StatCard label="Waiting to Start" value={String(pipeline.waitingToStart.length)} sub={canSeeFinancials ? `${formatCurrency(sumContract(pipeline.waitingToStart))} contracted` : undefined} />
+                <StatCard label="Scheduled" value={String(pipeline.scheduled.length)} sub={canSeeFinancials ? `${formatCurrency(sumContract(pipeline.scheduled))} contracted` : undefined} />
+                <StatCard label="In Progress" value={String(pipeline.inProgress.length)} sub={canSeeFinancials ? `${formatCurrency(sumContract(pipeline.inProgress))} contracted` : undefined} />
             </div>
 
-            {/* Start calendar */}
-            <div className="hui-card mb-6 overflow-hidden">
-                <div className="flex items-center justify-between px-4 py-3 border-b border-hui-border">
-                    <h2 className="text-base font-semibold text-hui-textMain">Project Starts — {monthLabel}</h2>
-                    <div className="flex items-center gap-2">
-                        {isAdmin && overlays && (
-                            <div className="flex items-center gap-1 mr-3">
-                                <button
-                                    onClick={() => setShowIncome(v => !v)}
-                                    className={`text-xs font-semibold px-2 py-1 rounded-full border transition ${showIncome ? "bg-green-100 text-green-700 border-green-300" : "bg-white text-hui-textMuted border-hui-border"}`}
-                                >
-                                    Income
-                                </button>
-                                <button
-                                    onClick={() => setShowExpenses(v => !v)}
-                                    className={`text-xs font-semibold px-2 py-1 rounded-full border transition ${showExpenses ? "bg-red-100 text-red-700 border-red-300" : "bg-white text-hui-textMuted border-hui-border"}`}
-                                >
-                                    Expenses
-                                </button>
-                                <button
-                                    onClick={() => setShowProjectedCo(v => !v)}
-                                    className={`text-xs font-semibold px-2 py-1 rounded-full border transition ${showProjectedCo ? "bg-amber-100 text-amber-800 border-amber-300" : "bg-white text-hui-textMuted border-hui-border"}`}
-                                >
-                                    Projected CO
-                                </button>
-                                <button
-                                    onClick={() => setShowHours(v => !v)}
-                                    className={`text-xs font-semibold px-2 py-1 rounded-full border transition ${showHours ? "bg-blue-100 text-blue-700 border-blue-300" : "bg-white text-hui-textMuted border-hui-border"}`}
-                                >
-                                    Hours
-                                </button>
-                            </div>
-                        )}
-                        <button onClick={() => router.push(`?month=${shiftMonth(month, -1)}`)} className="hui-btn hui-btn-secondary text-sm">← Prev</button>
-                        <button onClick={() => router.push("?")} className="hui-btn hui-btn-secondary text-sm">Today</button>
-                        <button onClick={() => router.push(`?month=${shiftMonth(month, 1)}`)} className="hui-btn hui-btn-secondary text-sm">Next →</button>
-                    </div>
+            <ScheduleBoard
+                data={data}
+                externallyPendingProjectIds={legacyPendingProjectIds}
+                isProjectExternallyPending={isPageProjectPending}
+                onEffectivePendingProjectIdsChange={publishBoardPendingProjectIds}
+            />
+
+            {legacyRefreshCount > 0 && (
+                <div role="status" className="mb-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+                    Refreshing start-date changes...{" "}
+                    <button type="button" className="font-semibold underline" onClick={() => router.refresh()}>Retry now</button>
                 </div>
-                <div className="grid grid-cols-7 bg-white border-b border-hui-border">
-                    {WEEKDAY_LABELS.map(w => (
-                        <div key={w} className="px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-slate-400">{w}</div>
-                    ))}
-                </div>
-                <div className="grid grid-cols-7 grid-rows-6">
-                    {days.map((day, idx) => {
-                        const dayKey = formatDate(day);
-                        const isToday = isSameUTCDay(day, today);
-                        const isCurrentMonth = day.getUTCMonth() === currentMonth;
-                        const projectStarts = projectStartsByDay.get(dayKey) ?? [];
-                        const leadStarts = leadStartsByDay.get(dayKey) ?? [];
-                        const incomeTotal = showIncome ? incomeByDay.get(dayKey) : undefined;
-                        const projectedCoTotal = showProjectedCo ? projectedCoByDay.get(dayKey) : undefined;
-                        const expenseTotal = showExpenses ? expensesByDay.get(dayKey) : undefined;
-                        const hoursTotal = showHours ? hoursByDay.get(dayKey) : undefined;
-                        return (
-                            <div
-                                key={idx}
-                                className={`border-r border-b border-hui-border p-1.5 min-h-[96px] ${isCurrentMonth ? (isWeekend(day) ? "bg-slate-50/60" : "bg-white") : "bg-slate-50/40"} ${isToday ? "ring-1 ring-inset ring-indigo-300" : ""}`}
-                            >
-                                <span className={`text-xs font-semibold ${isToday ? "inline-flex items-center justify-center w-6 h-6 rounded-full bg-indigo-600 text-white" : isCurrentMonth ? "text-hui-textMain" : "text-slate-400"}`}>
-                                    {day.getUTCDate()}
-                                </span>
-                                <div className="mt-1 flex flex-col gap-0.5">
-                                    {projectStarts.map(p => {
-                                        const crew = crewByProject.get(p.id) ?? [];
-                                        return (
-                                            <Link
-                                                key={p.id}
-                                                href={`/projects/${p.id}`}
-                                                title={`${p.name}${p.client ? ` — ${p.client}` : ""}${crew.length ? ` — crew: ${crew.map(c => c.name).join(", ")}` : ""}`}
-                                                className="block text-[11px] px-1.5 py-0.5 rounded bg-hui-primary text-white hover:opacity-90 transition"
-                                            >
-                                                <span className="block truncate">{p.name}</span>
-                                                {crew.length > 0 && (
-                                                    <span className="block text-[9px] opacity-90">
-                                                        {crew.slice(0, 3).map(c => initials(c.name)).join(" ")}{crew.length > 3 ? ` +${crew.length - 3}` : ""}
-                                                    </span>
-                                                )}
-                                            </Link>
-                                        );
-                                    })}
-                                    {leadStarts.map(l => (
-                                        <Link
-                                            key={l.id}
-                                            href={`/leads/${l.id}`}
-                                            title={`${l.name}${l.client ? ` — ${l.client}` : ""} (lead)`}
-                                            className="block text-[11px] px-1.5 py-0.5 rounded truncate border border-dashed border-hui-primary text-hui-primary hover:bg-green-50 transition"
-                                        >
-                                            {l.name}
-                                        </Link>
-                                    ))}
-                                    {incomeTotal != null && incomeTotal > 0 && (
-                                        <span className="text-[10px] font-medium text-green-700 px-1.5" title="Income due this day (effective due date)">
-                                            {formatCurrency(incomeTotal)} due
-                                        </span>
-                                    )}
-                                    {projectedCoTotal != null && projectedCoTotal > 0 && (
-                                        <span className="text-[10px] font-medium text-amber-700 px-1.5" title="Approved, unbilled change-order income projected this day">
-                                            {formatCurrency(projectedCoTotal)} projected CO
-                                        </span>
-                                    )}
-                                    {expenseTotal != null && expenseTotal > 0 && (
-                                        <span className="text-[10px] font-medium text-red-700 px-1.5" title="Expenses this day">
-                                            −{formatCurrency(expenseTotal)}
-                                        </span>
-                                    )}
-                                    {hoursTotal != null && hoursTotal > 0 && (
-                                        <span className="text-[10px] font-medium text-blue-700 px-1.5" title="Hours logged this day">
-                                            {hoursTotal.toFixed(1)}h
-                                        </span>
-                                    )}
-                                </div>
-                            </div>
-                        );
-                    })}
-                </div>
-            </div>
+            )}
 
             {/* Schedule & crew */}
             <div className="hui-card mb-6">
@@ -616,7 +566,14 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
                             </thead>
                             <tbody className="divide-y divide-slate-100">
                                 {pipeline.waitingToStart.map(p => (
-                                    <StartDateRow key={p.id} project={p} />
+                                    <StartDateRow
+                                        key={p.id}
+                                        project={p}
+                                        isProjectPending={pagePendingProjectIds.has(p.id)}
+                                        beginProjectMutation={beginLegacyProjectMutation}
+                                        awaitProjectRefresh={awaitLegacyProjectRefresh}
+                                        clearProjectMutation={clearLegacyProjectMutation}
+                                    />
                                 ))}
                             </tbody>
                         </table>

--- a/src/app/company-dashboard/page.tsx
+++ b/src/app/company-dashboard/page.tsx
@@ -9,9 +9,9 @@ import CompanyDashboardClient from "./CompanyDashboardClient";
 // funnel, start calendar with crew + money/hours overlays, waiting-to-start
 // editor, crew conflicts, and the ADMIN-only cashflow/per-project strips.
 //
-// Authorization (unchanged from P1): the page admits anyone holding the
-// `financialReports` permission (hasPermission — honors explicit per-user
-// overrides, so nav and page can never disagree). Overlays and per-project
+// Authorization: the page admits anyone holding `financialReports` or
+// `schedules` (hasPermission honors explicit per-user overrides, so nav and
+// page can never disagree). Overlays and per-project
 // financial data are only QUERIED and serialized when role === "ADMIN"
 // (enforced inside getCompanyDashboardData); editing is ADMIN/MANAGER only.
 export default async function CompanyDashboardPage({
@@ -26,7 +26,7 @@ export default async function CompanyDashboardPage({
     // Dev sessions can exist without a matching User row (same passthrough the
     // reports pages use); production always has the row.
     const effectiveUser = user ?? (process.env.NODE_ENV === "development" ? { role: "ADMIN", permissions: null } : null);
-    if (!effectiveUser || !hasPermission(effectiveUser, "financialReports")) {
+    if (!effectiveUser || (!hasPermission(effectiveUser, "financialReports") && !hasPermission(effectiveUser, "schedules"))) {
         return <div className="p-8 text-red-500">Access Denied.</div>;
     }
 
@@ -38,6 +38,9 @@ export default async function CompanyDashboardPage({
     const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
     const month = /^\d{4}-(0[1-9]|1[0-2])$/.test(rawMonth) ? rawMonth : currentMonth;
 
-    const data = await getCompanyDashboardData(effectiveUser, month);
+    const data = await getCompanyDashboardData(
+        { role: effectiveUser.role, canSeeFinancials: hasPermission(effectiveUser, "financialReports") },
+        month,
+    );
     return <CompanyDashboardClient data={data} />;
 }

--- a/src/app/company-dashboard/schedule-board/MilestoneMarker.tsx
+++ b/src/app/company-dashboard/schedule-board/MilestoneMarker.tsx
@@ -1,0 +1,36 @@
+import { addDays, formatCurrency, getDaysBetween, parseUTCDate } from "@/app/projects/[id]/schedule/schedule-utils";
+import { toTimelineRect, type DateRange } from "./useBarLayout";
+
+interface MilestoneMarkerProps {
+    name: string;
+    amount: number;
+    effectiveDueDate: string;
+    visibleRange: DateRange;
+    kind: "income" | "change-order";
+    offsetPixels?: number;
+    timelineOrigin?: Date;
+    dayWidth?: number;
+}
+
+export function MilestoneMarker({ name, amount, effectiveDueDate, visibleRange, kind, offsetPixels = 0, timelineOrigin, dayWidth }: MilestoneMarkerProps) {
+    const date = parseUTCDate(effectiveDueDate.slice(0, 10));
+    if (date < visibleRange.start || date >= visibleRange.end) return null;
+
+    const visibleDays = getDaysBetween(visibleRange.start, visibleRange.end);
+    const left = (getDaysBetween(visibleRange.start, date) + 0.5) / visibleDays * 100;
+    const timelineLeft = timelineOrigin && dayWidth
+        ? toTimelineRect({ start: date, end: addDays(date, 1) }, timelineOrigin, dayWidth).left + dayWidth / 2
+        : null;
+    const typeLabel = kind === "income" ? "Income" : "Projected change order";
+    const title = `${typeLabel}: ${name} — ${formatCurrency(amount)} — UTC ${effectiveDueDate.slice(0, 10)}`;
+
+    return (
+        <span
+            className={`absolute top-[17px] z-30 h-2.5 w-2.5 -translate-x-1/2 rotate-45 border border-white shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-600 ${kind === "income" ? "bg-emerald-500" : "bg-amber-400"}`}
+            style={{ left: timelineLeft ?? `${left}%`, marginLeft: offsetPixels }}
+            title={title}
+            aria-label={title}
+            tabIndex={0}
+        />
+    );
+}

--- a/src/app/company-dashboard/schedule-board/MonthBarsView.tsx
+++ b/src/app/company-dashboard/schedule-board/MonthBarsView.tsx
@@ -1,0 +1,387 @@
+"use client";
+
+import { useState, type DragEvent } from "react";
+import type {
+    CalendarOverlays,
+    CompanyDashboardData,
+    DashboardProjectRow,
+    OverlayChangeOrderItem,
+    OverlayIncomeItem,
+} from "@/lib/schedule-core";
+import {
+    addDays,
+    formatCurrency,
+    formatDate,
+    getMonthGrid,
+    isSameUTCDay,
+    isWeekend,
+    parseUTCDate,
+    todayUTC,
+} from "@/app/projects/[id]/schedule/schedule-utils";
+import { ProjectBar, ProjectBarGridStartContext, type ProjectEditCallbacks } from "./ProjectBar";
+import { TaskBlockSegment, type ActiveTaskKeyboardEdit, type TaskEditCallbacks } from "./TaskBlockSegment";
+import { MilestoneMarker } from "./MilestoneMarker";
+import { PROJECT_DRAG_MIME } from "./UnscheduledTray";
+import { assignMonthProjectLanes, getEffectiveProjectRange, segmentProjectRange } from "./useBarLayout";
+
+const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const PROJECT_FALLBACK_COLORS = ["#2563eb", "#7c3aed", "#0f766e", "#c2410c", "#be123c", "#4338ca", "#047857", "#a21caf"];
+const EMPTY_INCOME: OverlayIncomeItem[] = [];
+const EMPTY_CHANGE_ORDERS: OverlayChangeOrderItem[] = [];
+
+interface MonthBarsViewProps extends TaskEditCallbacks, ProjectEditCallbacks {
+    data: CompanyDashboardData;
+    showIncome: boolean;
+    showProjectedCo: boolean;
+    showExpenses: boolean;
+    showHours: boolean;
+    pendingProjectIds: ReadonlySet<string>;
+    pendingTaskIds: ReadonlySet<string>;
+    activeTaskKeyboardEdit: ActiveTaskKeyboardEdit | null;
+    onTrayProjectDrop: (_project: DashboardProjectRow, _targetStart: string) => void;
+}
+
+function fallbackProjectColor(projectId: string): string {
+    let hash = 0;
+    for (let index = 0; index < projectId.length; index++) hash = (hash * 31 + projectId.charCodeAt(index)) >>> 0;
+    return PROJECT_FALLBACK_COLORS[hash % PROJECT_FALLBACK_COLORS.length];
+}
+
+function projectConflictNames(projectId: string, conflicts: CompanyDashboardData["crewConflicts"]): string[] {
+    if (!conflicts) return [];
+    return [...new Set(conflicts.flatMap(conflict =>
+        conflict.pairs.some(pair => pair.projectA.id === projectId || pair.projectB.id === projectId)
+            ? [conflict.name]
+            : [],
+    ))];
+}
+
+function hasProjectDragPayload(event: DragEvent<HTMLDivElement>): boolean {
+    return event.dataTransfer.types.includes(PROJECT_DRAG_MIME);
+}
+
+function buildDayTotals(overlays: CalendarOverlays | null) {
+    if (!overlays) return null;
+    const income = new Map<string, number>();
+    const projectedCo = new Map<string, number>();
+    const expenses = new Map<string, number>();
+    const hours = new Map<string, number>();
+    for (const item of overlays.income) {
+        const key = item.effectiveDueDate.slice(0, 10);
+        income.set(key, (income.get(key) ?? 0) + item.amount);
+    }
+    for (const item of overlays.changeOrders) {
+        const key = item.effectiveDueDate.slice(0, 10);
+        projectedCo.set(key, (projectedCo.get(key) ?? 0) + item.amount);
+    }
+    for (const item of overlays.expenses) {
+        const key = item.date.slice(0, 10);
+        expenses.set(key, (expenses.get(key) ?? 0) + item.amount);
+    }
+    for (const item of overlays.hours) {
+        const key = item.startTime.slice(0, 10);
+        hours.set(key, (hours.get(key) ?? 0) + item.durationHours);
+    }
+    return { income, projectedCo, expenses, hours };
+}
+
+export function MonthBarsView({
+    data,
+    showIncome,
+    showProjectedCo,
+    showExpenses,
+    showHours,
+    pendingProjectIds,
+    pendingTaskIds,
+    activeTaskKeyboardEdit,
+    onTrayProjectDrop,
+    onProjectMoveCommit,
+    activeProjectKeyboardId,
+    onProjectPointerEditStart,
+    onProjectKeyboardStart,
+    onProjectKeyboardAdjust,
+    onProjectKeyboardCommit,
+    onProjectKeyboardCancel,
+    onTaskPointerEditStart,
+    onTaskKeyboardStart,
+    onTaskKeyboardAdjust,
+    onTaskKeyboardCommit,
+    onTaskKeyboardCancel,
+    onTaskDatesCommit,
+    onTaskMoveBy,
+}: MonthBarsViewProps) {
+    const [expandedWeeks, setExpandedWeeks] = useState<Set<number>>(() => new Set());
+    const [dragOverDate, setDragOverDate] = useState<string | null>(null);
+    const anchor = parseUTCDate(`${data.month}-01`);
+    const days = getMonthGrid(anchor);
+    const gridStart = days[0];
+    const gridEnd = addDays(gridStart, 42);
+    const today = todayUTC();
+    const currentMonth = anchor.getUTCMonth();
+    const projects: DashboardProjectRow[] = [
+        ...data.pipeline.waitingToStart,
+        ...data.pipeline.scheduled,
+        ...data.pipeline.inProgress,
+        ...data.pipeline.substantialCompletion,
+    ];
+
+    const workSegmentsByProject = new Map<string, ReturnType<typeof segmentProjectRange>>();
+    for (const project of projects) {
+        const range = getEffectiveProjectRange(project);
+        workSegmentsByProject.set(project.id, range ? segmentProjectRange(project.id, range, gridStart, gridEnd) : []);
+    }
+
+    const projectById = new Map(projects.map(project => [project.id, project]));
+    const adminOverlays = data.isAdmin ? data.overlays : null;
+    const visibleIncomeMilestones = adminOverlays
+        ? showIncome ? adminOverlays.income : EMPTY_INCOME
+        : EMPTY_INCOME;
+    const visibleChangeOrderMilestones = adminOverlays
+        ? showProjectedCo ? adminOverlays.changeOrders : EMPTY_CHANGE_ORDERS
+        : EMPTY_CHANGE_ORDERS;
+    const milestoneMaps = adminOverlays ? {
+        income: new Map(projects.map(project => [project.id, visibleIncomeMilestones.filter(item => item.projectId === project.id)])),
+        changeOrders: new Map(projects.map(project => [project.id, visibleChangeOrderMilestones.filter(item => item.projectId === project.id)])),
+    } : null;
+    const milestoneRowsByProjectDate = adminOverlays ? new Map<string, Array<{
+        key: string;
+        name: string;
+        amount: number;
+        effectiveDueDate: string;
+        kind: "income" | "change-order";
+    }>>() : null;
+    if (milestoneRowsByProjectDate) {
+        for (const item of visibleIncomeMilestones) {
+            if (!item.projectId || !projectById.has(item.projectId)) continue;
+            const key = `${item.projectId}|${item.effectiveDueDate.slice(0, 10)}`;
+            milestoneRowsByProjectDate.set(key, [...(milestoneRowsByProjectDate.get(key) ?? []), {
+                key: `income-${item.id}`,
+                name: item.name,
+                amount: item.amount,
+                effectiveDueDate: item.effectiveDueDate,
+                kind: "income",
+            }]);
+        }
+        for (const item of visibleChangeOrderMilestones) {
+            if (!item.projectId || !projectById.has(item.projectId)) continue;
+            const key = `${item.projectId}|${item.effectiveDueDate.slice(0, 10)}`;
+            milestoneRowsByProjectDate.set(key, [...(milestoneRowsByProjectDate.get(key) ?? []), {
+                key: `co-${item.paymentScheduleId}`,
+                name: item.name,
+                amount: item.amount,
+                effectiveDueDate: item.effectiveDueDate,
+                kind: "change-order",
+            }]);
+        }
+    }
+    const milestoneDaysByProject = new Map<string, Date[]>();
+    if (milestoneRowsByProjectDate) {
+        for (const key of milestoneRowsByProjectDate.keys()) {
+            const [projectId, dateKey] = key.split("|");
+            milestoneDaysByProject.set(projectId, [...(milestoneDaysByProject.get(projectId) ?? []), parseUTCDate(dateKey)]);
+        }
+    }
+    for (const project of projects) {
+        const taskMilestoneDays = project.tasks
+            .filter(task => task.type === "milestone")
+            .map(task => parseUTCDate(task.startDate.slice(0, 10)));
+        milestoneDaysByProject.set(project.id, [...(milestoneDaysByProject.get(project.id) ?? []), ...taskMilestoneDays]);
+    }
+    const layout = assignMonthProjectLanes(workSegmentsByProject, milestoneDaysByProject, gridStart, gridEnd);
+    const dayTotals = buildDayTotals(adminOverlays);
+
+    function handleDayDragOver(dayKey: string, event: DragEvent<HTMLDivElement>) {
+        if (!data.canEdit || !hasProjectDragPayload(event)) return;
+        event.preventDefault();
+        event.dataTransfer.dropEffect = "move";
+        setDragOverDate(dayKey);
+    }
+
+    function handleDayDragLeave(dayKey: string, event: DragEvent<HTMLDivElement>) {
+        if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) return;
+        setDragOverDate(current => current === dayKey ? null : current);
+    }
+
+    function handleDayDrop(dayKey: string, event: DragEvent<HTMLDivElement>) {
+        if (!data.canEdit || !hasProjectDragPayload(event)) return;
+        event.preventDefault();
+        setDragOverDate(null);
+        const projectId = event.dataTransfer.getData(PROJECT_DRAG_MIME);
+        const project = data.pipeline.waitingToStart.find(candidate => candidate.id === projectId);
+        if (project) onTrayProjectDrop(project, dayKey);
+    }
+
+    return (
+        <ProjectBarGridStartContext.Provider value={gridStart}>
+            <div className="overflow-x-auto">
+                <div className="min-w-[760px]">
+                    <div className="grid grid-cols-7 border-b border-hui-border bg-white">
+                    {WEEKDAY_LABELS.map(label => (
+                        <div key={label} className="px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-slate-400">{label}</div>
+                    ))}
+                </div>
+                    <div>
+                    {Array.from({ length: 6 }, (_, weekIndex) => {
+                        const weekDays = days.slice(weekIndex * 7, weekIndex * 7 + 7);
+                        const visibleSegments = layout.visibleWork.filter(segment => segment.weekIndex === weekIndex);
+                        const visibleMilestoneHosts = layout.visibleMilestoneHosts.filter(host => host.weekIndex === weekIndex);
+                        const hiddenProjectIds = layout.hiddenProjectIdsByWeek.get(weekIndex) ?? [];
+                        const hiddenProjects = hiddenProjectIds
+                            .map(projectId => projectById.get(projectId))
+                            .filter((project): project is DashboardProjectRow => Boolean(project));
+                        const hiddenCount = hiddenProjects.length;
+                        const expanded = expandedWeeks.has(weekIndex);
+
+                        return (
+                            <div key={weekIndex} className="relative grid min-h-[246px] grid-cols-7 border-b border-hui-border last:border-b-0">
+                                {weekDays.map(day => {
+                                    const dayKey = formatDate(day);
+                                    const isToday = isSameUTCDay(day, today);
+                                    const isCurrentMonth = day.getUTCMonth() === currentMonth;
+                                    const incomeTotal = showIncome ? dayTotals?.income.get(dayKey) : undefined;
+                                    const projectedCoTotal = showProjectedCo ? dayTotals?.projectedCo.get(dayKey) : undefined;
+                                    const expenseTotal = showExpenses ? dayTotals?.expenses.get(dayKey) : undefined;
+                                    const hoursTotal = showHours ? dayTotals?.hours.get(dayKey) : undefined;
+                                    return (
+                                        <div
+                                            key={dayKey}
+                                            data-schedule-date={dayKey}
+                                            onDragOver={event => handleDayDragOver(dayKey, event)}
+                                            onDragLeave={event => handleDayDragLeave(dayKey, event)}
+                                            onDrop={event => handleDayDrop(dayKey, event)}
+                                            className={`min-w-0 border-r border-hui-border p-1.5 last:border-r-0 ${isCurrentMonth ? (isWeekend(day) ? "bg-slate-50/60" : "bg-white") : "bg-slate-50/40"} ${isToday ? "ring-1 ring-inset ring-indigo-300" : ""} ${dragOverDate === dayKey ? "bg-indigo-50 ring-2 ring-inset ring-indigo-500" : ""}`}
+                                        >
+                                            <span className={`text-xs font-semibold ${isToday ? "inline-flex h-6 w-6 items-center justify-center rounded-full bg-indigo-600 text-white" : isCurrentMonth ? "text-hui-textMain" : "text-slate-400"}`}>{day.getUTCDate()}</span>
+                                            <div className="space-y-0.5 pt-[164px]">
+                                                {incomeTotal != null && incomeTotal > 0 && <div className="truncate px-1 text-[10px] font-medium text-green-700" title="Income due this day (effective due date)">{formatCurrency(incomeTotal)} due</div>}
+                                                {projectedCoTotal != null && projectedCoTotal > 0 && <div className="truncate px-1 text-[10px] font-medium text-amber-700" title="Approved, unbilled change-order income projected this day">{formatCurrency(projectedCoTotal)} projected CO</div>}
+                                                {expenseTotal != null && expenseTotal > 0 && <div className="truncate px-1 text-[10px] font-medium text-red-700" title="Expenses this day">−{formatCurrency(expenseTotal)}</div>}
+                                                {hoursTotal != null && hoursTotal > 0 && <div className="truncate px-1 text-[10px] font-medium text-blue-700" title="Hours logged this day">{hoursTotal.toFixed(1)}h</div>}
+                                            </div>
+                                        </div>
+                                    );
+                                })}
+                                <div className="pointer-events-none absolute inset-x-0 top-8 grid h-[152px] grid-cols-7 grid-rows-[repeat(4,38px)] gap-y-0 px-0.5">
+                                    {visibleSegments.map(segment => {
+                                        const project = projectById.get(segment.projectId);
+                                        if (!project) return null;
+                                        return (
+                                            <div
+                                                key={`${segment.projectId}-${segment.weekIndex}`}
+                                                className="pointer-events-auto min-w-0 px-0.5 py-px"
+                                                style={{ gridColumn: `${segment.startColumn + 1} / span ${segment.spanDays}`, gridRow: segment.lane + 1 }}
+                                            >
+                                                <ProjectBar
+                                                    project={project}
+                                                    segment={segment}
+                                                    projectColor={project.color || fallbackProjectColor(project.id)}
+                                                    conflictNames={projectConflictNames(project.id, data.crewConflicts)}
+                                                    incomeMilestones={milestoneMaps?.income.get(project.id) ?? EMPTY_INCOME}
+                                                    changeOrderMilestones={milestoneMaps?.changeOrders.get(project.id) ?? EMPTY_CHANGE_ORDERS}
+                                                    canEdit={data.canEdit}
+                                                    canMoveProject={data.canEdit && (project.status === "Waiting to Start" || project.status === "In Progress")}
+                                                    isPending={pendingProjectIds.has(project.id)}
+                                                    pendingTaskIds={pendingTaskIds}
+                                                    activeTaskKeyboardEdit={activeTaskKeyboardEdit}
+                                                    activeProjectKeyboardId={activeProjectKeyboardId}
+                                                    onProjectPointerEditStart={onProjectPointerEditStart}
+                                                    onProjectKeyboardStart={onProjectKeyboardStart}
+                                                    onProjectKeyboardAdjust={onProjectKeyboardAdjust}
+                                                    onProjectKeyboardCommit={onProjectKeyboardCommit}
+                                                    onProjectKeyboardCancel={onProjectKeyboardCancel}
+                                                    onMoveCommit={onProjectMoveCommit}
+                                                    onTaskPointerEditStart={onTaskPointerEditStart}
+                                                    onTaskKeyboardStart={onTaskKeyboardStart}
+                                                    onTaskKeyboardAdjust={onTaskKeyboardAdjust}
+                                                    onTaskKeyboardCommit={onTaskKeyboardCommit}
+                                                    onTaskKeyboardCancel={onTaskKeyboardCancel}
+                                                    onTaskDatesCommit={onTaskDatesCommit}
+                                                    onTaskMoveBy={onTaskMoveBy}
+                                                />
+                                            </div>
+                                        );
+                                    })}
+                                    {visibleMilestoneHosts.map(host => {
+                                        const project = projectById.get(host.projectId);
+                                        const rows = milestoneRowsByProjectDate?.get(`${host.projectId}|${host.dateKey}`) ?? [];
+                                        const visibleRange = { start: parseUTCDate(host.dateKey), end: addDays(parseUTCDate(host.dateKey), 1) };
+                                        const taskMilestones = project?.tasks.filter(task => task.type === "milestone" && task.startDate.slice(0, 10) === host.dateKey) ?? [];
+                                        return (
+                                            <div
+                                                key={`milestone-host-${host.projectId}-${host.dateKey}`}
+                                                className="pointer-events-auto relative min-w-0"
+                                                style={{ gridColumn: `${host.startColumn + 1} / span 1`, gridRow: host.lane + 1 }}
+                                            >
+                                                <div className="relative h-9" aria-label={`${projectById.get(host.projectId)?.name ?? "Project"} milestones`}>
+                                                    {rows.map((row, index) => (
+                                                        <MilestoneMarker
+                                                            key={row.key}
+                                                            name={row.name}
+                                                            amount={row.amount}
+                                                            effectiveDueDate={row.effectiveDueDate}
+                                                            visibleRange={visibleRange}
+                                                            kind={row.kind}
+                                                            offsetPixels={(index - (rows.length - 1) / 2) * 8}
+                                                        />
+                                                    ))}
+                                                    {project && taskMilestones.length > 0 && (
+                                                        <div className="absolute inset-x-0 bottom-0 h-[18px]">
+                                                            {taskMilestones.map(task => (
+                                                                <TaskBlockSegment
+                                                                    key={task.id}
+                                                                    task={task}
+                                                                    projectRange={getEffectiveProjectRange(project) ?? visibleRange}
+                                                                    visibleRange={visibleRange}
+                                                                    projectColor={project.color || fallbackProjectColor(project.id)}
+                                                                    canEdit={data.canEdit}
+                                                                    isPending={pendingProjectIds.has(project.id) || pendingTaskIds.has(task.id)}
+                                                                    activeTaskKeyboardEdit={activeTaskKeyboardEdit}
+                                                                    onTaskPointerEditStart={onTaskPointerEditStart}
+                                                                    onTaskKeyboardStart={onTaskKeyboardStart}
+                                                                    onTaskKeyboardAdjust={onTaskKeyboardAdjust}
+                                                                    onTaskKeyboardCommit={onTaskKeyboardCommit}
+                                                                    onTaskKeyboardCancel={onTaskKeyboardCancel}
+                                                                    onTaskDatesCommit={onTaskDatesCommit}
+                                                                    onTaskMoveBy={onTaskMoveBy}
+                                                                />
+                                                            ))}
+                                                        </div>
+                                                    )}
+                                                </div>
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                                {hiddenCount > 0 && (
+                                    <div className="absolute right-2 top-[180px] z-40 text-right">
+                                        <button
+                                            type="button"
+                                            onClick={() => setExpandedWeeks(current => {
+                                                const next = new Set(current);
+                                                if (next.has(weekIndex)) next.delete(weekIndex);
+                                                else next.add(weekIndex);
+                                                return next;
+                                            })}
+                                            aria-expanded={expanded}
+                                            className="rounded bg-white px-2 py-1 text-[10px] font-semibold text-indigo-700 shadow-sm ring-1 ring-inset ring-indigo-200 hover:bg-indigo-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+                                        >
+                                            +{hiddenCount} more
+                                        </button>
+                                        {expanded && (
+                                            <ul className="mt-1 w-56 rounded-md border border-hui-border bg-white p-1 text-left shadow-lg">
+                                                {hiddenProjects.map(project => (
+                                                    <li key={project.id} className="truncate px-2 py-1 text-xs text-hui-textMain" title={project.name}>{project.name}</li>
+                                                ))}
+                                            </ul>
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+                        );
+                    })}
+                    </div>
+                </div>
+            </div>
+        </ProjectBarGridStartContext.Provider>
+    );
+}

--- a/src/app/company-dashboard/schedule-board/ProjectBar.tsx
+++ b/src/app/company-dashboard/schedule-board/ProjectBar.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { createContext, useContext, useEffect, useRef, useState, type FormEvent, type KeyboardEvent, type PointerEvent as ReactPointerEvent, type RefObject } from "react";
+import Link from "next/link";
+import type {
+    DashboardProjectRow,
+    OverlayChangeOrderItem,
+    OverlayIncomeItem,
+} from "@/lib/schedule-core";
+import { addDays, formatDate } from "@/app/projects/[id]/schedule/schedule-utils";
+import { getEffectiveProjectRange, type WeekSegment } from "./useBarLayout";
+import { MilestoneMarker } from "./MilestoneMarker";
+import { TaskBlockSegment, type ActiveTaskKeyboardEdit, type TaskEditCallbacks } from "./TaskBlockSegment";
+
+export interface ProjectEditCallbacks {
+    activeProjectKeyboardId: string | null;
+    onProjectPointerEditStart: (_project: DashboardProjectRow, _start: ProjectPointerEditStart) => void;
+    onProjectKeyboardStart: (_project: DashboardProjectRow, _sourceElement: HTMLElement) => void;
+    onProjectKeyboardAdjust: (_project: DashboardProjectRow, _deltaDays: number) => void;
+    onProjectKeyboardCommit: (_project: DashboardProjectRow) => void;
+    onProjectKeyboardCancel: (_project: DashboardProjectRow) => void;
+    onProjectMoveCommit: (_project: DashboardProjectRow, _targetStart: string) => void;
+}
+
+export interface ProjectBarProps extends TaskEditCallbacks {
+    project: DashboardProjectRow;
+    segment: WeekSegment;
+    projectColor: string;
+    conflictNames: string[];
+    incomeMilestones: OverlayIncomeItem[];
+    changeOrderMilestones: OverlayChangeOrderItem[];
+    canEdit: boolean;
+    canMoveProject: boolean;
+    isPending: boolean;
+    pendingTaskIds: ReadonlySet<string>;
+    activeTaskKeyboardEdit: ActiveTaskKeyboardEdit | null;
+    timelineDayWidth?: number;
+    timelineLeftInset?: number;
+    timelineScrollContainerRef?: RefObject<HTMLDivElement | null>;
+    activeProjectKeyboardId: ProjectEditCallbacks["activeProjectKeyboardId"];
+    onProjectPointerEditStart: ProjectEditCallbacks["onProjectPointerEditStart"];
+    onProjectKeyboardStart: ProjectEditCallbacks["onProjectKeyboardStart"];
+    onProjectKeyboardAdjust: ProjectEditCallbacks["onProjectKeyboardAdjust"];
+    onProjectKeyboardCommit: ProjectEditCallbacks["onProjectKeyboardCommit"];
+    onProjectKeyboardCancel: ProjectEditCallbacks["onProjectKeyboardCancel"];
+    onMoveCommit: ProjectEditCallbacks["onProjectMoveCommit"];
+}
+
+export const ProjectBarGridStartContext = createContext<Date | null>(null);
+export interface ProjectPointerEditStart {
+    pointerId: number;
+    pointerType: string;
+    clientX: number;
+    clientY: number;
+    sourceElement: HTMLElement;
+    originalStart: string;
+    fallbackGrabDate: string;
+    timelineDayWidth?: number;
+    timelineLeftInset?: number;
+    timelineScrollContainerRef?: RefObject<HTMLDivElement | null>;
+}
+
+function initials(name: string): string {
+    return name.trim().split(/\s+/).map(part => part[0]).join("").toUpperCase().slice(0, 2) || "?";
+}
+
+export function ProjectBar({
+    project,
+    segment,
+    projectColor,
+    conflictNames,
+    incomeMilestones,
+    changeOrderMilestones,
+    canEdit,
+    canMoveProject,
+    isPending,
+    pendingTaskIds,
+    activeTaskKeyboardEdit,
+    timelineDayWidth,
+    timelineLeftInset,
+    timelineScrollContainerRef,
+    activeProjectKeyboardId,
+    onProjectPointerEditStart,
+    onProjectKeyboardStart,
+    onProjectKeyboardAdjust,
+    onProjectKeyboardCommit,
+    onProjectKeyboardCancel,
+    onMoveCommit,
+    onTaskPointerEditStart,
+    onTaskKeyboardStart,
+    onTaskKeyboardAdjust,
+    onTaskKeyboardCommit,
+    onTaskKeyboardCancel,
+    onTaskDatesCommit,
+    onTaskMoveBy,
+}: ProjectBarProps) {
+    const gridStart = useContext(ProjectBarGridStartContext);
+    const projectRange = getEffectiveProjectRange(project);
+    const projectStart = projectRange ? formatDate(projectRange.start) : "";
+    const actionDetailsRef = useRef<HTMLDetailsElement>(null);
+    const actionResetKey = `${isPending ? "pending" : "ready"}:${projectStart}`;
+    const [targetStartDraft, setTargetStartDraft] = useState(() => ({ resetKey: actionResetKey, value: projectStart }));
+    const targetStart = targetStartDraft.resetKey === actionResetKey ? targetStartDraft.value : projectStart;
+    if (targetStartDraft.resetKey !== actionResetKey) {
+        setTargetStartDraft({ resetKey: actionResetKey, value: projectStart });
+    }
+    useEffect(() => {
+        if (actionDetailsRef.current) actionDetailsRef.current.open = false;
+    }, [actionResetKey]);
+    if (!gridStart || !projectRange) return null;
+
+    const visibleStart = addDays(gridStart, segment.weekIndex * 7 + segment.startColumn);
+    const visibleRange = { start: visibleStart, end: addDays(visibleStart, segment.spanDays) };
+    const crewLabel = project.crew.length > 0 ? project.crew.map(member => member.name).join(", ") : "No project crew";
+    const projectTitle = `${project.name}${project.client ? ` — ${project.client}` : ""} — ${crewLabel}`;
+    const milestoneMarkers = [
+        ...incomeMilestones.map(item => ({
+            key: `income-${item.id}`,
+            name: item.name,
+            amount: item.amount,
+            effectiveDueDate: item.effectiveDueDate,
+            kind: "income" as const,
+        })),
+        ...changeOrderMilestones.map(item => ({
+            key: `co-${item.paymentScheduleId}`,
+            name: item.name,
+            amount: item.amount,
+            effectiveDueDate: item.effectiveDueDate,
+            kind: "change-order" as const,
+        })),
+    ];
+
+    function handlePointerDown(event: ReactPointerEvent<HTMLDivElement>) {
+        if (!canMoveProject || isPending || !event.isPrimary || (event.pointerType === "mouse" && event.button !== 0)) return;
+        if ((event.target as HTMLElement).closest("a,button,input,summary,form,details")) return;
+        onProjectPointerEditStart(project, {
+            pointerId: event.pointerId,
+            pointerType: event.pointerType,
+            clientX: event.clientX,
+            clientY: event.clientY,
+            sourceElement: event.currentTarget,
+            originalStart: formatDate(projectRange!.start),
+            fallbackGrabDate: formatDate(visibleStart),
+            timelineDayWidth,
+            timelineLeftInset,
+            timelineScrollContainerRef,
+        });
+    }
+
+    function handleKeyboard(event: KeyboardEvent<HTMLDivElement>) {
+        if (event.target !== event.currentTarget || !canMoveProject || isPending) return;
+        const editing = activeProjectKeyboardId === project.id;
+        if (!editing && (event.key === " " || event.key === "Enter")) {
+            event.preventDefault();
+            onProjectKeyboardStart(project, event.currentTarget);
+            return;
+        }
+        if (!editing) return;
+        const step = event.shiftKey ? 7 : 1;
+        if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+            event.preventDefault();
+            onProjectKeyboardAdjust(project, -step);
+        } else if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+            event.preventDefault();
+            onProjectKeyboardAdjust(project, step);
+        } else if (event.key === "Enter") {
+            event.preventDefault();
+            onProjectKeyboardCommit(project);
+        } else if (event.key === "Escape") {
+            event.preventDefault();
+            onProjectKeyboardCancel(project);
+        }
+    }
+
+    function handleDateSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!targetStart || isPending) return;
+        onMoveCommit(project, targetStart);
+    }
+
+    return (
+        <div
+            className={`group/project relative h-9 touch-pan-y select-none overflow-visible rounded-md border border-black/10 text-white shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 ${canMoveProject && !isPending ? "cursor-move" : ""}`}
+            style={{ backgroundColor: projectColor }}
+            data-can-edit={canEdit ? "true" : "false"}
+            role="group"
+            aria-label={`${project.name} project bar`}
+            aria-disabled={!canMoveProject || isPending}
+            aria-busy={isPending}
+            tabIndex={canMoveProject && !isPending ? 0 : undefined}
+            onPointerDown={handlePointerDown}
+            onKeyDown={handleKeyboard}
+        >
+            <div className="absolute inset-x-0 top-0 z-10 flex h-[18px] min-w-0 items-center gap-1 px-1 text-[10px] leading-none">
+                {segment.continuesBefore && <span aria-hidden="true">‹</span>}
+                <Link href={`/projects/${project.id}`} title={projectTitle} className="min-w-0 flex-1 truncate font-semibold text-white outline-none hover:underline focus-visible:ring-2 focus-visible:ring-white">
+                    {project.name}
+                </Link>
+                {project.crew.length > 0 && (
+                    <span className="shrink-0 text-[9px] font-medium text-white/90" title={`Crew: ${crewLabel}`}>
+                        {project.crew.slice(0, 3).map(member => initials(member.name)).join(" ")}{project.crew.length > 3 ? ` +${project.crew.length - 3}` : ""}
+                    </span>
+                )}
+                {conflictNames.length > 0 && (
+                    <span className="inline-flex min-w-4 shrink-0 items-center justify-center rounded-full bg-red-600 px-1 py-0.5 text-[9px] font-bold text-white" title={`Crew conflicts: ${conflictNames.join(", ")}`} aria-label={`${conflictNames.length} crew conflict${conflictNames.length === 1 ? "" : "s"}`}>
+                        !{conflictNames.length}
+                    </span>
+                )}
+                {canMoveProject && (
+                    <details ref={actionDetailsRef} className="relative shrink-0 opacity-0 pointer-events-none transition group-hover/project:opacity-100 group-hover/project:pointer-events-auto group-focus-within/project:opacity-100 group-focus-within/project:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto">
+                        <summary className="cursor-pointer list-none rounded bg-white/20 px-1 py-0.5 text-[9px] font-bold text-white hover:bg-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white" aria-label={`Project actions for ${project.name}`}>
+                            Actions
+                        </summary>
+                        <form onSubmit={handleDateSubmit} className="absolute right-0 top-full z-[80] mt-1 w-56 space-y-2 rounded-md border border-hui-border bg-white p-3 text-left text-hui-textMain shadow-xl">
+                            <label className="block text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted" htmlFor={`bar-project-date-${project.id}-${segment.weekIndex}`}>Start date</label>
+                            <input
+                                id={`bar-project-date-${project.id}-${segment.weekIndex}`}
+                                type="date"
+                                value={targetStart}
+                                onChange={event => setTargetStartDraft({ resetKey: actionResetKey, value: event.target.value })}
+                                disabled={isPending}
+                                className="hui-input w-full px-2 py-1 text-xs"
+                            />
+                            <button type="submit" disabled={isPending || !targetStart} className="hui-btn hui-btn-primary w-full text-xs disabled:cursor-wait disabled:opacity-60">
+                                Move project
+                            </button>
+                        </form>
+                    </details>
+                )}
+                {segment.continuesAfter && <span aria-hidden="true">›</span>}
+            </div>
+            <div className="absolute inset-x-0 bottom-0 h-[18px] overflow-visible rounded-b-md">
+                {project.tasks.map(task => (
+                    <TaskBlockSegment
+                        key={task.id}
+                        task={task}
+                        projectRange={projectRange}
+                        visibleRange={visibleRange}
+                        projectColor={projectColor}
+                        canEdit={canEdit}
+                        isPending={isPending || pendingTaskIds.has(task.id)}
+                        activeTaskKeyboardEdit={activeTaskKeyboardEdit}
+                        timelineDayWidth={timelineDayWidth}
+                        timelineLeftInset={timelineLeftInset}
+                        timelineScrollContainerRef={timelineScrollContainerRef}
+                        onTaskPointerEditStart={onTaskPointerEditStart}
+                        onTaskKeyboardStart={onTaskKeyboardStart}
+                        onTaskKeyboardAdjust={onTaskKeyboardAdjust}
+                        onTaskKeyboardCommit={onTaskKeyboardCommit}
+                        onTaskKeyboardCancel={onTaskKeyboardCancel}
+                        onTaskDatesCommit={onTaskDatesCommit}
+                        onTaskMoveBy={onTaskMoveBy}
+                    />
+                ))}
+            </div>
+            {milestoneMarkers.map(marker => {
+                const sameDayMarkers = milestoneMarkers.filter(item => item.effectiveDueDate.slice(0, 10) === marker.effectiveDueDate.slice(0, 10));
+                const sameDayIndex = sameDayMarkers.findIndex(item => item.key === marker.key);
+                return (
+                    <MilestoneMarker
+                        key={marker.key}
+                        name={marker.name}
+                        amount={marker.amount}
+                        effectiveDueDate={marker.effectiveDueDate}
+                        visibleRange={visibleRange}
+                        kind={marker.kind}
+                        offsetPixels={(sameDayIndex - (sameDayMarkers.length - 1) / 2) * 8}
+                    />
+                );
+            })}
+        </div>
+    );
+}

--- a/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
+++ b/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
@@ -1,0 +1,1257 @@
+"use client";
+
+import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { shiftNotStartedTasksAction, updateCompanyScheduleTaskDatesAction, updateProjectStartDateAction } from "@/lib/actions";
+import type { CompanyDashboardData, DashboardProjectRow, DashboardTaskRow, OverlayIncomeItem } from "@/lib/schedule-core";
+import { addDays, formatDate, getDaysBetween, parseUTCDate } from "@/app/projects/[id]/schedule/schedule-utils";
+import { MonthBarsView } from "./MonthBarsView";
+import { TimelineView } from "./TimelineView";
+import { ShiftConfirmDialog, type ProjectMoveChoice } from "./ShiftConfirmDialog";
+import { UnscheduledTray } from "./UnscheduledTray";
+import {
+    createProjectDropIntent,
+    getEffectivePendingProjectIds,
+    getEffectiveProjectRange,
+    getNewlyPendingProjectIds,
+    getTimelineAutoscrollStep,
+    getTimelinePointerDelta,
+    previewProjectMove,
+    previewProjectWithPersistedTaskDates,
+    previewProjectIncomeOverlays,
+    previewShiftedTaskIncomeOverlays,
+    previewTaskDates,
+    previewTaskPointerCandidate,
+    projectRefreshMatches,
+    taskDatesMatch,
+    type ProjectDropIntent,
+    type ProjectRefreshExpectation,
+    type TaskDateOverride,
+    type TaskEditMode,
+} from "./useBarLayout";
+import type { TaskPointerEditStart } from "./TaskBlockSegment";
+import type { ProjectPointerEditStart } from "./ProjectBar";
+
+export type { ProjectMoveChoice } from "./ShiftConfirmDialog";
+export type { ProjectDropIntent } from "./useBarLayout";
+export type BoardView = "month" | "timeline";
+
+const MONTH_LABELS = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+const BOARD_VIEW_STORAGE_KEY = "gtr-company-schedule-board-view";
+const TASK_MOUSE_DRAG_THRESHOLD_PX = 5;
+const TASK_TOUCH_DRAG_THRESHOLD_PX = 8;
+const PROJECT_MOUSE_DRAG_THRESHOLD_PX = 5;
+const PROJECT_TOUCH_DRAG_THRESHOLD_PX = 8;
+const EDGE_AUTOSCROLL_THRESHOLD_PX = 48;
+const MAX_AUTOSCROLL_PX_PER_FRAME = 16;
+const EMPTY_PROJECT_IDS: ReadonlySet<string> = new Set();
+
+interface ScheduleBoardProps {
+    data: CompanyDashboardData;
+    externallyPendingProjectIds: ReadonlySet<string>;
+    isProjectExternallyPending: (projectId: string) => boolean;
+    onEffectivePendingProjectIdsChange: (projectIds: ReadonlySet<string>) => void;
+}
+
+interface TaskKeyboardEditState {
+    taskId: string;
+    projectId: string;
+    mode: TaskEditMode;
+    deltaDays: number;
+}
+
+interface ActiveTaskPointerEdit {
+    taskId: string;
+    projectId: string;
+    pointerId: number;
+    pointerType: string;
+    startX: number;
+    startY: number;
+    originX: number;
+    latestClientX: number;
+    latestClientY: number;
+    grabDate: string | null;
+    mode: TaskEditMode;
+    active: boolean;
+    currentCandidate: TaskDateOverride | null;
+    animationFrameId: number | null;
+    sourceElement: HTMLElement;
+    previousTouchAction: string;
+    cleanup: () => void;
+}
+
+interface ProjectKeyboardEditState {
+    projectId: string;
+    targetStart: string;
+}
+
+interface ActiveProjectPointerEdit {
+    projectId: string;
+    project: DashboardProjectRow;
+    pointerId: number;
+    pointerType: string;
+    startX: number;
+    startY: number;
+    originX: number;
+    latestClientX: number;
+    latestClientY: number;
+    grabDate: string;
+    originalStart: string;
+    active: boolean;
+    animationFrameId: number | null;
+    sourceElement: HTMLElement;
+    previousTouchAction: string;
+    start: ProjectPointerEditStart;
+    cleanup: () => void;
+}
+
+function hitTestScheduleDate(clientX: number, clientY: number): string | null {
+    for (const element of document.elementsFromPoint(clientX, clientY)) {
+        const cell = element instanceof HTMLElement ? element.closest<HTMLElement>("[data-schedule-date]") : null;
+        if (cell?.dataset.scheduleDate) return cell.dataset.scheduleDate;
+    }
+    return null;
+}
+
+function hitTestTimelineScheduleGrid(clientX: number, clientY: number): boolean {
+    for (const element of document.elementsFromPoint(clientX, clientY)) {
+        if (!(element instanceof HTMLElement)) continue;
+        if (element.closest("[data-timeline-sticky-label]")) return false;
+        const grid = element.closest<HTMLElement>("[data-timeline-schedule-grid]");
+        if (!grid) continue;
+        const bounds = grid.getBoundingClientRect();
+        return clientX >= bounds.left && clientX <= bounds.right
+            && clientY >= bounds.top && clientY <= bounds.bottom;
+    }
+    return false;
+}
+
+function isInteractiveTaskFallbackTarget(target: EventTarget | null): boolean {
+    return target instanceof HTMLElement && Boolean(target.closest(
+        'a,button,input,select,textarea,summary,[contenteditable="true"],[role="button"],[role="group"],[tabindex]:not([tabindex="-1"])',
+    ));
+}
+
+function shiftMonth(month: string, delta: number): string {
+    const [year, monthNumber] = month.split("-").map(Number);
+    const shifted = new Date(Date.UTC(year, monthNumber - 1 + delta, 1));
+    return `${shifted.getUTCFullYear()}-${String(shifted.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+export function ScheduleBoard({
+    data,
+    externallyPendingProjectIds,
+    isProjectExternallyPending,
+    onEffectivePendingProjectIdsChange,
+}: ScheduleBoardProps) {
+    const router = useRouter();
+    const { month, isAdmin, overlays } = data;
+    const [showIncome, setShowIncome] = useState(true);
+    const [showProjectedCo, setShowProjectedCo] = useState(true);
+    const [showExpenses, setShowExpenses] = useState(false);
+    const [showHours, setShowHours] = useState(false);
+    const [boardView, setBoardView] = useState<BoardView>("month");
+    const [projectPreviewOverrides, setProjectPreviewOverrides] = useState<Record<string, DashboardProjectRow>>({});
+    const [projectIncomeOverrides, setProjectIncomeOverrides] = useState<Record<string, OverlayIncomeItem[]>>({});
+    const [projectRefreshExpectations, setProjectRefreshExpectations] = useState<Record<string, ProjectRefreshExpectation>>({});
+    const [taskDateOverrides, setTaskDateOverrides] = useState<Record<string, TaskDateOverride>>({});
+    const [pendingProjectIds, setPendingProjectIds] = useState<Set<string>>(() => new Set());
+    const [pendingTaskIds, setPendingTaskIds] = useState<Set<string>>(() => new Set());
+    const [awaitingTaskRefreshIds, setAwaitingTaskRefreshIds] = useState<Set<string>>(() => new Set());
+    const [taskKeyboardEdit, setTaskKeyboardEdit] = useState<TaskKeyboardEditState | null>(null);
+    const taskKeyboardEditRef = useRef<TaskKeyboardEditState | null>(null);
+    const taskKeyboardCleanupRef = useRef<(() => void) | null>(null);
+    const taskKeyboardSourceRef = useRef<HTMLElement | null>(null);
+    const taskKeyboardSentinelRef = useRef<HTMLSpanElement>(null);
+    const activeTaskPointerRef = useRef<ActiveTaskPointerEdit | null>(null);
+    const [projectKeyboardEdit, setProjectKeyboardEdit] = useState<ProjectKeyboardEditState | null>(null);
+    const projectKeyboardEditRef = useRef<ProjectKeyboardEditState | null>(null);
+    const projectKeyboardCleanupRef = useRef<(() => void) | null>(null);
+    const projectKeyboardSentinelRef = useRef<HTMLSpanElement>(null);
+    const activeProjectPointerRef = useRef<ActiveProjectPointerEdit | null>(null);
+    const effectivePendingTaskIdsRef = useRef<Set<string>>(new Set());
+    const effectivePendingProjectIdsRef = useRef<Set<string>>(new Set());
+    const previousExternallyPendingProjectIdsRef = useRef<ReadonlySet<string>>(new Set(externallyPendingProjectIds));
+    const [confirmIntent, setConfirmIntent] = useState<ProjectDropIntent | null>(null);
+    const confirmIntentRef = useRef<ProjectDropIntent | null>(null);
+    confirmIntentRef.current = confirmIntent;
+    const [, startTransition] = useTransition();
+    useEffect(() => {
+        try {
+            const stored = localStorage.getItem(BOARD_VIEW_STORAGE_KEY);
+            if (stored === "month" || stored === "timeline") setBoardView(stored);
+        } catch {
+            // Storage can be unavailable in privacy-restricted browser contexts.
+        }
+    }, []);
+    const anchor = parseUTCDate(`${month}-01`);
+    const monthLabel = `${MONTH_LABELS[anchor.getUTCMonth()]} ${anchor.getUTCFullYear()}`;
+    const canonicalProjects = useMemo(() => [
+        ...data.pipeline.waitingToStart,
+        ...data.pipeline.scheduled,
+        ...data.pipeline.inProgress,
+        ...data.pipeline.substantialCompletion,
+    ], [data.pipeline]);
+    const canonicalProjectById = useMemo(() => new Map(canonicalProjects.map(project => [project.id, project])), [canonicalProjects]);
+    const canonicalTaskById = useMemo(() => new Map(canonicalProjects.flatMap(project => project.tasks.map(task => [task.id, task] as const))), [canonicalProjects]);
+    const canonicalTaskProjectById = useMemo(() => new Map(canonicalProjects.flatMap(project => (
+        project.tasks.map(task => [task.id, project.id] as const)
+    ))), [canonicalProjects]);
+    const effectivePendingTaskIds = useMemo(
+        () => new Set([...pendingTaskIds, ...awaitingTaskRefreshIds]),
+        [awaitingTaskRefreshIds, pendingTaskIds],
+    );
+    const effectivePendingProjectIds = useMemo(() => getEffectivePendingProjectIds(
+        [...pendingProjectIds, ...Object.keys(projectRefreshExpectations), ...externallyPendingProjectIds],
+        effectivePendingTaskIds,
+        canonicalTaskProjectById,
+    ), [canonicalTaskProjectById, effectivePendingTaskIds, externallyPendingProjectIds, pendingProjectIds, projectRefreshExpectations]);
+    effectivePendingTaskIdsRef.current = effectivePendingTaskIds;
+    effectivePendingProjectIdsRef.current = effectivePendingProjectIds;
+    const isProjectPending = (projectId: string) => (
+        effectivePendingProjectIdsRef.current.has(projectId) || isProjectExternallyPending(projectId)
+    );
+    const publishEffectivePendingProjectIds = useCallback((next: ReadonlySet<string>) => {
+        effectivePendingProjectIdsRef.current = new Set(next);
+        onEffectivePendingProjectIdsChange(next);
+    }, [onEffectivePendingProjectIdsChange]);
+    useEffect(() => {
+        publishEffectivePendingProjectIds(effectivePendingProjectIds);
+    }, [effectivePendingProjectIds, publishEffectivePendingProjectIds]);
+    useEffect(() => () => onEffectivePendingProjectIdsChange(EMPTY_PROJECT_IDS), [onEffectivePendingProjectIdsChange]);
+    const isTaskOrProjectPending = (taskId: string) => {
+        const projectId = canonicalTaskProjectById.get(taskId);
+        return effectivePendingTaskIdsRef.current.has(taskId) || Boolean(projectId && isProjectPending(projectId));
+    };
+    const projectRefreshCount = Object.keys(projectRefreshExpectations).length;
+    const pendingRefreshKinds = [
+        projectRefreshCount > 0 ? "project" : null,
+        awaitingTaskRefreshIds.size > 0 ? "task" : null,
+    ].filter((kind): kind is string => Boolean(kind));
+    const applyPreview = (project: DashboardProjectRow) => {
+        const projectPreview = projectPreviewOverrides[project.id] ?? project;
+        return {
+            ...projectPreview,
+            tasks: projectPreview.tasks.map(task => {
+                const dates = taskDateOverrides[task.id];
+                return dates ? { ...task, ...dates } : task;
+            }),
+        };
+    };
+    let previewOverlays = data.overlays;
+    if (previewOverlays) {
+        for (const [projectId, rows] of Object.entries(projectIncomeOverrides)) {
+            const rowById = new Map(rows.map(row => [row.id, row]));
+            previewOverlays = {
+                ...previewOverlays,
+                income: previewOverlays.income.map(row => row.projectId === projectId ? rowById.get(row.id) ?? row : row),
+            };
+        }
+    }
+    const boardData: CompanyDashboardData = {
+        ...data,
+        pipeline: {
+            ...data.pipeline,
+            waitingToStart: data.pipeline.waitingToStart.map(applyPreview),
+            scheduled: data.pipeline.scheduled.map(applyPreview),
+            inProgress: data.pipeline.inProgress.map(applyPreview),
+            substantialCompletion: data.pipeline.substantialCompletion.map(applyPreview),
+        },
+        overlays: data.overlays ? previewOverlays : null,
+    };
+
+    function setProjectPending(projectId: string, pending: boolean) {
+        if (pending) {
+            const next = new Set(effectivePendingProjectIdsRef.current).add(projectId);
+            publishEffectivePendingProjectIds(next);
+        }
+        setPendingProjectIds(current => {
+            const next = new Set(current);
+            if (pending) next.add(projectId);
+            else next.delete(projectId);
+            return next;
+        });
+    }
+
+    function setTaskPending(taskId: string, pending: boolean) {
+        if (pending) {
+            effectivePendingTaskIdsRef.current = new Set(effectivePendingTaskIdsRef.current).add(taskId);
+            const projectId = canonicalTaskProjectById.get(taskId);
+            if (projectId) {
+                const next = new Set(effectivePendingProjectIdsRef.current).add(projectId);
+                publishEffectivePendingProjectIds(next);
+            }
+        }
+        setPendingTaskIds(current => {
+            const next = new Set(current);
+            if (pending) next.add(taskId);
+            else next.delete(taskId);
+            return next;
+        });
+    }
+
+    function setTaskKeyboardState(next: TaskKeyboardEditState | null) {
+        taskKeyboardEditRef.current = next;
+        setTaskKeyboardEdit(next);
+    }
+
+    function setTaskPreview(taskId: string, dates: TaskDateOverride) {
+        setTaskDateOverrides(current => ({ ...current, [taskId]: dates }));
+    }
+
+    function clearTaskPreview(taskId: string) {
+        setTaskDateOverrides(current => {
+            if (!(taskId in current)) return current;
+            const next = { ...current };
+            delete next[taskId];
+            return next;
+        });
+    }
+
+    function cancelTaskEditsForProjects(projectIds: ReadonlySet<string>) {
+        const pointerEdit = activeTaskPointerRef.current;
+        if (pointerEdit && projectIds.has(pointerEdit.projectId)) {
+            pointerEdit.cleanup();
+            clearTaskPreview(pointerEdit.taskId);
+        }
+        const keyboardEdit = taskKeyboardEditRef.current;
+        if (keyboardEdit && projectIds.has(keyboardEdit.projectId)) {
+            clearTaskPreview(keyboardEdit.taskId);
+            taskKeyboardCleanupRef.current?.();
+            setTaskKeyboardState(null);
+        }
+    }
+
+    function cancelActiveTaskEdit() {
+        const pointerEdit = activeTaskPointerRef.current;
+        if (pointerEdit) {
+            pointerEdit.cleanup();
+            clearTaskPreview(pointerEdit.taskId);
+        }
+        const keyboardEdit = taskKeyboardEditRef.current;
+        if (keyboardEdit) clearTaskPreview(keyboardEdit.taskId);
+        taskKeyboardCleanupRef.current?.();
+        setTaskKeyboardState(null);
+    }
+
+    useEffect(() => {
+        const refreshedTaskById = new Map([
+            ...data.pipeline.waitingToStart,
+            ...data.pipeline.scheduled,
+            ...data.pipeline.inProgress,
+            ...data.pipeline.substantialCompletion,
+        ].flatMap(project => project.tasks.map(task => [task.id, task] as const)));
+        const reconciledTaskIds = [...awaitingTaskRefreshIds].filter(taskId => {
+            const canonicalTask = refreshedTaskById.get(taskId);
+            const dates = taskDateOverrides[taskId];
+            return Boolean(canonicalTask && dates && taskDatesMatch(canonicalTask, dates));
+        });
+        if (reconciledTaskIds.length === 0) return;
+
+        // Prop reconciliation is intentionally deferred out of the effect body.
+        // Until refreshed canonical rows match, saved overrides stay rendered and
+        // the task remains gated against stale-base sequential edits.
+        const timeoutId = window.setTimeout(() => {
+            const reconciled = new Set(reconciledTaskIds);
+            setTaskDateOverrides(current => Object.fromEntries(
+                Object.entries(current).filter(([taskId]) => !reconciled.has(taskId)),
+            ));
+            setPendingTaskIds(current => new Set([...current].filter(taskId => !reconciled.has(taskId))));
+            setAwaitingTaskRefreshIds(current => new Set([...current].filter(taskId => !reconciled.has(taskId))));
+        }, 0);
+        return () => window.clearTimeout(timeoutId);
+    }, [awaitingTaskRefreshIds, data, taskDateOverrides]);
+
+    useEffect(() => {
+        const reconciledProjectIds = Object.entries(projectRefreshExpectations).flatMap(([projectId, expectation]) => {
+            const canonical = canonicalProjectById.get(projectId);
+            return projectRefreshMatches(canonical, expectation) ? [projectId] : [];
+        });
+        if (reconciledProjectIds.length === 0) return;
+        const reconciled = new Set(reconciledProjectIds);
+        const timeoutId = window.setTimeout(() => {
+            setProjectPreviewOverrides(current => Object.fromEntries(Object.entries(current).filter(([id]) => !reconciled.has(id))));
+            setProjectIncomeOverrides(current => Object.fromEntries(Object.entries(current).filter(([id]) => !reconciled.has(id))));
+            setProjectRefreshExpectations(current => Object.fromEntries(Object.entries(current).filter(([id]) => !reconciled.has(id))));
+            setPendingProjectIds(current => new Set([...current].filter(id => !reconciled.has(id))));
+        }, 0);
+        return () => window.clearTimeout(timeoutId);
+    }, [canonicalProjectById, projectRefreshExpectations]);
+
+    useEffect(() => {
+        if (Object.keys(projectRefreshExpectations).length === 0 && awaitingTaskRefreshIds.size === 0) return;
+        const intervalId = window.setInterval(() => router.refresh(), 2_000);
+        return () => window.clearInterval(intervalId);
+    }, [awaitingTaskRefreshIds.size, projectRefreshExpectations, router]);
+
+    useEffect(() => () => {
+        activeProjectPointerRef.current?.cleanup();
+        projectKeyboardCleanupRef.current?.();
+        activeTaskPointerRef.current?.cleanup();
+        taskKeyboardCleanupRef.current?.();
+    }, []);
+
+    function selectBoardView(nextView: BoardView) {
+        cancelActiveProjectEdit();
+        cancelActiveTaskEdit();
+        setBoardView(nextView);
+        try {
+            localStorage.setItem(BOARD_VIEW_STORAGE_KEY, nextView);
+        } catch {
+            // The selected view still applies for this session when persistence fails.
+        }
+    }
+
+    function setProjectPreview(project: DashboardProjectRow, targetStart: string) {
+        const preview = previewProjectMove(project, targetStart);
+        setProjectPreviewOverrides(current => ({ ...current, [project.id]: preview }));
+        if (data.overlays && project.status === "Waiting to Start" && project.startDate) {
+            const intent = createProjectDropIntent(project, targetStart);
+            if (intent) {
+                setProjectIncomeOverrides(current => ({
+                    ...current,
+                    [project.id]: previewProjectIncomeOverlays(data.overlays!.income, project.id, intent.deltaDays),
+                }));
+            }
+        }
+    }
+
+    function clearProjectPreview(projectId: string) {
+        setProjectPreviewOverrides(current => {
+            if (!(projectId in current)) return current;
+            const next = { ...current };
+            delete next[projectId];
+            return next;
+        });
+        setProjectIncomeOverrides(current => {
+            if (!(projectId in current)) return current;
+            const next = { ...current };
+            delete next[projectId];
+            return next;
+        });
+    }
+
+    function awaitProjectRefresh(
+        project: DashboardProjectRow,
+        expectation: ProjectRefreshExpectation,
+        income: OverlayIncomeItem[] | null,
+    ) {
+        setProjectPreviewOverrides(current => ({ ...current, [project.id]: project }));
+        if (income) setProjectIncomeOverrides(current => ({ ...current, [project.id]: income }));
+        else setProjectIncomeOverrides(current => {
+            const next = { ...current };
+            delete next[project.id];
+            return next;
+        });
+        setProjectRefreshExpectations(current => ({ ...current, [project.id]: expectation }));
+        router.refresh();
+    }
+
+    async function commitTaskDates(taskId: string, dates: TaskDateOverride): Promise<void> {
+        const canonicalTask = canonicalTaskById.get(taskId);
+        if (!data.canEdit || isTaskOrProjectPending(taskId) || !canonicalTask) {
+            clearTaskPreview(taskId);
+            return;
+        }
+
+        const normalizedDates = {
+            startDate: formatDate(parseUTCDate(dates.startDate)),
+            endDate: canonicalTask.type === "milestone"
+                ? formatDate(parseUTCDate(dates.startDate))
+                : formatDate(parseUTCDate(dates.endDate)),
+        };
+        if (canonicalTask.type !== "milestone" && parseUTCDate(normalizedDates.endDate) <= parseUTCDate(normalizedDates.startDate)) {
+            clearTaskPreview(taskId);
+            toast.error("Task end date must be after its start date");
+            return;
+        }
+        const originalDates = {
+            startDate: canonicalTask.startDate.slice(0, 10),
+            endDate: canonicalTask.endDate.slice(0, 10),
+        };
+        if (normalizedDates.startDate === originalDates.startDate && normalizedDates.endDate === originalDates.endDate) {
+            clearTaskPreview(taskId);
+            return;
+        }
+
+        dates = normalizedDates;
+        setTaskPreview(taskId, normalizedDates);
+        setTaskPending(taskId, true);
+        try {
+            const saved = await updateCompanyScheduleTaskDatesAction(taskId, { startDate: dates.startDate, endDate: dates.endDate });
+            const persistedDates = { startDate: formatDate(saved.startDate), endDate: formatDate(saved.endDate) };
+            setTaskPreview(taskId, persistedDates);
+            toast.success("Task dates updated");
+            setAwaitingTaskRefreshIds(current => new Set(current).add(taskId));
+            router.refresh();
+        } catch (error) {
+            clearTaskPreview(taskId);
+            setAwaitingTaskRefreshIds(current => {
+                const next = new Set(current);
+                next.delete(taskId);
+                return next;
+            });
+            setTaskPending(taskId, false);
+            toast.error(error instanceof Error ? error.message : "Failed to update task dates");
+        }
+    }
+
+    function showSuccess(message: string, notes: string[]) {
+        if (notes.length > 0) toast.success(message, { description: notes.join(" ") });
+        else toast.success(message);
+    }
+
+    function showFailure(error: unknown, fallback: string) {
+        toast.error(error instanceof Error ? error.message : fallback);
+    }
+
+    function scheduleUnscheduledProject(project: DashboardProjectRow, targetStart: string) {
+        const canonicalProject = canonicalProjectById.get(project.id);
+        if (!data.canEdit || !canonicalProject || isProjectPending(project.id)) return;
+        cancelActiveTaskEdit();
+        const normalizedTarget = formatDate(parseUTCDate(targetStart));
+        setProjectPreview(canonicalProject, normalizedTarget);
+        setProjectPending(project.id, true);
+        startTransition(async () => {
+            try {
+                const result = await updateProjectStartDateAction(project.id, normalizedTarget, true);
+                toast.success("Project scheduled", result.notes.length > 0 ? { description: result.notes.join(" ") } : undefined);
+                const preview = previewProjectWithPersistedTaskDates(canonicalProject, result.startDate, result.shiftedTaskDates);
+                awaitProjectRefresh(preview, {
+                    projectStartDate: result.startDate,
+                    taskDates: result.shiftedTaskDates,
+                }, data.overlays?.income ?? null);
+            } catch (error) {
+                clearProjectPreview(project.id);
+                showFailure(error, "Failed to schedule project");
+            } finally {
+                setProjectPending(project.id, false);
+            }
+        });
+    }
+
+    function commitWaitingProjectMove(intent: ProjectDropIntent) {
+        if (!data.canEdit || isProjectPending(intent.project.id)) {
+            clearProjectPreview(intent.project.id);
+            return;
+        }
+        cancelActiveTaskEdit();
+        setProjectPending(intent.project.id, true);
+        startTransition(async () => {
+            try {
+                const result = await updateProjectStartDateAction(intent.project.id, intent.targetStart, true);
+                showSuccess("Project moved", result.notes);
+                const expected = previewProjectWithPersistedTaskDates(intent.project, result.startDate, result.shiftedTaskDates);
+                const income = data.overlays
+                    ? previewProjectIncomeOverlays(data.overlays.income, intent.project.id, intent.deltaDays)
+                    : null;
+                awaitProjectRefresh(expected, {
+                    projectStartDate: result.startDate,
+                    taskDates: result.shiftedTaskDates,
+                }, income);
+            } catch (error) {
+                clearProjectPreview(intent.project.id);
+                showFailure(error, "Failed to move project");
+            } finally {
+                setProjectPending(intent.project.id, false);
+            }
+        });
+    }
+
+    function handleProjectMovePreview(project: DashboardProjectRow, targetStart: string) {
+        const canonicalProject = canonicalProjectById.get(project.id);
+        if (!data.canEdit || !canonicalProject || isProjectPending(project.id)) {
+            clearProjectPreview(project.id);
+            return;
+        }
+        const intent = createProjectDropIntent(canonicalProject, targetStart);
+        if (!intent || intent.deltaDays === 0) clearProjectPreview(project.id);
+        else setProjectPreview(canonicalProject, intent.targetStart);
+    }
+
+    function handleProjectMoveCommit(project: DashboardProjectRow, targetStart: string) {
+        const canonicalProject = canonicalProjectById.get(project.id);
+        if (!data.canEdit || !canonicalProject || isProjectPending(project.id)) {
+            clearProjectPreview(project.id);
+            setConfirmIntent(null);
+            return;
+        }
+        cancelActiveTaskEdit();
+        const intent = createProjectDropIntent(canonicalProject, targetStart);
+        if (!intent || intent.deltaDays === 0) {
+            clearProjectPreview(project.id);
+            setConfirmIntent(null);
+            return;
+        }
+
+        setProjectPreview(canonicalProject, intent.targetStart);
+        if (canonicalProject.status === "In Progress") setConfirmIntent(intent);
+        else commitWaitingProjectMove(intent);
+    }
+
+    function handleMoveChoice(choice: ProjectMoveChoice) {
+        const intent = confirmIntent;
+        if (!data.canEdit || !intent) return;
+        if (isProjectPending(intent.project.id)) {
+            clearProjectPreview(intent.project.id);
+            setConfirmIntent(null);
+            return;
+        }
+        cancelActiveTaskEdit();
+        setProjectPending(intent.project.id, true);
+        startTransition(async () => {
+            try {
+                if (choice === "marker-only") {
+                    const result = await updateProjectStartDateAction(intent.project.id, intent.targetStart, false);
+                    showSuccess("Start marker moved", result.notes);
+                    const preview = previewProjectWithPersistedTaskDates(intent.project, result.startDate, []);
+                    awaitProjectRefresh(preview, { projectStartDate: result.startDate, taskDates: [] }, data.overlays?.income ?? null);
+                } else {
+                    const result = await shiftNotStartedTasksAction(intent.project.id, intent.deltaDays);
+                    showSuccess("Not Started tasks shifted", result.notes);
+                    const shiftedTaskIds = new Set(result.shiftedTaskIds);
+                    const expected = previewProjectWithPersistedTaskDates(intent.project, intent.project.startDate, result.shiftedTaskDates);
+                    const income = data.overlays
+                        ? previewShiftedTaskIncomeOverlays(data.overlays.income, intent.project.id, intent.deltaDays, shiftedTaskIds)
+                        : null;
+                    awaitProjectRefresh(expected, { taskDates: result.shiftedTaskDates }, income);
+                }
+                setConfirmIntent(null);
+            } catch (error) {
+                setConfirmIntent(null);
+                clearProjectPreview(intent.project.id);
+                showFailure(error, "Failed to move project");
+            } finally {
+                setProjectPending(intent.project.id, false);
+            }
+        });
+    }
+
+    function cancelConfirmedMove() {
+        if (!confirmIntent || pendingProjectIds.has(confirmIntent.project.id)) return;
+        clearProjectPreview(confirmIntent.project.id);
+        setConfirmIntent(null);
+    }
+
+    function setProjectKeyboardState(next: ProjectKeyboardEditState | null) {
+        projectKeyboardEditRef.current = next;
+        setProjectKeyboardEdit(next);
+    }
+
+    function cancelProjectEditsForProjects(projectIds: ReadonlySet<string>) {
+        const pointerEdit = activeProjectPointerRef.current;
+        if (pointerEdit && projectIds.has(pointerEdit.projectId)) {
+            pointerEdit.cleanup();
+            clearProjectPreview(pointerEdit.projectId);
+        }
+        const keyboardEdit = projectKeyboardEditRef.current;
+        if (keyboardEdit && projectIds.has(keyboardEdit.projectId)) {
+            clearProjectPreview(keyboardEdit.projectId);
+            projectKeyboardCleanupRef.current?.();
+            setProjectKeyboardState(null);
+        }
+    }
+
+    function cancelActiveProjectEdit() {
+        const pointerEdit = activeProjectPointerRef.current;
+        if (pointerEdit) {
+            pointerEdit.cleanup();
+            clearProjectPreview(pointerEdit.projectId);
+        }
+        const keyboardEdit = projectKeyboardEditRef.current;
+        if (keyboardEdit) clearProjectPreview(keyboardEdit.projectId);
+        projectKeyboardCleanupRef.current?.();
+        setProjectKeyboardState(null);
+    }
+
+    const cancelExternallyLockedProjectEdits = useEffectEvent((newlyPendingProjectIds: ReadonlySet<string>) => {
+        cancelProjectEditsForProjects(newlyPendingProjectIds);
+        cancelTaskEditsForProjects(newlyPendingProjectIds);
+        const intent = confirmIntentRef.current;
+        if (intent && newlyPendingProjectIds.has(intent.project.id)) {
+            clearProjectPreview(intent.project.id);
+            setConfirmIntent(null);
+        }
+    });
+
+    useEffect(() => {
+        const newlyPendingProjectIds = getNewlyPendingProjectIds(
+            previousExternallyPendingProjectIdsRef.current,
+            externallyPendingProjectIds,
+        );
+        previousExternallyPendingProjectIdsRef.current = new Set(externallyPendingProjectIds);
+        if (newlyPendingProjectIds.size === 0) return;
+
+        cancelExternallyLockedProjectEdits(newlyPendingProjectIds);
+    }, [externallyPendingProjectIds]);
+
+    function handleProjectPointerEditStart(project: DashboardProjectRow, start: ProjectPointerEditStart) {
+        const canonicalProject = canonicalProjectById.get(project.id);
+        if (!data.canEdit || !canonicalProject || isProjectPending(project.id)) return;
+        cancelActiveProjectEdit();
+        cancelActiveTaskEdit();
+        const drag: ActiveProjectPointerEdit = {
+            projectId: project.id,
+            project: canonicalProject,
+            pointerId: start.pointerId,
+            pointerType: start.pointerType,
+            startX: start.clientX,
+            startY: start.clientY,
+            originX: start.clientX,
+            latestClientX: start.clientX,
+            latestClientY: start.clientY,
+            grabDate: hitTestScheduleDate(start.clientX, start.clientY) ?? start.fallbackGrabDate,
+            originalStart: start.originalStart,
+            active: false,
+            animationFrameId: null,
+            sourceElement: start.sourceElement,
+            previousTouchAction: start.sourceElement.style.touchAction,
+            start,
+            cleanup: () => undefined,
+        };
+
+        const calculateProjectPointerCandidate = (): string | null => {
+            let deltaDays: number | null = null;
+            if (drag.start.timelineDayWidth) {
+                if (hitTestTimelineScheduleGrid(drag.latestClientX, drag.latestClientY)) {
+                    deltaDays = getTimelinePointerDelta(drag.latestClientX, drag.originX, drag.start.timelineDayWidth);
+                }
+            } else {
+                const hitDate = hitTestScheduleDate(drag.latestClientX, drag.latestClientY);
+                if (hitDate) deltaDays = getDaysBetween(parseUTCDate(drag.grabDate), parseUTCDate(hitDate));
+            }
+            return deltaDays == null ? null : formatDate(addDays(parseUTCDate(drag.originalStart), deltaDays));
+        };
+        const getProjectAutoscrollStep = () => {
+            const container = drag.start.timelineScrollContainerRef?.current;
+            if (!container || !drag.start.timelineDayWidth) return 0;
+            const bounds = container.getBoundingClientRect();
+            return getTimelineAutoscrollStep({
+                clientX: drag.latestClientX,
+                containerLeft: bounds.left,
+                containerRight: bounds.right,
+                timelineLeftInset: drag.start.timelineLeftInset ?? 0,
+                scrollLeft: container.scrollLeft,
+                scrollWidth: container.scrollWidth,
+                clientWidth: container.clientWidth,
+                threshold: EDGE_AUTOSCROLL_THRESHOLD_PX,
+                maxStep: MAX_AUTOSCROLL_PX_PER_FRAME,
+            });
+        };
+        const runProjectPointerFrame = () => {
+            drag.animationFrameId = null;
+            if (!drag.active) return;
+            const container = drag.start.timelineScrollContainerRef?.current;
+            const scrollDelta = getProjectAutoscrollStep();
+            if (container && scrollDelta !== 0) {
+                const before = container.scrollLeft;
+                container.scrollLeft += scrollDelta;
+                drag.originX -= container.scrollLeft - before;
+            }
+            const candidate = calculateProjectPointerCandidate();
+            if (candidate) handleProjectMovePreview(drag.project, candidate);
+            else clearProjectPreview(drag.projectId);
+            if (getProjectAutoscrollStep() !== 0 && drag.animationFrameId == null) {
+                drag.animationFrameId = requestAnimationFrame(runProjectPointerFrame);
+            }
+        };
+        const requestProjectPointerFrame = () => {
+            if (drag.animationFrameId == null) drag.animationFrameId = requestAnimationFrame(runProjectPointerFrame);
+        };
+        const onPointerMove = (event: PointerEvent) => {
+            if (event.pointerId !== drag.pointerId) return;
+            drag.latestClientX = event.clientX;
+            drag.latestClientY = event.clientY;
+            if (!drag.active) {
+                const threshold = drag.pointerType === "touch" ? PROJECT_TOUCH_DRAG_THRESHOLD_PX : PROJECT_MOUSE_DRAG_THRESHOLD_PX;
+                if (Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY) < threshold) return;
+                drag.active = true;
+                drag.sourceElement.style.touchAction = "none";
+            }
+            event.preventDefault();
+            requestProjectPointerFrame();
+        };
+        const finish = (cancelled: boolean, releaseEvent?: PointerEvent) => {
+            if (releaseEvent) {
+                drag.latestClientX = releaseEvent.clientX;
+                drag.latestClientY = releaseEvent.clientY;
+            }
+            if (drag.animationFrameId != null) cancelAnimationFrame(drag.animationFrameId);
+            drag.animationFrameId = null;
+            const candidate = drag.active && !cancelled ? calculateProjectPointerCandidate() : null;
+            drag.cleanup();
+            if (!drag.active || cancelled || !candidate) {
+                clearProjectPreview(drag.projectId);
+                return;
+            }
+            handleProjectMoveCommit(drag.project, candidate);
+        };
+        const onPointerUp = (event: PointerEvent) => {
+            if (event.pointerId === drag.pointerId) finish(false, event);
+        };
+        const onPointerCancel = (event: PointerEvent) => {
+            if (event.pointerId === drag.pointerId) finish(true);
+        };
+        const onWindowBlur = () => finish(true);
+        drag.cleanup = () => {
+            if (activeProjectPointerRef.current === drag) activeProjectPointerRef.current = null;
+            window.removeEventListener("pointermove", onPointerMove);
+            window.removeEventListener("pointerup", onPointerUp);
+            window.removeEventListener("pointercancel", onPointerCancel);
+            window.removeEventListener("blur", onWindowBlur);
+            if (drag.animationFrameId != null) cancelAnimationFrame(drag.animationFrameId);
+            drag.animationFrameId = null;
+            drag.sourceElement.style.touchAction = drag.previousTouchAction;
+            try {
+                if (drag.sourceElement.hasPointerCapture(drag.pointerId)) drag.sourceElement.releasePointerCapture(drag.pointerId);
+            } catch {
+                // The optimistic preview may re-key the originating segment.
+            }
+        };
+        activeProjectPointerRef.current = drag;
+        try {
+            start.sourceElement.setPointerCapture(start.pointerId);
+        } catch {
+            // Window listeners keep ownership stable when capture is unavailable.
+        }
+        window.addEventListener("pointermove", onPointerMove, { passive: false });
+        window.addEventListener("pointerup", onPointerUp);
+        window.addEventListener("pointercancel", onPointerCancel);
+        window.addEventListener("blur", onWindowBlur);
+    }
+
+    function handleProjectKeyboardStart(project: DashboardProjectRow, sourceElement: HTMLElement) {
+        const canonicalProject = canonicalProjectById.get(project.id);
+        if (!data.canEdit || !canonicalProject || isProjectPending(project.id)) return;
+        const range = getEffectiveProjectRange(canonicalProject);
+        if (!range) return;
+        const intent = createProjectDropIntent(canonicalProject, formatDate(range.start));
+        if (!intent) return;
+        cancelActiveProjectEdit();
+        cancelActiveTaskEdit();
+        setProjectKeyboardState({ projectId: project.id, targetStart: intent.originalStart });
+        const onWindowKeyDown = (event: globalThis.KeyboardEvent) => {
+            const activeElement = document.activeElement;
+            if (isInteractiveTaskFallbackTarget(event.target) || isInteractiveTaskFallbackTarget(activeElement)) return;
+            const sentinelOwnsFocus = document.activeElement === projectKeyboardSentinelRef.current;
+            const disconnectedFocus = !sourceElement.isConnected && activeElement === document.body;
+            if (!sentinelOwnsFocus && !disconnectedFocus) return;
+            if (disconnectedFocus) projectKeyboardSentinelRef.current?.focus({ preventScroll: true });
+            const current = projectKeyboardEditRef.current;
+            if (!current) return;
+            if (event.key === "Escape") {
+                event.preventDefault();
+                handleProjectKeyboardCancel(canonicalProject);
+            } else if (event.key === "Enter") {
+                event.preventDefault();
+                handleProjectKeyboardCommit(canonicalProject);
+            } else {
+                const step = event.shiftKey ? 7 : 1;
+                if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+                    event.preventDefault();
+                    handleProjectKeyboardAdjust(canonicalProject, -step);
+                } else if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+                    event.preventDefault();
+                    handleProjectKeyboardAdjust(canonicalProject, step);
+                }
+            }
+        };
+        projectKeyboardCleanupRef.current = () => {
+            window.removeEventListener("keydown", onWindowKeyDown);
+            if (document.activeElement === projectKeyboardSentinelRef.current) projectKeyboardSentinelRef.current?.blur();
+            projectKeyboardCleanupRef.current = null;
+        };
+        window.addEventListener("keydown", onWindowKeyDown);
+    }
+
+    function handleProjectKeyboardAdjust(project: DashboardProjectRow, deltaDays: number) {
+        const current = projectKeyboardEditRef.current;
+        if (!current || current.projectId !== project.id || isProjectPending(project.id)) return;
+        const targetStart = formatDate(addDays(parseUTCDate(current.targetStart), deltaDays));
+        setProjectKeyboardState({ ...current, targetStart });
+        handleProjectMovePreview(project, targetStart);
+    }
+
+    function handleProjectKeyboardCommit(project: DashboardProjectRow) {
+        const current = projectKeyboardEditRef.current;
+        if (!current || current.projectId !== project.id) return;
+        if (isProjectPending(project.id)) {
+            handleProjectKeyboardCancel(project);
+            return;
+        }
+        projectKeyboardCleanupRef.current?.();
+        setProjectKeyboardState(null);
+        handleProjectMoveCommit(project, current.targetStart);
+    }
+
+    function handleProjectKeyboardCancel(project: DashboardProjectRow) {
+        if (projectKeyboardEditRef.current?.projectId !== project.id) return;
+        clearProjectPreview(project.id);
+        projectKeyboardCleanupRef.current?.();
+        setProjectKeyboardState(null);
+    }
+
+    function handleTaskPointerEditStart(task: DashboardTaskRow, mode: TaskEditMode, start: TaskPointerEditStart) {
+        const canonicalTask = canonicalTaskById.get(task.id);
+        const projectId = canonicalTaskProjectById.get(task.id);
+        if (!data.canEdit || isTaskOrProjectPending(task.id) || !canonicalTask || !projectId) return;
+        if (canonicalTask.type === "milestone" && mode !== "move") return;
+
+        cancelActiveTaskEdit();
+        cancelActiveProjectEdit();
+        const originalDates = previewTaskDates(canonicalTask, "move", 0);
+        if (!originalDates) return;
+        const drag: ActiveTaskPointerEdit = {
+            taskId: task.id,
+            projectId,
+            pointerId: start.pointerId,
+            pointerType: start.pointerType,
+            startX: start.clientX,
+            startY: start.clientY,
+            originX: start.clientX,
+            latestClientX: start.clientX,
+            latestClientY: start.clientY,
+            grabDate: hitTestScheduleDate(start.clientX, start.clientY),
+            mode,
+            active: false,
+            currentCandidate: originalDates,
+            animationFrameId: null,
+            sourceElement: start.sourceElement,
+            previousTouchAction: start.sourceElement.style.touchAction,
+            cleanup: () => undefined,
+        };
+
+        const calculatePointerCandidate = (): TaskDateOverride | null => {
+            let deltaDays: number | null = null;
+            if (start.timelineDayWidth) {
+                if (hitTestTimelineScheduleGrid(drag.latestClientX, drag.latestClientY)) {
+                    deltaDays = getTimelinePointerDelta(drag.latestClientX, drag.originX, start.timelineDayWidth);
+                }
+            } else {
+                const hitDate = hitTestScheduleDate(drag.latestClientX, drag.latestClientY);
+                if (drag.grabDate && hitDate) {
+                    deltaDays = getDaysBetween(parseUTCDate(drag.grabDate), parseUTCDate(hitDate));
+                }
+            }
+            return previewTaskPointerCandidate(canonicalTask, mode, deltaDays);
+        };
+        const applyPointerCandidate = (): TaskDateOverride | null => {
+            const candidate = calculatePointerCandidate();
+            const previousCandidate = drag.currentCandidate;
+            drag.currentCandidate = candidate;
+            if (!candidate) {
+                drag.currentCandidate = null;
+                clearTaskPreview(task.id);
+                return null;
+            }
+            if (previousCandidate?.startDate === candidate.startDate && previousCandidate.endDate === candidate.endDate) return candidate;
+            if (candidate.startDate === originalDates.startDate && candidate.endDate === originalDates.endDate) clearTaskPreview(task.id);
+            else setTaskPreview(task.id, candidate);
+            return candidate;
+        };
+        const getTaskAutoscrollStep = () => {
+            const container = start.timelineScrollContainerRef?.current;
+            if (!container || !start.timelineDayWidth) return 0;
+            const bounds = container.getBoundingClientRect();
+            return getTimelineAutoscrollStep({
+                clientX: drag.latestClientX,
+                containerLeft: bounds.left,
+                containerRight: bounds.right,
+                timelineLeftInset: start.timelineLeftInset ?? 0,
+                scrollLeft: container.scrollLeft,
+                scrollWidth: container.scrollWidth,
+                clientWidth: container.clientWidth,
+                threshold: EDGE_AUTOSCROLL_THRESHOLD_PX,
+                maxStep: MAX_AUTOSCROLL_PX_PER_FRAME,
+            });
+        };
+        const runTaskPointerFrame = () => {
+            drag.animationFrameId = null;
+            if (!drag.active) return;
+            const container = start.timelineScrollContainerRef?.current;
+            const scrollDelta = getTaskAutoscrollStep();
+            if (container && scrollDelta !== 0) {
+                const before = container.scrollLeft;
+                container.scrollLeft += scrollDelta;
+                drag.originX -= container.scrollLeft - before;
+            }
+            applyPointerCandidate();
+            if (getTaskAutoscrollStep() !== 0 && drag.animationFrameId == null) {
+                drag.animationFrameId = requestAnimationFrame(runTaskPointerFrame);
+            }
+        };
+        const onPointerMove = (event: PointerEvent) => {
+            if (event.pointerId !== drag.pointerId) return;
+            drag.latestClientX = event.clientX;
+            drag.latestClientY = event.clientY;
+            if (!drag.active) {
+                const threshold = drag.pointerType === "touch" ? TASK_TOUCH_DRAG_THRESHOLD_PX : TASK_MOUSE_DRAG_THRESHOLD_PX;
+                if (Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY) < threshold) return;
+                drag.active = true;
+                drag.sourceElement.style.touchAction = "none";
+            }
+            event.preventDefault();
+            if (drag.animationFrameId == null) drag.animationFrameId = requestAnimationFrame(runTaskPointerFrame);
+        };
+        const finish = (cancelled: boolean, releaseEvent?: PointerEvent) => {
+            if (releaseEvent) {
+                drag.latestClientX = releaseEvent.clientX;
+                drag.latestClientY = releaseEvent.clientY;
+            }
+            if (drag.animationFrameId != null) {
+                cancelAnimationFrame(drag.animationFrameId);
+                drag.animationFrameId = null;
+            }
+            const candidate = drag.active && !cancelled ? calculatePointerCandidate() : null;
+            drag.currentCandidate = candidate;
+            drag.cleanup();
+            if (!drag.active || cancelled || !candidate) {
+                clearTaskPreview(task.id);
+                return;
+            }
+            setTaskPreview(task.id, candidate);
+            void commitTaskDates(task.id, candidate);
+        };
+        const onPointerUp = (event: PointerEvent) => {
+            if (event.pointerId === drag.pointerId) finish(false, event);
+        };
+        const onPointerCancel = (event: PointerEvent) => {
+            if (event.pointerId === drag.pointerId) finish(true);
+        };
+        const onWindowBlur = () => finish(true);
+
+        drag.cleanup = () => {
+            if (activeTaskPointerRef.current === drag) activeTaskPointerRef.current = null;
+            window.removeEventListener("pointermove", onPointerMove);
+            window.removeEventListener("pointerup", onPointerUp);
+            window.removeEventListener("pointercancel", onPointerCancel);
+            window.removeEventListener("blur", onWindowBlur);
+            if (drag.animationFrameId != null) cancelAnimationFrame(drag.animationFrameId);
+            drag.animationFrameId = null;
+            drag.sourceElement.style.touchAction = drag.previousTouchAction;
+            try {
+                if (drag.sourceElement.hasPointerCapture(drag.pointerId)) drag.sourceElement.releasePointerCapture(drag.pointerId);
+            } catch {
+                // A task preview can unmount its original weekly segment.
+            }
+        };
+        activeTaskPointerRef.current = drag;
+        try {
+            start.sourceElement.setPointerCapture(start.pointerId);
+        } catch {
+            // Window listeners still provide a stable controller when capture is unavailable.
+        }
+        window.addEventListener("pointermove", onPointerMove, { passive: false });
+        window.addEventListener("pointerup", onPointerUp);
+        window.addEventListener("pointercancel", onPointerCancel);
+        window.addEventListener("blur", onWindowBlur);
+    }
+
+    function handleTaskKeyboardStart(task: DashboardTaskRow, mode: TaskEditMode, sourceElement: HTMLElement) {
+        const canonicalTask = canonicalTaskById.get(task.id);
+        const projectId = canonicalTaskProjectById.get(task.id);
+        if (!data.canEdit || isTaskOrProjectPending(task.id) || !canonicalTask || !projectId) return;
+        if (canonicalTask.type === "milestone" && mode !== "move") return;
+        cancelActiveTaskEdit();
+        cancelActiveProjectEdit();
+        taskKeyboardSourceRef.current = sourceElement;
+        setTaskKeyboardState({ taskId: task.id, projectId, mode, deltaDays: 0 });
+        const onWindowKeyDown = (event: globalThis.KeyboardEvent) => {
+            const activeElement = document.activeElement;
+            if (isInteractiveTaskFallbackTarget(event.target) || isInteractiveTaskFallbackTarget(activeElement)) return;
+            const sentinelOwnsFocus = document.activeElement === taskKeyboardSentinelRef.current;
+            const disconnectedFocus = !sourceElement.isConnected && activeElement === document.body;
+            if (!sentinelOwnsFocus && !disconnectedFocus) return;
+            if (disconnectedFocus) taskKeyboardSentinelRef.current?.focus({ preventScroll: true });
+            if (event.key === "Escape") {
+                event.preventDefault();
+                handleTaskKeyboardCancel(canonicalTask);
+                return;
+            }
+            if (event.key === "Enter") {
+                event.preventDefault();
+                handleTaskKeyboardCommit(canonicalTask, mode);
+                return;
+            }
+            const step = event.shiftKey ? 7 : 1;
+            if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+                event.preventDefault();
+                handleTaskKeyboardAdjust(canonicalTask, mode, -step);
+            } else if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+                event.preventDefault();
+                handleTaskKeyboardAdjust(canonicalTask, mode, step);
+            }
+        };
+        taskKeyboardCleanupRef.current = () => {
+            window.removeEventListener("keydown", onWindowKeyDown);
+            if (document.activeElement === taskKeyboardSentinelRef.current) taskKeyboardSentinelRef.current?.blur();
+            taskKeyboardSourceRef.current = null;
+            taskKeyboardCleanupRef.current = null;
+        };
+        window.addEventListener("keydown", onWindowKeyDown);
+    }
+
+    function handleTaskKeyboardAdjust(task: DashboardTaskRow, mode: TaskEditMode, deltaDays: number) {
+        const canonicalTask = canonicalTaskById.get(task.id);
+        const current = taskKeyboardEditRef.current;
+        if (!data.canEdit || isTaskOrProjectPending(task.id) || !canonicalTask || current?.taskId !== task.id || current.mode !== mode) return;
+        const nextDeltaDays = current.deltaDays + deltaDays;
+        const dates = previewTaskDates(canonicalTask, mode, nextDeltaDays);
+        if (!dates) return;
+        const originalDates = previewTaskDates(canonicalTask, "move", 0);
+        if (originalDates && dates.startDate === originalDates.startDate && dates.endDate === originalDates.endDate) clearTaskPreview(task.id);
+        else setTaskPreview(task.id, dates);
+        setTaskKeyboardState({ ...current, deltaDays: nextDeltaDays });
+    }
+
+    function handleTaskKeyboardCommit(task: DashboardTaskRow, mode: TaskEditMode) {
+        const canonicalTask = canonicalTaskById.get(task.id);
+        const current = taskKeyboardEditRef.current;
+        if (!data.canEdit || isTaskOrProjectPending(task.id) || !canonicalTask || current?.taskId !== task.id || current.mode !== mode) return;
+        const dates = previewTaskDates(canonicalTask, mode, current.deltaDays);
+        taskKeyboardCleanupRef.current?.();
+        setTaskKeyboardState(null);
+        if (dates) void commitTaskDates(task.id, dates);
+    }
+
+    function handleTaskKeyboardCancel(task: DashboardTaskRow) {
+        if (!data.canEdit || taskKeyboardEditRef.current?.taskId !== task.id) return;
+        clearTaskPreview(task.id);
+        taskKeyboardCleanupRef.current?.();
+        setTaskKeyboardState(null);
+    }
+
+    function handleTaskDatesCommit(task: DashboardTaskRow, dates: TaskDateOverride) {
+        if (!data.canEdit || isTaskOrProjectPending(task.id) || !canonicalTaskById.has(task.id)) return;
+        cancelActiveTaskEdit();
+        cancelActiveProjectEdit();
+        void commitTaskDates(task.id, dates);
+    }
+
+    function handleTaskMoveBy(task: DashboardTaskRow, deltaDays: number) {
+        const canonicalTask = canonicalTaskById.get(task.id);
+        if (!data.canEdit || isTaskOrProjectPending(task.id) || !canonicalTask) return;
+        cancelActiveTaskEdit();
+        cancelActiveProjectEdit();
+        const dates = previewTaskDates(canonicalTask, "move", deltaDays);
+        if (dates) void commitTaskDates(task.id, dates);
+    }
+
+    return (
+        <div className="hui-card mb-6 overflow-hidden">
+            <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3 border-b border-hui-border">
+                <h2 className="text-base font-semibold text-hui-textMain">Project Schedule — {monthLabel}</h2>
+                <div className="flex flex-wrap items-center justify-end gap-2">
+                    <div className="inline-flex rounded-md border border-hui-border bg-white p-0.5" role="group" aria-label="Schedule view">
+                        <button
+                            type="button"
+                            onClick={() => selectBoardView("month")}
+                            aria-pressed={boardView === "month"}
+                            className={`rounded px-2 py-1 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary ${boardView === "month" ? "bg-hui-primary text-white" : "text-hui-textMuted hover:bg-slate-50"}`}
+                        >
+                            Month
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => selectBoardView("timeline")}
+                            aria-pressed={boardView === "timeline"}
+                            className={`rounded px-2 py-1 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary ${boardView === "timeline" ? "bg-hui-primary text-white" : "text-hui-textMuted hover:bg-slate-50"}`}
+                        >
+                            Timeline
+                        </button>
+                    </div>
+                    {isAdmin && overlays && (
+                        <div className="flex flex-wrap items-center gap-1 mr-1">
+                            <button type="button" onClick={() => setShowIncome(value => !value)} className={`text-xs font-semibold px-2 py-1 rounded-full border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary ${showIncome ? "bg-green-100 text-green-700 border-green-300" : "bg-white text-hui-textMuted border-hui-border"}`}>Income</button>
+                            <button type="button" onClick={() => setShowExpenses(value => !value)} className={`text-xs font-semibold px-2 py-1 rounded-full border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary ${showExpenses ? "bg-red-100 text-red-700 border-red-300" : "bg-white text-hui-textMuted border-hui-border"}`}>Expenses</button>
+                            <button type="button" onClick={() => setShowProjectedCo(value => !value)} className={`text-xs font-semibold px-2 py-1 rounded-full border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary ${showProjectedCo ? "bg-amber-100 text-amber-800 border-amber-300" : "bg-white text-hui-textMuted border-hui-border"}`}>Projected CO</button>
+                            <button type="button" onClick={() => setShowHours(value => !value)} className={`text-xs font-semibold px-2 py-1 rounded-full border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary ${showHours ? "bg-blue-100 text-blue-700 border-blue-300" : "bg-white text-hui-textMuted border-hui-border"}`}>Hours</button>
+                        </div>
+                    )}
+                    <button type="button" onClick={() => router.push('/company-dashboard?month=' + shiftMonth(month, -1))} className="hui-btn hui-btn-secondary text-sm">← Prev</button>
+                    <button type="button" onClick={() => router.push("/company-dashboard")} className="hui-btn hui-btn-secondary text-sm">Today</button>
+                    <button type="button" onClick={() => router.push('/company-dashboard?month=' + shiftMonth(month, 1))} className="hui-btn hui-btn-secondary text-sm">Next →</button>
+                </div>
+            </div>
+            <UnscheduledTray
+                estimating={data.pipeline.estimating}
+                projects={data.pipeline.waitingToStart}
+                canEdit={data.canEdit}
+                pendingProjectIds={effectivePendingProjectIds}
+                onMoveProject={scheduleUnscheduledProject}
+            />
+            {(projectRefreshCount > 0 || awaitingTaskRefreshIds.size > 0) && (
+                <div className="flex items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-900" role="status">
+                    <span>Refreshing saved {pendingRefreshKinds.join(" and ")} schedule changes...</span>
+                    <button type="button" className="font-semibold underline" onClick={() => router.refresh()}>Retry now</button>
+                </div>
+            )}
+            <span ref={projectKeyboardSentinelRef} tabIndex={-1} className="sr-only" aria-live="polite" data-project-keyboard-sentinel="true">
+                {projectKeyboardEdit ? `Moving project to ${projectKeyboardEdit.targetStart}. Use arrow keys, Enter to save, or Escape to cancel.` : ""}
+            </span>
+            <span ref={taskKeyboardSentinelRef} tabIndex={-1} className="sr-only" aria-live="polite" data-task-keyboard-sentinel="true">
+                {taskKeyboardEdit ? `Keyboard editing ${taskKeyboardEdit.mode}` : ""}
+            </span>
+            {boardView === "month" ? (
+                <MonthBarsView
+                    data={boardData}
+                    showIncome={showIncome}
+                    showProjectedCo={showProjectedCo}
+                    showExpenses={showExpenses}
+                    showHours={showHours}
+                    pendingProjectIds={effectivePendingProjectIds}
+                    pendingTaskIds={effectivePendingTaskIds}
+                    activeTaskKeyboardEdit={taskKeyboardEdit}
+                    onTrayProjectDrop={scheduleUnscheduledProject}
+                    activeProjectKeyboardId={projectKeyboardEdit?.projectId ?? null}
+                    onProjectPointerEditStart={handleProjectPointerEditStart}
+                    onProjectKeyboardStart={handleProjectKeyboardStart}
+                    onProjectKeyboardAdjust={handleProjectKeyboardAdjust}
+                    onProjectKeyboardCommit={handleProjectKeyboardCommit}
+                    onProjectKeyboardCancel={handleProjectKeyboardCancel}
+                    onProjectMoveCommit={handleProjectMoveCommit}
+                    onTaskPointerEditStart={handleTaskPointerEditStart}
+                    onTaskKeyboardStart={handleTaskKeyboardStart}
+                    onTaskKeyboardAdjust={handleTaskKeyboardAdjust}
+                    onTaskKeyboardCommit={handleTaskKeyboardCommit}
+                    onTaskKeyboardCancel={handleTaskKeyboardCancel}
+                    onTaskDatesCommit={handleTaskDatesCommit}
+                    onTaskMoveBy={handleTaskMoveBy}
+                />
+            ) : (
+                <TimelineView
+                    data={boardData}
+                    showIncome={showIncome}
+                    showProjectedCo={showProjectedCo}
+                    showExpenses={showExpenses}
+                    showHours={showHours}
+                    pendingProjectIds={effectivePendingProjectIds}
+                    pendingTaskIds={effectivePendingTaskIds}
+                    activeTaskKeyboardEdit={taskKeyboardEdit}
+                    onTrayProjectDrop={scheduleUnscheduledProject}
+                    activeProjectKeyboardId={projectKeyboardEdit?.projectId ?? null}
+                    onProjectPointerEditStart={handleProjectPointerEditStart}
+                    onProjectKeyboardStart={handleProjectKeyboardStart}
+                    onProjectKeyboardAdjust={handleProjectKeyboardAdjust}
+                    onProjectKeyboardCommit={handleProjectKeyboardCommit}
+                    onProjectKeyboardCancel={handleProjectKeyboardCancel}
+                    onProjectMoveCommit={handleProjectMoveCommit}
+                    onTaskPointerEditStart={handleTaskPointerEditStart}
+                    onTaskKeyboardStart={handleTaskKeyboardStart}
+                    onTaskKeyboardAdjust={handleTaskKeyboardAdjust}
+                    onTaskKeyboardCommit={handleTaskKeyboardCommit}
+                    onTaskKeyboardCancel={handleTaskKeyboardCancel}
+                    onTaskDatesCommit={handleTaskDatesCommit}
+                    onTaskMoveBy={handleTaskMoveBy}
+                />
+            )}
+            <ShiftConfirmDialog
+                intent={confirmIntent}
+                isPending={Boolean(confirmIntent && isProjectPending(confirmIntent.project.id))}
+                onChoice={handleMoveChoice}
+                onCancel={cancelConfirmedMove}
+            />
+        </div>
+    );
+}

--- a/src/app/company-dashboard/schedule-board/ShiftConfirmDialog.tsx
+++ b/src/app/company-dashboard/schedule-board/ShiftConfirmDialog.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import type { ProjectDropIntent } from "./useBarLayout";
+
+export type ProjectMoveChoice = "marker-only" | "not-started-tasks";
+
+interface ShiftConfirmDialogProps {
+    intent: ProjectDropIntent | null;
+    isPending: boolean;
+    onChoice: (_choice: ProjectMoveChoice) => void;
+    onCancel: () => void;
+}
+
+export function ShiftConfirmDialog({ intent, isPending, onChoice, onCancel }: ShiftConfirmDialogProps) {
+    const magnitude = Math.abs(intent?.deltaDays ?? 0);
+    const direction = (intent?.deltaDays ?? 0) < 0 ? "earlier" : "later";
+
+    return (
+        <Dialog.Root open={Boolean(intent)} onOpenChange={open => { if (!open && !isPending) onCancel(); }}>
+            <Dialog.Portal>
+                <Dialog.Overlay className="fixed inset-0 z-[70] bg-black/45" />
+                <Dialog.Content className="fixed left-1/2 top-1/2 z-[71] w-[min(92vw,32rem)] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-hui-border bg-white p-5 shadow-2xl focus:outline-none">
+                    <Dialog.Title className="text-base font-semibold text-hui-textMain">Move In Progress project</Dialog.Title>
+                    <Dialog.Description className="mt-2 text-sm text-hui-textMuted">
+                        {intent ? `${intent.project.name} is previewed ${magnitude} day${magnitude === 1 ? "" : "s"} ${direction}. Choose one edit; these actions are intentionally not combined.` : "Choose how to move this project."}
+                    </Dialog.Description>
+                    <div className="mt-5 space-y-2">
+                        <button
+                            type="button"
+                            disabled={isPending}
+                            onClick={() => onChoice("marker-only")}
+                            className="hui-btn hui-btn-primary w-full justify-center text-sm disabled:cursor-wait disabled:opacity-60"
+                        >
+                            Move start marker only
+                        </button>
+                        <button
+                            type="button"
+                            disabled={isPending}
+                            onClick={() => onChoice("not-started-tasks")}
+                            className="hui-btn hui-btn-secondary w-full justify-center text-sm disabled:cursor-wait disabled:opacity-60"
+                        >
+                            Also shift all Not Started tasks by {magnitude} day{magnitude === 1 ? "" : "s"} {direction}
+                        </button>
+                    </div>
+                    <div className="mt-4 flex justify-end">
+                        <Dialog.Close asChild>
+                            <button type="button" disabled={isPending} className="rounded-md px-3 py-2 text-sm font-semibold text-hui-textMuted hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 disabled:cursor-wait disabled:opacity-60">
+                                Cancel
+                            </button>
+                        </Dialog.Close>
+                    </div>
+                </Dialog.Content>
+            </Dialog.Portal>
+        </Dialog.Root>
+    );
+}

--- a/src/app/company-dashboard/schedule-board/TaskBlockSegment.tsx
+++ b/src/app/company-dashboard/schedule-board/TaskBlockSegment.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { useCallback, useEffect, useId, useRef, useState, type FormEvent, type KeyboardEvent, type PointerEvent as ReactPointerEvent, type RefObject } from "react";
+import type { DashboardTaskRow } from "@/lib/schedule-core";
+import { addDays, formatDate, getDaysBetween, getDefaultColorForTaskName, parseUTCDate } from "@/app/projects/[id]/schedule/schedule-utils";
+import { clipRange, type DateRange, type TaskDateOverride, type TaskEditMode } from "./useBarLayout";
+
+export interface TaskPointerEditStart {
+    pointerId: number;
+    pointerType: string;
+    clientX: number;
+    clientY: number;
+    sourceElement: HTMLElement;
+    timelineDayWidth?: number;
+    timelineLeftInset?: number;
+    timelineScrollContainerRef?: RefObject<HTMLDivElement | null>;
+}
+
+export interface ActiveTaskKeyboardEdit {
+    taskId: string;
+    mode: TaskEditMode;
+}
+
+export interface TaskEditCallbacks {
+    onTaskPointerEditStart: (_task: DashboardTaskRow, _mode: TaskEditMode, _start: TaskPointerEditStart) => void;
+    onTaskKeyboardStart: (_task: DashboardTaskRow, _mode: TaskEditMode, _sourceElement: HTMLElement) => void;
+    onTaskKeyboardAdjust: (_task: DashboardTaskRow, _mode: TaskEditMode, _deltaDays: number) => void;
+    onTaskKeyboardCommit: (_task: DashboardTaskRow, _mode: TaskEditMode) => void;
+    onTaskKeyboardCancel: (_task: DashboardTaskRow) => void;
+    onTaskDatesCommit: (_task: DashboardTaskRow, _dates: TaskDateOverride) => void;
+    onTaskMoveBy: (_task: DashboardTaskRow, _deltaDays: number) => void;
+}
+
+export interface TaskBlockSegmentProps extends TaskEditCallbacks {
+    task: DashboardTaskRow;
+    projectRange: DateRange;
+    visibleRange: DateRange;
+    projectColor: string;
+    canEdit: boolean;
+    isPending: boolean;
+    activeTaskKeyboardEdit: ActiveTaskKeyboardEdit | null;
+    timelineDayWidth?: number;
+    timelineLeftInset?: number;
+    timelineScrollContainerRef?: RefObject<HTMLDivElement | null>;
+}
+
+function readableText(color: string): string {
+    const normalized = color.replace("#", "");
+    if (normalized.length !== 6) return "#ffffff";
+    const red = Number.parseInt(normalized.slice(0, 2), 16);
+    const green = Number.parseInt(normalized.slice(2, 4), 16);
+    const blue = Number.parseInt(normalized.slice(4, 6), 16);
+    return red * 299 + green * 587 + blue * 114 > 155_000 ? "#0f172a" : "#ffffff";
+}
+
+function initials(name: string): string {
+    return name.trim().split(/\s+/).map(part => part[0]).join("").toUpperCase().slice(0, 2) || "?";
+}
+
+export function TaskBlockSegment({
+    task,
+    projectRange,
+    visibleRange,
+    projectColor,
+    canEdit,
+    isPending,
+    activeTaskKeyboardEdit,
+    timelineDayWidth,
+    timelineLeftInset,
+    timelineScrollContainerRef,
+    onTaskPointerEditStart,
+    onTaskKeyboardStart,
+    onTaskKeyboardAdjust,
+    onTaskKeyboardCommit,
+    onTaskKeyboardCancel,
+    onTaskDatesCommit,
+    onTaskMoveBy,
+}: TaskBlockSegmentProps) {
+    const observerRef = useRef<ResizeObserver | null>(null);
+    const fragmentId = useId().replace(/:/g, "");
+    const [allocatedWidth, setAllocatedWidth] = useState(0);
+    const actionDetailsRef = useRef<HTMLDetailsElement>(null);
+    const actionResetKey = `${isPending ? "pending" : "ready"}:${task.startDate}:${task.endDate}`;
+    const [menuDraft, setMenuDraft] = useState<{ resetKey: string; dates: TaskDateOverride | null }>(() => ({
+        resetKey: actionResetKey,
+        dates: null,
+    }));
+    const menuDates = menuDraft.resetKey === actionResetKey ? menuDraft.dates : null;
+    if (menuDraft.resetKey !== actionResetKey) {
+        setMenuDraft({ resetKey: actionResetKey, dates: null });
+    }
+    const isMilestone = task.type === "milestone";
+    const menuStartDate = menuDates?.startDate ?? task.startDate.slice(0, 10);
+    const menuEndDate = menuDates?.endDate ?? (isMilestone ? task.startDate.slice(0, 10) : task.endDate.slice(0, 10));
+    const taskStart = parseUTCDate(task.startDate.slice(0, 10));
+    const taskEnd = parseUTCDate(task.endDate.slice(0, 10));
+    const visualEnd = isMilestone ? addDays(taskStart, 1) : taskEnd;
+    const taskRange = { start: taskStart, end: visualEnd };
+    const clipped = clipRange(taskRange, visibleRange);
+    const activeMode = activeTaskKeyboardEdit?.taskId === task.id ? activeTaskKeyboardEdit.mode : null;
+
+    const setMeasuredElement = useCallback((element: HTMLDivElement | null) => {
+        observerRef.current?.disconnect();
+        observerRef.current = null;
+        if (!element) return;
+
+        setAllocatedWidth(element.getBoundingClientRect().width);
+        if (typeof ResizeObserver === "undefined") return;
+        observerRef.current = new ResizeObserver(entries => setAllocatedWidth(entries[0]?.contentRect.width ?? 0));
+        observerRef.current.observe(element);
+    }, []);
+
+    useEffect(() => () => observerRef.current?.disconnect(), []);
+    useEffect(() => {
+        if (actionDetailsRef.current) actionDetailsRef.current.open = false;
+    }, [actionResetKey]);
+
+    if (!clipped || (!isMilestone && taskEnd <= taskStart)) return null;
+
+    const visibleDays = getDaysBetween(visibleRange.start, visibleRange.end);
+    const left = getDaysBetween(visibleRange.start, clipped.start) / visibleDays * 100;
+    const width = getDaysBetween(clipped.start, clipped.end) / visibleDays * 100;
+    const color = task.color || getDefaultColorForTaskName(task.name) || projectColor;
+    const progress = Math.max(0, Math.min(100, task.progress));
+    const crew = task.assignments.length > 0 ? task.assignments.map(assignment => assignment.name).join(", ") : "Unassigned";
+    const assignmentInitials = task.assignments.slice(0, 2).map(assignment => initials(assignment.name)).join(" ");
+    const title = `${task.name} — ${task.status} — UTC ${formatDate(taskStart)} → ${formatDate(isMilestone ? taskStart : taskEnd)} — ${progress}% — Crew: ${crew}`;
+    const mutationDisabled = !canEdit || isPending;
+
+    function beginPointerEdit(event: ReactPointerEvent<HTMLElement>, mode: TaskEditMode) {
+        event.stopPropagation();
+        if (!canEdit || isPending || !event.isPrimary || (event.pointerType === "mouse" && event.button !== 0)) return;
+        if (mode === "move" && (event.target as HTMLElement).closest("button,input,summary,form,details")) return;
+        onTaskPointerEditStart(task, mode, {
+            pointerId: event.pointerId,
+            pointerType: event.pointerType,
+            clientX: event.clientX,
+            clientY: event.clientY,
+            sourceElement: event.currentTarget,
+            timelineDayWidth,
+            timelineLeftInset,
+            timelineScrollContainerRef,
+        });
+    }
+
+    function handleKeyboard(event: KeyboardEvent<HTMLElement>, mode: TaskEditMode) {
+        if (event.target !== event.currentTarget) return;
+        if (!canEdit || isPending) return;
+        const editing = activeMode === mode;
+        if (!editing && (event.key === " " || event.key === "Enter")) {
+            event.preventDefault();
+            event.stopPropagation();
+            onTaskKeyboardStart(task, mode, event.currentTarget);
+            return;
+        }
+        if (!editing) return;
+        if (event.key === "Escape") {
+            event.preventDefault();
+            event.stopPropagation();
+            onTaskKeyboardCancel(task);
+            return;
+        }
+        if (event.key === "Enter") {
+            event.preventDefault();
+            event.stopPropagation();
+            onTaskKeyboardCommit(task, mode);
+            return;
+        }
+        const step = event.shiftKey ? 7 : 1;
+        if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+            event.preventDefault();
+            event.stopPropagation();
+            onTaskKeyboardAdjust(task, mode, -step);
+        } else if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+            event.preventDefault();
+            event.stopPropagation();
+            onTaskKeyboardAdjust(task, mode, step);
+        }
+    }
+
+    function handleDateSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (mutationDisabled || !menuStartDate || (!isMilestone && !menuEndDate)) return;
+        onTaskDatesCommit(task, {
+            startDate: menuStartDate,
+            endDate: isMilestone ? menuStartDate : menuEndDate,
+        });
+        setMenuDraft({ resetKey: actionResetKey, dates: null });
+    }
+
+    return (
+        <div
+            ref={setMeasuredElement}
+            className={`group/task absolute inset-y-0 touch-pan-y select-none overflow-visible rounded-sm border border-black/10 text-[9px] font-semibold leading-[16px] shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white ${canEdit && !isPending ? "cursor-move" : ""}`}
+            style={{ left: `${left}%`, width: `${width}%`, backgroundColor: color, color: readableText(color) }}
+            title={title}
+            role="group"
+            tabIndex={0}
+            aria-label={`${title}. ${canEdit ? "Press Space or Enter to move with the keyboard." : "Read only."}`}
+            aria-disabled={!canEdit || isPending}
+            aria-busy={isPending}
+            data-task-edit-block="true"
+            data-project-start={formatDate(projectRange.start)}
+            data-can-edit={canEdit ? "true" : "false"}
+            onPointerDown={event => beginPointerEdit(event, "move")}
+            onKeyDown={event => handleKeyboard(event, "move")}
+        >
+            <div className="absolute inset-0 overflow-hidden rounded-sm">
+                <span className="absolute inset-y-0 left-0 bg-white/25" style={{ width: `${progress}%` }} aria-hidden="true" />
+                <span className="relative z-10 flex min-w-0 items-center justify-between gap-0.5 px-1">
+                    {allocatedWidth >= 48 && <span className="min-w-0 truncate">{isMilestone ? `◆ ${task.name}` : task.name}</span>}
+                    {assignmentInitials && <span className="ml-auto shrink-0 text-[8px] opacity-90" title={`Task crew: ${crew}`}>{assignmentInitials}</span>}
+                </span>
+            </div>
+
+            {task.type !== "milestone" && (
+                <button
+                    type="button"
+                    className="absolute inset-y-0 left-0 z-20 w-2 touch-pan-y cursor-ew-resize rounded-l-sm bg-black/10 opacity-0 transition group-hover/task:opacity-100 group-focus-within/task:opacity-100 [@media(hover:none)]:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                    aria-label={`Resize start of ${task.name}`}
+                    aria-disabled={!canEdit || isPending}
+                    aria-pressed={activeMode === "resize-left"}
+                    disabled={mutationDisabled}
+                    onPointerDown={event => beginPointerEdit(event, "resize-left")}
+                    onKeyDown={event => handleKeyboard(event, "resize-left")}
+                />
+            )}
+            {task.type !== "milestone" && (
+                <button
+                    type="button"
+                    className="absolute inset-y-0 right-0 z-20 w-2 touch-pan-y cursor-ew-resize rounded-r-sm bg-black/10 opacity-0 transition group-hover/task:opacity-100 group-focus-within/task:opacity-100 [@media(hover:none)]:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                    aria-label={`Resize end of ${task.name}`}
+                    aria-disabled={!canEdit || isPending}
+                    aria-pressed={activeMode === "resize-right"}
+                    disabled={mutationDisabled}
+                    onPointerDown={event => beginPointerEdit(event, "resize-right")}
+                    onKeyDown={event => handleKeyboard(event, "resize-right")}
+                />
+            )}
+
+            {!mutationDisabled && (
+            <details ref={actionDetailsRef} className="absolute right-0 top-0 z-30 opacity-0 pointer-events-none transition group-hover/task:opacity-100 group-hover/task:pointer-events-auto group-focus-within/task:opacity-100 group-focus-within/task:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto">
+                <summary className="cursor-pointer list-none rounded bg-white/85 px-1 text-[8px] font-bold text-slate-800 shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" aria-label={`Task actions for ${task.name}`}>
+                    ⋯
+                </summary>
+                <form onSubmit={handleDateSubmit} onPointerDown={event => event.stopPropagation()} className="absolute right-0 top-full z-[90] mt-1 w-60 space-y-2 rounded-md border border-hui-border bg-white p-3 text-left text-hui-textMain shadow-xl">
+                    <label className="block text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted" htmlFor={`task-start-${task.id}-${fragmentId}`}>Start date</label>
+                    <input
+                        id={`task-start-${task.id}-${fragmentId}`}
+                        type="date"
+                        value={menuStartDate}
+                        max={!isMilestone && menuEndDate ? formatDate(addDays(parseUTCDate(menuEndDate), -1)) : undefined}
+                        onChange={event => {
+                            const nextStartDate = event.target.value;
+                            setMenuDraft({
+                                resetKey: actionResetKey,
+                                dates: { startDate: nextStartDate, endDate: isMilestone ? nextStartDate : menuEndDate },
+                            });
+                        }}
+                        disabled={mutationDisabled}
+                        className="hui-input w-full px-2 py-1 text-xs"
+                    />
+                    <label className="block text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted" htmlFor={`task-end-${task.id}-${fragmentId}`}>End date</label>
+                    <input
+                        id={`task-end-${task.id}-${fragmentId}`}
+                        type="date"
+                        value={isMilestone ? menuStartDate : menuEndDate}
+                        min={!isMilestone && menuStartDate ? formatDate(addDays(parseUTCDate(menuStartDate), 1)) : undefined}
+                        onChange={event => setMenuDraft({
+                            resetKey: actionResetKey,
+                            dates: { startDate: menuStartDate, endDate: event.target.value },
+                        })}
+                        disabled={mutationDisabled || isMilestone}
+                        className="hui-input w-full px-2 py-1 text-xs"
+                    />
+                    <div className="grid grid-cols-2 gap-2">
+                        <button type="button" disabled={mutationDisabled} onClick={() => onTaskMoveBy(task, -1)} className="hui-btn hui-btn-secondary text-[10px] disabled:opacity-60">Move Earlier</button>
+                        <button type="button" disabled={mutationDisabled} onClick={() => onTaskMoveBy(task, 1)} className="hui-btn hui-btn-secondary text-[10px] disabled:opacity-60">Move Later</button>
+                    </div>
+                    <button type="submit" disabled={mutationDisabled || !menuStartDate || (!isMilestone && !menuEndDate)} className="hui-btn hui-btn-primary w-full text-xs disabled:opacity-60">
+                        Save task dates
+                    </button>
+                </form>
+            </details>
+            )}
+        </div>
+    );
+}

--- a/src/app/company-dashboard/schedule-board/TimelineView.tsx
+++ b/src/app/company-dashboard/schedule-board/TimelineView.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import { useRef, useState, type DragEvent } from "react";
+import Link from "next/link";
+import type { CompanyDashboardData, DashboardProjectRow } from "@/lib/schedule-core";
+import {
+    addDays,
+    formatCurrency,
+    formatDate,
+    getDaysBetween,
+    getMonthGrid,
+    isSameUTCDay,
+    isWeekend,
+    parseUTCDate,
+    todayUTC,
+} from "@/app/projects/[id]/schedule/schedule-utils";
+import { MilestoneMarker } from "./MilestoneMarker";
+import { ProjectBar, ProjectBarGridStartContext, type ProjectEditCallbacks } from "./ProjectBar";
+import { TaskBlockSegment, type ActiveTaskKeyboardEdit, type TaskEditCallbacks } from "./TaskBlockSegment";
+import { PROJECT_DRAG_MIME } from "./UnscheduledTray";
+import { clipRange, getEffectiveProjectRange, toTimelineRect, type WeekSegment } from "./useBarLayout";
+
+const DAY_WIDTH = 20;
+const TIMELINE_DAYS = 42;
+const LABEL_WIDTH = 240;
+const CANVAS_WIDTH = DAY_WIDTH * TIMELINE_DAYS;
+const FALLBACK_COLORS = ["#2563eb", "#7c3aed", "#0f766e", "#c2410c", "#be123c", "#4338ca", "#047857", "#a21caf"];
+
+interface TimelineViewProps extends TaskEditCallbacks, ProjectEditCallbacks {
+    data: CompanyDashboardData;
+    showIncome: boolean;
+    showProjectedCo: boolean;
+    showExpenses: boolean;
+    showHours: boolean;
+    pendingProjectIds: ReadonlySet<string>;
+    pendingTaskIds: ReadonlySet<string>;
+    activeTaskKeyboardEdit: ActiveTaskKeyboardEdit | null;
+    onTrayProjectDrop: (_project: DashboardProjectRow, _targetStart: string) => void;
+}
+
+export function TimelineView({
+    data,
+    showIncome,
+    showProjectedCo,
+    showExpenses,
+    showHours,
+    pendingProjectIds,
+    pendingTaskIds,
+    activeTaskKeyboardEdit,
+    onTrayProjectDrop,
+    onProjectMoveCommit,
+    activeProjectKeyboardId,
+    onProjectPointerEditStart,
+    onProjectKeyboardStart,
+    onProjectKeyboardAdjust,
+    onProjectKeyboardCommit,
+    onProjectKeyboardCancel,
+    onTaskPointerEditStart,
+    onTaskKeyboardStart,
+    onTaskKeyboardAdjust,
+    onTaskKeyboardCommit,
+    onTaskKeyboardCancel,
+    onTaskDatesCommit,
+    onTaskMoveBy,
+}: TimelineViewProps) {
+    const scrollContainerRef = useRef<HTMLDivElement>(null);
+    const [dragOverDate, setDragOverDate] = useState<string | null>(null);
+    const anchor = parseUTCDate(`${data.month}-01`);
+    const days = getMonthGrid(anchor).slice(0, TIMELINE_DAYS);
+    const gridStart = days[0];
+    const gridEnd = addDays(gridStart, TIMELINE_DAYS);
+    const visibleRange = { start: gridStart, end: gridEnd };
+    const today = todayUTC();
+    const projects: DashboardProjectRow[] = [
+        ...data.pipeline.waitingToStart,
+        ...data.pipeline.scheduled,
+        ...data.pipeline.inProgress,
+        ...data.pipeline.substantialCompletion,
+    ];
+    const adminOverlays = data.isAdmin ? data.overlays : null;
+    const visibleIncomeMilestones = adminOverlays && showIncome ? adminOverlays.income : [];
+    const visibleChangeOrderMilestones = adminOverlays && showProjectedCo ? adminOverlays.changeOrders : [];
+    const incomeTotals = new Map<string, number>();
+    const projectedCoTotals = new Map<string, number>();
+    const expenseTotals = new Map<string, number>();
+    const hoursTotals = new Map<string, number>();
+    if (adminOverlays) {
+        for (const item of adminOverlays.income) {
+            const key = item.effectiveDueDate.slice(0, 10);
+            incomeTotals.set(key, (incomeTotals.get(key) ?? 0) + item.amount);
+        }
+        for (const item of adminOverlays.changeOrders) {
+            const key = item.effectiveDueDate.slice(0, 10);
+            projectedCoTotals.set(key, (projectedCoTotals.get(key) ?? 0) + item.amount);
+        }
+        for (const item of adminOverlays.expenses) {
+            const key = item.date.slice(0, 10);
+            expenseTotals.set(key, (expenseTotals.get(key) ?? 0) + item.amount);
+        }
+        for (const item of adminOverlays.hours) {
+            const key = item.startTime.slice(0, 10);
+            hoursTotals.set(key, (hoursTotals.get(key) ?? 0) + item.durationHours);
+        }
+    }
+
+    function hasProjectDragPayload(event: DragEvent<HTMLDivElement>): boolean {
+        return event.dataTransfer.types.includes(PROJECT_DRAG_MIME);
+    }
+
+    function handleDayDragOver(dayKey: string, event: DragEvent<HTMLDivElement>) {
+        if (!data.canEdit || !hasProjectDragPayload(event)) return;
+        event.preventDefault();
+        event.dataTransfer.dropEffect = "move";
+        setDragOverDate(dayKey);
+    }
+
+    function handleDayDrop(dayKey: string, event: DragEvent<HTMLDivElement>) {
+        if (!data.canEdit || !hasProjectDragPayload(event)) return;
+        event.preventDefault();
+        setDragOverDate(null);
+        const projectId = event.dataTransfer.getData(PROJECT_DRAG_MIME);
+        const project = data.pipeline.waitingToStart.find(candidate => candidate.id === projectId);
+        if (project) onTrayProjectDrop(project, dayKey);
+    }
+
+    return (
+        <ProjectBarGridStartContext.Provider value={gridStart}>
+            <div ref={scrollContainerRef} className="overflow-x-auto" aria-label="Project schedule timeline">
+                <div style={{ width: LABEL_WIDTH + CANVAS_WIDTH }}>
+                    <div className="flex border-b border-hui-border bg-white">
+                        <div data-timeline-sticky-label="true" className="sticky left-0 z-50 flex shrink-0 items-end border-r border-hui-border bg-white px-3 pb-2 text-[10px] font-semibold uppercase tracking-wide text-slate-500" style={{ width: LABEL_WIDTH }}>
+                            Project
+                        </div>
+                        <div className="shrink-0" style={{ width: CANVAS_WIDTH }}>
+                            <div className="grid grid-cols-6 border-b border-hui-border">
+                                {Array.from({ length: 6 }, (_, weekIndex) => {
+                                    const weekStart = days[weekIndex * 7];
+                                    return (
+                                        <div key={formatDate(weekStart)} className="border-r border-hui-border px-1 py-1 text-[9px] font-semibold text-slate-500 last:border-r-0" style={{ width: DAY_WIDTH * 7 }}>
+                                            Week of {formatDate(weekStart)}
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                            <div className="grid" style={{ gridTemplateColumns: `repeat(${TIMELINE_DAYS}, ${DAY_WIDTH}px)` }}>
+                                {days.map(day => {
+                                    const dayKey = formatDate(day);
+                                    const isToday = isSameUTCDay(day, today);
+                                    return (
+                                        <div key={dayKey} className={`border-r border-hui-border py-1 text-center text-[8px] font-semibold ${isWeekend(day) ? "bg-slate-100 text-slate-500" : "text-slate-600"} ${isToday ? "bg-indigo-100 text-indigo-700" : ""}`} title={`UTC ${dayKey}`}>
+                                            {day.getUTCDate()}
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        </div>
+                    </div>
+
+                    {adminOverlays && (showIncome || showProjectedCo || showExpenses || showHours) && (
+                        <div className="flex border-b border-hui-border bg-slate-50/70" aria-label="Visible overlay totals by day">
+                            <div data-timeline-sticky-label="true" className="sticky left-0 z-40 shrink-0 border-r border-hui-border bg-slate-50 px-3 py-2 text-[10px] font-semibold text-slate-500" style={{ width: LABEL_WIDTH }}>
+                                Overlay summary
+                            </div>
+                            <div className="grid h-14 shrink-0" style={{ width: CANVAS_WIDTH, gridTemplateColumns: `repeat(${TIMELINE_DAYS}, ${DAY_WIDTH}px)` }}>
+                                {days.map(day => {
+                                    const dayKey = formatDate(day);
+                                    const labels = [
+                                        showIncome && (incomeTotals.get(dayKey) ?? 0) > 0 ? `${formatCurrency(incomeTotals.get(dayKey) ?? 0)} due` : null,
+                                        showProjectedCo && (projectedCoTotals.get(dayKey) ?? 0) > 0 ? `${formatCurrency(projectedCoTotals.get(dayKey) ?? 0)} projected CO` : null,
+                                        showExpenses && (expenseTotals.get(dayKey) ?? 0) > 0 ? `${formatCurrency(expenseTotals.get(dayKey) ?? 0)} expenses` : null,
+                                        showHours && (hoursTotals.get(dayKey) ?? 0) > 0 ? `${(hoursTotals.get(dayKey) ?? 0).toFixed(1)} hours` : null,
+                                    ].filter((label): label is string => Boolean(label));
+                                    return (
+                                        <div
+                                            key={dayKey}
+                                            className={`group/overlay relative min-w-0 overflow-visible border-r border-hui-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 ${isWeekend(day) ? "bg-slate-100/80" : ""}`}
+                                            title={labels.join("; ")}
+                                            tabIndex={labels.length > 0 ? 0 : undefined}
+                                            aria-label={labels.length > 0 ? `UTC ${dayKey}: ${labels.join(", ")}` : undefined}
+                                        >
+                                            {labels.length > 0 && <span className="sr-only">UTC {dayKey}: {labels.join(", ")}</span>}
+                                            {labels.length > 0 && <span aria-hidden="true" className="mx-auto mt-1 block h-2 w-2 rounded-full bg-indigo-400" />}
+                                            {labels.length > 0 && (
+                                                <span aria-hidden="true" className="pointer-events-none absolute left-1/2 top-5 z-[70] hidden w-max max-w-56 -translate-x-1/2 rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium leading-4 text-white shadow-lg group-focus/overlay:block">
+                                                    {labels.join(", ")}
+                                                </span>
+                                            )}
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        </div>
+                    )}
+
+                    {projects.map((project, projectIndex) => {
+                        const range = getEffectiveProjectRange(project);
+                        const clipped = range ? clipRange(range, visibleRange) : null;
+                        const rect = clipped ? toTimelineRect(clipped, gridStart, DAY_WIDTH) : null;
+                        const startOffset = clipped ? getDaysBetween(gridStart, clipped.start) : 0;
+                        const segment: WeekSegment | null = range
+                            ? clipped
+                                ? {
+                                    projectId: project.id,
+                                    weekIndex: Math.floor(startOffset / 7),
+                                    startColumn: startOffset % 7,
+                                    spanDays: getDaysBetween(clipped.start, clipped.end),
+                                    continuesBefore: clipped.start > range.start,
+                                    continuesAfter: clipped.end < range.end,
+                                    lane: 0,
+                                }
+                                : {
+                                    projectId: project.id,
+                                    weekIndex: 0,
+                                    startColumn: 0,
+                                    spanDays: 1,
+                                    continuesBefore: range.start < gridStart,
+                                    continuesAfter: range.end > gridEnd,
+                                    lane: 0,
+                                }
+                            : null;
+                        const conflictNames = [...new Set((data.crewConflicts ?? []).flatMap(conflict =>
+                            conflict.pairs.some(pair => pair.projectA.id === project.id || pair.projectB.id === project.id)
+                                ? [conflict.name]
+                                : [],
+                        ))];
+                        const crewLabel = project.crew.length > 0 ? project.crew.map(member => member.name).join(", ") : "No project crew";
+                        const milestoneRows = [
+                            ...visibleIncomeMilestones.filter(item => item.projectId === project.id).map(item => ({
+                                key: `income-${item.id}`,
+                                name: item.name,
+                                amount: item.amount,
+                                effectiveDueDate: item.effectiveDueDate,
+                                kind: "income" as const,
+                            })),
+                            ...visibleChangeOrderMilestones.filter(item => item.projectId === project.id).map(item => ({
+                                key: `co-${item.paymentScheduleId}`,
+                                name: item.name,
+                                amount: item.amount,
+                                effectiveDueDate: item.effectiveDueDate,
+                                kind: "change-order" as const,
+                            })),
+                        ];
+                        const outsideTaskMilestones = project.tasks.filter(task => {
+                            if (task.type !== "milestone") return false;
+                            const day = parseUTCDate(task.startDate.slice(0, 10));
+                            return day >= gridStart && day < gridEnd && (!range || day < range.start || day >= range.end);
+                        });
+
+                        return (
+                            <div key={project.id} className="flex min-h-[64px] border-b border-hui-border last:border-b-0">
+                                <div data-timeline-sticky-label="true" className="sticky left-0 z-40 flex shrink-0 items-center justify-between gap-2 border-r border-hui-border bg-white px-3 py-2" style={{ width: LABEL_WIDTH }}>
+                                    <div className="min-w-0">
+                                        <Link href={`/projects/${project.id}`} className="block truncate text-xs font-semibold text-hui-textMain hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary">
+                                            {project.name}
+                                        </Link>
+                                        <div className="truncate text-[10px] text-hui-textMuted" title={`Crew: ${crewLabel}`}>{crewLabel}</div>
+                                    </div>
+                                    {conflictNames.length > 0 && (
+                                        <span className="shrink-0 rounded-full bg-red-100 px-1.5 py-0.5 text-[9px] font-bold text-red-700" title={`Crew conflicts: ${conflictNames.join(", ")}`} aria-label={`${conflictNames.length} crew conflict${conflictNames.length === 1 ? "" : "s"}`}>
+                                            !{conflictNames.length}
+                                        </span>
+                                    )}
+                                </div>
+                                <div data-timeline-schedule-grid="true" className="relative h-16 shrink-0" style={{ width: CANVAS_WIDTH }}>
+                                    <div className="absolute inset-0 grid" style={{ gridTemplateColumns: `repeat(${TIMELINE_DAYS}, ${DAY_WIDTH}px)` }} aria-hidden="true">
+                                        {days.map(day => {
+                                            const dayKey = formatDate(day);
+                                            return (
+                                                <div
+                                                    key={dayKey}
+                                                    data-schedule-date={dayKey}
+                                                    onDragOver={event => handleDayDragOver(dayKey, event)}
+                                                    onDragLeave={() => setDragOverDate(current => current === dayKey ? null : current)}
+                                                    onDrop={event => handleDayDrop(dayKey, event)}
+                                                    className={`border-r border-hui-border ${isWeekend(day) ? "bg-slate-100/70" : "bg-white"} ${dragOverDate === dayKey ? "bg-indigo-100 ring-1 ring-inset ring-indigo-500" : ""}`}
+                                                />
+                                            );
+                                        })}
+                                    </div>
+                                    {today >= gridStart && today < gridEnd && (
+                                        <span className="pointer-events-none absolute inset-y-0 z-20 w-px bg-indigo-500" style={{ left: toTimelineRect({ start: today, end: addDays(today, 1) }, gridStart, DAY_WIDTH).left + DAY_WIDTH / 2 }} aria-hidden="true" />
+                                    )}
+                                    {segment && (
+                                        <div className={`absolute z-10 py-1 ${rect ? "" : "invisible pointer-events-none"}`} style={{ left: rect?.left ?? 0, top: 8, width: Math.max(rect?.width ?? DAY_WIDTH, DAY_WIDTH) }}>
+                                            <ProjectBar
+                                                project={project}
+                                                segment={segment}
+                                                projectColor={project.color || FALLBACK_COLORS[projectIndex % FALLBACK_COLORS.length]}
+                                                conflictNames={conflictNames}
+                                                incomeMilestones={[]}
+                                                changeOrderMilestones={[]}
+                                                canEdit={data.canEdit}
+                                                canMoveProject={data.canEdit && (project.status === "Waiting to Start" || project.status === "In Progress")}
+                                                isPending={pendingProjectIds.has(project.id)}
+                                                pendingTaskIds={pendingTaskIds}
+                                                activeTaskKeyboardEdit={activeTaskKeyboardEdit}
+                                                activeProjectKeyboardId={activeProjectKeyboardId}
+                                                timelineDayWidth={DAY_WIDTH}
+                                                timelineLeftInset={LABEL_WIDTH}
+                                                timelineScrollContainerRef={scrollContainerRef}
+                                                onProjectPointerEditStart={onProjectPointerEditStart}
+                                                onProjectKeyboardStart={onProjectKeyboardStart}
+                                                onProjectKeyboardAdjust={onProjectKeyboardAdjust}
+                                                onProjectKeyboardCommit={onProjectKeyboardCommit}
+                                                onProjectKeyboardCancel={onProjectKeyboardCancel}
+                                                onMoveCommit={onProjectMoveCommit}
+                                                onTaskPointerEditStart={onTaskPointerEditStart}
+                                                onTaskKeyboardStart={onTaskKeyboardStart}
+                                                onTaskKeyboardAdjust={onTaskKeyboardAdjust}
+                                                onTaskKeyboardCommit={onTaskKeyboardCommit}
+                                                onTaskKeyboardCancel={onTaskKeyboardCancel}
+                                                onTaskDatesCommit={onTaskDatesCommit}
+                                                onTaskMoveBy={onTaskMoveBy}
+                                            />
+                                        </div>
+                                    )}
+                                    {outsideTaskMilestones.map(task => {
+                                        const milestoneStart = parseUTCDate(task.startDate.slice(0, 10));
+                                        const milestoneRange = { start: milestoneStart, end: addDays(milestoneStart, 1) };
+                                        return (
+                                            <div key={`task-milestone-${task.id}`} className="absolute z-30 h-[18px]" style={{ left: toTimelineRect(milestoneRange, gridStart, DAY_WIDTH).left, top: 26, width: DAY_WIDTH }}>
+                                                <TaskBlockSegment
+                                                    task={task}
+                                                    projectRange={range ?? milestoneRange}
+                                                    visibleRange={milestoneRange}
+                                                    projectColor={project.color || FALLBACK_COLORS[projectIndex % FALLBACK_COLORS.length]}
+                                                    canEdit={data.canEdit}
+                                                    isPending={pendingProjectIds.has(project.id) || pendingTaskIds.has(task.id)}
+                                                    activeTaskKeyboardEdit={activeTaskKeyboardEdit}
+                                                    timelineDayWidth={DAY_WIDTH}
+                                                    timelineLeftInset={LABEL_WIDTH}
+                                                    timelineScrollContainerRef={scrollContainerRef}
+                                                    onTaskPointerEditStart={onTaskPointerEditStart}
+                                                    onTaskKeyboardStart={onTaskKeyboardStart}
+                                                    onTaskKeyboardAdjust={onTaskKeyboardAdjust}
+                                                    onTaskKeyboardCommit={onTaskKeyboardCommit}
+                                                    onTaskKeyboardCancel={onTaskKeyboardCancel}
+                                                    onTaskDatesCommit={onTaskDatesCommit}
+                                                    onTaskMoveBy={onTaskMoveBy}
+                                                />
+                                            </div>
+                                        );
+                                    })}
+                                    {milestoneRows.map(marker => {
+                                        const sameDayMarkers = milestoneRows.filter(item => item.effectiveDueDate.slice(0, 10) === marker.effectiveDueDate.slice(0, 10));
+                                        const sameDayIndex = sameDayMarkers.findIndex(item => item.key === marker.key);
+                                        return (
+                                            <MilestoneMarker
+                                                key={marker.key}
+                                                name={marker.name}
+                                                amount={marker.amount}
+                                                effectiveDueDate={marker.effectiveDueDate}
+                                                visibleRange={visibleRange}
+                                                kind={marker.kind}
+                                                offsetPixels={(sameDayIndex - (sameDayMarkers.length - 1) / 2) * 8}
+                                                timelineOrigin={gridStart}
+                                                dayWidth={DAY_WIDTH}
+                                            />
+                                        );
+                                    })}
+                                </div>
+                            </div>
+                        );
+                    })}
+                    {projects.length === 0 && <div className="px-4 py-8 text-center text-sm text-hui-textMuted">No scheduled projects in this window.</div>}
+                </div>
+            </div>
+        </ProjectBarGridStartContext.Provider>
+    );
+}

--- a/src/app/company-dashboard/schedule-board/UnscheduledTray.tsx
+++ b/src/app/company-dashboard/schedule-board/UnscheduledTray.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useState, type DragEvent, type FormEvent } from "react";
+import Link from "next/link";
+import type { CompanyDashboardData, DashboardProjectRow } from "@/lib/schedule-core";
+
+export const PROJECT_DRAG_MIME = "application/x-gtr-project-id";
+
+interface UnscheduledTrayProps {
+    estimating: CompanyDashboardData["pipeline"]["estimating"];
+    projects: DashboardProjectRow[];
+    canEdit: boolean;
+    pendingProjectIds: ReadonlySet<string>;
+    onMoveProject: (_project: DashboardProjectRow, _targetStart: string) => void;
+}
+
+function ProjectActions({
+    project,
+    disabled,
+    onMoveProject,
+}: {
+    project: DashboardProjectRow;
+    disabled: boolean;
+    onMoveProject: (_project: DashboardProjectRow, _targetStart: string) => void;
+}) {
+    const [targetStart, setTargetStart] = useState("");
+
+    function handleSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!targetStart || disabled) return;
+        onMoveProject(project, targetStart);
+    }
+
+    return (
+        <details className="relative shrink-0 opacity-0 pointer-events-none transition group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto">
+            <summary className="cursor-pointer list-none rounded px-2 py-1 text-[10px] font-semibold text-indigo-700 hover:bg-indigo-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
+                Project actions
+            </summary>
+            <form onSubmit={handleSubmit} className="absolute right-0 top-full z-50 mt-1 w-56 space-y-2 rounded-md border border-hui-border bg-white p-3 text-left shadow-lg">
+                <label className="block text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted" htmlFor={`tray-project-date-${project.id}`}>Start date</label>
+                <input
+                    id={`tray-project-date-${project.id}`}
+                    type="date"
+                    value={targetStart}
+                    onChange={event => setTargetStart(event.target.value)}
+                    disabled={disabled}
+                    className="hui-input w-full px-2 py-1 text-xs"
+                />
+                <button type="submit" disabled={disabled || !targetStart} className="hui-btn hui-btn-primary w-full text-xs disabled:cursor-wait disabled:opacity-60">
+                    Move project
+                </button>
+            </form>
+        </details>
+    );
+}
+
+export function UnscheduledTray({ estimating, projects, canEdit, pendingProjectIds, onMoveProject }: UnscheduledTrayProps) {
+    function handleDragStart(project: DashboardProjectRow, event: DragEvent<HTMLElement>) {
+        if (!canEdit || pendingProjectIds.has(project.id)) {
+            event.preventDefault();
+            return;
+        }
+        event.dataTransfer.effectAllowed = "move";
+        event.dataTransfer.setData(PROJECT_DRAG_MIME, project.id);
+    }
+
+    if (projects.length === 0 && estimating.length === 0) return null;
+
+    return (
+        <section className="border-b border-hui-border bg-slate-50/70 px-4 py-3" aria-labelledby="unscheduled-projects-heading">
+            <div className="mb-2 flex items-center justify-between gap-3">
+                <h3 id="unscheduled-projects-heading" className="text-xs font-semibold uppercase tracking-wide text-hui-textMuted">Unscheduled</h3>
+                <p className="text-[10px] text-hui-textMuted">
+                    {canEdit ? "Drag a Waiting-to-Start project onto a day or use Project actions." : "Unscheduled projects are read-only for your role."}
+                </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+                {projects.map(project => {
+                    const pending = pendingProjectIds.has(project.id);
+                    return (
+                        <article
+                            key={project.id}
+                            draggable={canEdit && !pending ? true : undefined}
+                            onDragStart={event => handleDragStart(project, event)}
+                            aria-busy={pending}
+                            className={`group flex min-w-52 items-center gap-2 rounded-md border border-indigo-200 bg-white px-3 py-2 shadow-sm ${canEdit && !pending ? "cursor-grab active:cursor-grabbing" : "opacity-60"}`}
+                        >
+                            <div className="min-w-0 flex-1">
+                                <Link href={`/projects/${project.id}`} className="block truncate text-xs font-semibold text-hui-textMain hover:text-hui-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
+                                    {project.name}
+                                </Link>
+                                <span className="block truncate text-[10px] text-hui-textMuted">{project.client ?? "No client"} · Waiting to Start</span>
+                            </div>
+                            {canEdit && <ProjectActions project={project} disabled={pending} onMoveProject={onMoveProject} />}
+                        </article>
+                    );
+                })}
+                {estimating.map(lead => (
+                    <div key={lead.id} aria-disabled="true" className="min-w-44 rounded-md border border-dashed border-slate-300 bg-slate-100 px-3 py-2 opacity-60">
+                        <span className="block truncate text-xs font-semibold text-slate-600">{lead.name}</span>
+                        <span className="block truncate text-[10px] text-slate-500">{lead.client ?? "Lead"} · Estimating</span>
+                    </div>
+                ))}
+            </div>
+        </section>
+    );
+}

--- a/src/app/company-dashboard/schedule-board/useBarLayout.ts
+++ b/src/app/company-dashboard/schedule-board/useBarLayout.ts
@@ -79,14 +79,28 @@ export function getEffectiveProjectRange(project: DashboardProjectRow): DateRang
         (earliest, range) => !earliest || range.start < earliest ? range.start : earliest,
         null,
     );
-    const start = project.startDate ? parseSerializedUTCDay(project.startDate) : earliestTaskStart;
+    // A marker-only start move (In Progress) leaves tasks in place, so the
+    // marker can sit AFTER existing work — the bar must still cover those
+    // tasks or they'd clip out of both views. Span from the earliest of
+    // marker/first-task to the latest task end.
+    const markerStart = project.startDate ? parseSerializedUTCDay(project.startDate) : null;
+    const start = markerStart && earliestTaskStart
+        ? (earliestTaskStart < markerStart ? earliestTaskStart : markerStart)
+        : (markerStart ?? earliestTaskStart);
     if (!start) return null;
 
     const latestTaskEnd = taskRanges.reduce<Date | null>(
         (latest, range) => range.end > start && (!latest || range.end > latest) ? range.end : latest,
         null,
     );
-    return { start, end: latestTaskEnd ?? addDays(start, 1) };
+    // The marker day itself must stay visible even when it sits beyond the
+    // last task (end-exclusive, so marker + 1 day).
+    const markerEnd = markerStart ? addDays(markerStart, 1) : null;
+    const end = [latestTaskEnd, markerEnd].reduce<Date | null>(
+        (latest, candidate) => candidate && (!latest || candidate > latest) ? candidate : latest,
+        null,
+    );
+    return { start, end: end ?? addDays(start, 1) };
 }
 
 export function createProjectDropIntent(project: DashboardProjectRow, targetStart: string): ProjectDropIntent | null {

--- a/src/app/company-dashboard/schedule-board/useBarLayout.ts
+++ b/src/app/company-dashboard/schedule-board/useBarLayout.ts
@@ -1,0 +1,473 @@
+import type { CalendarOverlays, DashboardProjectRow, DashboardTaskRow, OverlayIncomeItem, PersistedScheduleTaskDate } from "@/lib/schedule-core";
+import { addDays, formatDate, getDaysBetween, parseUTCDate } from "@/app/projects/[id]/schedule/schedule-utils";
+
+export interface DateRange {
+    start: Date;
+    end: Date;
+}
+
+export interface WeekSegment {
+    projectId: string;
+    weekIndex: number;
+    startColumn: number;
+    spanDays: number;
+    continuesBefore: boolean;
+    continuesAfter: boolean;
+    lane: number;
+}
+
+export interface TimelineRect {
+    left: number;
+    width: number;
+}
+
+export type UnlanedWeekSegment = Omit<WeekSegment, "lane">;
+
+export interface MilestoneHost extends WeekSegment {
+    dateKey: string;
+}
+
+export interface MonthProjectLaneLayout {
+    visibleWork: WeekSegment[];
+    visibleMilestoneHosts: MilestoneHost[];
+    hiddenProjectIdsByWeek: Map<number, string[]>;
+}
+
+export interface ProjectDropIntent {
+    project: DashboardProjectRow;
+    originalStart: string;
+    targetStart: string;
+    deltaDays: number;
+}
+
+export type TaskEditMode = "move" | "resize-left" | "resize-right";
+
+export interface TaskDateOverride {
+    startDate: string;
+    endDate: string;
+}
+
+export type PersistedTaskDate = PersistedScheduleTaskDate;
+
+export interface ProjectRefreshExpectation {
+    projectStartDate?: string | null;
+    taskDates: PersistedTaskDate[];
+}
+
+function toUTCDay(date: Date): Date {
+    return parseUTCDate(formatDate(date));
+}
+
+function parseSerializedUTCDay(value: string): Date {
+    return parseUTCDate(value.slice(0, 10));
+}
+
+export function rangesOverlap(a: DateRange, b: DateRange): boolean {
+    return a.start < b.end && b.start < a.end;
+}
+
+export function getEffectiveProjectRange(project: DashboardProjectRow): DateRange | null {
+    const taskRanges = project.tasks
+        .filter(task => task.type !== "milestone")
+        .map(task => ({
+            start: parseSerializedUTCDay(task.startDate),
+            end: parseSerializedUTCDay(task.endDate),
+        }))
+        .filter(range => range.end > range.start);
+
+    const earliestTaskStart = taskRanges.reduce<Date | null>(
+        (earliest, range) => !earliest || range.start < earliest ? range.start : earliest,
+        null,
+    );
+    const start = project.startDate ? parseSerializedUTCDay(project.startDate) : earliestTaskStart;
+    if (!start) return null;
+
+    const latestTaskEnd = taskRanges.reduce<Date | null>(
+        (latest, range) => range.end > start && (!latest || range.end > latest) ? range.end : latest,
+        null,
+    );
+    return { start, end: latestTaskEnd ?? addDays(start, 1) };
+}
+
+export function createProjectDropIntent(project: DashboardProjectRow, targetStart: string): ProjectDropIntent | null {
+    const range = getEffectiveProjectRange(project);
+    if (!range) return null;
+
+    const normalizedTarget = formatDate(parseSerializedUTCDay(targetStart));
+    const originalStart = formatDate(range.start);
+    return {
+        project,
+        originalStart,
+        targetStart: normalizedTarget,
+        deltaDays: getDaysBetween(range.start, parseSerializedUTCDay(normalizedTarget)),
+    };
+}
+
+export function previewProjectMove(project: DashboardProjectRow, targetStart: string): DashboardProjectRow {
+    const normalizedTarget = formatDate(parseSerializedUTCDay(targetStart));
+    if (!project.startDate) return { ...project, startDate: normalizedTarget };
+
+    const range = getEffectiveProjectRange(project);
+    if (!range) return { ...project, startDate: normalizedTarget };
+
+    const deltaDays = getDaysBetween(range.start, parseSerializedUTCDay(normalizedTarget));
+    return {
+        ...project,
+        startDate: normalizedTarget,
+        tasks: project.tasks.map(task => ({
+            ...task,
+            startDate: formatDate(addDays(parseSerializedUTCDay(task.startDate), deltaDays)),
+            endDate: formatDate(addDays(parseSerializedUTCDay(task.endDate), deltaDays)),
+        })),
+    };
+}
+
+export function previewProjectWithPersistedTaskDates(
+    project: DashboardProjectRow,
+    projectStartDate: string | null,
+    taskDates: PersistedTaskDate[],
+): DashboardProjectRow {
+    const taskDatesById = new Map(taskDates.map(task => [task.id, task]));
+    return {
+        ...project,
+        startDate: projectStartDate,
+        tasks: project.tasks.map(task => {
+            const persisted = taskDatesById.get(task.id);
+            return persisted ? { ...task, startDate: persisted.startDate, endDate: persisted.endDate } : task;
+        }),
+    };
+}
+
+export function previewTaskDates(
+    task: DashboardTaskRow,
+    mode: TaskEditMode,
+    deltaDays: number,
+): TaskDateOverride | null {
+    const originalStart = parseSerializedUTCDay(task.startDate);
+    const originalEnd = parseSerializedUTCDay(task.endDate);
+    const milestone = task.type === "milestone";
+
+    if (milestone) {
+        if (mode !== "move") return null;
+        const movedDate = formatDate(addDays(originalStart, deltaDays));
+        return { startDate: movedDate, endDate: movedDate };
+    }
+    if (originalEnd <= originalStart) return null;
+
+    if (mode === "move") {
+        return {
+            startDate: formatDate(addDays(originalStart, deltaDays)),
+            endDate: formatDate(addDays(originalEnd, deltaDays)),
+        };
+    }
+    if (mode === "resize-left") {
+        const newStart = addDays(originalStart, deltaDays);
+        if (newStart >= originalEnd) return null;
+        return { startDate: formatDate(newStart), endDate: formatDate(originalEnd) };
+    }
+
+    const newEnd = addDays(originalEnd, deltaDays);
+    if (newEnd <= originalStart) return null;
+    return { startDate: formatDate(originalStart), endDate: formatDate(newEnd) };
+}
+
+export function taskDatesMatch(task: DashboardTaskRow, dates: TaskDateOverride): boolean {
+    return task.startDate.slice(0, 10) === dates.startDate.slice(0, 10)
+        && task.endDate.slice(0, 10) === dates.endDate.slice(0, 10);
+}
+
+export function projectRefreshMatches(
+    canonical: DashboardProjectRow | undefined,
+    expected: ProjectRefreshExpectation,
+): boolean {
+    if (!canonical) return false;
+    if (expected.projectStartDate !== undefined
+        && canonical.startDate?.slice(0, 10) !== expected.projectStartDate?.slice(0, 10)) return false;
+    const canonicalTasks = new Map(canonical.tasks.map(task => [task.id, task]));
+    return expected.taskDates.every(task => {
+        const canonicalTask = canonicalTasks.get(task.id);
+        return Boolean(canonicalTask && taskDatesMatch(canonicalTask, task));
+    });
+}
+
+export function getEffectivePendingProjectIds(
+    pendingProjectIds: Iterable<string>,
+    pendingTaskIds: Iterable<string>,
+    taskProjectById: ReadonlyMap<string, string>,
+): Set<string> {
+    const result = new Set(pendingProjectIds);
+    for (const taskId of pendingTaskIds) {
+        const projectId = taskProjectById.get(taskId);
+        if (projectId) result.add(projectId);
+    }
+    return result;
+}
+
+export function mergeProjectPendingIds(...sources: Iterable<string>[]): Set<string> {
+    return new Set(sources.flatMap(source => [...source]));
+}
+
+export function getNewlyPendingProjectIds(
+    previous: ReadonlySet<string>,
+    current: ReadonlySet<string>,
+): Set<string> {
+    return new Set([...current].filter(projectId => !previous.has(projectId)));
+}
+
+export function projectIdSetsEqual(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+    return left.size === right.size && [...left].every(projectId => right.has(projectId));
+}
+
+export function previewTaskPointerCandidate(
+    task: DashboardTaskRow,
+    mode: TaskEditMode,
+    deltaDays: number | null,
+): TaskDateOverride | null {
+    return deltaDays == null ? null : previewTaskDates(task, mode, deltaDays);
+}
+
+export function previewProjectIncomeOverlays(
+    rows: OverlayIncomeItem[],
+    projectId: string,
+    deltaDays: number,
+    eligibleTaskIds?: ReadonlySet<string>,
+): OverlayIncomeItem[] {
+    if (deltaDays === 0) return rows;
+    return rows.map(row => {
+        if (row.projectId !== projectId || !row.anchoredToTask || row.inQuickBooks) return row;
+        if (eligibleTaskIds && (!row.scheduleTaskId || !eligibleTaskIds.has(row.scheduleTaskId))) return row;
+        return {
+            ...row,
+            dueDate: row.dueDate ? formatDate(addDays(parseSerializedUTCDay(row.dueDate), deltaDays)) : null,
+            effectiveDueDate: formatDate(addDays(parseSerializedUTCDay(row.effectiveDueDate), deltaDays)),
+        };
+    });
+}
+
+export function previewShiftedTaskIncomeOverlays(
+    rows: OverlayIncomeItem[],
+    projectId: string,
+    deltaDays: number,
+    eligibleTaskIds: ReadonlySet<string>,
+): OverlayIncomeItem[] {
+    if (deltaDays === 0) return rows;
+    return rows.map(row => {
+        // shiftNotStartedTasks does not write payment rows. Only a null-dated
+        // milestone inherits its moved task's start date; explicit due dates
+        // remain fixed and QB-linked rows remain outside optimistic money edits.
+        if (row.projectId !== projectId || row.dueDate !== null || row.inQuickBooks
+            || !row.scheduleTaskId || !eligibleTaskIds.has(row.scheduleTaskId)) return row;
+        return {
+            ...row,
+            effectiveDueDate: formatDate(addDays(parseSerializedUTCDay(row.effectiveDueDate), deltaDays)),
+        };
+    });
+}
+
+export function previewProjectOverlays(
+    overlays: CalendarOverlays,
+    projectId: string,
+    deltaDays: number,
+): CalendarOverlays {
+    return {
+        ...overlays,
+        income: previewProjectIncomeOverlays(overlays.income, projectId, deltaDays),
+    };
+}
+
+export function clipRange(range: DateRange, window: DateRange): DateRange | null {
+    const start = toUTCDay(range.start) > toUTCDay(window.start) ? toUTCDay(range.start) : toUTCDay(window.start);
+    const end = toUTCDay(range.end) < toUTCDay(window.end) ? toUTCDay(range.end) : toUTCDay(window.end);
+
+    return end > start ? { start, end } : null;
+}
+
+export function segmentProjectRange(
+    projectId: string,
+    range: DateRange,
+    gridStart: Date,
+    gridEnd: Date,
+): UnlanedWeekSegment[] {
+    const normalizedRange = { start: toUTCDay(range.start), end: toUTCDay(range.end) };
+    const normalizedGridStart = toUTCDay(gridStart);
+    const clipped = clipRange(normalizedRange, { start: normalizedGridStart, end: toUTCDay(gridEnd) });
+    if (!clipped) return [];
+
+    const segments: UnlanedWeekSegment[] = [];
+    let segmentStart = clipped.start;
+    while (segmentStart < clipped.end) {
+        const daysFromGridStart = getDaysBetween(normalizedGridStart, segmentStart);
+        const weekIndex = Math.floor(daysFromGridStart / 7);
+        const startColumn = daysFromGridStart % 7;
+        const weekEnd = addDays(normalizedGridStart, (weekIndex + 1) * 7);
+        const segmentEnd = clipped.end < weekEnd ? clipped.end : weekEnd;
+
+        segments.push({
+            projectId,
+            weekIndex,
+            startColumn,
+            spanDays: getDaysBetween(segmentStart, segmentEnd),
+            continuesBefore: segmentStart > normalizedRange.start,
+            continuesAfter: segmentEnd < normalizedRange.end,
+        });
+        segmentStart = segmentEnd;
+    }
+
+    return segments;
+}
+
+function segmentRange(segment: UnlanedWeekSegment): DateRange {
+    const epoch = parseUTCDate("1970-01-01");
+    const start = addDays(epoch, segment.weekIndex * 7 + segment.startColumn);
+    return { start, end: addDays(start, segment.spanDays) };
+}
+
+export function assignProjectLanes(
+    segmentsByProject: Map<string, UnlanedWeekSegment[]>,
+): { visible: WeekSegment[]; hiddenByWeek: Map<number, number> } {
+    const occupiedByLane: DateRange[][] = [];
+    const visible: WeekSegment[] = [];
+    const hiddenByWeek = new Map<number, number>();
+
+    for (const segments of segmentsByProject.values()) {
+        const ranges = segments.map(segmentRange);
+        let lane = 0;
+        while (occupiedByLane[lane]?.some(occupied => ranges.some(range => rangesOverlap(occupied, range)))) {
+            lane++;
+        }
+        (occupiedByLane[lane] ??= []).push(...ranges);
+
+        for (const segment of segments) {
+            const lanedSegment = { ...segment, lane };
+            if (lane < 4) {
+                visible.push(lanedSegment);
+            } else {
+                hiddenByWeek.set(segment.weekIndex, (hiddenByWeek.get(segment.weekIndex) ?? 0) + 1);
+            }
+        }
+    }
+
+    return { visible, hiddenByWeek };
+}
+
+function segmentOffset(segment: UnlanedWeekSegment): number {
+    return segment.weekIndex * 7 + segment.startColumn;
+}
+
+function segmentContainsDay(segment: UnlanedWeekSegment, dayOffset: number): boolean {
+    const start = segmentOffset(segment);
+    return dayOffset >= start && dayOffset < start + segment.spanDays;
+}
+
+export function assignMonthProjectLanes(
+    workSegmentsByProject: Map<string, UnlanedWeekSegment[]>,
+    milestoneDaysByProject: Map<string, Date[]>,
+    gridStart: Date,
+    gridEnd: Date,
+): MonthProjectLaneLayout {
+    const normalizedGridStart = toUTCDay(gridStart);
+    const normalizedGridEnd = toUTCDay(gridEnd);
+    const projectIds = new Set([...workSegmentsByProject.keys(), ...milestoneDaysByProject.keys()]);
+    const occupancyByProject = new Map<string, UnlanedWeekSegment[]>();
+    const milestoneHosts: Array<UnlanedWeekSegment & { dateKey: string }> = [];
+
+    for (const projectId of projectIds) {
+        const workSegments = workSegmentsByProject.get(projectId) ?? [];
+        const hosts: Array<UnlanedWeekSegment & { dateKey: string }> = [];
+        const seenDays = new Set<string>();
+
+        for (const milestoneDay of milestoneDaysByProject.get(projectId) ?? []) {
+            const day = toUTCDay(milestoneDay);
+            const dateKey = formatDate(day);
+            if (seenDays.has(dateKey) || day < normalizedGridStart || day >= normalizedGridEnd) continue;
+            seenDays.add(dateKey);
+
+            const dayOffset = getDaysBetween(normalizedGridStart, day);
+            if (workSegments.some(segment => segmentContainsDay(segment, dayOffset))) continue;
+
+            const [host] = segmentProjectRange(projectId, { start: day, end: addDays(day, 1) }, normalizedGridStart, normalizedGridEnd);
+            if (host) hosts.push({ ...host, dateKey });
+        }
+
+        occupancyByProject.set(projectId, [...workSegments, ...hosts]);
+        milestoneHosts.push(...hosts);
+    }
+
+    const assigned = assignProjectLanes(occupancyByProject);
+    const laneByProject = new Map<string, number>();
+    for (const segment of assigned.visible) laneByProject.set(segment.projectId, segment.lane);
+
+    const visibleWork: WeekSegment[] = [];
+    for (const [projectId, segments] of workSegmentsByProject) {
+        const lane = laneByProject.get(projectId);
+        if (lane == null) continue;
+        visibleWork.push(...segments.map(segment => ({ ...segment, lane })));
+    }
+
+    const visibleMilestoneHosts = milestoneHosts.flatMap(host => {
+        const lane = laneByProject.get(host.projectId);
+        return lane == null ? [] : [{ ...host, lane }];
+    });
+
+    const hiddenProjectIdsByWeek = new Map<number, string[]>();
+    for (const [projectId, segments] of occupancyByProject) {
+        if (laneByProject.has(projectId)) continue;
+        for (const weekIndex of new Set(segments.map(segment => segment.weekIndex))) {
+            hiddenProjectIdsByWeek.set(weekIndex, [...(hiddenProjectIdsByWeek.get(weekIndex) ?? []), projectId]);
+        }
+    }
+
+    return { visibleWork, visibleMilestoneHosts, hiddenProjectIdsByWeek };
+}
+
+export function toTimelineRect(range: DateRange, origin: Date, dayWidth: number): TimelineRect {
+    const normalizedOrigin = toUTCDay(origin);
+    const start = toUTCDay(range.start);
+    const end = toUTCDay(range.end);
+    return {
+        left: getDaysBetween(normalizedOrigin, start) * dayWidth,
+        width: getDaysBetween(start, end) * dayWidth,
+    };
+}
+
+export function getTimelinePointerDelta(clientX: number, originX: number, dayWidth: number): number {
+    return Math.round((clientX - originX) / dayWidth);
+}
+
+export interface TimelineAutoscrollInput {
+    clientX: number;
+    containerLeft: number;
+    containerRight: number;
+    timelineLeftInset: number;
+    scrollLeft: number;
+    scrollWidth: number;
+    clientWidth: number;
+    threshold: number;
+    maxStep: number;
+}
+
+export function getTimelineAutoscrollStep({
+    clientX,
+    containerLeft,
+    containerRight,
+    timelineLeftInset,
+    scrollLeft,
+    scrollWidth,
+    clientWidth,
+    threshold,
+    maxStep,
+}: TimelineAutoscrollInput): number {
+    const visibleLeft = containerLeft + timelineLeftInset;
+    const leftDistance = Math.abs(clientX - visibleLeft);
+    if (scrollLeft > 0 && leftDistance < threshold) {
+        return -Math.min(maxStep, Math.ceil((threshold - leftDistance) / 3));
+    }
+
+    const maxScrollLeft = Math.max(0, scrollWidth - clientWidth);
+    const rightDistance = Math.abs(clientX - containerRight);
+    if (scrollLeft < maxScrollLeft && rightDistance < threshold) {
+        return Math.min(maxStep, Math.ceil((threshold - rightDistance) / 3));
+    }
+
+    return 0;
+}

--- a/src/app/projects/[id]/schedule/schedule-utils.ts
+++ b/src/app/projects/[id]/schedule/schedule-utils.ts
@@ -46,6 +46,11 @@ export function parseUTCDate(yyyyMmDd: string): Date {
     const [y, m, d] = yyyyMmDd.split("-").map(Number);
     return new Date(Date.UTC(y, m - 1, d));
 }
+// Deliberately built from LOCAL date components: schedule dates are
+// timezone-less user-entered calendar days stored as UTC midnights, so
+// "today" must be the USER'S current calendar day mapped into that same
+// UTC-day space. Using getUTC* here would highlight tomorrow for any
+// US-evening user (00:00+ UTC). Do not "fix" this to getUTC*.
 export function todayUTC(): Date {
     const now = new Date();
     return new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));

--- a/src/components/nav/navItems.tsx
+++ b/src/components/nav/navItems.tsx
@@ -7,11 +7,15 @@ import type { ReactNode } from "react";
 
 type IconProps = { className?: string };
 
-const svg = (children: ReactNode) => ({ className }: IconProps) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-    {children}
-  </svg>
-);
+const svg = (children: ReactNode) => {
+  const NavIcon = ({ className }: IconProps) => (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      {children}
+    </svg>
+  );
+  NavIcon.displayName = "NavIcon";
+  return NavIcon;
+};
 
 const DashboardIcon = svg(
   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
@@ -56,7 +60,7 @@ export type NavItem = {
 };
 
 export const NAV_ITEMS: NavItem[] = [
-  { key: "dashboard", href: "/company-dashboard", label: "Dashboard", Icon: DashboardIcon, show: (can) => can("financialReports") },
+  { key: "dashboard", href: "/company-dashboard", label: "Dashboard", Icon: DashboardIcon, show: (can) => can("financialReports") || can("schedules") },
   // Projects is always visible (the API filters by ProjectAccess).
   { key: "projects", href: "/projects", label: "Projects", Icon: ProjectsIcon, show: () => true },
   { key: "leads", href: "/leads", label: "Leads", Icon: LeadsIcon, show: (can) => can("leadAccess") },

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -17,7 +17,9 @@ import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { enqueueMilestonePaid, drainPaymentNotifications } from "./payment-outbox";
 import { deleteChangeOrderCore, updateChangeOrderCore } from "./change-order-core";
 import { approveChangeOrderWithSignature } from "./change-order-approval";
-import { applyChangeOrderToSchedule, autoGenerateScheduleForApprovedEstimate, setProjectStartDate, parseStartDateInput, generateScheduleFromEstimate, setProjectCrew, setTaskCrew, CONTRACT_ESTIMATE_STATUSES } from "./schedule-core";
+import { applyChangeOrderToSchedule, autoGenerateScheduleForApprovedEstimate, setProjectStartDate, shiftNotStartedTasks, parseStartDateInput, generateScheduleFromEstimate, setProjectCrew, setTaskCrew, CONTRACT_ESTIMATE_STATUSES } from "./schedule-core";
+import { CLOSED_PROJECT_STATUSES } from "./gpt-estimate";
+import type { ShiftNotStartedTasksResult } from "./schedule-core";
 import type { ChangeOrderUpdateInput } from "./change-order-core";
 import { emptyDoc } from "@/lib/studio/doc";
 import type { RoomType } from "@/lib/studio/templates";
@@ -6543,11 +6545,10 @@ export async function updateScheduleTask(taskId: string, data: {
     type?: string;
     estimateItemId?: string | null;
 }) {
-    await assertScheduleTaskAccess(taskId);
+    const hasDatePatch = data.startDate !== undefined || data.endDate !== undefined;
+    const { user, projectId } = await assertScheduleTaskAccess(taskId);
     const updateData: any = {};
     if (data.name !== undefined) updateData.name = data.name;
-    if (data.startDate !== undefined) updateData.startDate = new Date(data.startDate);
-    if (data.endDate !== undefined) updateData.endDate = new Date(data.endDate);
     if (data.color !== undefined) updateData.color = data.color;
     if (data.progress !== undefined) updateData.progress = data.progress;
     if (data.status !== undefined) updateData.status = data.status;
@@ -6572,9 +6573,67 @@ export async function updateScheduleTask(taskId: string, data: {
             }
         }
     }
-    // Milestones always have same start and end date
-    if (data.type === "milestone" && updateData.startDate) {
-        updateData.endDate = updateData.startDate;
+    if (hasDatePatch) {
+        const suppliedStartDate = data.startDate === undefined ? null : parseStartDateInput(data.startDate);
+        const suppliedEndDate = data.endDate === undefined ? null : parseStartDateInput(data.endDate);
+        const task = await withTxRetry(() => prisma.$transaction(async (tx) => {
+            // Canonical lock family: parent Project first, then the task row.
+            await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${projectId} FOR UPDATE`;
+            await tx.$queryRaw`SELECT id FROM "ScheduleTask" WHERE id = ${taskId} FOR UPDATE`;
+            const persistedTask = await tx.scheduleTask.findUnique({
+                where: { id: taskId },
+                select: {
+                    id: true, name: true, projectId: true, type: true,
+                    startDate: true, endDate: true,
+                    project: { select: { status: true } },
+                },
+            });
+            if (!persistedTask) throw new Error("Task not found");
+            if (!persistedTask.projectId || persistedTask.projectId !== projectId) {
+                throw new Error("Task moved to another project; refresh and retry");
+            }
+            if (!persistedTask.project) throw new Error("Task is not attached to a project");
+            if (CLOSED_PROJECT_STATUSES.includes(persistedTask.project.status)) {
+                throw new Error(`Cannot update a task on a closed project (${persistedTask.project.status})`);
+            }
+            if (data.type !== undefined && data.type !== persistedTask.type) {
+                throw new Error("Change task type separately before editing its dates");
+            }
+
+            const startDate = suppliedStartDate ?? persistedTask.startDate;
+            const requestedEndDate = suppliedEndDate ?? persistedTask.endDate;
+            const endDate = persistedTask.type === "milestone" ? startDate : requestedEndDate;
+            if (persistedTask.type !== "milestone" && endDate <= startDate) {
+                throw new Error("Task end date must be after its start date");
+            }
+
+            const saved = await tx.scheduleTask.update({
+                where: { id: taskId },
+                data: { ...updateData, startDate, endDate },
+            });
+            await tx.activityLog.create({
+                data: {
+                    projectId,
+                    actorType: "TEAM",
+                    actorName: user.name || user.email,
+                    action: "updated_company_schedule_task_dates",
+                    entityType: "task",
+                    entityId: taskId,
+                    entityName: persistedTask.name,
+                    metadata: JSON.stringify({
+                        previousStartDate: persistedTask.startDate.toISOString().slice(0, 10),
+                        previousEndDate: persistedTask.endDate.toISOString().slice(0, 10),
+                        startDate: startDate.toISOString().slice(0, 10),
+                        endDate: endDate.toISOString().slice(0, 10),
+                        type: persistedTask.type,
+                    }),
+                },
+            });
+            return saved;
+        }));
+        revalidatePath("/company-dashboard");
+        revalidatePath(`/projects/${task.projectId}/schedule`);
+        return task;
     }
 
     const task = await prisma.scheduleTask.update({
@@ -7107,6 +7166,20 @@ export async function getActiveSubcontractors() {
 
 // ========== PROJECT BOARD ACTIONS ==========
 
+// Company-board authorization adapter only. updateScheduleTask remains the
+// single validation, locking, mutation, audit, and revalidation capability.
+export async function updateCompanyScheduleTaskDatesAction(taskId: string, dates: {
+    startDate: string;
+    endDate: string;
+}) {
+    const session = await getServerSession(authOptions);
+    const caller = session?.user?.email
+        ? await prisma.user.findUnique({ where: { email: session.user.email }, select: { role: true } })
+        : null;
+    if (!caller || !["ADMIN", "MANAGER"].includes(caller.role)) throw new Error("Forbidden");
+    return updateScheduleTask(taskId, dates);
+}
+
 export async function updateProjectStatus(projectId: string, status: string) {
     await assertActiveStaff();
     await prisma.project.update({
@@ -7131,6 +7204,24 @@ export async function updateProjectStartDateAction(projectId: string, startDateI
         projectId,
         startDate: startDateISO ? parseStartDateInput(startDateISO) : null,
         shiftJobTasks,
+        actor: { type: "TEAM", name: caller.name || caller.email },
+    });
+    revalidatePath("/company-dashboard");
+    revalidatePath("/projects");
+    return result;
+}
+
+// Shift unfinished work on an active project without moving its company-level
+// start marker or any payment milestone. ADMIN/MANAGER only.
+export async function shiftNotStartedTasksAction(projectId: string, deltaDays: number): Promise<ShiftNotStartedTasksResult> {
+    const session = await getServerSession(authOptions);
+    const caller = session?.user?.email
+        ? await prisma.user.findUnique({ where: { email: session.user.email }, select: { role: true, name: true, email: true } })
+        : null;
+    if (!caller || !["ADMIN", "MANAGER"].includes(caller.role)) throw new Error("Forbidden");
+    const result = await shiftNotStartedTasks({
+        projectId,
+        deltaDays,
         actor: { type: "TEAM", name: caller.name || caller.email },
     });
     revalidatePath("/company-dashboard");

--- a/src/lib/schedule-core.ts
+++ b/src/lib/schedule-core.ts
@@ -56,6 +56,7 @@ export interface PipelineProject {
     client: string | null;
     status: string;
     startDate: string | null;
+    color: string | null;
     // totalAmount of the project's most recent Approved/Invoiced/Partially
     // Paid/Paid estimate; null when none exists.
     contractValue: number | null;
@@ -106,7 +107,7 @@ export async function getCompanyPipeline(): Promise<CompanyPipeline> {
             where: { status: { in: OPEN_PROJECT_STATUSES } },
             orderBy: { createdAt: "desc" },
             select: {
-                id: true, name: true, status: true, startDate: true,
+                id: true, name: true, status: true, startDate: true, color: true,
                 client: { select: { name: true } },
                 crew: { select: { id: true, name: true, email: true, status: true } },
                 estimates: {
@@ -125,6 +126,7 @@ export async function getCompanyPipeline(): Promise<CompanyPipeline> {
         client: p.client?.name ?? null,
         status: p.status,
         startDate: p.startDate ? p.startDate.toISOString() : null,
+        color: p.color,
         contractValue: p.estimates[0] ? Number(p.estimates[0].totalAmount) : null,
         crew: p.crew.map(u => ({ id: u.id, name: u.name || u.email, status: u.status })),
     });
@@ -274,11 +276,18 @@ export interface SkippedQbMilestone {
     paymentScheduleIds: string[];
 }
 
+export interface PersistedScheduleTaskDate {
+    id: string;
+    startDate: string;
+    endDate: string;
+}
+
 export interface SetProjectStartDateResult {
     projectId: string;
     previousStartDate: string | null;
     startDate: string | null;
     shiftedTasks: number;
+    shiftedTaskDates: PersistedScheduleTaskDate[];
     shiftedMilestones: number;
     skippedQbMilestones: SkippedQbMilestone[];
     notes: string[];
@@ -332,6 +341,7 @@ export async function setProjectStartDate(input: {
         const notes: string[] = [];
         const skippedQbMilestones: SkippedQbMilestone[] = [];
         let shiftedTasks = 0;
+        let shiftedTaskDates: PersistedScheduleTaskDate[] = [];
         let shiftedMilestones = 0;
 
         // Delta shift only applies to a Waiting-to-Start project with both an
@@ -356,13 +366,22 @@ export async function setProjectStartDate(input: {
             const daysParam = String(shiftDays);
 
             // (a) Every job task shifts in ONE update.
-            shiftedTasks = await tx.$executeRaw`
+            const shiftedTaskRows = await tx.$queryRaw<{ id: string; startDate: Date; endDate: Date }[]>`
                 UPDATE "ScheduleTask"
                 SET "startDate" = "startDate" + (${daysParam} || ' days')::interval,
                     "endDate" = "endDate" + (${daysParam} || ' days')::interval,
                     "updatedAt" = NOW()
                 WHERE "projectId" = ${projectId}
+                RETURNING "id", "startDate", "endDate"
             `;
+            shiftedTaskDates = shiftedTaskRows
+                .map(task => ({
+                    id: task.id,
+                    startDate: task.startDate.toISOString(),
+                    endDate: task.endDate.toISOString(),
+                }))
+                .sort((a, b) => a.id.localeCompare(b.id));
+            shiftedTasks = shiftedTaskDates.length;
 
             // (b) Milestone mirror groups anchored to this project's tasks:
             // two bounded reads, then skip/shift computed in memory. The
@@ -540,6 +559,7 @@ export async function setProjectStartDate(input: {
             previousStartDate: previousStartDate ? previousStartDate.toISOString() : null,
             startDate: startDate ? startDate.toISOString() : null,
             shiftedTasks,
+            shiftedTaskDates,
             shiftedMilestones,
             skippedQbMilestones,
             notes,
@@ -575,6 +595,131 @@ export async function setProjectStartDate(input: {
     }
 
     return result;
+}
+
+export interface ShiftNotStartedTasksInput {
+    projectId: string;
+    deltaDays: number;
+    actor: { type: "TEAM" | "SYSTEM"; name: string };
+}
+
+export interface ShiftNotStartedTasksResult {
+    projectId: string;
+    deltaDays: number;
+    shiftedTaskIds: string[];
+    shiftedTaskDates: PersistedScheduleTaskDate[];
+    shiftedTasks: number;
+    notes: string[];
+}
+
+/**
+ * Shift only exact `Not Started` tasks on an active project. Explicitly dated
+ * Pending payment milestones stay fixed and are returned as operator notes;
+ * this path never changes the project marker or any payment/money row.
+ */
+export async function shiftNotStartedTasks(
+    input: ShiftNotStartedTasksInput,
+): Promise<ShiftNotStartedTasksResult> {
+    const { projectId, deltaDays, actor } = input;
+    if (!Number.isInteger(deltaDays) || deltaDays === 0) {
+        throw new Error("deltaDays must be a nonzero whole integer");
+    }
+
+    return withTxRetry(() => prisma.$transaction(async (tx) => {
+        // Keep this lock first: all schedule moves serialize on Project before
+        // selecting child tasks, matching setProjectStartDate's lock family.
+        await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${projectId} FOR UPDATE`;
+        const project = await tx.project.findUnique({
+            where: { id: projectId },
+            select: { id: true, name: true, status: true },
+        });
+        if (!project) throw new Error("Project not found");
+        if (project.status !== "In Progress") {
+            throw new Error("Only In Progress projects can shift Not Started tasks");
+        }
+
+        const tasks = await tx.$queryRaw<{ id: string; startDate: Date; endDate: Date }[]>`
+            SELECT "id", "startDate", "endDate"
+            FROM "ScheduleTask"
+            WHERE "projectId" = ${projectId}
+              AND "status" = 'Not Started'
+            ORDER BY "id"
+            FOR UPDATE
+        `;
+        const shiftedTaskIds = tasks.map(task => task.id);
+        const shiftedTaskDates: PersistedScheduleTaskDate[] = [];
+
+        for (const task of tasks) {
+            const shiftedStartDate = addDays(task.startDate, deltaDays);
+            const shiftedEndDate = addDays(task.endDate, deltaDays);
+            await tx.$executeRaw`
+                UPDATE "ScheduleTask"
+                SET "startDate" = ${shiftedStartDate},
+                    "endDate" = ${shiftedEndDate}
+                WHERE "id" = ${task.id}
+            `;
+            shiftedTaskDates.push({
+                id: task.id,
+                startDate: shiftedStartDate.toISOString(),
+                endDate: shiftedEndDate.toISOString(),
+            });
+        }
+
+        const notes: string[] = [];
+        if (shiftedTaskIds.length > 0) {
+            const estimateMilestones = await tx.estimatePaymentSchedule.findMany({
+                where: {
+                    scheduleTaskId: { in: shiftedTaskIds },
+                    status: "Pending",
+                    dueDate: { not: null },
+                },
+                orderBy: { id: "asc" },
+                select: { id: true, name: true },
+            });
+            const invoiceMilestones = await tx.paymentSchedule.findMany({
+                where: {
+                    scheduleTaskId: { in: shiftedTaskIds },
+                    status: "Pending",
+                    dueDate: { not: null },
+                },
+                orderBy: { id: "asc" },
+                select: { id: true, name: true },
+            });
+            for (const milestone of estimateMilestones) {
+                notes.push(`Estimate milestone "${milestone.name}" (${milestone.id}) has an explicit due date and was not shifted.`);
+            }
+            for (const milestone of invoiceMilestones) {
+                notes.push(`Invoice milestone "${milestone.name}" (${milestone.id}) has an explicit due date and was not shifted.`);
+            }
+        }
+
+        await tx.activityLog.create({
+            data: {
+                projectId,
+                actorType: actor.type,
+                actorName: actor.name,
+                action: "shift_not_started_tasks",
+                entityType: "project",
+                entityId: projectId,
+                entityName: project.name,
+                metadata: JSON.stringify({
+                    deltaDays,
+                    shiftedTasks: shiftedTaskIds.length,
+                    shiftedTaskIds,
+                    explicitDueDateMilestones: notes.length,
+                }),
+            },
+        });
+
+        return {
+            projectId,
+            deltaDays,
+            shiftedTaskIds,
+            shiftedTaskDates,
+            shiftedTasks: shiftedTaskIds.length,
+            notes,
+        };
+    }));
 }
 
 export interface CashflowBucket {
@@ -1428,6 +1573,7 @@ export interface OverlayIncomeItem {
     invoiceCode: string;
     projectId: string | null;
     projectName: string | null;
+    scheduleTaskId: string | null;
     anchoredToTask: boolean;
     inQuickBooks: boolean;
 }
@@ -1452,6 +1598,7 @@ export interface OverlayHoursItem {
 }
 
 export interface OverlayChangeOrderItem {
+    paymentScheduleId: string;
     changeOrderId: string;
     code: string;
     title: string;
@@ -1518,6 +1665,7 @@ export async function getChangeOrderOverlayRows(from: Date, to: Date): Promise<O
                 const effective = row.dueDate ?? (row.scheduleTaskId ? taskStartById.get(row.scheduleTaskId) : undefined) ?? null;
                 if (!effective || effective < from || effective >= to) continue;
                 rows.push({
+                    paymentScheduleId: row.id,
                     changeOrderId: co.id,
                     code: co.code,
                     title: co.title,
@@ -1534,6 +1682,7 @@ export async function getChangeOrderOverlayRows(from: Date, to: Date): Promise<O
             const synthDate = co.generatedScheduleTasks[0]?.startDate ?? null;
             if (!synthDate || synthDate < from || synthDate >= to) continue;
             rows.push({
+                paymentScheduleId: `synthetic:${co.id}`,
                 changeOrderId: co.id,
                 code: co.code,
                 title: co.title,
@@ -1608,6 +1757,7 @@ export async function getCalendarOverlays(
                 invoiceCode: m.invoice.code,
                 projectId: m.invoice.project?.id ?? null,
                 projectName: m.invoice.project?.name ?? null,
+                scheduleTaskId: m.scheduleTaskId,
                 anchoredToTask: !!m.scheduleTaskId,
                 inQuickBooks: !!m.qbInvoiceId,
             };
@@ -1677,6 +1827,9 @@ export interface DashboardTaskRow {
     name: string;
     startDate: string;
     endDate: string;
+    color: string | null;
+    parentId: string | null;
+    progress: number;
     status: string;
     type: string;
     assignments: DashboardTaskAssignment[];
@@ -1712,12 +1865,17 @@ export interface CompanyDashboardData {
     role: string;
     canEdit: boolean;
     isAdmin: boolean;
+    // Pipeline money (contractValue, targetRevenue, latestEstimateTotal) is
+    // serialized only for holders of financialReports; schedules-only viewers
+    // (FIELD_CREW/EMPLOYEE read-only board) get nulls — redaction happens at
+    // serialization, matching the overlays/cashflow/strip rule.
+    canSeeFinancials: boolean;
     pipeline: {
         estimating: CompanyPipeline["estimating"];
         waitingToStart: DashboardProjectRow[];
         scheduled: DashboardProjectRow[];
         inProgress: DashboardProjectRow[];
-        substantialCompletion: CompanyPipeline["substantialCompletion"];
+        substantialCompletion: DashboardProjectRow[];
     };
     calendar: StartCalendar;
     cashflow: CashflowOutlook | null;
@@ -1853,12 +2011,16 @@ async function getProjectMonthStrip(from: Date, to: Date, coRows: OverlayChangeO
  * `month` must be a validated "YYYY-MM" string (the page validates).
  */
 export async function getCompanyDashboardData(
-    userLike: { role: string },
+    userLike: { role: string; canSeeFinancials?: boolean },
     month: string,
 ): Promise<CompanyDashboardData> {
     const role = userLike.role;
     const isAdmin = role === "ADMIN";
     const canEdit = role === "ADMIN" || role === "MANAGER";
+    // Explicit flag wins (the page computes hasPermission(user, "financialReports")
+    // so per-user overrides are honored); the role fallback mirrors the default
+    // permission matrix for callers that don't pass it.
+    const canSeeFinancials = userLike.canSeeFinancials ?? !["FIELD_CREW", "EMPLOYEE"].includes(role);
 
     // Same 42-day grid as the calendar; `to` exclusive (getStartCalendar rule).
     const grid = getMonthGrid(parseUTCDate(`${month}-01`));
@@ -1885,13 +2047,14 @@ export async function getCompanyDashboardData(
         ...pipeline.waitingToStart.map(p => p.id),
         ...pipeline.scheduled.map(p => p.id),
         ...pipeline.inProgress.map(p => p.id),
+        ...pipeline.substantialCompletion.map(p => p.id),
     ];
     const [taskRows, qualifying, unappliedByProject] = await Promise.all([
         prisma.scheduleTask.findMany({
             where: { projectId: { in: rowIds } },
             orderBy: [{ order: "asc" }, { startDate: "asc" }, { id: "asc" }],
             select: {
-                id: true, projectId: true, name: true, startDate: true, endDate: true, status: true, type: true,
+                id: true, projectId: true, name: true, startDate: true, endDate: true, color: true, parentId: true, progress: true, status: true, type: true,
                 assignments: {
                     orderBy: { createdAt: "asc" },
                     select: { id: true, userId: true, user: { select: { name: true, email: true, status: true } } },
@@ -1910,6 +2073,9 @@ export async function getCompanyDashboardData(
             name: task.name,
             startDate: task.startDate.toISOString(),
             endDate: task.endDate.toISOString(),
+            color: task.color,
+            parentId: task.parentId,
+            progress: task.progress,
             status: task.status,
             type: task.type,
             assignments: task.assignments.map(a => ({
@@ -1940,17 +2106,26 @@ export async function getCompanyDashboardData(
         })).map(u => ({ id: u.id, name: u.name || u.email, email: u.email }))
         : null;
 
+    // Money redaction for schedules-only viewers: null out pipeline dollar
+    // fields at serialization (the UI renders "—" for null). Task/crew/date
+    // data stays intact — that's what the read-only board needs.
+    const redactProject = (p: DashboardProjectRow): DashboardProjectRow =>
+        canSeeFinancials ? p : { ...p, contractValue: null };
+    const redactLead = (l: CompanyPipeline["estimating"][number]): CompanyPipeline["estimating"][number] =>
+        canSeeFinancials ? l : { ...l, targetRevenue: null, latestEstimateTotal: null };
+
     return {
         month,
         role,
         canEdit,
         isAdmin,
+        canSeeFinancials,
         pipeline: {
-            estimating: pipeline.estimating,
-            waitingToStart: pipeline.waitingToStart.map(enrich),
-            scheduled: pipeline.scheduled.map(enrich),
-            inProgress: pipeline.inProgress.map(enrich),
-            substantialCompletion: pipeline.substantialCompletion,
+            estimating: pipeline.estimating.map(redactLead),
+            waitingToStart: pipeline.waitingToStart.map(enrich).map(redactProject),
+            scheduled: pipeline.scheduled.map(enrich).map(redactProject),
+            inProgress: pipeline.inProgress.map(enrich).map(redactProject),
+            substantialCompletion: pipeline.substantialCompletion.map(enrich).map(redactProject),
         },
         calendar,
         cashflow,

--- a/src/lib/schedule-core.ts
+++ b/src/lib/schedule-core.ts
@@ -621,8 +621,14 @@ export async function shiftNotStartedTasks(
     input: ShiftNotStartedTasksInput,
 ): Promise<ShiftNotStartedTasksResult> {
     const { projectId, deltaDays, actor } = input;
-    if (!Number.isInteger(deltaDays) || deltaDays === 0) {
+    if (!Number.isSafeInteger(deltaDays) || deltaDays === 0) {
         throw new Error("deltaDays must be a nonzero whole integer");
+    }
+    // Hard magnitude cap: a schedule never legitimately moves more than a year
+    // in one gesture, and an unbounded delta from a direct action call could
+    // push dates outside representable ranges.
+    if (Math.abs(deltaDays) > 365) {
+        throw new Error("deltaDays cannot exceed 365 days in a single shift");
     }
 
     return withTxRetry(() => prisma.$transaction(async (tx) => {
@@ -655,7 +661,8 @@ export async function shiftNotStartedTasks(
             await tx.$executeRaw`
                 UPDATE "ScheduleTask"
                 SET "startDate" = ${shiftedStartDate},
-                    "endDate" = ${shiftedEndDate}
+                    "endDate" = ${shiftedEndDate},
+                    "updatedAt" = NOW()
                 WHERE "id" = ${task.id}
             `;
             shiftedTaskDates.push({
@@ -685,11 +692,24 @@ export async function shiftNotStartedTasks(
                 orderBy: { id: "asc" },
                 select: { id: true, name: true },
             });
+            // CO payment rows carry the same task link since PB-pipeline-003 and
+            // have no status column — any explicit dueDate is billing's authority.
+            const coMilestones = await tx.changeOrderPaymentSchedule.findMany({
+                where: {
+                    scheduleTaskId: { in: shiftedTaskIds },
+                    dueDate: { not: null },
+                },
+                orderBy: { id: "asc" },
+                select: { id: true, name: true },
+            });
             for (const milestone of estimateMilestones) {
                 notes.push(`Estimate milestone "${milestone.name}" (${milestone.id}) has an explicit due date and was not shifted.`);
             }
             for (const milestone of invoiceMilestones) {
                 notes.push(`Invoice milestone "${milestone.name}" (${milestone.id}) has an explicit due date and was not shifted.`);
+            }
+            for (const milestone of coMilestones) {
+                notes.push(`Change-order milestone "${milestone.name}" (${milestone.id}) has an explicit due date and was not shifted.`);
             }
         }
 


### PR DESCRIPTION
Turns `/company-dashboard` into the company's interactive scheduling surface (owner request, follows PB-pipeline-001..003).

## What's new
- **Month + Timeline views** (toggle, localStorage-persisted): colored multi-week project bars with proportional task blocks ("Framing", "Drywall"...), crew chips, continuation chevrons, today/weekend styling, crew-conflict badges.
- **Unscheduled tray**: drag a Waiting-to-Start project onto a calendar day → sets its start date (existing `setProjectStartDate` full-shift path). Estimating leads shown as read-only ghost chips.
- **In-place editing**: whole-bar drag (Waiting to Start = silent full shift; **In Progress = confirm dialog** — "move marker only" vs "shift Not Started tasks"), task-block drag/resize on any status via the canonical `updateScheduleTask`, keyboard alternatives for every drag.
- **ADMIN-only milestone diamonds** on bars (income + projected CO from the existing overlay queries — no new money fetches).
- **New core `shiftNotStartedTasks`**: Project-first locks, date-only writes, ZERO payment-table writes; explicit-dueDate milestones are reported in notes and never moved. ADMIN/MANAGER action.
- **Hardened `updateScheduleTask` date path**: strict YYYY-MM-DD, Project→task lock order, closed-project rejection, milestone same-day rule, audit log. All existing callers already pass YYYY-MM-DD (verified).
- **Read-only board for field roles**: route/nav admit `schedules`-permission users; pipeline money (`contractValue`, `targetRevenue`, `latestEstimateTotal`) is **redacted at serialization** for callers without `financialReports` (flag flows from `hasPermission`, honoring per-user overrides).
- **Next.js 16.1.6 → 16.2.11**: GHSA-mq59-m269-xvcx (Server Actions CSRF via null Origin) — 16.1.6 was in the vulnerable range (< 16.1.7).

## Verification
- DB-backed verifier `scripts/verify-schedule-board.ts`: 51 checks green (role gating incl. new money-redaction cases, byte-identical payment/QB rows through shifts, lock/retry behavior, fixture cleanup).
- Layout + render-contract verifiers green; `tsc --noEmit` 0 errors; `npm run build` clean, 96/96 pages on Next 16.2.11.
- Implementation by the coding AI; independently reviewed by Claude (found + fixed a pipeline-money leak to schedules-permission roles before this PR).
- Post-merge prod walkthrough planned on the internal "Shop" job — schedule moves send no client email (side-effect grep re-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)