### PR TITLE
feat(schedule): owner feedback round — draft-save editing, crew fixes, by-crew view, guide

### DIFF
--- a/scripts/verify-schedule-board-layout.ts
+++ b/scripts/verify-schedule-board-layout.ts
@@ -77,6 +77,13 @@ assert.deepEqual(preview.tasks.map(task => [task.startDate, task.endDate]), [
 assert.equal(new Date(preview.tasks[0].endDate).getTime() - new Date(preview.tasks[0].startDate).getTime(), 3 * 86_400_000);
 const unscheduledPreview = previewProjectMove({ ...project, id: "p-unscheduled", startDate: null, tasks: [] }, "2037-03-15");
 assert.equal(unscheduledPreview.startDate, "2037-03-15");
+// In Progress preview moves the start marker ONLY (owner-decided semantics):
+// neither save choice shifts started work, and the "also shift" choice is
+// consented to in the dialog — the preview never promises more than the
+// guaranteed minimum.
+const inProgressPreview = previewProjectMove({ ...project, id: "p-in-progress", status: "In Progress", startDate: "2037-01-03T00:00:00.000Z" }, "2037-03-15");
+assert.equal(inProgressPreview.startDate, "2037-03-15");
+assert.deepEqual(inProgressPreview.tasks, project.tasks, "In Progress preview must not shift tasks");
 
 type TaskEditMode = import("../src/app/company-dashboard/schedule-board/useBarLayout").TaskEditMode;
 const taskEditModes: TaskEditMode[] = ["move", "resize-left", "resize-right"];

--- a/scripts/verify-schedule-board-layout.ts
+++ b/scripts/verify-schedule-board-layout.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import {
     assignMonthProjectLanes,
     assignProjectLanes,
+    assignTaskLanes,
     clipRange,
     getEffectiveProjectRange,
     segmentProjectRange,
@@ -367,4 +368,32 @@ const milestoneOnlyDays = new Map(Array.from({ length: 5 }, (_, index) => [`m${i
 const milestoneOnlyLanes = assignMonthProjectLanes(new Map(), milestoneOnlyDays, laneGridStart, laneGridEnd);
 assert.equal(milestoneOnlyLanes.visibleMilestoneHosts.length, 4);
 assert.deepEqual(milestoneOnlyLanes.hiddenProjectIdsByWeek.get(3), ["m4"]);
+// Item 5: overlapping mini-lanes inside one project bar (concrete + deck run
+// concurrently) — capped at MAX_TASK_LANES, greedy interval-partition.
+const laneDay = (n: number) => new Date(Date.UTC(2038, 0, n));
+const nonOverlapping = assignTaskLanes([
+    { id: "a", start: laneDay(1), end: laneDay(3) },
+    { id: "b", start: laneDay(3), end: laneDay(5) },
+]);
+assert.deepEqual([...nonOverlapping.laneByTaskId.entries()].sort(), [["a", 0], ["b", 0]], "back-to-back tasks share lane 0");
+assert.equal(nonOverlapping.laneCount, 1);
+assert.deepEqual(nonOverlapping.hiddenTaskIds, []);
+
+const twoOverlapping = assignTaskLanes([
+    { id: "concrete", start: laneDay(1), end: laneDay(5) },
+    { id: "deck", start: laneDay(2), end: laneDay(6) },
+]);
+assert.deepEqual([...twoOverlapping.laneByTaskId.entries()].sort(), [["concrete", 0], ["deck", 1]]);
+assert.equal(twoOverlapping.laneCount, 2);
+
+const fourOverlapping = assignTaskLanes([
+    { id: "t1", start: laneDay(1), end: laneDay(10) },
+    { id: "t2", start: laneDay(1), end: laneDay(10) },
+    { id: "t3", start: laneDay(1), end: laneDay(10) },
+    { id: "t4", start: laneDay(1), end: laneDay(10) },
+]);
+assert.equal(fourOverlapping.laneCount, 3, "lane assignment caps at MAX_TASK_LANES");
+assert.equal(fourOverlapping.hiddenTaskIds.length, 1, "the 4th concurrent task is reported hidden for the +N chip");
+assert.deepEqual([...fourOverlapping.laneByTaskId.values()].sort(), [0, 1, 2]);
+
 console.log("schedule-board layout verification: PASS");

--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -131,7 +131,8 @@ assert.match(boardSource, /function clearTaskPreview\(taskId: string\) \{\n[^}]*
 assert.match(boardSource, /rewriteAwaitingOverridesFromShift\(shiftedPersistedDates\)/, "board-owned shifts must rewrite saved-awaiting overrides to the persisted dates");
 assert.match(boardSource, /rewriteAwaitingOverridesFromShift\(unseen\.flatMap\(event => event\.taskDates\)\)/, "external (legacy StartDateRow) shifts must ALSO rewrite saved-awaiting overrides — ALL unseen events, not just the latest");
 assert.match(boardSource, /externalShiftEvents\.filter\(event => event\.nonce > lastExternalShiftNonceRef\.current\)/, "every unseen external-shift nonce is applied exactly once");
-assert.match(companyDashboardSource, /setExternalShiftEvents\(current => \[\.\.\.current, event\]\.slice\(-20\)\)/, "the legacy path publishes shifts via a functional append (batch-safe queue), never a latest-payload slot");
+assert.match(companyDashboardSource, /setExternalShiftEvents\(current => \[\.\.\.current, event\]\)/, "the legacy path publishes shifts via an UNCAPPED functional append — any truncation can silently drop an unseen event");
+assert.doesNotMatch(companyDashboardSource, /setExternalShiftEvents\([^)]*slice\(/, "the external-shift queue must never be truncated");
 assert.match(companyDashboardSource, /externalShiftEvents=\{externalShiftEvents\}/, "the board must receive the external-shift event queue");
 assert.match(boardSource, /catch \(chunkError: any\) \{/, "chunk failures are isolated per chunk");
 assert.match(boardSource, /chunk\.map\(change => \(\{ taskId: change\.taskId, ok: false as const, error: message \}\)\)/, "a rejected chunk synthesizes failures for its own tasks only");

--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -1,446 +1,182 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
-const monthSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/MonthBarsView.tsx", import.meta.url), "utf8");
-const taskSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/TaskBlockSegment.tsx", import.meta.url), "utf8");
-const boardSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/ScheduleBoard.tsx", import.meta.url), "utf8");
-const projectSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/ProjectBar.tsx", import.meta.url), "utf8");
-function optionalSource(path: string): string {
-    try {
-        return readFileSync(new URL(path, import.meta.url), "utf8");
-    } catch {
-        return "";
-    }
-}
-const traySource = optionalSource("../src/app/company-dashboard/schedule-board/UnscheduledTray.tsx");
-const dialogSource = optionalSource("../src/app/company-dashboard/schedule-board/ShiftConfirmDialog.tsx");
-const timelineSource = optionalSource("../src/app/company-dashboard/schedule-board/TimelineView.tsx");
-const milestoneSource = optionalSource("../src/app/company-dashboard/schedule-board/MilestoneMarker.tsx");
-const layoutSource = optionalSource("../src/app/company-dashboard/schedule-board/useBarLayout.ts");
-const actionsSource = optionalSource("../src/lib/actions.ts");
-const coreSource = optionalSource("../src/lib/schedule-core.ts");
-const pageSource = optionalSource("../src/app/company-dashboard/page.tsx");
-const navSource = optionalSource("../src/components/nav/navItems.tsx");
-const companyDashboardSource = optionalSource("../src/app/company-dashboard/CompanyDashboardClient.tsx");
+// Owner-feedback round (2026-07-22) rewrote the company schedule board from
+// per-drag auto-save + project locking to local draft-mode + one explicit
+// Save. This contract asserts the NEW architecture's real invariants —
+// spec items 1-8 — rather than mirroring implementation lines 1:1.
 
-assert.match(monthSource, /showIncome\s*\?\s*adminOverlays\.income\s*:\s*EMPTY_INCOME/);
-assert.match(monthSource, /showProjectedCo\s*\?\s*adminOverlays\.changeOrders\s*:\s*EMPTY_CHANGE_ORDERS/);
-assert.match(monthSource, /visibleMilestoneHosts/);
-assert.match(taskSource, /task\.assignments\.slice\(0,\s*2\).*initials\(assignment\.name\)/s);
-assert.match(taskSource, /ref=\{setMeasuredElement\}/);
-assert.match(traySource, /application\/x-gtr-project-id/);
-assert.match(traySource, /dataTransfer\.setData/);
-assert.match(traySource, /aria-disabled="true"/);
-assert.match(traySource, /type="date"/);
-assert.match(traySource, /\[@media\(hover:none\)\]:opacity-100/);
-assert.match(traySource, /canEdit\s*\?\s*"Drag a Waiting-to-Start project onto a day or use Project actions\."\s*:\s*"Unscheduled projects are read-only for your role\."/);
-assert.match(monthSource, /data-schedule-date=\{dayKey\}/);
-assert.match(monthSource, /if \(!data\.canEdit \|\| !hasProjectDragPayload\(event\)\) return;[\s\S]*?preventDefault\(\)/);
-assert.match(monthSource, /dragOverDate/);
-assert.match(monthSource, /dataTransfer\.types\.includes\(PROJECT_DRAG_MIME\)/);
-assert.equal((monthSource.match(/!hasProjectDragPayload\(event\)/g) ?? []).length, 2);
-assert.doesNotMatch(projectSource, /window\.addEventListener\("pointermove"|requestAnimationFrame|elementsFromPoint/);
-assert.match(boardSource, /activeProjectPointerRef/);
-assert.match(boardSource, /window\.addEventListener\("pointermove"/);
-assert.match(boardSource, /hitTestTimelineScheduleGrid/);
-assert.match(projectSource, /type="date"/);
-assert.match(projectSource, /\[@media\(hover:none\)\]:opacity-100/);
-assert.match(projectSource, /onProjectPointerEditStart/);
-assert.match(dialogSource, /Dialog\.Title/);
-assert.match(dialogSource, /Dialog\.Description/);
+function src(path: string): string {
+    return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
+const boardSource = src("../src/app/company-dashboard/schedule-board/ScheduleBoard.tsx");
+const monthSource = src("../src/app/company-dashboard/schedule-board/MonthBarsView.tsx");
+const timelineSource = src("../src/app/company-dashboard/schedule-board/TimelineView.tsx");
+const projectBarSource = src("../src/app/company-dashboard/schedule-board/ProjectBar.tsx");
+const taskBlockSource = src("../src/app/company-dashboard/schedule-board/TaskBlockSegment.tsx");
+const traySource = src("../src/app/company-dashboard/schedule-board/UnscheduledTray.tsx");
+const dialogSource = src("../src/app/company-dashboard/schedule-board/ShiftConfirmDialog.tsx");
+const layoutSource = src("../src/app/company-dashboard/schedule-board/useBarLayout.ts");
+const popoverSource = src("../src/app/company-dashboard/schedule-board/FloatingPopover.tsx");
+const actionsSource = src("../src/lib/actions.ts");
+const coreSource = src("../src/lib/schedule-core.ts");
+const companyDashboardSource = src("../src/app/company-dashboard/CompanyDashboardClient.tsx");
+
+// ── Item 2: draft mode replaces per-drag auto-save ──
+
+// Drafting never calls a server action — draftTaskChange/draftProjectMove
+// are pure local-state writers.
+const draftTaskChangeStart = boardSource.indexOf("function draftTaskChange(");
+const draftTaskChangeEnd = boardSource.indexOf("function draftProjectMove(", draftTaskChangeStart);
+const draftTaskChangeBody = boardSource.slice(draftTaskChangeStart, draftTaskChangeEnd);
+assert.ok(draftTaskChangeStart >= 0, "draftTaskChange must exist");
+assert.doesNotMatch(draftTaskChangeBody, /await |updateCompanyScheduleTaskDatesAction|saveCompanyScheduleTaskDatesAction/, "drafting a task change must never touch the server");
+assert.match(draftTaskChangeBody, /setTaskPreview\(taskId, normalizedDates\)/);
+
+const draftProjectMoveStart = boardSource.indexOf("function draftProjectMove(");
+const draftProjectMoveEnd = boardSource.indexOf("function discardAllDrafts(", draftProjectMoveStart);
+const draftProjectMoveBody = boardSource.slice(draftProjectMoveStart, draftProjectMoveEnd);
+assert.ok(draftProjectMoveStart >= 0, "draftProjectMove must exist");
+assert.doesNotMatch(draftProjectMoveBody, /await |updateProjectStartDateAction|shiftNotStartedTasksAction/, "drafting a project move must never touch the server");
+assert.match(draftProjectMoveBody, /setProjectDrafts\(current => /);
+
+// Every pointer/keyboard "finish" path routes into the draft writers, not a
+// commit-to-server function.
+assert.match(boardSource, /draftTaskChange\(task\.id, candidate\)/, "task pointer-drag finish must draft, not commit to the server");
+assert.match(boardSource, /if \(dates\) draftTaskChange\(task\.id, dates\)/, "task keyboard commit must draft, not commit to the server");
+assert.match(boardSource, /draftProjectMove\(drag\.project, candidate\)/, "project pointer-drag finish must draft, not commit to the server");
+assert.match(boardSource, /draftProjectMove\(project, current\.targetStart\)/, "project keyboard commit must draft, not commit to the server");
+assert.doesNotMatch(boardSource, /updateCompanyScheduleTaskDatesAction/, "the board no longer calls the single-task write action directly");
+
+// The batch save is the ONLY place these three server actions are called,
+// and it fires exactly once per Save click.
+assert.match(boardSource, /import \{ saveCompanyScheduleTaskDatesAction, shiftNotStartedTasksAction, updateProjectStartDateAction \} from "@\/lib\/actions"/);
+const saveAllDraftsStart = boardSource.indexOf("async function saveAllDrafts()");
+const saveAllDraftsEnd = boardSource.indexOf("function cancelProjectEditsForProjects", saveAllDraftsStart);
+const saveAllDraftsBody = boardSource.slice(saveAllDraftsStart, saveAllDraftsEnd);
+assert.ok(saveAllDraftsStart >= 0, "saveAllDrafts must exist");
+assert.match(saveAllDraftsBody, /saveCompanyScheduleTaskDatesAction\(changes\)/);
+assert.match(saveAllDraftsBody, /updateProjectStartDateAction\(/);
+assert.match(saveAllDraftsBody, /shiftNotStartedTasksAction\(/);
+assert.equal((saveAllDraftsBody.match(/router\.refresh\(\)/g) ?? []).length, 1, "exactly one router.refresh() after the whole batch settles");
+
+// In-Progress confirm now runs INSIDE the save loop (per drafted project),
+// not at drag-commit time.
+assert.match(saveAllDraftsBody, /canonicalProject\.status === "In Progress"/);
+assert.match(saveAllDraftsBody, /waitForConfirmChoice\(\)/);
+assert.doesNotMatch(draftProjectMoveBody, /confirmIntent|ShiftConfirmDialog/, "dragging an In Progress project must not surface the confirm dialog");
+assert.match(boardSource, /function waitForConfirmChoice\(\): Promise<ProjectMoveChoice \| "cancel">/);
+
+// Failures are isolated and reported per item; succeeded drafts clear,
+// failed ones remain pending for retry.
+assert.match(saveAllDraftsBody, /catch \(error\) \{\s*failedProjectNames\.push/);
+assert.match(boardSource, /failedTaskNames = batchResult\.results/);
+assert.match(boardSource, /toast\.error\(/);
+assert.match(boardSource, /toast\.success\(`Saved \$\{totalSucceeded\}/);
+
+// No project/task locking while merely drafting — only isSaving (or an
+// externally-locked project) blocks an edit.
+const isProjectLockedStart = boardSource.indexOf("const isProjectLocked = useCallback");
+const isProjectLockedEnd = boardSource.indexOf("const isTaskLocked = useCallback", isProjectLockedStart);
+const isProjectLockedBody = boardSource.slice(isProjectLockedStart, isProjectLockedEnd);
+assert.match(isProjectLockedBody, /isSaving \|\| isProjectExternallyPending\(projectId\)/);
+assert.doesNotMatch(isProjectLockedBody, /projectDrafts|taskDateOverrides/, "a drafted item must never be locked purely for being drafted");
+
+// Sticky action bar: draft count + Save + Discard.
+assert.match(boardSource, /\{draftCount > 0 && \(/);
+assert.match(boardSource, /\{draftCount\} unsaved change\{draftCount === 1 \? "" : "s"\}/);
+assert.match(boardSource, /onClick=\{discardAllDrafts\}/);
+assert.match(boardSource, /onClick=\{\(\) => void saveAllDrafts\(\)\}/);
+assert.match(boardSource, /\{isSaving \? "Saving\.\.\." : "Save"\}/);
+
+// Drafted visuals: dashed/desaturated, but never disabled via isPending.
+assert.match(projectBarSource, /isDraft\?: boolean/);
+assert.match(projectBarSource, /isDraft \? "border-dashed border-2 border-white\/90 saturate-\[\.55\] brightness-95"/);
+assert.doesNotMatch(projectBarSource, /canMoveProject && !isPending && !isDraft/, "a drafted project bar must stay as interactive as a saved one");
+assert.match(taskBlockSource, /isDraft\?: boolean/);
+assert.match(taskBlockSource, /isDraft \? "border-dashed border-2 border-white\/90 saturate-\[\.55\] brightness-95"/);
+
+// ── Item 1: crew ACTIVATED validation is added-only ──
+const setProjectCrewStart = coreSource.indexOf("export async function setProjectCrew");
+const setProjectCrewEnd = coreSource.indexOf("export interface CrewConflictPair", setProjectCrewStart);
+const setProjectCrewBody = coreSource.slice(setProjectCrewStart, setProjectCrewEnd);
+assert.match(setProjectCrewBody, /toConnect\.map\(id => byId\.get\(id\)!\)\.filter\(u => u\.status !== "ACTIVATED"\)/);
+assert.ok(setProjectCrewBody.indexOf("toConnect = wanted.filter") < setProjectCrewBody.indexOf("notActivated ="), "toConnect must be computed before the ACTIVATED check runs against it");
+const setTaskCrewBody = coreSource.slice(coreSource.indexOf("export async function setTaskCrew"));
+assert.match(setTaskCrewBody, /toAdd\.map\(id => byId\.get\(id\)!\)\.filter\(u => u\.status !== "ACTIVATED"\)/);
+
+// ── Item 3: floating popovers escape clipping via a portal ──
+assert.match(popoverSource, /createPortal\(/);
+assert.match(popoverSource, /document\.body/);
+assert.match(popoverSource, /event\.key !== "Escape"/);
+assert.match(popoverSource, /anchorRef\.current\?\.focus\(\)/);
+assert.match(popoverSource, /flipAbove/);
+assert.match(popoverSource, /VIEWPORT_MARGIN_PX/);
+assert.match(projectBarSource, /import \{ FloatingPopover \} from "\.\/FloatingPopover"/);
+assert.match(taskBlockSource, /import \{ FloatingPopover \} from "\.\/FloatingPopover"/);
+assert.doesNotMatch(projectBarSource, /<details/, "the project bar's Actions menu must no longer be a clipped native <details>");
+assert.doesNotMatch(taskBlockSource, /<details/, "the task block's date menu must no longer be a clipped native <details>");
+
+// ── Item 4: no Estimating leads anywhere on the board ──
+assert.doesNotMatch(traySource, /estimating/i, "the tray must not reference Estimating leads at all");
+assert.doesNotMatch(boardSource, /estimating=\{data\.pipeline\.estimating\}/, "the board must not pass estimating leads into the tray");
+for (const source of [monthSource, timelineSource]) {
+    assert.doesNotMatch(source, /pipeline\.estimating/, "month/timeline project sourcing must never include Estimating leads");
+}
+
+// ── Item 5: overlapping task blocks stack into capped mini-lanes ──
+assert.match(layoutSource, /export const MAX_TASK_LANES = 3/);
+assert.match(layoutSource, /export function assignTaskLanes/);
+assert.match(projectBarSource, /assignTaskLanes\(taskLaneInput\)/);
+assert.match(projectBarSource, /hiddenTasks\.length > 0/, "a +N overflow affordance must exist for tasks beyond the lane cap");
+assert.match(taskBlockSource, /laneTop\?: number/);
+assert.match(taskBlockSource, /laneHeight\?: number/);
+
+// ── Item 6: a bar click toggles its menu, never navigates ──
+assert.match(projectBarSource, /function handleBarClick\(/);
+assert.match(projectBarSource, /setMenuOpen\(value => !value\)/);
+assert.doesNotMatch(projectBarSource, /onClick=\{.*router\.push|onClick=\{.*navigate/, "the bar itself must never navigate on click");
+assert.match(projectBarSource, />\s*Open project\s*<\/Link>/, "Open project must be a menu item inside the Actions dropdown");
+
+// ── Item 7: crew picker hygiene (FINANCE exclusion + name disambiguation) ──
+assert.match(coreSource, /where: \{ status: "ACTIVATED", role: \{ not: "FINANCE" \} \}/);
+assert.match(coreSource, /nameCounts\.get\(r\.name\)! > 1 \? \{ \.\.\.r, name: `\$\{r\.name\} \(\$\{r\.email\}\)` \} : r/);
+assert.match(companyDashboardSource, /c\.role === "FINANCE" \? "finance" : "inactive"/);
+assert.match(companyDashboardSource, /a\.role === "FINANCE" \? " \(finance\)"/);
+
+// ── Item 8: crew-grouped Timeline toggle ──
+// By-project rows must size from the shared lane geometry — a fixed h-16 row
+// overflows when a 3-lane (60px) bar renders inside it.
+assert.match(timelineSource, /const rowHeight = Math\.max\(64, 12 \+ computeTaskLaneLayout\(project\.tasks\)\.barHeight \+ 8\)/, "Timeline by-project row height must derive from computeTaskLaneLayout");
+assert.doesNotMatch(timelineSource, /data-timeline-schedule-grid="true" className="relative h-16/, "Timeline schedule grid must not use a fixed h-16 row");
+assert.match(projectBarSource, /export function computeTaskLaneLayout/, "bar lane geometry must be the shared exported helper");
+assert.match(timelineSource, /gtr-company-schedule-board-crew-mode/);
+assert.match(timelineSource, /function buildCrewTimelineRows/);
+assert.match(timelineSource, /member\.status !== "ACTIVATED"/);
+assert.match(timelineSource, /assignedProjectIdsByUser\.get\(member\.id\)\?\.has\(project\.id\)/, "unassigned-but-on-crew coverage must use the same project-window fallback source data");
+assert.match(timelineSource, /toggleGroupByCrew/);
+assert.match(timelineSource, />\s*By crew\s*</);
+
+// ── Cross-cutting: the ShiftConfirmDialog contract is unchanged in shape ──
 assert.match(dialogSource, /Move start marker only/);
 assert.match(dialogSource, /Also shift all Not Started tasks by/);
-assert.match(boardSource, /updateProjectStartDateAction\(intent\.project\.id, intent\.targetStart, false\)/);
-assert.match(boardSource, /shiftNotStartedTasksAction\(intent\.project\.id, intent\.deltaDays\)/);
-assert.match(boardSource, /toast\.success\("Project scheduled"/);
-assert.match(boardSource, /router\.refresh\(\)/);
-assert.match(boardSource, /previewProjectIncomeOverlays/);
-assert.match(boardSource, /project\.status === "Waiting to Start" && project\.startDate/);
-assert.match(boardSource, /overlays:\s*data\.overlays\s*\?/);
+assert.match(boardSource, /<ShiftConfirmDialog[\s\S]*?intent=\{confirmIntent\}[\s\S]*?onChoice=\{handleMoveChoice\}[\s\S]*?onCancel=\{cancelConfirmedMove\}/);
 
-assert.match(timelineSource, /export function TimelineView/);
-assert.match(boardSource, /export type BoardView\s*=\s*"month"\s*\|\s*"timeline"/);
-assert.match(boardSource, /gtr-company-schedule-board-view/);
-assert.match(boardSource, /useState<BoardView>\("month"\)/);
-assert.match(boardSource, /useEffect\(\(\)\s*=>\s*\{[\s\S]*?localStorage\.getItem\([\s\S]*?stored\s*===\s*"month"\s*\|\|\s*stored\s*===\s*"timeline"[\s\S]*?setBoardView\(stored\)/);
-assert.match(boardSource, /localStorage\.setItem\([\s\S]*?gtr-company-schedule-board-view|localStorage\.setItem\(BOARD_VIEW_STORAGE_KEY/);
-assert.equal((boardSource.match(/aria-pressed=\{boardView === /g) ?? []).length, 2);
-assert.match(boardSource, /boardView\s*===\s*"month"[\s\S]*?<MonthBarsView[\s\S]*?\)\s*:\s*\(\s*<TimelineView/);
-
-assert.match(timelineSource, /DAY_WIDTH\s*=\s*20/);
-assert.match(timelineSource, /TIMELINE_DAYS\s*=\s*42/);
-assert.match(timelineSource, /toTimelineRect\([\s\S]*?DAY_WIDTH/);
-assert.match(timelineSource, /getMonthGrid/);
-assert.match(timelineSource, /position:\s*"sticky"|sticky left-0/);
-assert.match(timelineSource, /overflow-x-auto/);
-assert.match(timelineSource, /isWeekend/);
-assert.match(timelineSource, /isSameUTCDay/);
-assert.match(timelineSource, /ProjectBar/);
-assert.match(timelineSource, /MilestoneMarker/);
-assert.match(timelineSource, /timelineOrigin=\{gridStart\}/);
-assert.match(timelineSource, /dayWidth=\{DAY_WIDTH\}/);
-assert.match(milestoneSource, /timelineOrigin\?:\s*Date/);
-assert.match(milestoneSource, /dayWidth\?:\s*number/);
-assert.match(milestoneSource, /toTimelineRect/);
-assert.match(timelineSource, /adminOverlays\.income/);
-assert.match(timelineSource, /adminOverlays\.changeOrders/);
-assert.match(timelineSource, /showIncome/);
-assert.match(timelineSource, /showProjectedCo/);
-assert.match(timelineSource, /showExpenses/);
-assert.match(timelineSource, /showHours/);
-assert.match(timelineSource, /onMoveCommit=\{onProjectMoveCommit\}/);
-assert.match(timelineSource, /onProjectPointerEditStart=\{onProjectPointerEditStart\}/);
-assert.match(timelineSource, /LABEL_WIDTH\s*=\s*240/);
-assert.match(timelineSource, /timelineLeftInset=\{LABEL_WIDTH\}/);
-assert.match(timelineSource, /tabIndex=\{labels\.length\s*>\s*0\s*\?\s*0\s*:\s*undefined\}/);
-assert.match(timelineSource, /aria-label=\{labels\.length\s*>\s*0/);
-assert.match(timelineSource, /focus-visible:ring-2/);
-assert.match(timelineSource, /group\/overlay/);
-assert.match(timelineSource, /group-focus\/overlay:block/);
-assert.match(timelineSource, /labels\.join\(", "\)/);
-
-// Task 7 Timeline release regression: only the date body is a valid pointer-up target.
-assert.match(timelineSource, /data-timeline-schedule-grid="true"/);
-assert.match(timelineSource, /data-timeline-sticky-label="true"/);
-assert.match(boardSource, /function hitTestTimelineScheduleGrid\(clientX: number, clientY: number\): boolean/);
-const timelineGridHitTestStart = boardSource.indexOf("function hitTestTimelineScheduleGrid");
-const timelineGridHitTestEnd = boardSource.indexOf("function isInteractiveTaskFallbackTarget", timelineGridHitTestStart);
-const timelineGridHitTestBody = boardSource.slice(timelineGridHitTestStart, timelineGridHitTestEnd);
-assert.match(timelineGridHitTestBody, /document\.elementsFromPoint\(clientX, clientY\)/);
-assert.match(timelineGridHitTestBody, /data-timeline-sticky-label/);
-assert.match(timelineGridHitTestBody, /data-timeline-schedule-grid/);
-assert.match(timelineGridHitTestBody, /getBoundingClientRect\(\)/);
-const taskPointerStart = boardSource.indexOf("function handleTaskPointerEditStart");
-const taskPointerEnd = boardSource.indexOf("function handleTaskKeyboardStart", taskPointerStart);
-const taskPointerBody = boardSource.slice(taskPointerStart, taskPointerEnd);
-assert.match(taskPointerBody, /if \(start\.timelineDayWidth\) \{\s*if \(hitTestTimelineScheduleGrid\(drag\.latestClientX, drag\.latestClientY\)\) \{\s*deltaDays = getTimelinePointerDelta/);
-
-assert.match(boardSource, /getTimelineAutoscrollStep\(/);
-assert.match(boardSource, /timelineScrollContainerRef/);
-assert.match(boardSource, /drag\.latestClientX\s*=\s*event\.clientX;[\s\S]*?drag\.latestClientY\s*=\s*event\.clientY;[\s\S]*?calculateProjectPointerCandidate/);
-assert.match(boardSource, /cancelActiveProjectEdit\(\);[\s\S]*?cancelActiveTaskEdit\(\);[\s\S]*?setBoardView\(nextView\)/);
-
-// Task 7: task movement, resize, accessible fallbacks, and stable controller ownership.
-assert.match(layoutSource, /export type TaskEditMode\s*=\s*"move"\s*\|\s*"resize-left"\s*\|\s*"resize-right"/);
-assert.match(layoutSource, /export interface TaskDateOverride\s*\{[\s\S]*?startDate:\s*string;[\s\S]*?endDate:\s*string;/);
-assert.match(boardSource, /const \[taskDateOverrides, setTaskDateOverrides\]\s*=\s*useState<Record<string, TaskDateOverride>>/);
-assert.match(boardSource, /canonicalTaskById/);
-assert.match(boardSource, /previewTaskDates\(canonicalTask/);
-assert.equal((boardSource.match(/updateCompanyScheduleTaskDatesAction\(taskId,\s*\{\s*startDate:\s*dates\.startDate,\s*endDate:\s*dates\.endDate\s*\}\)/g) ?? []).length, 1);
-assert.match(boardSource, /toast\.success\("Task dates updated"\);[\s\S]*?router\.refresh\(\)/);
-assert.match(boardSource, /catch \(error\)\s*\{[\s\S]*?clearTaskPreview\(taskId\)[\s\S]*?toast\.error/);
-assert.match(boardSource, /pendingTaskIds/);
-assert.match(boardSource, /TASK_MOUSE_DRAG_THRESHOLD_PX\s*=\s*5/);
-assert.match(boardSource, /TASK_TOUCH_DRAG_THRESHOLD_PX\s*=\s*8/);
-assert.match(boardSource, /requestAnimationFrame/);
-assert.match(boardSource, /window\.addEventListener\("pointermove"/);
-assert.match(boardSource, /window\.removeEventListener\("pointermove"/);
-assert.match(boardSource, /window\.addEventListener\("keydown",\s*onWindowKeyDown\)/);
-assert.match(boardSource, /window\.removeEventListener\("keydown",\s*onWindowKeyDown\)/);
-assert.match(boardSource, /activeTaskPointerRef/);
-assert.match(boardSource, /cancelActiveTaskEdit\(\);[\s\S]*?setBoardView\(nextView\)/);
-assert.match(boardSource, /sourceElement\.style\.touchAction\s*=\s*"none"/);
-assert.match(boardSource, /sourceElement\.style\.touchAction\s*=\s*drag\.previousTouchAction/);
-assert.match(boardSource, /if \(!data\.canEdit \|\| isTaskOrProjectPending\(/);
-assert.match(taskSource, /timelineScrollContainerRef/);
-assert.match(taskSource, /timelineLeftInset/);
-assert.match(taskPointerBody, /getTaskAutoscrollStep/);
-assert.match(taskPointerBody, /timelineScrollContainerRef\?\.current/);
-assert.match(taskPointerBody, /timelineLeftInset/);
-assert.match(taskPointerBody, /MAX_AUTOSCROLL_PX_PER_FRAME/);
-assert.match(taskPointerBody, /container\.scrollLeft \+= scrollDelta/);
-assert.match(taskPointerBody, /drag\.originX -= container\.scrollLeft - before/);
-assert.match(taskPointerBody, /requestAnimationFrame\(runTaskPointerFrame\)/);
-
-assert.equal((monthSource.match(/onTaskPointerEditStart=\{onTaskPointerEditStart\}/g) ?? []).length, 2);
-assert.equal((timelineSource.match(/onTaskPointerEditStart=\{onTaskPointerEditStart\}/g) ?? []).length, 2);
-assert.match(projectSource, /onTaskPointerEditStart=\{onTaskPointerEditStart\}/);
-assert.match(projectSource, /isPending=\{isPending \|\| pendingTaskIds\.has\(task\.id\)\}/);
-assert.match(monthSource, /isPending=\{pendingProjectIds\.has\(project\.id\) \|\| pendingTaskIds\.has\(task\.id\)\}/);
-assert.match(timelineSource, /isPending=\{pendingProjectIds\.has\(project\.id\) \|\| pendingTaskIds\.has\(task\.id\)\}/);
-assert.match(taskSource, /onTaskPointerEditStart/);
-assert.match(taskSource, /if \(!canEdit \|\| isPending/);
-assert.match(taskSource, /w-2/);
-assert.equal((taskSource.match(/Resize (?:start|end) of/g) ?? []).length, 2);
-assert.match(taskSource, /task\.type\s*!==\s*"milestone"[\s\S]*?resize-left/);
-assert.match(taskSource, /task\.type\s*!==\s*"milestone"[\s\S]*?resize-right/);
-assert.match(taskSource, /touch-pan-y/);
-assert.match(taskSource, /tabIndex=\{0\}/);
-assert.match(taskSource, /data-task-edit-block="true"/);
-assert.match(taskSource, /event\.key === " " \|\| event\.key === "Enter"/);
-assert.match(taskSource, /event\.shiftKey \? 7 : 1/);
-assert.match(taskSource, /event\.key === "ArrowLeft" \|\| event\.key === "ArrowUp"/);
-assert.match(taskSource, /event\.key === "ArrowRight" \|\| event\.key === "ArrowDown"/);
-assert.match(taskSource, /event\.key === "Escape"/);
-assert.match(taskSource, /type="date"/);
-assert.match(taskSource, /Move Earlier/);
-assert.match(taskSource, /Move Later/);
-assert.match(taskSource, /\[@media\(hover:none\)\]:opacity-100/);
-assert.match(taskSource, /group-focus-within\/task:opacity-100/);
-assert.match(taskSource, /aria-disabled=\{!canEdit \|\| isPending\}/);
-
-// Task 8 focused re-review: the company board adds authorization only; the
-// established project schedule action remains the single mutation core.
-assert.doesNotMatch(coreSource, /export async function updateCompanyScheduleTaskDates/);
-const canonicalTaskActionStart = actionsSource.indexOf("export async function updateScheduleTask");
-const canonicalTaskActionEnd = actionsSource.indexOf("export async function deleteScheduleTask", canonicalTaskActionStart);
-const canonicalTaskActionBody = actionsSource.slice(canonicalTaskActionStart, canonicalTaskActionEnd);
-assert.match(canonicalTaskActionBody, /await assertScheduleTaskAccess\(taskId\)/);
-assert.doesNotMatch(canonicalTaskActionBody, /\["ADMIN",\s*"MANAGER"\]\.includes\((?:user|caller)\.role\)/);
-assert.match(canonicalTaskActionBody, /withTxRetry\(\(\)\s*=>\s*prisma\.\$transaction/);
-assert.match(canonicalTaskActionBody, /SELECT id FROM "Project"[\s\S]*?FOR UPDATE/);
-assert.match(canonicalTaskActionBody, /SELECT id FROM "ScheduleTask"[\s\S]*?FOR UPDATE/);
-assert.match(canonicalTaskActionBody, /parseStartDateInput/);
-assert.match(canonicalTaskActionBody, /persistedTask\.type === "milestone"/);
-assert.match(canonicalTaskActionBody, /endDate <= startDate/);
-assert.match(canonicalTaskActionBody, /activityLog\.create/);
-assert.match(canonicalTaskActionBody, /revalidatePath\("\/company-dashboard"\)/);
-const companyTaskAdapterStart = actionsSource.indexOf("export async function updateCompanyScheduleTaskDatesAction");
-const companyTaskAdapterEnd = actionsSource.indexOf("export async function updateProjectStatus", companyTaskAdapterStart);
-const companyTaskAdapterBody = actionsSource.slice(companyTaskAdapterStart, companyTaskAdapterEnd);
-assert.ok(companyTaskAdapterStart >= 0, "company schedule task-date authorization adapter must exist");
-assert.match(companyTaskAdapterBody, /\["ADMIN",\s*"MANAGER"\]\.includes\(caller\.role\)/);
-assert.equal((companyTaskAdapterBody.match(/updateScheduleTask\(/g) ?? []).length, 1, "adapter delegates exactly once to the canonical action");
-assert.doesNotMatch(companyTaskAdapterBody, /parseStartDateInput|withTxRetry|\$transaction|\$queryRaw|scheduleTask\.update|activityLog\.create|revalidatePath/);
-assert.match(boardSource, /import \{[^}]*updateCompanyScheduleTaskDatesAction[^}]*\} from "@\/lib\/actions"/s);
-assert.doesNotMatch(boardSource, /\bupdateScheduleTask\(/);
-
-assert.match(taskSource, /if \(event\.target !== event\.currentTarget\) return;/);
-assert.match(boardSource, /taskKeyboardSentinelRef/);
-assert.match(boardSource, /sourceElement\.isConnected/);
-assert.match(boardSource, /isInteractiveTaskFallbackTarget/);
-assert.match(boardSource, /document\.activeElement === taskKeyboardSentinelRef\.current/);
-assert.match(taskSource, /useId\(\)/);
-assert.match(taskSource, /task-start-\$\{task\.id\}-\$\{fragmentId\}/);
-assert.match(taskSource, /!mutationDisabled\s*&&\s*\(\s*<details/);
-
-assert.match(boardSource, /currentCandidate:\s*TaskDateOverride \| null/);
-assert.match(boardSource, /drag\.currentCandidate\s*=\s*null;[\s\S]*?clearTaskPreview\(task\.id\)/);
-assert.match(boardSource, /drag\.latestClientX\s*=\s*event\.clientX;[\s\S]*?drag\.latestClientY\s*=\s*event\.clientY;[\s\S]*?calculatePointerCandidate\(\)/);
-assert.match(boardSource, /if \(!candidate\)\s*\{[\s\S]*?clearTaskPreview\(task\.id\)[\s\S]*?return;/);
-
-assert.match(boardSource, /awaitingTaskRefreshIds/);
-assert.match(boardSource, /taskDatesMatch\(canonicalTask,\s*dates\)/);
-assert.match(boardSource, /setAwaitingTaskRefreshIds/);
-const taskCommitStart = boardSource.indexOf("async function commitTaskDates");
-const taskCommitEnd = boardSource.indexOf("function showSuccess", taskCommitStart);
-const taskCommitBody = boardSource.slice(taskCommitStart, taskCommitEnd);
-const taskSuccessStart = taskCommitBody.indexOf('toast.success("Task dates updated")');
-const taskSuccessEnd = taskCommitBody.indexOf("catch (error)", taskSuccessStart);
-const taskSuccessBody = taskCommitBody.slice(taskSuccessStart, taskSuccessEnd);
-assert.doesNotMatch(taskSuccessBody, /clearTaskPreview\(taskId\)|setTaskPending\(taskId, false\)/);
-assert.match(taskSuccessBody, /setAwaitingTaskRefreshIds/);
-assert.match(taskSuccessBody, /router\.refresh\(\)/);
-
-// Parent-project pending state blocks every child-task entry/commit path, and
-// project/task pointer + keyboard controllers cannot coexist.
-assert.match(boardSource, /canonicalTaskProjectById/);
-assert.match(boardSource, /const isTaskOrProjectPending = \(taskId: string\)/);
-assert.match(layoutSource, /export function getEffectivePendingProjectIds/);
-assert.match(boardSource, /getEffectivePendingProjectIds\([\s\S]*?effectivePendingTaskIds[\s\S]*?canonicalTaskProjectById/);
-assert.match(boardSource, /effectivePendingProjectIdsRef\.current = effectivePendingProjectIds/);
-assert.match(boardSource, /const isProjectPending = \(projectId: string\) =>[\s\S]*?effectivePendingProjectIdsRef\.current\.has\(projectId\)/);
-assert.match(taskCommitBody, /isTaskOrProjectPending\(taskId\)/);
-assert.match(taskPointerBody, /isTaskOrProjectPending\(task\.id\)/);
-assert.match(taskPointerBody, /cancelActiveProjectEdit\(\)/);
-const taskKeyboardStart = boardSource.indexOf("function handleTaskKeyboardStart");
-const taskKeyboardEnd = boardSource.indexOf("function handleTaskKeyboardAdjust", taskKeyboardStart);
-const taskKeyboardBody = boardSource.slice(taskKeyboardStart, taskKeyboardEnd);
-assert.match(taskKeyboardBody, /isTaskOrProjectPending\(task\.id\)/);
-assert.match(taskKeyboardBody, /cancelActiveProjectEdit\(\)/);
-const projectPointerStart = boardSource.indexOf("function handleProjectPointerEditStart");
-const projectPointerEnd = boardSource.indexOf("function handleProjectKeyboardStart", projectPointerStart);
-const projectPointerBody = boardSource.slice(projectPointerStart, projectPointerEnd);
-assert.match(projectPointerBody, /cancelActiveTaskEdit\(\)/);
-const projectKeyboardStart = boardSource.indexOf("function handleProjectKeyboardStart");
-const projectKeyboardEnd = boardSource.indexOf("function handleProjectKeyboardAdjust", projectKeyboardStart);
-assert.match(boardSource.slice(projectKeyboardStart, projectKeyboardEnd), /cancelActiveTaskEdit\(\)/);
-for (const [startMarker, endMarker] of [
-    ["function handleTaskKeyboardAdjust", "function handleTaskKeyboardCommit"],
-    ["function handleTaskKeyboardCommit", "function handleTaskKeyboardCancel"],
-    ["function handleTaskDatesCommit", "function handleTaskMoveBy"],
-    ["function handleTaskMoveBy", "return ("],
-] as const) {
-    const start = boardSource.indexOf(startMarker);
-    const end = boardSource.indexOf(endMarker, start);
-    assert.match(boardSource.slice(start, end), /isTaskOrProjectPending\(task\.id\)/, `${startMarker} must reject child work while the project is pending`);
+// ── Money-path invariants: unchanged by this feature round ──
+for (const source of [boardSource, monthSource, timelineSource, projectBarSource, taskBlockSource, popoverSource]) {
+    assert.doesNotMatch(source, /PaymentSchedule\.(update|create|delete)|EstimatePaymentSchedule\.(update|create|delete)|ChangeOrderPaymentSchedule\.(update|create|delete)/);
+    assert.doesNotMatch(source, /\bfetch\s*\(/);
 }
+assert.match(monthSource, /const adminOverlays = data\.isAdmin \? data\.overlays : null/);
+assert.match(timelineSource, /const adminOverlays = data\.isAdmin \? data\.overlays : null/);
+assert.match(monthSource, /canEdit=\{data\.canEdit\}/);
+assert.match(timelineSource, /canEdit=\{data\.canEdit\}/);
+assert.match(projectBarSource, /canEdit=\{canEdit\}/);
 
-// Reverse exclusion is live at every project start/preview/final-commit path,
-// including controllers whose listeners were created before a child save.
-for (const [startMarker, endMarker] of [
-    ["function scheduleUnscheduledProject", "function commitWaitingProjectMove"],
-    ["function commitWaitingProjectMove", "function handleProjectMovePreview"],
-    ["function handleProjectMovePreview", "function handleProjectMoveCommit"],
-    ["function handleProjectMoveCommit", "function handleMoveChoice"],
-    ["function handleMoveChoice", "function cancelConfirmedMove"],
-    ["function handleProjectPointerEditStart", "function handleProjectKeyboardStart"],
-    ["function handleProjectKeyboardStart", "function handleProjectKeyboardAdjust"],
-    ["function handleProjectKeyboardAdjust", "function handleProjectKeyboardCommit"],
-    ["function handleProjectKeyboardCommit", "function handleProjectKeyboardCancel"],
-] as const) {
-    const start = boardSource.indexOf(startMarker);
-    const end = boardSource.indexOf(endMarker, start);
-    assert.match(boardSource.slice(start, end), /isProjectPending\(/, `${startMarker} must read the live task-derived parent pending state`);
-}
-const projectCommitStart = boardSource.indexOf("function handleProjectMoveCommit");
-const projectCommitEnd = boardSource.indexOf("function handleMoveChoice", projectCommitStart);
-assert.match(boardSource.slice(projectCommitStart, projectCommitEnd), /isProjectPending\(project\.id\)[\s\S]*?clearProjectPreview\(project\.id\)/);
-assert.match(boardSource, /<UnscheduledTray[\s\S]*?pendingProjectIds=\{effectivePendingProjectIds\}/);
-assert.equal((boardSource.match(/pendingProjectIds=\{effectivePendingProjectIds\}/g) ?? []).length, 3, "tray and both views receive task-derived project pending state");
-
-// Task 8 final integration: page-wide project mutation exclusion coordinates
-// the sibling legacy StartDateRow and every board task/project entry point.
-assert.match(boardSource, /interface ScheduleBoardProps[\s\S]*?externallyPendingProjectIds:\s*ReadonlySet<string>[\s\S]*?isProjectExternallyPending:\s*\(projectId: string\) => boolean[\s\S]*?onEffectivePendingProjectIdsChange:\s*\(projectIds: ReadonlySet<string>\) => void/);
-assert.match(boardSource, /getEffectivePendingProjectIds\([\s\S]*?externallyPendingProjectIds[\s\S]*?effectivePendingTaskIds[\s\S]*?canonicalTaskProjectById/);
-assert.match(boardSource, /const isProjectPending = \(projectId: string\) =>[\s\S]*?effectivePendingProjectIdsRef\.current\.has\(projectId\)[\s\S]*?isProjectExternallyPending\(projectId\)/);
-assert.match(boardSource, /const publishEffectivePendingProjectIds = useCallback\([\s\S]*?onEffectivePendingProjectIdsChange\(next\)/);
-const projectPendingSetterStart = boardSource.indexOf("function setProjectPending");
-const taskPendingSetterStart = boardSource.indexOf("function setTaskPending", projectPendingSetterStart);
-const taskPendingSetterEnd = boardSource.indexOf("function setTaskKeyboardState", taskPendingSetterStart);
-assert.match(boardSource.slice(projectPendingSetterStart, taskPendingSetterStart), /if \(pending\)[\s\S]*?publishEffectivePendingProjectIds/);
-assert.match(boardSource.slice(taskPendingSetterStart, taskPendingSetterEnd), /if \(pending\)[\s\S]*?canonicalTaskProjectById\.get\(taskId\)[\s\S]*?publishEffectivePendingProjectIds/);
-assert.match(boardSource, /useEffect\(\(\) => \{\s*publishEffectivePendingProjectIds\(effectivePendingProjectIds\);\s*\}, \[effectivePendingProjectIds, publishEffectivePendingProjectIds\]\)/);
-assert.match(boardSource, /useEffect\(\(\) => \(\) => onEffectivePendingProjectIdsChange\(EMPTY_PROJECT_IDS\), \[onEffectivePendingProjectIdsChange\]\)/);
-
-assert.match(companyDashboardSource, /const boardPendingProjectIdsRef = useRef<Set<string>>/);
-assert.match(companyDashboardSource, /const legacyProjectMutationsRef = useRef<Map<string, LegacyProjectMutation>>/);
-assert.match(companyDashboardSource, /const isPageProjectPending = useCallback\(\(projectId: string\) =>[\s\S]*?boardPendingProjectIdsRef\.current\.has\(projectId\)[\s\S]*?legacyProjectMutationsRef\.current\.has\(projectId\)/);
-assert.match(companyDashboardSource, /const publishBoardPendingProjectIds = useCallback[\s\S]*?projectIdSetsEqual[\s\S]*?setBoardPendingProjectIds/);
-assert.match(companyDashboardSource, /<ScheduleBoard[\s\S]*?externallyPendingProjectIds=\{legacyPendingProjectIds\}[\s\S]*?isProjectExternallyPending=\{isPageProjectPending\}[\s\S]*?onEffectivePendingProjectIdsChange=\{publishBoardPendingProjectIds\}/);
-assert.match(companyDashboardSource, /<StartDateRow[\s\S]*?isProjectPending=\{pagePendingProjectIds\.has\(p\.id\)\}[\s\S]*?beginProjectMutation=\{beginLegacyProjectMutation\}[\s\S]*?awaitProjectRefresh=\{awaitLegacyProjectRefresh\}[\s\S]*?clearProjectMutation=\{clearLegacyProjectMutation\}/);
-
-const startDateRowStart = companyDashboardSource.indexOf("function StartDateRow");
-const startDateRowEnd = companyDashboardSource.indexOf("export default function CompanyDashboardClient", startDateRowStart);
-const startDateRowBody = companyDashboardSource.slice(startDateRowStart, startDateRowEnd);
-assert.equal((companyDashboardSource.match(/updateProjectStartDateAction\(/g) ?? []).length, 1, "the company dashboard has exactly one legacy project-start writer");
-assert.match(startDateRowBody, /if \(!beginProjectMutation\(project\.id\)\) return;/);
-assert.ok(startDateRowBody.indexOf("beginProjectMutation(project.id)") < startDateRowBody.indexOf("updateProjectStartDateAction(project.id"), "the live page lock must be acquired before the legacy action starts");
-assert.match(startDateRowBody, /awaitProjectRefresh\(project\.id,\s*\{[\s\S]*?projectStartDate:\s*result\.startDate[\s\S]*?taskDates:\s*result\.shiftedTaskDates/);
-const legacySuccessStart = startDateRowBody.indexOf("const result = await updateProjectStartDateAction");
-const legacySuccessEnd = startDateRowBody.indexOf("catch (error)", legacySuccessStart);
-assert.doesNotMatch(startDateRowBody.slice(legacySuccessStart, legacySuccessEnd), /clearProjectMutation/, "legacy success keeps the parent lock through canonical refresh");
-assert.match(startDateRowBody, /catch \(error\)[\s\S]*?clearProjectMutation\(project\.id\)/);
-assert.equal((startDateRowBody.match(/disabled=\{isPending \|\| isProjectPending\}/g) ?? []).length, 2, "legacy date input and button both render the shared page lock");
-assert.match(companyDashboardSource, /legacyRefreshCount > 0[\s\S]*?Refreshing start-date changes\.\.\.[\s\S]*?>Retry now<\/button>/);
-assert.match(companyDashboardSource, /window\.setInterval\(\(\) => router\.refresh\(\), 2_000\)/);
-assert.match(companyDashboardSource, /projectRefreshMatches\(canonicalProjectById\.get\(projectId\), mutation\.expectation\)/);
-assert.match(companyDashboardSource, /!canonicalProjectById\.has\(projectId\)/, "a canonical project removal must release a stale parent lock");
-assert.match(companyDashboardSource, /pageMountedRef\.current = false;[\s\S]*?boardPendingProjectIdsRef\.current = new Set\(\);[\s\S]*?legacyProjectMutationsRef\.current = new Map\(\)/);
-
-// A rising legacy lock is a cancellation boundary for pre-existing board
-// controllers and stable-key local menu drafts, not merely a disabled state.
-assert.match(layoutSource, /export function getNewlyPendingProjectIds/);
-assert.match(boardSource, /const previousExternallyPendingProjectIdsRef = useRef<ReadonlySet<string>>/);
-assert.match(boardSource, /interface TaskKeyboardEditState\s*\{[\s\S]*?taskId:\s*string;[\s\S]*?projectId:\s*string;/);
-assert.match(boardSource, /interface ActiveTaskPointerEdit\s*\{[\s\S]*?taskId:\s*string;[\s\S]*?projectId:\s*string;/);
-const scopedTaskCancelStart = boardSource.indexOf("function cancelTaskEditsForProjects");
-const scopedTaskCancelEnd = boardSource.indexOf("function cancelActiveTaskEdit", scopedTaskCancelStart);
-const scopedTaskCancelBody = boardSource.slice(scopedTaskCancelStart, scopedTaskCancelEnd);
-assert.match(scopedTaskCancelBody, /activeTaskPointerRef\.current/);
-assert.match(scopedTaskCancelBody, /projectIds\.has\(pointerEdit\.projectId\)/);
-assert.match(scopedTaskCancelBody, /pointerEdit\.cleanup\(\)[\s\S]*?clearTaskPreview\(pointerEdit\.taskId\)/);
-assert.match(scopedTaskCancelBody, /projectIds\.has\(keyboardEdit\.projectId\)/);
-assert.match(scopedTaskCancelBody, /clearTaskPreview\(keyboardEdit\.taskId\)[\s\S]*?taskKeyboardCleanupRef\.current\?\.\(\)[\s\S]*?setTaskKeyboardState\(null\)/);
-const scopedProjectCancelStart = boardSource.indexOf("function cancelProjectEditsForProjects");
-const scopedProjectCancelEnd = boardSource.indexOf("function cancelActiveProjectEdit", scopedProjectCancelStart);
-const scopedProjectCancelBody = boardSource.slice(scopedProjectCancelStart, scopedProjectCancelEnd);
-assert.match(scopedProjectCancelBody, /activeProjectPointerRef\.current/);
-assert.match(scopedProjectCancelBody, /projectIds\.has\(pointerEdit\.projectId\)[\s\S]*?pointerEdit\.cleanup\(\)[\s\S]*?clearProjectPreview\(pointerEdit\.projectId\)/);
-assert.match(scopedProjectCancelBody, /projectIds\.has\(keyboardEdit\.projectId\)[\s\S]*?clearProjectPreview\(keyboardEdit\.projectId\)[\s\S]*?projectKeyboardCleanupRef\.current\?\.\(\)[\s\S]*?setProjectKeyboardState\(null\)/);
-const externalLockEffectStart = boardSource.indexOf("const newlyPendingProjectIds = getNewlyPendingProjectIds");
-const externalLockEffectEnd = boardSource.indexOf("}, [externallyPendingProjectIds])", externalLockEffectStart);
-const externalLockEffectBody = boardSource.slice(externalLockEffectStart, externalLockEffectEnd);
-assert.match(externalLockEffectBody, /previousExternallyPendingProjectIdsRef\.current = new Set\(externallyPendingProjectIds\)/);
-assert.match(externalLockEffectBody, /cancelExternallyLockedProjectEdits\(newlyPendingProjectIds\)/);
-assert.match(boardSource, /const cancelExternallyLockedProjectEdits = useEffectEvent\([\s\S]*?cancelProjectEditsForProjects\(newlyPendingProjectIds\)[\s\S]*?cancelTaskEditsForProjects\(newlyPendingProjectIds\)[\s\S]*?confirmIntentRef\.current[\s\S]*?newlyPendingProjectIds\.has\(intent\.project\.id\)[\s\S]*?clearProjectPreview\(intent\.project\.id\)[\s\S]*?setConfirmIntent\(null\)/);
-assert.match(taskSource, /const actionDetailsRef = useRef<HTMLDetailsElement>\(null\)/);
-assert.match(taskSource, /const actionResetKey = `\$\{isPending \? "pending" : "ready"\}:\$\{task\.startDate\}:\$\{task\.endDate\}`/);
-assert.match(taskSource, /const menuDates = menuDraft\.resetKey === actionResetKey \? menuDraft\.dates : null/);
-assert.match(taskSource, /if \(menuDraft\.resetKey !== actionResetKey\) \{\s*setMenuDraft\(\{ resetKey: actionResetKey, dates: null \}\)/);
-assert.match(taskSource, /useEffect\(\(\) => \{\s*if \(actionDetailsRef\.current\) actionDetailsRef\.current\.open = false;\s*\}, \[actionResetKey\]\)/);
-assert.match(taskSource, /<details\s+ref=\{actionDetailsRef\}/);
-assert.match(projectSource, /const actionDetailsRef = useRef<HTMLDetailsElement>\(null\)/);
-assert.match(projectSource, /const actionResetKey = `\$\{isPending \? "pending" : "ready"\}:\$\{projectStart\}`/);
-assert.match(projectSource, /const targetStart = targetStartDraft\.resetKey === actionResetKey \? targetStartDraft\.value : projectStart/);
-assert.match(projectSource, /if \(targetStartDraft\.resetKey !== actionResetKey\) \{\s*setTargetStartDraft\(\{ resetKey: actionResetKey, value: projectStart \}\)/);
-assert.match(projectSource, /useEffect\(\(\) => \{\s*if \(actionDetailsRef\.current\) actionDetailsRef\.current\.open = false;\s*\}, \[actionResetKey\]\)/);
-assert.match(projectSource, /<details\s+ref=\{actionDetailsRef\}/);
-assert.equal((monthSource.match(/isPending=\{pendingProjectIds\.has\(project\.id\)\}/g) ?? []).length, 1, "Month project menus receive the external parent lock");
-assert.equal((timelineSource.match(/isPending=\{pendingProjectIds\.has\(project\.id\)\}/g) ?? []).length, 1, "Timeline project menus receive the external parent lock");
-assert.match(monthSource, /isPending=\{pendingProjectIds\.has\(project\.id\) \|\| pendingTaskIds\.has\(task\.id\)\}/);
-assert.match(timelineSource, /isPending=\{pendingProjectIds\.has\(project\.id\) \|\| pendingTaskIds\.has\(task\.id\)\}/);
-
-// Project reconciliation is based only on canonical Project/ScheduleTask truth.
-const refreshExpectationStart = layoutSource.indexOf("export interface ProjectRefreshExpectation");
-const refreshExpectationEnd = layoutSource.indexOf("function toUTCDay", refreshExpectationStart);
-const refreshExpectationBody = layoutSource.slice(refreshExpectationStart, refreshExpectationEnd);
-assert.match(refreshExpectationBody, /projectStartDate\?:\s*string \| null/);
-assert.match(refreshExpectationBody, /taskDates:\s*PersistedTaskDate\[\]/);
-assert.doesNotMatch(refreshExpectationBody, /project:\s*DashboardProjectRow|income|OverlayIncomeItem/);
-const projectReconciliationStart = boardSource.indexOf("const reconciledProjectIds");
-const projectReconciliationEnd = boardSource.indexOf("useEffect(() => {", projectReconciliationStart);
-const projectReconciliationBody = boardSource.slice(projectReconciliationStart, projectReconciliationEnd);
-assert.match(projectReconciliationBody, /projectRefreshMatches\(canonical, expectation\)/);
-assert.doesNotMatch(projectReconciliationBody, /income|data\.overlays|actualIncome/);
-assert.match(boardSource, /setProjectRefreshExpectations\(current => \(\{ \.\.\.current, \[project\.id\]: expectation \}\)\)/);
-assert.equal((boardSource.match(/awaitProjectRefresh\(/g) ?? []).length, 5, "all four project success paths retain a reconciliation-backed optimistic preview");
-assert.match(boardSource, /previewProjectIncomeOverlays/);
-assert.match(boardSource, /previewShiftedTaskIncomeOverlays/);
-assert.match(layoutSource, /export function previewProjectWithPersistedTaskDates/);
-assert.match(coreSource, /interface SetProjectStartDateResult[\s\S]*?shiftedTaskDates:\s*PersistedScheduleTaskDate\[\]/);
-assert.match(coreSource, /interface ShiftNotStartedTasksResult[\s\S]*?shiftedTaskDates:\s*PersistedScheduleTaskDate\[\]/);
-assert.match(coreSource, /UPDATE "ScheduleTask"[\s\S]*?RETURNING "id", "startDate", "endDate"/);
-const trayScheduleStart = boardSource.indexOf("function scheduleUnscheduledProject");
-const trayScheduleEnd = boardSource.indexOf("function commitWaitingProjectMove", trayScheduleStart);
-const waitingMoveStart = trayScheduleEnd;
-const waitingMoveEnd = boardSource.indexOf("function handleProjectMovePreview", waitingMoveStart);
-for (const body of [boardSource.slice(trayScheduleStart, trayScheduleEnd), boardSource.slice(waitingMoveStart, waitingMoveEnd)]) {
-    assert.match(body, /projectStartDate:\s*result\.startDate/);
-    assert.match(body, /taskDates:\s*result\.shiftedTaskDates/);
-    assert.match(body, /previewProjectWithPersistedTaskDates/);
-}
-const moveChoiceStart = boardSource.indexOf("function handleMoveChoice");
-const moveChoiceEnd = boardSource.indexOf("function cancelConfirmedMove", moveChoiceStart);
-const moveChoiceBody = boardSource.slice(moveChoiceStart, moveChoiceEnd);
-assert.match(moveChoiceBody, /choice === "marker-only"[\s\S]*?taskDates:\s*\[\]/);
-assert.match(moveChoiceBody, /shiftNotStartedTasksAction[\s\S]*?taskDates:\s*result\.shiftedTaskDates/);
-assert.doesNotMatch(moveChoiceBody, /intent\.project\.tasks\.map/);
-
-// A task-only reconciliation exposes the same visible/manual recovery path.
-assert.match(boardSource, /projectRefreshCount > 0 \|\| awaitingTaskRefreshIds\.size > 0/);
-assert.match(boardSource, /pendingRefreshKinds/);
-assert.match(boardSource, /Refreshing saved \{pendingRefreshKinds\.join\(" and "\)\} schedule changes\.\.\./);
-assert.doesNotMatch(boardSource, /Ã|Â|â€¦/);
-assert.match(boardSource, />Retry now<\/button>/);
-
-// Task 8 coverage/access/reconciliation/identity contracts.
-for (const source of [boardSource, monthSource, timelineSource]) assert.match(source, /substantialCompletion/);
-assert.match(coreSource, /substantialCompletion:\s*DashboardProjectRow\[\]/);
-assert.match(coreSource, /substantialCompletion:\s*pipeline\.substantialCompletion\.map\(enrich\)/);
-assert.match(pageSource, /hasPermission\(effectiveUser, "financialReports"\)[\s\S]*?hasPermission\(effectiveUser, "schedules"\)/);
-assert.match(navSource, /key:\s*"dashboard"[\s\S]*?can\("financialReports"\)\s*\|\|\s*can\("schedules"\)/);
-assert.match(coreSource, /paymentScheduleId:\s*string/);
-assert.match(coreSource, /paymentScheduleId:\s*row\.id/);
-assert.match(coreSource, /paymentScheduleId:\s*`synthetic:/);
-assert.match(projectSource, /item\.paymentScheduleId/);
-assert.match(monthSource, /item\.paymentScheduleId/);
-assert.match(timelineSource, /item\.paymentScheduleId/);
-assert.doesNotMatch([projectSource, monthSource, timelineSource].join("\n"), /co-\$\{item\.changeOrderId\}-\$\{item\.effectiveDueDate\}-\$\{item\.name\}/);
-const duplicateNameDateRows = [
-    { paymentScheduleId: "payment-row-a", changeOrderId: "co-1", name: "Progress", effectiveDueDate: "2037-01-10" },
-    { paymentScheduleId: "payment-row-b", changeOrderId: "co-1", name: "Progress", effectiveDueDate: "2037-01-10" },
-];
-assert.equal(new Set(duplicateNameDateRows.map(row => `co-${row.paymentScheduleId}`)).size, 2, "duplicate CO name/date rows retain distinct stable identities");
-assert.match(boardSource, /projectRefreshExpectations/);
-assert.match(boardSource, /window\.setInterval\([\s\S]*?router\.refresh\(\)/);
-assert.match(projectSource, /onProjectKeyboardStart/);
-assert.match(projectSource, /event\.key === " " \|\| event\.key === "Enter"/);
-assert.match(projectSource, /event\.shiftKey \? 7 : 1/);
-assert.match(boardSource, /projectKeyboardSentinelRef/);
-assert.match(boardSource, /aria-live="polite"/);
-const shiftActionStart = actionsSource.indexOf("export async function shiftNotStartedTasksAction");
-const shiftActionEnd = actionsSource.indexOf("export async function", shiftActionStart + 30);
-assert.match(actionsSource.slice(shiftActionStart, shiftActionEnd), /actor:\s*\{\s*type:\s*"TEAM",\s*name:\s*caller\.name\s*\|\|\s*caller\.email\s*\}/);
+// ── Board-view persistence untouched ──
+assert.match(boardSource, /const BOARD_VIEW_STORAGE_KEY = "gtr-company-schedule-board-view"/);
+assert.match(boardSource, /localStorage\.getItem\(BOARD_VIEW_STORAGE_KEY\)/);
+assert.match(boardSource, /localStorage\.setItem\(BOARD_VIEW_STORAGE_KEY, nextView\)/);
 
 console.log("schedule-board render contract verification: PASS");

--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -56,7 +56,7 @@ const saveAllDraftsStart = boardSource.indexOf("async function saveAllDrafts()")
 const saveAllDraftsEnd = boardSource.indexOf("function cancelProjectEditsForProjects", saveAllDraftsStart);
 const saveAllDraftsBody = boardSource.slice(saveAllDraftsStart, saveAllDraftsEnd);
 assert.ok(saveAllDraftsStart >= 0, "saveAllDrafts must exist");
-assert.match(saveAllDraftsBody, /saveCompanyScheduleTaskDatesAction\(changes\)/);
+assert.match(saveAllDraftsBody, /saveCompanyScheduleTaskDatesAction\(changes\.slice\(offset, offset \+ 200\)\)/, "Save batches task changes through the one canonical action, chunked to the server cap");
 assert.match(saveAllDraftsBody, /updateProjectStartDateAction\(/);
 assert.match(saveAllDraftsBody, /shiftNotStartedTasksAction\(/);
 assert.equal((saveAllDraftsBody.match(/router\.refresh\(\)/g) ?? []).length, 1, "exactly one router.refresh() after the whole batch settles");
@@ -71,7 +71,7 @@ assert.match(boardSource, /function waitForConfirmChoice\(\): Promise<ProjectMov
 // Failures are isolated and reported per item; succeeded drafts clear,
 // failed ones remain pending for retry.
 assert.match(saveAllDraftsBody, /catch \(error\) \{\s*failedProjectNames\.push/);
-assert.match(boardSource, /failedTaskNames = batchResult\.results/);
+assert.match(boardSource, /failedTaskNames = allResults/, "per-task failures are collected across all chunks");
 assert.match(boardSource, /toast\.error\(/);
 assert.match(boardSource, /toast\.success\(`Saved \$\{totalSucceeded\}/);
 
@@ -114,9 +114,20 @@ assert.match(popoverSource, /anchorRef\.current\?\.focus\(\)/);
 // Vertical placement must handle the neither-side-fits case (open on the
 // larger side, capped + scrollable) and the horizontal floor must be applied
 // last so narrow viewports pin to the margin instead of going negative.
-assert.match(popoverSource, /openAbove/);
+assert.match(popoverSource, /const openAbove = !fitsBelow && \(fitsAbove \|\| spaceAbove > spaceBelow\)/, "vertical placement must compare which side has more room");
 assert.match(popoverSource, /maxHeight: effectiveHeight/);
+assert.match(popoverSource, /overflowY: "auto"/, "capped popover must scroll internally");
+assert.match(popoverSource, /Math\.max\(openAbove \? spaceAbove : spaceBelow, 0\)/, "no artificial floor larger than the side's real room");
+assert.match(popoverSource, /viewportHeight - 2 \* VIEWPORT_MARGIN_PX/, "degenerate viewports detach from the anchor and use the full viewport");
 assert.match(popoverSource, /Math\.max\(Math\.min\(left, viewportWidth - panelWidth - VIEWPORT_MARGIN_PX\), VIEWPORT_MARGIN_PX\)/);
+
+// Draft/save state-machine contracts from the codex round-2 blockers:
+assert.match(boardSource, /!awaitingTaskRefreshIds\.has\(taskId\)\s*&&\s*normalizedDates\.startDate === originalDates\.startDate/, "back-to-canonical shortcut must not apply to saved-awaiting tasks");
+assert.match(boardSource, /Object\.entries\(current\)\.filter\(\(\[taskId\]\) => awaitingTaskRefreshIds\.has\(taskId\)\)/, "Discard must preserve saved-awaiting overrides");
+assert.match(boardSource, /-previousDelta/, "cancelling a project draft must undo its task-draft rebase");
+assert.match(boardSource, /failedProjectIds\.has\(projectId\)/, "task drafts of failed project shifts must be retained, not batched");
+assert.match(boardSource, /changes\.slice\(offset, offset \+ 200\)/, "client saves chunk to the server's 200 cap");
+assert.match(boardSource, /const markerResult = await updateProjectStartDateAction\(projectId, draft\.targetStart, false\);\s*\n\s*const shiftResult = await shiftNotStartedTasksAction\(projectId, draft\.deltaDays\)/, "In Progress shift choice moves the marker AND the not-started work");
 assert.match(popoverSource, /VIEWPORT_MARGIN_PX/);
 assert.match(projectBarSource, /import \{ FloatingPopover \} from "\.\/FloatingPopover"/);
 assert.match(taskBlockSource, /import \{ FloatingPopover \} from "\.\/FloatingPopover"/);
@@ -165,7 +176,7 @@ assert.match(timelineSource, />\s*By crew\s*</);
 
 // ── Cross-cutting: the ShiftConfirmDialog contract is unchanged in shape ──
 assert.match(dialogSource, /Move start marker only/);
-assert.match(dialogSource, /Also shift all Not Started tasks by/);
+assert.match(dialogSource, /Move the start marker AND shift all Not Started tasks by/);
 assert.match(boardSource, /<ShiftConfirmDialog[\s\S]*?intent=\{confirmIntent\}[\s\S]*?onChoice=\{handleMoveChoice\}[\s\S]*?onCancel=\{cancelConfirmedMove\}/);
 
 // ── Money-path invariants: unchanged by this feature round ──

--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -56,7 +56,7 @@ const saveAllDraftsStart = boardSource.indexOf("async function saveAllDrafts()")
 const saveAllDraftsEnd = boardSource.indexOf("function cancelProjectEditsForProjects", saveAllDraftsStart);
 const saveAllDraftsBody = boardSource.slice(saveAllDraftsStart, saveAllDraftsEnd);
 assert.ok(saveAllDraftsStart >= 0, "saveAllDrafts must exist");
-assert.match(saveAllDraftsBody, /saveCompanyScheduleTaskDatesAction\(changes\.slice\(offset, offset \+ 200\)\)/, "Save batches task changes through the one canonical action, chunked to the server cap");
+assert.match(saveAllDraftsBody, /const chunk = changes\.slice\(offset, offset \+ 200\);\s*\n\s*try \{\s*\n\s*const batchResult = await saveCompanyScheduleTaskDatesAction\(chunk\)/, "Save batches task changes through the one canonical action, chunked to the server cap with per-chunk isolation");
 assert.match(saveAllDraftsBody, /updateProjectStartDateAction\(/);
 assert.match(saveAllDraftsBody, /shiftNotStartedTasksAction\(/);
 assert.equal((saveAllDraftsBody.match(/router\.refresh\(\)/g) ?? []).length, 1, "exactly one router.refresh() after the whole batch settles");
@@ -127,6 +127,10 @@ assert.match(boardSource, /Object\.entries\(current\)\.filter\(\(\[taskId\]\) =>
 assert.match(boardSource, /-previousDelta/, "cancelling a project draft must undo its task-draft rebase");
 assert.match(boardSource, /failedProjectIds\.has\(projectId\)/, "task drafts of failed project shifts must be retained, not batched");
 assert.match(boardSource, /changes\.slice\(offset, offset \+ 200\)/, "client saves chunk to the server's 200 cap");
+assert.match(boardSource, /function clearTaskPreview\(taskId: string\) \{\n[^}]*if \(awaitingTaskRefreshIds\.has\(taskId\)\) return;/, "cancelling a speculative edit must never delete a saved-awaiting override");
+assert.match(boardSource, /const shiftedById = new Map\(shiftedPersistedDates\.map\(row => \[row\.id, row\]\)\)/, "successful shifts must rewrite saved-awaiting overrides to the persisted dates");
+assert.match(boardSource, /catch \(chunkError: any\) \{/, "chunk failures are isolated per chunk");
+assert.match(boardSource, /chunk\.map\(change => \(\{ taskId: change\.taskId, ok: false as const, error: message \}\)\)/, "a rejected chunk synthesizes failures for its own tasks only");
 assert.match(boardSource, /const markerResult = await updateProjectStartDateAction\(projectId, draft\.targetStart, false\);\s*\n\s*const shiftResult = await shiftNotStartedTasksAction\(projectId, draft\.deltaDays\)/, "In Progress shift choice moves the marker AND the not-started work");
 assert.match(popoverSource, /VIEWPORT_MARGIN_PX/);
 assert.match(projectBarSource, /import \{ FloatingPopover \} from "\.\/FloatingPopover"/);

--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -128,7 +128,10 @@ assert.match(boardSource, /-previousDelta/, "cancelling a project draft must und
 assert.match(boardSource, /failedProjectIds\.has\(projectId\)/, "task drafts of failed project shifts must be retained, not batched");
 assert.match(boardSource, /changes\.slice\(offset, offset \+ 200\)/, "client saves chunk to the server's 200 cap");
 assert.match(boardSource, /function clearTaskPreview\(taskId: string\) \{\n[^}]*if \(awaitingTaskRefreshIds\.has\(taskId\)\) return;/, "cancelling a speculative edit must never delete a saved-awaiting override");
-assert.match(boardSource, /const shiftedById = new Map\(shiftedPersistedDates\.map\(row => \[row\.id, row\]\)\)/, "successful shifts must rewrite saved-awaiting overrides to the persisted dates");
+assert.match(boardSource, /rewriteAwaitingOverridesFromShift\(shiftedPersistedDates\)/, "board-owned shifts must rewrite saved-awaiting overrides to the persisted dates");
+assert.match(boardSource, /rewriteAwaitingOverridesFromShift\(externalShiftedTaskDates\.taskDates\)/, "external (legacy StartDateRow) shifts must ALSO rewrite saved-awaiting overrides");
+assert.match(companyDashboardSource, /setExternalShiftedTaskDates\(\{ nonce: externalShiftNonceRef\.current, taskDates: expectation\.taskDates \}\)/, "the legacy path must publish its persisted shifts to the board");
+assert.match(companyDashboardSource, /externalShiftedTaskDates=\{externalShiftedTaskDates\}/, "the board must receive the external-shift prop");
 assert.match(boardSource, /catch \(chunkError: any\) \{/, "chunk failures are isolated per chunk");
 assert.match(boardSource, /chunk\.map\(change => \(\{ taskId: change\.taskId, ok: false as const, error: message \}\)\)/, "a rejected chunk synthesizes failures for its own tasks only");
 assert.match(boardSource, /const markerResult = await updateProjectStartDateAction\(projectId, draft\.targetStart, false\);\s*\n\s*const shiftResult = await shiftNotStartedTasksAction\(projectId, draft\.deltaDays\)/, "In Progress shift choice moves the marker AND the not-started work");

--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -111,7 +111,12 @@ assert.match(popoverSource, /createPortal\(/);
 assert.match(popoverSource, /document\.body/);
 assert.match(popoverSource, /event\.key !== "Escape"/);
 assert.match(popoverSource, /anchorRef\.current\?\.focus\(\)/);
-assert.match(popoverSource, /flipAbove/);
+// Vertical placement must handle the neither-side-fits case (open on the
+// larger side, capped + scrollable) and the horizontal floor must be applied
+// last so narrow viewports pin to the margin instead of going negative.
+assert.match(popoverSource, /openAbove/);
+assert.match(popoverSource, /maxHeight: effectiveHeight/);
+assert.match(popoverSource, /Math\.max\(Math\.min\(left, viewportWidth - panelWidth - VIEWPORT_MARGIN_PX\), VIEWPORT_MARGIN_PX\)/);
 assert.match(popoverSource, /VIEWPORT_MARGIN_PX/);
 assert.match(projectBarSource, /import \{ FloatingPopover \} from "\.\/FloatingPopover"/);
 assert.match(taskBlockSource, /import \{ FloatingPopover \} from "\.\/FloatingPopover"/);

--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -129,9 +129,10 @@ assert.match(boardSource, /failedProjectIds\.has\(projectId\)/, "task drafts of 
 assert.match(boardSource, /changes\.slice\(offset, offset \+ 200\)/, "client saves chunk to the server's 200 cap");
 assert.match(boardSource, /function clearTaskPreview\(taskId: string\) \{\n[^}]*if \(awaitingTaskRefreshIds\.has\(taskId\)\) return;/, "cancelling a speculative edit must never delete a saved-awaiting override");
 assert.match(boardSource, /rewriteAwaitingOverridesFromShift\(shiftedPersistedDates\)/, "board-owned shifts must rewrite saved-awaiting overrides to the persisted dates");
-assert.match(boardSource, /rewriteAwaitingOverridesFromShift\(externalShiftedTaskDates\.taskDates\)/, "external (legacy StartDateRow) shifts must ALSO rewrite saved-awaiting overrides");
-assert.match(companyDashboardSource, /setExternalShiftedTaskDates\(\{ nonce: externalShiftNonceRef\.current, taskDates: expectation\.taskDates \}\)/, "the legacy path must publish its persisted shifts to the board");
-assert.match(companyDashboardSource, /externalShiftedTaskDates=\{externalShiftedTaskDates\}/, "the board must receive the external-shift prop");
+assert.match(boardSource, /rewriteAwaitingOverridesFromShift\(unseen\.flatMap\(event => event\.taskDates\)\)/, "external (legacy StartDateRow) shifts must ALSO rewrite saved-awaiting overrides — ALL unseen events, not just the latest");
+assert.match(boardSource, /externalShiftEvents\.filter\(event => event\.nonce > lastExternalShiftNonceRef\.current\)/, "every unseen external-shift nonce is applied exactly once");
+assert.match(companyDashboardSource, /setExternalShiftEvents\(current => \[\.\.\.current, event\]\.slice\(-20\)\)/, "the legacy path publishes shifts via a functional append (batch-safe queue), never a latest-payload slot");
+assert.match(companyDashboardSource, /externalShiftEvents=\{externalShiftEvents\}/, "the board must receive the external-shift event queue");
 assert.match(boardSource, /catch \(chunkError: any\) \{/, "chunk failures are isolated per chunk");
 assert.match(boardSource, /chunk\.map\(change => \(\{ taskId: change\.taskId, ok: false as const, error: message \}\)\)/, "a rejected chunk synthesizes failures for its own tasks only");
 assert.match(boardSource, /const markerResult = await updateProjectStartDateAction\(projectId, draft\.targetStart, false\);\s*\n\s*const shiftResult = await shiftNotStartedTasksAction\(projectId, draft\.deltaDays\)/, "In Progress shift choice moves the marker AND the not-started work");

--- a/scripts/verify-schedule-board.ts
+++ b/scripts/verify-schedule-board.ts
@@ -574,9 +574,11 @@ async function main() {
         const batchActionBody = actionsSource.slice(batchActionStart, batchActionEnd);
         check("saveCompanyScheduleTaskDatesAction exists and is ADMIN/MANAGER gated",
             batchActionStart >= 0 && batchActionBody.includes('["ADMIN", "MANAGER"].includes(caller.role)'));
-        check("saveCompanyScheduleTaskDatesAction loops the canonical updateScheduleTask exactly once per change (not a second mutation core)",
+        check("saveCompanyScheduleTaskDatesAction loops the canonical updateScheduleTask exactly once per deduped change (not a second mutation core)",
             (batchActionBody.match(/updateScheduleTask\(/g) ?? []).length === 1
-            && batchActionBody.includes("for (const change of changes)"));
+            && batchActionBody.includes("for (const change of deduped)")
+            && batchActionBody.includes("changes.length > 200")
+            && batchActionBody.includes("new Map(changes.map(change => [change.taskId, change]))"));
         check("saveCompanyScheduleTaskDatesAction isolates per-task failures and reports per-task ok/succeeded/failed results",
             batchActionBody.includes("try {") && batchActionBody.includes("catch (err")
             && batchActionBody.includes("ok: true") && batchActionBody.includes("ok: false")

--- a/scripts/verify-schedule-board.ts
+++ b/scripts/verify-schedule-board.ts
@@ -4,9 +4,10 @@ import { readFileSync } from "node:fs";
 import { Prisma } from "@prisma/client";
 
 import { prisma } from "../src/lib/prisma";
-import { getCompanyDashboardData, setProjectStartDate, shiftNotStartedTasks } from "../src/lib/schedule-core";
+import { getCompanyDashboardData, setProjectCrew, setProjectStartDate, setTaskCrew, shiftNotStartedTasks } from "../src/lib/schedule-core";
 import { canAccessProject, hasPermission } from "../src/lib/permissions";
 import { withTxRetry } from "../src/lib/tx-retry";
+import { saveCompanyScheduleTaskDatesAction } from "../src/lib/actions";
 
 type Check = [label: string, passed: boolean];
 
@@ -47,6 +48,7 @@ async function main() {
     const projectIds: string[] = [];
     const estimateIds: string[] = [];
     const invoiceIds: string[] = [];
+    const userIds: string[] = [];
     let clientId: string | null = null;
 
     try {
@@ -465,6 +467,134 @@ async function main() {
             && !["ADMIN", "MANAGER"].includes(authorizedFieldCrew.role));
         check("TEAM actor expression stays pinned to the authenticated caller", actionBody.includes('actor: { type: "TEAM", name: caller.name || caller.email }'));
 
+        // ── Owner-feedback round: crew ACTIVATED-added-only validation (fix 1),
+        // FINANCE exclusion + name disambiguation (fix 7), batch task-date save
+        // (fix 2) ──
+        const crewUsers = [
+            await prisma.user.create({ data: { email: `board-active-${tag}@example.invalid`, name: `Board Active ${tag}`, role: "FIELD_CREW", status: "ACTIVATED" } }),
+            await prisma.user.create({ data: { email: `board-pending-${tag}@example.invalid`, name: `Board Pending ${tag}`, role: "FIELD_CREW", status: "PENDING" } }),
+            await prisma.user.create({ data: { email: `board-legacy-${tag}@example.invalid`, name: `Board Legacy ${tag}`, role: "FIELD_CREW", status: "DISABLED" } }),
+            await prisma.user.create({ data: { email: `board-finance-${tag}@example.invalid`, name: `Board Finance ${tag}`, role: "FINANCE", status: "ACTIVATED" } }),
+            await prisma.user.create({ data: { email: `board-dupe-a-${tag}@example.invalid`, name: `Board Dupe ${tag}`, role: "FIELD_CREW", status: "ACTIVATED" } }),
+            await prisma.user.create({ data: { email: `board-dupe-b-${tag}@example.invalid`, name: `Board Dupe ${tag}`, role: "FIELD_CREW", status: "ACTIVATED" } }),
+        ];
+        userIds.push(...crewUsers.map(u => u.id));
+        const [activeUser, pendingUser, legacyUser, financeUser, dupeUserA, dupeUserB] = crewUsers;
+
+        const crewProject = await prisma.project.create({
+            data: {
+                name: `BOARD CREW VERIFY ${tag} DELETE ME`,
+                clientId: client.id,
+                status: "Waiting to Start",
+                startDate: at(20),
+                crew: { connect: [{ id: activeUser.id }, { id: legacyUser.id }] },
+            },
+        });
+        projectIds.push(crewProject.id);
+        const crewTask = await prisma.scheduleTask.create({
+            data: { projectId: crewProject.id, name: `Crew task ${tag}`, startDate: at(21), endDate: at(22), status: "Not Started" },
+        });
+        await prisma.taskAssignment.createMany({
+            data: [
+                { taskId: crewTask.id, userId: activeUser.id, role: "assigned" },
+                { taskId: crewTask.id, userId: legacyUser.id, role: "assigned" },
+            ],
+        });
+
+        const crewKeepResult = await setProjectCrew({ projectId: crewProject.id, userIds: [activeUser.id, legacyUser.id], actor });
+        check("setProjectCrew: keeping an already-assigned inactive member does not throw",
+            crewKeepResult.crew.length === 2 && crewKeepResult.crew.some(c => c.id === legacyUser.id));
+
+        const crewRemoveResult = await setProjectCrew({ projectId: crewProject.id, userIds: [activeUser.id], actor });
+        check("setProjectCrew: removing an inactive member never throws",
+            crewRemoveResult.crew.length === 1 && crewRemoveResult.crew[0].id === activeUser.id);
+
+        let addNonActivatedRejected = false;
+        try {
+            await setProjectCrew({ projectId: crewProject.id, userIds: [activeUser.id, pendingUser.id], actor });
+        } catch (error) {
+            addNonActivatedRejected = /ACTIVATED/i.test(String((error as Error).message));
+        }
+        const crewAfterAddReject = await prisma.project.findUniqueOrThrow({ where: { id: crewProject.id }, select: { crew: { select: { id: true } } } });
+        check("setProjectCrew: adding a NEW non-ACTIVATED user still rejects, existing crew untouched",
+            addNonActivatedRejected && crewAfterAddReject.crew.length === 1 && crewAfterAddReject.crew[0].id === activeUser.id);
+
+        const taskKeepResult = await setTaskCrew({ taskId: crewTask.id, userIds: [activeUser.id, legacyUser.id], actor });
+        check("setTaskCrew: keeping an already-assigned inactive member does not throw",
+            taskKeepResult.assignments.length === 2 && taskKeepResult.assignments.some(a => a.userId === legacyUser.id));
+
+        const taskRemoveResult = await setTaskCrew({ taskId: crewTask.id, userIds: [activeUser.id], actor });
+        check("setTaskCrew: removing an inactive member never throws",
+            taskRemoveResult.assignments.length === 1 && taskRemoveResult.assignments[0].userId === activeUser.id);
+
+        let taskAddNonActivatedRejected = false;
+        try {
+            await setTaskCrew({ taskId: crewTask.id, userIds: [activeUser.id, pendingUser.id], actor });
+        } catch (error) {
+            taskAddNonActivatedRejected = /ACTIVATED/i.test(String((error as Error).message));
+        }
+        const taskAssignmentsAfterReject = await prisma.taskAssignment.findMany({ where: { taskId: crewTask.id } });
+        check("setTaskCrew: adding a NEW non-ACTIVATED user still rejects, existing assignments untouched",
+            taskAddNonActivatedRejected && taskAssignmentsAfterReject.length === 1 && taskAssignmentsAfterReject[0].userId === activeUser.id);
+
+        await prisma.project.update({ where: { id: crewProject.id }, data: { crew: { connect: [{ id: legacyUser.id }, { id: financeUser.id }] } } });
+        const dashboardForCrew = await getCompanyDashboardData({ role: "ADMIN" }, month);
+        check("teamMembers picker excludes FINANCE-role users", !(dashboardForCrew.teamMembers ?? []).some(u => u.id === financeUser.id));
+        const crewProjectRow = [...dashboardForCrew.pipeline.waitingToStart, ...dashboardForCrew.pipeline.scheduled]
+            .find(candidate => candidate.id === crewProject.id);
+        const financeCrewEntry = crewProjectRow?.crew.find(c => c.id === financeUser.id);
+        check("assigned FINANCE user still appears as a removable crew entry with role carried",
+            !!financeCrewEntry && financeCrewEntry.role === "FINANCE");
+        const inactiveCrewEntry = crewProjectRow?.crew.find(c => c.id === legacyUser.id);
+        check("assigned DISABLED user still appears as a removable crew entry", !!inactiveCrewEntry && inactiveCrewEntry.status !== "ACTIVATED");
+
+        const dupeEntries = (dashboardForCrew.teamMembers ?? []).filter(u => u.id === dupeUserA.id || u.id === dupeUserB.id);
+        check("teamMembers disambiguates identical display names with the email",
+            dupeEntries.length === 2 && dupeEntries.every(u => u.name.includes(u.email)) && dupeEntries[0].name !== dupeEntries[1].name);
+        const soloNamedEntry = (dashboardForCrew.teamMembers ?? []).find(u => u.id === activeUser.id);
+        check("teamMembers leaves unique display names unmodified",
+            soloNamedEntry?.name === (activeUser.name ?? activeUser.email) && !soloNamedEntry.name.includes("@"));
+
+        const scheduleCoreCrewStart = scheduleCoreSource.indexOf("export async function setProjectCrew");
+        const scheduleCoreCrewEnd = scheduleCoreSource.indexOf("export interface CrewConflictPair", scheduleCoreCrewStart);
+        const scheduleCoreCrewBody = scheduleCoreSource.slice(scheduleCoreCrewStart, scheduleCoreCrewEnd);
+        check("source validates ACTIVATED only for users being added to project crew",
+            scheduleCoreCrewBody.includes("toConnect.map(id => byId.get(id)!).filter(u => u.status !== \"ACTIVATED\")"));
+        const scheduleCoreTaskCrewStart = scheduleCoreSource.indexOf("export async function setTaskCrew");
+        const scheduleCoreTaskCrewBody = scheduleCoreSource.slice(scheduleCoreTaskCrewStart);
+        check("source validates ACTIVATED only for users being added to task crew",
+            scheduleCoreTaskCrewBody.includes("toAdd.map(id => byId.get(id)!).filter(u => u.status !== \"ACTIVATED\")"));
+        check("teamMembers query excludes FINANCE role", scheduleCoreSource.includes('role: { not: "FINANCE" }'));
+
+        // Batch task-date save (fix 2) — ADMIN/MANAGER gated, loops the ONE
+        // canonical updateScheduleTask (not a second mutation core), isolates
+        // per-task failures, and reports per-task results.
+        const batchActionStart = actionsSource.indexOf("export async function saveCompanyScheduleTaskDatesAction");
+        const batchActionEnd = actionsSource.indexOf("export async function updateProjectColor", batchActionStart);
+        const batchActionBody = actionsSource.slice(batchActionStart, batchActionEnd);
+        check("saveCompanyScheduleTaskDatesAction exists and is ADMIN/MANAGER gated",
+            batchActionStart >= 0 && batchActionBody.includes('["ADMIN", "MANAGER"].includes(caller.role)'));
+        check("saveCompanyScheduleTaskDatesAction loops the canonical updateScheduleTask exactly once per change (not a second mutation core)",
+            (batchActionBody.match(/updateScheduleTask\(/g) ?? []).length === 1
+            && batchActionBody.includes("for (const change of changes)"));
+        check("saveCompanyScheduleTaskDatesAction isolates per-task failures and reports per-task ok/succeeded/failed results",
+            batchActionBody.includes("try {") && batchActionBody.includes("catch (err")
+            && batchActionBody.includes("ok: true") && batchActionBody.includes("ok: false")
+            && batchActionBody.includes("succeeded:") && batchActionBody.includes("failed:"));
+
+        let batchActionRan = false;
+        let batchActionErr = "";
+        try {
+            const batchResult = await saveCompanyScheduleTaskDatesAction([{ taskId: crewTask.id, startDate: "2040-06-01", endDate: "2040-06-02" }]);
+            batchActionRan = true;
+            check("saveCompanyScheduleTaskDatesAction returns per-task results when it runs in a request scope",
+                Array.isArray(batchResult.results) && typeof batchResult.succeeded === "number" && typeof batchResult.failed === "number");
+        } catch (error) {
+            batchActionErr = String((error as Error)?.message ?? error);
+        }
+        check("saveCompanyScheduleTaskDatesAction is reachable (runs, or hits the expected script auth wall outside a request scope)",
+            batchActionRan || /Unauthorized|Forbidden|outside a request scope|headers/i.test(batchActionErr));
+
         const boardSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/ScheduleBoard.tsx", import.meta.url), "utf8");
         const monthSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/MonthBarsView.tsx", import.meta.url), "utf8");
         const timelineSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/TimelineView.tsx", import.meta.url), "utf8");
@@ -494,21 +624,25 @@ async function main() {
             if (projectIds.length > 0) {
                 await prisma.project.deleteMany({ where: { id: { in: projectIds } } });
             }
+            if (userIds.length > 0) {
+                await prisma.user.deleteMany({ where: { id: { in: userIds } } });
+            }
             if (clientId) {
                 await prisma.client.deleteMany({ where: { id: clientId } });
             }
 
-            const [projectsLeft, estimatesLeft, invoicesLeft, clientLeft] = await Promise.all([
+            const [projectsLeft, estimatesLeft, invoicesLeft, usersLeft, clientLeft] = await Promise.all([
                 prisma.project.count({ where: { id: { in: projectIds } } }),
                 prisma.estimate.count({ where: { id: { in: estimateIds } } }),
                 prisma.invoice.count({ where: { id: { in: invoiceIds } } }),
+                prisma.user.count({ where: { id: { in: userIds } } }),
                 clientId ? prisma.client.count({ where: { id: clientId } }) : Promise.resolve(0),
             ]);
-            cleanupPassed = projectsLeft === 0 && estimatesLeft === 0 && invoicesLeft === 0 && clientLeft === 0;
+            cleanupPassed = projectsLeft === 0 && estimatesLeft === 0 && invoicesLeft === 0 && usersLeft === 0 && clientLeft === 0;
         } catch (error) {
             console.error("Fixture cleanup error:", error);
         }
-        check("fixture cleanup removed collected client/project/estimate/invoice IDs", cleanupPassed);
+        check("fixture cleanup removed collected client/project/estimate/invoice/user IDs", cleanupPassed);
     }
 
     let failures = 0;

--- a/scripts/verify-schedule-board.ts
+++ b/scripts/verify-schedule-board.ts
@@ -577,7 +577,7 @@ async function main() {
         check("saveCompanyScheduleTaskDatesAction loops the canonical updateScheduleTask exactly once per deduped change (not a second mutation core)",
             (batchActionBody.match(/updateScheduleTask\(/g) ?? []).length === 1
             && batchActionBody.includes("for (const change of deduped)")
-            && batchActionBody.includes("changes.length > 200")
+            && batchActionBody.includes('if (changes.length > 200) throw new Error("Too many schedule changes')
             && batchActionBody.includes("new Map(changes.map(change => [change.taskId, change]))"));
         check("saveCompanyScheduleTaskDatesAction isolates per-task failures and reports per-task ok/succeeded/failed results",
             batchActionBody.includes("try {") && batchActionBody.includes("catch (err")

--- a/src/app/company-dashboard/CompanyDashboardClient.tsx
+++ b/src/app/company-dashboard/CompanyDashboardClient.tsx
@@ -4,7 +4,7 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState, useTransit
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import type { CompanyDashboardData, DashboardProjectRow, DashboardTaskRow, ProjectCrewMember } from "@/lib/schedule-core";
+import type { CompanyDashboardData, DashboardProjectRow, DashboardTaskRow, PipelineCrewMember } from "@/lib/schedule-core";
 import { PROJECT_STATUSES } from "@/lib/project-status";
 import { applyChangeOrderToScheduleAction, generateProjectScheduleAction, updateProjectCrewAction, updateProjectStartDateAction, updateTaskCrewAction } from "@/lib/actions";
 import { formatCurrency, parseUTCDate } from "@/app/projects/[id]/schedule/schedule-utils";
@@ -45,7 +45,7 @@ function CrewPicker({
     teamMembers,
 }: {
     projectId: string;
-    crew: ProjectCrewMember[];
+    crew: PipelineCrewMember[];
     teamMembers: { id: string; name: string; email: string }[];
 }) {
     const router = useRouter();
@@ -72,14 +72,16 @@ function CrewPicker({
         });
     }
 
-    // Option list: the ACTIVATED team list PLUS any currently-assigned member
-    // who is no longer ACTIVATED — rendered as a removable "(inactive)" entry,
-    // checked by default (they ARE assigned); unchecking them before saving
-    // removes them (the core validates the FINAL set).
-    const inactiveAssigned = crew.filter(c => !teamMembers.some(m => m.id === c.id));
+    // Option list: the picker team list PLUS any currently-assigned member who
+    // isn't in it — either because they're no longer ACTIVATED (removable
+    // "(inactive)" entry) or because they're a FINANCE user excluded from the
+    // picker (removable "(finance)" entry). Checked by default (they ARE
+    // assigned); unchecking them before saving removes them (the core
+    // validates only newly-ADDED members against ACTIVATED).
+    const unlistedAssigned = crew.filter(c => !teamMembers.some(m => m.id === c.id));
     const options = [
         ...teamMembers.map(m => ({ id: m.id, label: m.name || m.email })),
-        ...inactiveAssigned.map(c => ({ id: c.id, label: `${c.name} (inactive)` })),
+        ...unlistedAssigned.map(c => ({ id: c.id, label: `${c.name} (${c.role === "FINANCE" ? "finance" : "inactive"})` })),
     ];
     const selectedNames = options.filter(o => selected.includes(o.id));
     return (
@@ -170,10 +172,10 @@ function TaskCrewPicker({ task, teamMembers }: { task: DashboardTaskRow; teamMem
     const assignmentKey = [...assignedIds].sort().join(",");
     const [override, setOverride] = useState<{ key: string; ids: string[] } | null>(null);
     const selected = override?.key === assignmentKey ? override.ids : assignedIds;
-    const inactive = task.assignments.filter(a => a.status !== "ACTIVATED" || !teamMembers.some(m => m.id === a.userId));
+    const unlisted = task.assignments.filter(a => !teamMembers.some(m => m.id === a.userId));
     const options = [
         ...teamMembers.map(member => ({ id: member.id, label: member.name || member.email })),
-        ...inactive.filter(a => !teamMembers.some(m => m.id === a.userId)).map(a => ({ id: a.userId, label: `${a.name} (inactive)` })),
+        ...unlisted.map(a => ({ id: a.userId, label: `${a.name} (${a.role === "FINANCE" ? "finance" : "inactive"})` })),
     ];
 
     function toggle(userId: string) {
@@ -525,7 +527,7 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
                                                                 <div className="text-xs text-hui-textMuted">
                                                                     {task.assignments.length === 0
                                                                         ? "No task crew"
-                                                                        : task.assignments.map(a => `${a.name}${a.status === "ACTIVATED" ? "" : " (inactive)"}`).join(", ")}
+                                                                        : task.assignments.map(a => `${a.name}${a.role === "FINANCE" ? " (finance)" : a.status === "ACTIVATED" ? "" : " (inactive)"}`).join(", ")}
                                                                 </div>
                                                                 {canEdit && teamMembers && <TaskCrewPicker task={task} teamMembers={teamMembers} />}
                                                             </div>

--- a/src/app/company-dashboard/CompanyDashboardClient.tsx
+++ b/src/app/company-dashboard/CompanyDashboardClient.tsx
@@ -307,7 +307,11 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
     const boardPendingProjectIdsRef = useRef<Set<string>>(new Set());
     const legacyProjectMutationsRef = useRef<Map<string, LegacyProjectMutation>>(new Map());
     const externalShiftNonceRef = useRef(0);
-    const [externalShiftedTaskDates, setExternalShiftedTaskDates] = useState<{ nonce: number; taskDates: { id: string; startDate: string; endDate: string }[] } | null>(null);
+    // Append-only event queue (functional updates compose within a React
+    // batch — a single "latest payload" slot would drop one of two legacy
+    // shifts resolving in the same batch). Capped: the board applies events
+    // within a render, so older entries are long-consumed.
+    const [externalShiftEvents, setExternalShiftEvents] = useState<{ nonce: number; taskDates: { id: string; startDate: string; endDate: string }[] }[]>([]);
     const [boardPendingProjectIds, setBoardPendingProjectIds] = useState<Set<string>>(() => new Set());
     const [legacyProjectMutations, setLegacyProjectMutations] = useState<Map<string, LegacyProjectMutation>>(() => new Map());
     const canonicalProjects = useMemo(() => [
@@ -359,7 +363,8 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
         // its pinned override must follow the persisted dates to reconcile.
         if (expectation.taskDates.length > 0) {
             externalShiftNonceRef.current += 1;
-            setExternalShiftedTaskDates({ nonce: externalShiftNonceRef.current, taskDates: expectation.taskDates });
+            const event = { nonce: externalShiftNonceRef.current, taskDates: expectation.taskDates };
+            setExternalShiftEvents(current => [...current, event].slice(-20));
         }
     }, []);
 
@@ -430,7 +435,7 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
                 externallyPendingProjectIds={legacyPendingProjectIds}
                 isProjectExternallyPending={isPageProjectPending}
                 onEffectivePendingProjectIdsChange={publishBoardPendingProjectIds}
-                externalShiftedTaskDates={externalShiftedTaskDates}
+                externalShiftEvents={externalShiftEvents}
             />
 
             {legacyRefreshCount > 0 && (

--- a/src/app/company-dashboard/CompanyDashboardClient.tsx
+++ b/src/app/company-dashboard/CompanyDashboardClient.tsx
@@ -306,6 +306,8 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
     const pageMountedRef = useRef(true);
     const boardPendingProjectIdsRef = useRef<Set<string>>(new Set());
     const legacyProjectMutationsRef = useRef<Map<string, LegacyProjectMutation>>(new Map());
+    const externalShiftNonceRef = useRef(0);
+    const [externalShiftedTaskDates, setExternalShiftedTaskDates] = useState<{ nonce: number; taskDates: { id: string; startDate: string; endDate: string }[] } | null>(null);
     const [boardPendingProjectIds, setBoardPendingProjectIds] = useState<Set<string>>(() => new Set());
     const [legacyProjectMutations, setLegacyProjectMutations] = useState<Map<string, LegacyProjectMutation>>(() => new Map());
     const canonicalProjects = useMemo(() => [
@@ -352,6 +354,13 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
         next.set(projectId, { expectation });
         legacyProjectMutationsRef.current = next;
         setLegacyProjectMutations(next);
+        // Publish the persisted shift to the board: a saved-awaiting task the
+        // board is tracking may have just been moved by this legacy shift, and
+        // its pinned override must follow the persisted dates to reconcile.
+        if (expectation.taskDates.length > 0) {
+            externalShiftNonceRef.current += 1;
+            setExternalShiftedTaskDates({ nonce: externalShiftNonceRef.current, taskDates: expectation.taskDates });
+        }
     }, []);
 
     const clearLegacyProjectMutation = useCallback((projectId: string) => {
@@ -421,6 +430,7 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
                 externallyPendingProjectIds={legacyPendingProjectIds}
                 isProjectExternallyPending={isPageProjectPending}
                 onEffectivePendingProjectIdsChange={publishBoardPendingProjectIds}
+                externalShiftedTaskDates={externalShiftedTaskDates}
             />
 
             {legacyRefreshCount > 0 && (

--- a/src/app/company-dashboard/CompanyDashboardClient.tsx
+++ b/src/app/company-dashboard/CompanyDashboardClient.tsx
@@ -364,7 +364,11 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
         if (expectation.taskDates.length > 0) {
             externalShiftNonceRef.current += 1;
             const event = { nonce: externalShiftNonceRef.current, taskDates: expectation.taskDates };
-            setExternalShiftEvents(current => [...current, event].slice(-20));
+            // No cap: any truncation can silently drop an unseen event while
+            // the board's nonce ref advances past it. Growth is bounded by
+            // actual legacy saves in this page's lifetime (tiny objects) and
+            // reclaimed on unmount.
+            setExternalShiftEvents(current => [...current, event]);
         }
     }, []);
 

--- a/src/app/company-dashboard/guide/page.tsx
+++ b/src/app/company-dashboard/guide/page.tsx
@@ -1,0 +1,78 @@
+import Link from "next/link";
+import { getSessionOrDev } from "@/lib/auth";
+import { getUserWithPermissionsByEmail, hasPermission } from "@/lib/permissions";
+
+export const dynamic = "force-dynamic";
+
+// Plain-English "how to use" for the company schedule board — written so a
+// PM/field lead can be sent this link cold (probuild.goldentouchremodeling.com
+// /company-dashboard/guide) and start scheduling. Same gate as the dashboard.
+export default async function CompanyDashboardGuidePage() {
+    const session = await getSessionOrDev();
+    const user = session?.user?.email ? await getUserWithPermissionsByEmail(session.user.email) : null;
+    const effectiveUser = user ?? (process.env.NODE_ENV === "development" ? { role: "ADMIN", permissions: null } : null);
+    if (!effectiveUser || (!hasPermission(effectiveUser, "financialReports") && !hasPermission(effectiveUser, "schedules"))) {
+        return <div className="p-8 text-red-500">Access Denied.</div>;
+    }
+
+    const Step = ({ n, title, children }: { n: number; title: string; children: React.ReactNode }) => (
+        <div className="flex gap-4">
+            <div className="flex-shrink-0 w-8 h-8 rounded-full bg-hui-primary text-white flex items-center justify-center text-sm font-bold">{n}</div>
+            <div className="pb-6">
+                <h3 className="text-sm font-semibold text-hui-textMain mb-1">{title}</h3>
+                <div className="text-sm text-hui-textMuted space-y-1">{children}</div>
+            </div>
+        </div>
+    );
+
+    return (
+        <div className="max-w-3xl mx-auto py-8 px-6">
+            <div className="mb-6">
+                <h1 className="text-xl font-bold text-hui-textMain">How to use the Project Schedule</h1>
+                <p className="text-sm text-hui-textMuted mt-1">
+                    The schedule board on the <Link href="/company-dashboard" className="text-hui-primary hover:underline">Company Dashboard</Link>{" "}
+                    is the one place to see every job, move dates, and assign crew.
+                </p>
+            </div>
+
+            <div className="hui-card p-6 mb-6">
+                <h2 className="text-base font-semibold text-hui-textMain mb-4">Reading the board</h2>
+                <ul className="text-sm text-hui-textMuted space-y-2 list-disc pl-5">
+                    <li>Every <strong>In Progress</strong> or scheduled job is a colored bar across its days. The labeled blocks inside the bar are its phases — Framing, Drywall, Paint — each with the crew initials working it.</li>
+                    <li>Phases can overlap (concrete curing while the deck gets framed) — they stack inside the bar.</li>
+                    <li><strong>Month</strong> shows a calendar; <strong>Timeline</strong> shows one straight row per job. Same jobs, same edits — use whichever reads better. The board remembers your choice.</li>
+                    <li>A red badge on a bar means someone is double-booked across two jobs that day.</li>
+                    <li>The blue line is today. Use <strong>← Prev / Today / Next →</strong> to change months.</li>
+                </ul>
+            </div>
+
+            <div className="hui-card p-6 mb-6">
+                <h2 className="text-base font-semibold text-hui-textMain mb-4">Scheduling a job</h2>
+                <Step n={1} title="Drag it from the Unscheduled shelf onto a day">
+                    <p>Jobs that are ready but have no start date sit in the <strong>Unscheduled</strong> shelf above the calendar. Drag one onto the day it starts — its whole task schedule comes with it.</p>
+                </Step>
+                <Step n={2} title="Adjust dates by dragging">
+                    <p>Drag a whole bar to move the job. Drag a single phase block to move just that phase. Drag a block&apos;s edge to make it longer or shorter. Nothing is saved yet while you do this — pending moves show with a dashed outline.</p>
+                </Step>
+                <Step n={3} title="Hit Save when it looks right">
+                    <p>A bar appears showing how many unsaved changes you have — <strong>Save</strong> writes them all at once, <strong>Discard</strong> puts everything back. If you move a job that&apos;s already In Progress, it asks whether to move just the start marker or also shift the work that hasn&apos;t started yet.</p>
+                </Step>
+                <Step n={4} title="Assign the crew">
+                    <p>In the <strong>Schedule &amp; crew</strong> table below the calendar, use the crew buttons to set who&apos;s on the job — expand a row (+) to assign people to individual tasks. The <strong>By crew</strong> view on the Timeline then shows each person&apos;s week across all jobs.</p>
+                </Step>
+            </div>
+
+            <div className="hui-card p-6 mb-6">
+                <h2 className="text-base font-semibold text-hui-textMain mb-4">Good to know</h2>
+                <ul className="text-sm text-hui-textMuted space-y-2 list-disc pl-5">
+                    <li>Clicking a bar opens its menu (dates, crew, <em>Open project</em>). It never jumps you into the project by accident.</li>
+                    <li>Every move is logged on the project&apos;s activity feed — nothing here emails a customer.</li>
+                    <li>Diamond markers and the money toggles (Income, Expenses, Projected CO, Hours) only appear for admin logins.</li>
+                    <li>Anything more detailed — dependencies, baselines, punch lists — lives on the job&apos;s own Schedule page (menu → Open project → Schedule).</li>
+                </ul>
+            </div>
+
+            <Link href="/company-dashboard" className="hui-btn hui-btn-primary">Open the schedule board →</Link>
+        </div>
+    );
+}

--- a/src/app/company-dashboard/schedule-board/FloatingPopover.tsx
+++ b/src/app/company-dashboard/schedule-board/FloatingPopover.tsx
@@ -56,11 +56,22 @@ export function FloatingPopover({ open, anchorRef, onClose, children, width = 22
             const fitsBelow = spaceBelow >= panelHeight;
             const fitsAbove = spaceAbove >= panelHeight;
             const openAbove = !fitsBelow && (fitsAbove || spaceAbove > spaceBelow);
-            const available = Math.max(openAbove ? spaceAbove : spaceBelow, 120);
-            const effectiveHeight = Math.min(panelHeight, available);
-            const top = openAbove
-                ? Math.max(rect.top - effectiveHeight - ANCHOR_GAP_PX, VIEWPORT_MARGIN_PX)
-                : rect.bottom + ANCHOR_GAP_PX;
+            const available = Math.max(openAbove ? spaceAbove : spaceBelow, 0);
+            let top: number;
+            let effectiveHeight: number;
+            if (available >= 40) {
+                // Anchor-attached: capped to the chosen side's real room (no
+                // artificial floor — a floor larger than the room overflows).
+                effectiveHeight = Math.min(panelHeight, available);
+                top = openAbove
+                    ? Math.max(rect.top - effectiveHeight - ANCHOR_GAP_PX, VIEWPORT_MARGIN_PX)
+                    : rect.bottom + ANCHOR_GAP_PX;
+            } else {
+                // Degenerate viewport (anchor pinned to an edge, no room either
+                // side): detach from the anchor and use the full viewport.
+                effectiveHeight = Math.min(panelHeight, viewportHeight - 2 * VIEWPORT_MARGIN_PX);
+                top = VIEWPORT_MARGIN_PX;
+            }
 
             setPosition({ top, left, maxHeight: effectiveHeight });
         }

--- a/src/app/company-dashboard/schedule-board/FloatingPopover.tsx
+++ b/src/app/company-dashboard/schedule-board/FloatingPopover.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { createPortal } from "react-dom";
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode, type RefObject } from "react";
+
+const VIEWPORT_MARGIN_PX = 8;
+const ANCHOR_GAP_PX = 4;
+
+export interface FloatingPopoverProps {
+    open: boolean;
+    anchorRef: RefObject<HTMLElement | null>;
+    onClose: () => void;
+    children: ReactNode;
+    /** Panel width in px — the panel right-aligns to the trigger by default (matching the prior `absolute right-0` menus), then clamps into the viewport. */
+    width?: number;
+}
+
+/**
+ * A portal-rendered dropdown/menu anchored to a trigger element. Fixes the
+ * schedule board's popover clipping: rendered to document.body (escapes any
+ * clipping/overflow ancestor and any CSS containment from a drag/scroll
+ * container), positioned from the trigger's live bounding rect, flipped
+ * above the trigger when there isn't room below, and clamped horizontally
+ * with an 8px viewport margin. Escape closes and returns focus to the
+ * trigger; a pointerdown outside the panel and trigger also closes it.
+ */
+export function FloatingPopover({ open, anchorRef, onClose, children, width = 224 }: FloatingPopoverProps) {
+    const panelRef = useRef<HTMLDivElement | null>(null);
+    const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
+
+    useLayoutEffect(() => {
+        if (!open) {
+            setPosition(null);
+            return;
+        }
+        const anchor = anchorRef.current;
+        if (!anchor) return;
+
+        function place() {
+            const rect = anchor!.getBoundingClientRect();
+            const viewportWidth = window.innerWidth;
+            const viewportHeight = window.innerHeight;
+            const panelWidth = panelRef.current?.offsetWidth ?? width;
+            const panelHeight = panelRef.current?.offsetHeight ?? 0;
+
+            let left = rect.right - panelWidth;
+            left = Math.min(Math.max(left, VIEWPORT_MARGIN_PX), viewportWidth - panelWidth - VIEWPORT_MARGIN_PX);
+
+            const spaceBelow = viewportHeight - rect.bottom;
+            const flipAbove = spaceBelow < panelHeight + ANCHOR_GAP_PX && rect.top > panelHeight + ANCHOR_GAP_PX;
+            const top = flipAbove ? rect.top - panelHeight - ANCHOR_GAP_PX : rect.bottom + ANCHOR_GAP_PX;
+
+            setPosition({ top, left });
+        }
+        place();
+        window.addEventListener("resize", place);
+        window.addEventListener("scroll", place, true);
+        return () => {
+            window.removeEventListener("resize", place);
+            window.removeEventListener("scroll", place, true);
+        };
+    }, [open, anchorRef, width]);
+
+    useEffect(() => {
+        if (!open) return;
+        function onKeyDown(event: KeyboardEvent) {
+            if (event.key !== "Escape") return;
+            event.preventDefault();
+            onClose();
+            anchorRef.current?.focus();
+        }
+        function onPointerDownOutside(event: PointerEvent) {
+            const target = event.target as Node;
+            if (panelRef.current?.contains(target)) return;
+            if (anchorRef.current?.contains(target)) return;
+            onClose();
+        }
+        window.addEventListener("keydown", onKeyDown);
+        window.addEventListener("pointerdown", onPointerDownOutside, true);
+        return () => {
+            window.removeEventListener("keydown", onKeyDown);
+            window.removeEventListener("pointerdown", onPointerDownOutside, true);
+        };
+    }, [open, onClose, anchorRef]);
+
+    if (!open || typeof document === "undefined") return null;
+
+    return createPortal(
+        <div
+            ref={panelRef}
+            style={{
+                position: "fixed",
+                top: position?.top ?? -9999,
+                left: position?.left ?? -9999,
+                width,
+                visibility: position ? "visible" : "hidden",
+            }}
+            className="z-[200] space-y-2 rounded-md border border-hui-border bg-white p-3 text-left text-hui-textMain shadow-xl"
+            onPointerDown={event => event.stopPropagation()}
+        >
+            {children}
+        </div>,
+        document.body,
+    );
+}

--- a/src/app/company-dashboard/schedule-board/FloatingPopover.tsx
+++ b/src/app/company-dashboard/schedule-board/FloatingPopover.tsx
@@ -26,7 +26,7 @@ export interface FloatingPopoverProps {
  */
 export function FloatingPopover({ open, anchorRef, onClose, children, width = 224 }: FloatingPopoverProps) {
     const panelRef = useRef<HTMLDivElement | null>(null);
-    const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
+    const [position, setPosition] = useState<{ top: number; left: number; maxHeight: number } | null>(null);
 
     useLayoutEffect(() => {
         if (!open) {
@@ -43,14 +43,26 @@ export function FloatingPopover({ open, anchorRef, onClose, children, width = 22
             const panelWidth = panelRef.current?.offsetWidth ?? width;
             const panelHeight = panelRef.current?.offsetHeight ?? 0;
 
+            // Clamp order matters: the left-edge floor is applied LAST so a
+            // viewport narrower than the panel pins to the margin instead of
+            // going negative off-screen.
             let left = rect.right - panelWidth;
-            left = Math.min(Math.max(left, VIEWPORT_MARGIN_PX), viewportWidth - panelWidth - VIEWPORT_MARGIN_PX);
+            left = Math.max(Math.min(left, viewportWidth - panelWidth - VIEWPORT_MARGIN_PX), VIEWPORT_MARGIN_PX);
 
-            const spaceBelow = viewportHeight - rect.bottom;
-            const flipAbove = spaceBelow < panelHeight + ANCHOR_GAP_PX && rect.top > panelHeight + ANCHOR_GAP_PX;
-            const top = flipAbove ? rect.top - panelHeight - ANCHOR_GAP_PX : rect.bottom + ANCHOR_GAP_PX;
+            const spaceBelow = viewportHeight - rect.bottom - ANCHOR_GAP_PX - VIEWPORT_MARGIN_PX;
+            const spaceAbove = rect.top - ANCHOR_GAP_PX - VIEWPORT_MARGIN_PX;
+            // Fit below if possible, else above if possible, else whichever
+            // side has more room — capped to that room and scrollable inside.
+            const fitsBelow = spaceBelow >= panelHeight;
+            const fitsAbove = spaceAbove >= panelHeight;
+            const openAbove = !fitsBelow && (fitsAbove || spaceAbove > spaceBelow);
+            const available = Math.max(openAbove ? spaceAbove : spaceBelow, 120);
+            const effectiveHeight = Math.min(panelHeight, available);
+            const top = openAbove
+                ? Math.max(rect.top - effectiveHeight - ANCHOR_GAP_PX, VIEWPORT_MARGIN_PX)
+                : rect.bottom + ANCHOR_GAP_PX;
 
-            setPosition({ top, left });
+            setPosition({ top, left, maxHeight: effectiveHeight });
         }
         place();
         window.addEventListener("resize", place);
@@ -92,6 +104,8 @@ export function FloatingPopover({ open, anchorRef, onClose, children, width = 22
                 position: "fixed",
                 top: position?.top ?? -9999,
                 left: position?.left ?? -9999,
+                maxHeight: position?.maxHeight,
+                overflowY: "auto",
                 width,
                 visibility: position ? "visible" : "hidden",
             }}

--- a/src/app/company-dashboard/schedule-board/MonthBarsView.tsx
+++ b/src/app/company-dashboard/schedule-board/MonthBarsView.tsx
@@ -37,6 +37,12 @@ interface MonthBarsViewProps extends TaskEditCallbacks, ProjectEditCallbacks {
     showHours: boolean;
     pendingProjectIds: ReadonlySet<string>;
     pendingTaskIds: ReadonlySet<string>;
+    // Drafted (unsaved) items — still fully interactive, rendered with a
+    // dashed/desaturated treatment. isSaving locks every project/task board-
+    // wide while a Save is committing.
+    draftProjectIds: ReadonlySet<string>;
+    draftTaskIds: ReadonlySet<string>;
+    isSaving: boolean;
     activeTaskKeyboardEdit: ActiveTaskKeyboardEdit | null;
     onTrayProjectDrop: (_project: DashboardProjectRow, _targetStart: string) => void;
 }
@@ -93,6 +99,9 @@ export function MonthBarsView({
     showHours,
     pendingProjectIds,
     pendingTaskIds,
+    draftProjectIds,
+    draftTaskIds,
+    isSaving,
     activeTaskKeyboardEdit,
     onTrayProjectDrop,
     onProjectMoveCommit,
@@ -233,7 +242,7 @@ export function MonthBarsView({
                         const expanded = expandedWeeks.has(weekIndex);
 
                         return (
-                            <div key={weekIndex} className="relative grid min-h-[246px] grid-cols-7 border-b border-hui-border last:border-b-0">
+                            <div key={weekIndex} className="relative grid min-h-[350px] grid-cols-7 border-b border-hui-border last:border-b-0">
                                 {weekDays.map(day => {
                                     const dayKey = formatDate(day);
                                     const isToday = isSameUTCDay(day, today);
@@ -252,7 +261,7 @@ export function MonthBarsView({
                                             className={`min-w-0 border-r border-hui-border p-1.5 last:border-r-0 ${isCurrentMonth ? (isWeekend(day) ? "bg-slate-50/60" : "bg-white") : "bg-slate-50/40"} ${isToday ? "ring-1 ring-inset ring-indigo-300" : ""} ${dragOverDate === dayKey ? "bg-indigo-50 ring-2 ring-inset ring-indigo-500" : ""}`}
                                         >
                                             <span className={`text-xs font-semibold ${isToday ? "inline-flex h-6 w-6 items-center justify-center rounded-full bg-indigo-600 text-white" : isCurrentMonth ? "text-hui-textMain" : "text-slate-400"}`}>{day.getUTCDate()}</span>
-                                            <div className="space-y-0.5 pt-[164px]">
+                                            <div className="space-y-0.5 pt-[268px]">
                                                 {incomeTotal != null && incomeTotal > 0 && <div className="truncate px-1 text-[10px] font-medium text-green-700" title="Income due this day (effective due date)">{formatCurrency(incomeTotal)} due</div>}
                                                 {projectedCoTotal != null && projectedCoTotal > 0 && <div className="truncate px-1 text-[10px] font-medium text-amber-700" title="Approved, unbilled change-order income projected this day">{formatCurrency(projectedCoTotal)} projected CO</div>}
                                                 {expenseTotal != null && expenseTotal > 0 && <div className="truncate px-1 text-[10px] font-medium text-red-700" title="Expenses this day">−{formatCurrency(expenseTotal)}</div>}
@@ -261,7 +270,7 @@ export function MonthBarsView({
                                         </div>
                                     );
                                 })}
-                                <div className="pointer-events-none absolute inset-x-0 top-8 grid h-[152px] grid-cols-7 grid-rows-[repeat(4,38px)] gap-y-0 px-0.5">
+                                <div className="pointer-events-none absolute inset-x-0 top-8 grid h-[256px] grid-cols-7 grid-rows-[repeat(4,64px)] gap-y-0 px-0.5">
                                     {visibleSegments.map(segment => {
                                         const project = projectById.get(segment.projectId);
                                         if (!project) return null;
@@ -280,8 +289,10 @@ export function MonthBarsView({
                                                     changeOrderMilestones={milestoneMaps?.changeOrders.get(project.id) ?? EMPTY_CHANGE_ORDERS}
                                                     canEdit={data.canEdit}
                                                     canMoveProject={data.canEdit && (project.status === "Waiting to Start" || project.status === "In Progress")}
-                                                    isPending={pendingProjectIds.has(project.id)}
+                                                    isPending={isSaving || pendingProjectIds.has(project.id)}
+                                                    isDraft={draftProjectIds.has(project.id)}
                                                     pendingTaskIds={pendingTaskIds}
+                                                    draftTaskIds={draftTaskIds}
                                                     activeTaskKeyboardEdit={activeTaskKeyboardEdit}
                                                     activeProjectKeyboardId={activeProjectKeyboardId}
                                                     onProjectPointerEditStart={onProjectPointerEditStart}
@@ -334,7 +345,8 @@ export function MonthBarsView({
                                                                     visibleRange={visibleRange}
                                                                     projectColor={project.color || fallbackProjectColor(project.id)}
                                                                     canEdit={data.canEdit}
-                                                                    isPending={pendingProjectIds.has(project.id) || pendingTaskIds.has(task.id)}
+                                                                    isPending={isSaving || pendingProjectIds.has(project.id) || pendingTaskIds.has(task.id)}
+                                                                    isDraft={draftProjectIds.has(project.id) || draftTaskIds.has(task.id)}
                                                                     activeTaskKeyboardEdit={activeTaskKeyboardEdit}
                                                                     onTaskPointerEditStart={onTaskPointerEditStart}
                                                                     onTaskKeyboardStart={onTaskKeyboardStart}
@@ -353,7 +365,7 @@ export function MonthBarsView({
                                     })}
                                 </div>
                                 {hiddenCount > 0 && (
-                                    <div className="absolute right-2 top-[180px] z-40 text-right">
+                                    <div className="absolute right-2 top-[284px] z-40 text-right">
                                         <button
                                             type="button"
                                             onClick={() => setExpandedWeeks(current => {

--- a/src/app/company-dashboard/schedule-board/ProjectBar.tsx
+++ b/src/app/company-dashboard/schedule-board/ProjectBar.tsx
@@ -1,16 +1,40 @@
 "use client";
 
-import { createContext, useContext, useEffect, useRef, useState, type FormEvent, type KeyboardEvent, type PointerEvent as ReactPointerEvent, type RefObject } from "react";
+import { createContext, useContext, useEffect, useRef, useState, type FormEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type RefObject } from "react";
 import Link from "next/link";
 import type {
     DashboardProjectRow,
     OverlayChangeOrderItem,
     OverlayIncomeItem,
 } from "@/lib/schedule-core";
-import { addDays, formatDate } from "@/app/projects/[id]/schedule/schedule-utils";
-import { getEffectiveProjectRange, type WeekSegment } from "./useBarLayout";
+import { addDays, formatDate, parseUTCDate } from "@/app/projects/[id]/schedule/schedule-utils";
+import { assignTaskLanes, getEffectiveProjectRange, type WeekSegment } from "./useBarLayout";
 import { MilestoneMarker } from "./MilestoneMarker";
 import { TaskBlockSegment, type ActiveTaskKeyboardEdit, type TaskEditCallbacks } from "./TaskBlockSegment";
+import { FloatingPopover } from "./FloatingPopover";
+
+// Mini-lane sizing for overlapping tasks inside one project bar (item 5): the
+// common single-lane case keeps the original 18px strip untouched; 2-3 lanes
+// pack into slightly shorter rows. Callers (MonthBarsView's fixed-height grid
+// rows) size their row budget for the MAX_TASK_LANES=3 case.
+const TASK_STRIP_SINGLE_LANE_HEIGHT = 18;
+const TASK_LANE_HEIGHT = 14;
+
+// One source of truth for a bar's mini-lane geometry: used by the bar itself
+// AND by row-height calculations in the views (Timeline rows must grow with
+// lane count or a 3-lane bar overflows into the row below).
+export function computeTaskLaneLayout(tasks: { id: string; startDate: string; endDate: string; type: string }[]) {
+    const taskLaneInput = tasks.map(task => {
+        const start = parseUTCDate(task.startDate.slice(0, 10));
+        const end = task.type === "milestone" ? addDays(start, 1) : parseUTCDate(task.endDate.slice(0, 10));
+        return { id: task.id, start, end };
+    });
+    const { laneByTaskId, hiddenTaskIds, laneCount: rawLaneCount } = assignTaskLanes(taskLaneInput);
+    const laneCount = Math.max(1, rawLaneCount);
+    const laneHeight = laneCount <= 1 ? TASK_STRIP_SINGLE_LANE_HEIGHT : TASK_LANE_HEIGHT;
+    const taskStripHeight = laneCount * laneHeight;
+    return { laneByTaskId, hiddenTaskIds, laneCount, laneHeight, taskStripHeight, barHeight: 18 + taskStripHeight };
+}
 
 export interface ProjectEditCallbacks {
     activeProjectKeyboardId: string | null;
@@ -32,7 +56,11 @@ export interface ProjectBarProps extends TaskEditCallbacks {
     canEdit: boolean;
     canMoveProject: boolean;
     isPending: boolean;
+    // Drafted (unsaved project-start move) — dashed ring + desaturated, but
+    // still fully draggable (draft mode never locks a drafted item).
+    isDraft?: boolean;
     pendingTaskIds: ReadonlySet<string>;
+    draftTaskIds: ReadonlySet<string>;
     activeTaskKeyboardEdit: ActiveTaskKeyboardEdit | null;
     timelineDayWidth?: number;
     timelineLeftInset?: number;
@@ -74,7 +102,9 @@ export function ProjectBar({
     canEdit,
     canMoveProject,
     isPending,
+    isDraft = false,
     pendingTaskIds,
+    draftTaskIds,
     activeTaskKeyboardEdit,
     timelineDayWidth,
     timelineLeftInset,
@@ -97,7 +127,10 @@ export function ProjectBar({
     const gridStart = useContext(ProjectBarGridStartContext);
     const projectRange = getEffectiveProjectRange(project);
     const projectStart = projectRange ? formatDate(projectRange.start) : "";
-    const actionDetailsRef = useRef<HTMLDetailsElement>(null);
+    const actionTriggerRef = useRef<HTMLButtonElement>(null);
+    const [menuOpen, setMenuOpen] = useState(false);
+    const overflowTriggerRef = useRef<HTMLButtonElement>(null);
+    const [overflowOpen, setOverflowOpen] = useState(false);
     const actionResetKey = `${isPending ? "pending" : "ready"}:${projectStart}`;
     const [targetStartDraft, setTargetStartDraft] = useState(() => ({ resetKey: actionResetKey, value: projectStart }));
     const targetStart = targetStartDraft.resetKey === actionResetKey ? targetStartDraft.value : projectStart;
@@ -105,7 +138,7 @@ export function ProjectBar({
         setTargetStartDraft({ resetKey: actionResetKey, value: projectStart });
     }
     useEffect(() => {
-        if (actionDetailsRef.current) actionDetailsRef.current.open = false;
+        setMenuOpen(false);
     }, [actionResetKey]);
     if (!gridStart || !projectRange) return null;
 
@@ -113,6 +146,13 @@ export function ProjectBar({
     const visibleRange = { start: visibleStart, end: addDays(visibleStart, segment.spanDays) };
     const crewLabel = project.crew.length > 0 ? project.crew.map(member => member.name).join(", ") : "No project crew";
     const projectTitle = `${project.name}${project.client ? ` — ${project.client}` : ""} — ${crewLabel}`;
+
+    // Mini-lane layout for tasks that overlap inside this bar (e.g. concrete
+    // + deck running concurrently) — capped at 3 lanes with a "+N" chip.
+    const { laneByTaskId, hiddenTaskIds, laneCount, laneHeight, taskStripHeight, barHeight } = computeTaskLaneLayout(project.tasks);
+    const hiddenTasks = hiddenTaskIds
+        .map(id => project.tasks.find(task => task.id === id))
+        .filter((task): task is DashboardProjectRow["tasks"][number] => Boolean(task));
     const milestoneMarkers = [
         ...incomeMilestones.map(item => ({
             key: `income-${item.id}`,
@@ -178,17 +218,30 @@ export function ProjectBar({
         onMoveCommit(project, targetStart);
     }
 
+    // A bare click on the bar (not a drag, and not on an interactive
+    // descendant like the name link or the Actions menu itself) toggles the
+    // Actions dropdown instead of doing nothing — the bar itself never
+    // navigates. An active drag calls preventDefault on pointermove once the
+    // threshold is crossed, which suppresses the browser's synthetic click,
+    // so this only fires for genuine clicks.
+    function handleBarClick(event: ReactMouseEvent<HTMLDivElement>) {
+        if (!canMoveProject || isPending) return;
+        if ((event.target as HTMLElement).closest("a,button,input,summary,form,details")) return;
+        setMenuOpen(value => !value);
+    }
+
     return (
         <div
-            className={`group/project relative h-9 touch-pan-y select-none overflow-visible rounded-md border border-black/10 text-white shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 ${canMoveProject && !isPending ? "cursor-move" : ""}`}
-            style={{ backgroundColor: projectColor }}
+            className={`group/project relative touch-pan-y select-none overflow-visible rounded-md border text-white shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 ${canMoveProject && !isPending ? "cursor-move" : ""} ${isDraft ? "border-dashed border-2 border-white/90 saturate-[.55] brightness-95" : "border-black/10"}`}
+            style={{ backgroundColor: projectColor, height: barHeight }}
             data-can-edit={canEdit ? "true" : "false"}
             role="group"
-            aria-label={`${project.name} project bar`}
+            aria-label={`${project.name} project bar${isDraft ? " (unsaved change)" : ""}`}
             aria-disabled={!canMoveProject || isPending}
             aria-busy={isPending}
             tabIndex={canMoveProject && !isPending ? 0 : undefined}
             onPointerDown={handlePointerDown}
+            onClick={handleBarClick}
             onKeyDown={handleKeyboard}
         >
             <div className="absolute inset-x-0 top-0 z-10 flex h-[18px] min-w-0 items-center gap-1 px-1 text-[10px] leading-none">
@@ -207,30 +260,67 @@ export function ProjectBar({
                     </span>
                 )}
                 {canMoveProject && (
-                    <details ref={actionDetailsRef} className="relative shrink-0 opacity-0 pointer-events-none transition group-hover/project:opacity-100 group-hover/project:pointer-events-auto group-focus-within/project:opacity-100 group-focus-within/project:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto">
-                        <summary className="cursor-pointer list-none rounded bg-white/20 px-1 py-0.5 text-[9px] font-bold text-white hover:bg-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white" aria-label={`Project actions for ${project.name}`}>
+                    <>
+                        <button
+                            ref={actionTriggerRef}
+                            type="button"
+                            onClick={event => { event.stopPropagation(); setMenuOpen(value => !value); }}
+                            aria-expanded={menuOpen}
+                            className="shrink-0 cursor-pointer rounded bg-white/20 px-1 py-0.5 text-[9px] font-bold text-white opacity-0 transition hover:bg-white/30 group-hover/project:opacity-100 group-focus-within/project:opacity-100 [@media(hover:none)]:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                            aria-label={`Project actions for ${project.name}`}
+                        >
                             Actions
-                        </summary>
-                        <form onSubmit={handleDateSubmit} className="absolute right-0 top-full z-[80] mt-1 w-56 space-y-2 rounded-md border border-hui-border bg-white p-3 text-left text-hui-textMain shadow-xl">
-                            <label className="block text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted" htmlFor={`bar-project-date-${project.id}-${segment.weekIndex}`}>Start date</label>
-                            <input
-                                id={`bar-project-date-${project.id}-${segment.weekIndex}`}
-                                type="date"
-                                value={targetStart}
-                                onChange={event => setTargetStartDraft({ resetKey: actionResetKey, value: event.target.value })}
-                                disabled={isPending}
-                                className="hui-input w-full px-2 py-1 text-xs"
-                            />
-                            <button type="submit" disabled={isPending || !targetStart} className="hui-btn hui-btn-primary w-full text-xs disabled:cursor-wait disabled:opacity-60">
-                                Move project
-                            </button>
-                        </form>
-                    </details>
+                        </button>
+                        <FloatingPopover open={menuOpen} anchorRef={actionTriggerRef} onClose={() => setMenuOpen(false)}>
+                            <form onSubmit={handleDateSubmit} className="space-y-2">
+                                <Link
+                                    href={`/projects/${project.id}`}
+                                    className="block w-full rounded px-2 py-1.5 text-xs font-semibold text-hui-primary hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary"
+                                >
+                                    Open project
+                                </Link>
+                                <label className="block text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted" htmlFor={`bar-project-date-${project.id}-${segment.weekIndex}`}>Start date</label>
+                                <input
+                                    id={`bar-project-date-${project.id}-${segment.weekIndex}`}
+                                    type="date"
+                                    value={targetStart}
+                                    onChange={event => setTargetStartDraft({ resetKey: actionResetKey, value: event.target.value })}
+                                    disabled={isPending}
+                                    className="hui-input w-full px-2 py-1 text-xs"
+                                />
+                                <button type="submit" disabled={isPending || !targetStart} className="hui-btn hui-btn-primary w-full text-xs disabled:cursor-wait disabled:opacity-60">
+                                    Move project
+                                </button>
+                            </form>
+                        </FloatingPopover>
+                    </>
                 )}
                 {segment.continuesAfter && <span aria-hidden="true">›</span>}
             </div>
-            <div className="absolute inset-x-0 bottom-0 h-[18px] overflow-visible rounded-b-md">
-                {project.tasks.map(task => (
+            {hiddenTasks.length > 0 && (
+                <>
+                    <button
+                        ref={overflowTriggerRef}
+                        type="button"
+                        onClick={event => { event.stopPropagation(); setOverflowOpen(value => !value); }}
+                        aria-expanded={overflowOpen}
+                        className="absolute bottom-0 right-0 z-20 rounded-tl bg-black/40 px-1 text-[8px] font-bold text-white hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                        aria-label={`${hiddenTasks.length} more overlapping task${hiddenTasks.length === 1 ? "" : "s"} on ${project.name}`}
+                    >
+                        +{hiddenTasks.length}
+                    </button>
+                    <FloatingPopover open={overflowOpen} anchorRef={overflowTriggerRef} onClose={() => setOverflowOpen(false)} width={200}>
+                        <p className="text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted">Also running</p>
+                        <ul className="space-y-1">
+                            {hiddenTasks.map(task => (
+                                <li key={task.id} className="truncate text-xs text-hui-textMain" title={task.name}>{task.name}</li>
+                            ))}
+                        </ul>
+                    </FloatingPopover>
+                </>
+            )}
+            <div className="absolute inset-x-0 bottom-0 overflow-visible rounded-b-md" style={{ height: taskStripHeight }}>
+                {project.tasks.filter(task => laneByTaskId.has(task.id)).map(task => (
                     <TaskBlockSegment
                         key={task.id}
                         task={task}
@@ -238,7 +328,10 @@ export function ProjectBar({
                         visibleRange={visibleRange}
                         projectColor={projectColor}
                         canEdit={canEdit}
+                        laneTop={laneByTaskId.get(task.id)! * laneHeight}
+                        laneHeight={laneHeight}
                         isPending={isPending || pendingTaskIds.has(task.id)}
+                        isDraft={isDraft || draftTaskIds.has(task.id)}
                         activeTaskKeyboardEdit={activeTaskKeyboardEdit}
                         timelineDayWidth={timelineDayWidth}
                         timelineLeftInset={timelineLeftInset}

--- a/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
+++ b/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
@@ -270,6 +270,10 @@ export function ScheduleBoard({
     }
 
     function clearTaskPreview(taskId: string) {
+        // A saved-awaiting task's override IS its committed state pending
+        // refresh — cancelling a speculative edit must restore it, never
+        // delete it (deleting strands the awaiting id and the refresh poll).
+        if (awaitingTaskRefreshIds.has(taskId)) return;
         setTaskDateOverrides(current => {
             if (!(taskId in current)) return current;
             const next = { ...current };
@@ -570,6 +574,10 @@ export function ScheduleBoard({
         const succeededProjectIds: string[] = [];
         const failedProjectIds = new Set<string>();
         const projectExpectations: Record<string, ProjectRefreshExpectation> = {};
+        // Persisted task dates from successful shifts — saved-awaiting tasks
+        // caught in a shift must have their pinned overrides rewritten to the
+        // shifted dates or their awaiting ids can never reconcile.
+        const shiftedPersistedDates: { id: string; startDate: string; endDate: string }[] = [];
 
         for (const [projectId, draft] of projectEntries) {
             const canonicalProject = canonicalProjectById.get(projectId);
@@ -597,6 +605,7 @@ export function ScheduleBoard({
                         // the job follows the drag; started work stays put.
                         const markerResult = await updateProjectStartDateAction(projectId, draft.targetStart, false);
                         const shiftResult = await shiftNotStartedTasksAction(projectId, draft.deltaDays);
+                        shiftedPersistedDates.push(...shiftResult.shiftedTaskDates);
                         projectExpectations[projectId] = {
                             projectStartDate: markerResult.startDate,
                             taskDates: shiftResult.shiftedTaskDates.filter(row => !batchedTaskIds.has(row.id)),
@@ -604,6 +613,7 @@ export function ScheduleBoard({
                     }
                 } else {
                     const result = await updateProjectStartDateAction(projectId, draft.targetStart, true);
+                    shiftedPersistedDates.push(...result.shiftedTaskDates);
                     projectExpectations[projectId] = { projectStartDate: result.startDate, taskDates: result.shiftedTaskDates.filter(row => !batchedTaskIds.has(row.id)) };
                 }
                 succeededProjectIds.push(projectId);
@@ -617,6 +627,21 @@ export function ScheduleBoard({
             const succeeded = new Set(succeededProjectIds);
             setProjectDrafts(current => Object.fromEntries(Object.entries(current).filter(([id]) => !succeeded.has(id))));
             setProjectRefreshExpectations(current => ({ ...current, ...projectExpectations }));
+            // Rewrite saved-awaiting overrides that a shift just moved: their
+            // pinned dates must track the PERSISTED (shifted) dates or their
+            // awaiting ids never match refreshed canonical rows.
+            const shiftedById = new Map(shiftedPersistedDates.map(row => [row.id, row]));
+            setTaskDateOverrides(current => {
+                let changed = false;
+                const next = { ...current };
+                for (const taskId of awaitingTaskRefreshIds) {
+                    const shifted = shiftedById.get(taskId);
+                    if (!shifted || !(taskId in next)) continue;
+                    next[taskId] = { startDate: shifted.startDate.slice(0, 10), endDate: shifted.endDate.slice(0, 10) };
+                    changed = true;
+                }
+                return changed ? next : current;
+            });
         }
 
         let failedTaskNames: string[] = [];
@@ -633,11 +658,20 @@ export function ScheduleBoard({
             const changes = sendableTaskEntries.map(([taskId, dates]) => ({ taskId, startDate: dates.startDate, endDate: dates.endDate }));
             try {
                 // Chunked to the server's 200-change cap so any draft count
-                // saves in one gesture.
+                // saves in one gesture. Failures are isolated PER CHUNK: a
+                // rejected chunk synthesizes failure rows for its own tasks
+                // only — earlier chunks' successes are never discarded or
+                // retried as if unsaved.
                 const allResults = [] as Awaited<ReturnType<typeof saveCompanyScheduleTaskDatesAction>>["results"];
                 for (let offset = 0; offset < changes.length; offset += 200) {
-                    const batchResult = await saveCompanyScheduleTaskDatesAction(changes.slice(offset, offset + 200));
-                    allResults.push(...batchResult.results);
+                    const chunk = changes.slice(offset, offset + 200);
+                    try {
+                        const batchResult = await saveCompanyScheduleTaskDatesAction(chunk);
+                        allResults.push(...batchResult.results);
+                    } catch (chunkError: any) {
+                        const message = chunkError?.message ?? "Save failed";
+                        allResults.push(...chunk.map(change => ({ taskId: change.taskId, ok: false as const, error: message })));
+                    }
                 }
                 const succeededRows = allResults.filter(row => row.ok);
                 failedTaskNames = allResults

--- a/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
+++ b/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
@@ -50,6 +50,9 @@ interface ScheduleBoardProps {
     externallyPendingProjectIds: ReadonlySet<string>;
     isProjectExternallyPending: (projectId: string) => boolean;
     onEffectivePendingProjectIdsChange: (projectIds: ReadonlySet<string>) => void;
+    // Persisted task shifts from sibling writers (legacy StartDateRow) so the
+    // board can rewrite saved-awaiting overrides caught in an external shift.
+    externalShiftedTaskDates: { nonce: number; taskDates: { id: string; startDate: string; endDate: string }[] } | null;
 }
 
 interface TaskKeyboardEditState {
@@ -149,6 +152,7 @@ export function ScheduleBoard({
     externallyPendingProjectIds,
     isProjectExternallyPending,
     onEffectivePendingProjectIdsChange,
+    externalShiftedTaskDates,
 }: ScheduleBoardProps) {
     const router = useRouter();
     const { month, isAdmin, overlays } = data;
@@ -268,6 +272,35 @@ export function ScheduleBoard({
     function setTaskPreview(taskId: string, dates: TaskDateOverride) {
         setTaskDateOverrides(current => ({ ...current, [taskId]: dates }));
     }
+
+    // Shared by the board's own save loop AND external (legacy StartDateRow)
+    // shifts: saved-awaiting overrides pinned to pre-shift dates can never
+    // reconcile — rewrite them to the persisted shifted dates.
+    function rewriteAwaitingOverridesFromShift(taskDates: { id: string; startDate: string; endDate: string }[]) {
+        if (taskDates.length === 0) return;
+        const shiftedById = new Map(taskDates.map(row => [row.id, row]));
+        setTaskDateOverrides(current => {
+            let changed = false;
+            const next = { ...current };
+            for (const taskId of awaitingTaskRefreshIds) {
+                const shifted = shiftedById.get(taskId);
+                if (!shifted || !(taskId in next)) continue;
+                next[taskId] = { startDate: shifted.startDate.slice(0, 10), endDate: shifted.endDate.slice(0, 10) };
+                changed = true;
+            }
+            return changed ? next : current;
+        });
+    }
+
+    // External writers (the legacy waiting-list date setter) report their
+    // persisted shifts here; each nonce is applied exactly once.
+    const lastExternalShiftNonceRef = useRef(0);
+    useEffect(() => {
+        if (!externalShiftedTaskDates || externalShiftedTaskDates.nonce === lastExternalShiftNonceRef.current) return;
+        lastExternalShiftNonceRef.current = externalShiftedTaskDates.nonce;
+        rewriteAwaitingOverridesFromShift(externalShiftedTaskDates.taskDates);
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- rewrite reads current awaiting state by design
+    }, [externalShiftedTaskDates]);
 
     function clearTaskPreview(taskId: string) {
         // A saved-awaiting task's override IS its committed state pending
@@ -630,18 +663,7 @@ export function ScheduleBoard({
             // Rewrite saved-awaiting overrides that a shift just moved: their
             // pinned dates must track the PERSISTED (shifted) dates or their
             // awaiting ids never match refreshed canonical rows.
-            const shiftedById = new Map(shiftedPersistedDates.map(row => [row.id, row]));
-            setTaskDateOverrides(current => {
-                let changed = false;
-                const next = { ...current };
-                for (const taskId of awaitingTaskRefreshIds) {
-                    const shifted = shiftedById.get(taskId);
-                    if (!shifted || !(taskId in next)) continue;
-                    next[taskId] = { startDate: shifted.startDate.slice(0, 10), endDate: shifted.endDate.slice(0, 10) };
-                    changed = true;
-                }
-                return changed ? next : current;
-            });
+            rewriteAwaitingOverridesFromShift(shiftedPersistedDates);
         }
 
         let failedTaskNames: string[] = [];

--- a/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
+++ b/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
@@ -203,7 +203,13 @@ export function ScheduleBoard({
     const canonicalTaskProjectById = useMemo(() => new Map(canonicalProjects.flatMap(project => (
         project.tasks.map(task => [task.id, project.id] as const)
     ))), [canonicalProjects]);
-    const draftTaskIds = useMemo(() => new Set(Object.keys(taskDateOverrides)), [taskDateOverrides]);
+    // A saved-but-not-yet-refreshed task keeps its override (pinned to the
+    // persisted dates) purely for rendering/reconciliation — it is NOT an
+    // unsaved draft and must not count toward or re-enter a Save.
+    const draftTaskIds = useMemo(
+        () => new Set(Object.keys(taskDateOverrides).filter(taskId => !awaitingTaskRefreshIds.has(taskId))),
+        [taskDateOverrides, awaitingTaskRefreshIds],
+    );
     const draftProjectIds = useMemo(() => new Set(Object.keys(projectDrafts)), [projectDrafts]);
     const draftCount = draftTaskIds.size + draftProjectIds.size;
 
@@ -421,6 +427,11 @@ export function ScheduleBoard({
             clearTaskPreview(taskId);
             return;
         }
+        // Re-editing a saved-awaiting task turns it back into a live draft.
+        setAwaitingTaskRefreshIds(current => {
+            if (!current.has(taskId)) return current;
+            return new Set([...current].filter(id => id !== taskId));
+        });
         setTaskPreview(taskId, normalizedDates);
     }
 
@@ -437,6 +448,25 @@ export function ScheduleBoard({
             return;
         }
         setProjectPreview(canonicalProject, intent.targetStart);
+        // Rebase this project's existing task drafts by the CHANGE in project
+        // delta (full-shift projects only — the preview shifts their tasks, so
+        // a task drafted at X before a +D project drag must follow to X+D or
+        // Save would write the stale pre-shift date over the shifted schedule).
+        // In Progress previews never move tasks, so their drafts stay absolute.
+        if (canonicalProject.status !== "In Progress") {
+            const previousDelta = projectDrafts[project.id]?.deltaDays ?? 0;
+            const deltaChange = intent.deltaDays - previousDelta;
+            if (deltaChange !== 0) {
+                const projectTaskIds = new Set(canonicalProject.tasks.map(task => task.id));
+                setTaskDateOverrides(current => Object.fromEntries(Object.entries(current).map(([taskId, dates]) => {
+                    if (!projectTaskIds.has(taskId)) return [taskId, dates];
+                    return [taskId, {
+                        startDate: formatDate(addDays(parseUTCDate(dates.startDate), deltaChange)),
+                        endDate: formatDate(addDays(parseUTCDate(dates.endDate), deltaChange)),
+                    }];
+                })));
+            }
+        }
         setProjectDrafts(current => ({
             ...current,
             [project.id]: { originalStart: intent.originalStart, targetStart: intent.targetStart, deltaDays: intent.deltaDays },
@@ -475,9 +505,30 @@ export function ScheduleBoard({
     // router.refresh() fires, after everything settles.
     async function saveAllDrafts() {
         if (isSaving) return;
-        const projectEntries = Object.entries(projectDrafts);
-        const taskEntries = Object.entries(taskDateOverrides);
+        // Drafts on a project the legacy StartDateRow is mutating RIGHT NOW are
+        // retained (not sent) — the board must never serialize over a sibling
+        // writer's in-flight result. They save on the next click.
+        const retainedForExternalLock: string[] = [];
+        const projectEntries = Object.entries(projectDrafts).filter(([projectId]) => {
+            if (!isProjectExternallyPending(projectId)) return true;
+            retainedForExternalLock.push(canonicalProjectById.get(projectId)?.name ?? projectId);
+            return false;
+        });
+        const taskEntries = Object.entries(taskDateOverrides).filter(([taskId]) => {
+            if (awaitingTaskRefreshIds.has(taskId)) return false; // already saved, awaiting refresh
+            const projectId = canonicalTaskProjectById.get(taskId);
+            if (!projectId || !isProjectExternallyPending(projectId)) return true;
+            retainedForExternalLock.push(canonicalTaskById.get(taskId)?.name ?? taskId);
+            return false;
+        });
+        if (retainedForExternalLock.length > 0) {
+            toast.info(`${retainedForExternalLock.length} draft${retainedForExternalLock.length === 1 ? "" : "s"} kept unsaved while another edit finishes: ${retainedForExternalLock.join(", ")}`);
+        }
         if (projectEntries.length === 0 && taskEntries.length === 0) return;
+        // The batch below reconciles these tasks itself (override + awaiting
+        // id); project-shift expectations must not also claim them or the two
+        // mechanisms deadlock the refresh poll on conflicting dates.
+        const batchedTaskIds = new Set(taskEntries.map(([taskId]) => taskId));
 
         setIsSaving(true);
         const lockedProjectIds = new Set<string>([
@@ -513,11 +564,11 @@ export function ScheduleBoard({
                         projectExpectations[projectId] = { projectStartDate: result.startDate, taskDates: [] };
                     } else {
                         const result = await shiftNotStartedTasksAction(projectId, draft.deltaDays);
-                        projectExpectations[projectId] = { taskDates: result.shiftedTaskDates };
+                        projectExpectations[projectId] = { taskDates: result.shiftedTaskDates.filter(row => !batchedTaskIds.has(row.id)) };
                     }
                 } else {
                     const result = await updateProjectStartDateAction(projectId, draft.targetStart, true);
-                    projectExpectations[projectId] = { projectStartDate: result.startDate, taskDates: result.shiftedTaskDates };
+                    projectExpectations[projectId] = { projectStartDate: result.startDate, taskDates: result.shiftedTaskDates.filter(row => !batchedTaskIds.has(row.id)) };
                 }
                 succeededProjectIds.push(projectId);
             } catch (error) {
@@ -537,15 +588,26 @@ export function ScheduleBoard({
             const changes = taskEntries.map(([taskId, dates]) => ({ taskId, startDate: dates.startDate, endDate: dates.endDate }));
             try {
                 const batchResult = await saveCompanyScheduleTaskDatesAction(changes);
-                const succeededTaskIds = batchResult.results.filter(row => row.ok).map(row => row.taskId);
+                const succeededRows = batchResult.results.filter(row => row.ok);
                 failedTaskNames = batchResult.results
                     .filter(row => !row.ok)
                     .map(row => canonicalTaskById.get(row.taskId)?.name ?? row.taskId);
-                succeededTaskCount = succeededTaskIds.length;
-                if (succeededTaskIds.length > 0) {
-                    const succeeded = new Set(succeededTaskIds);
-                    setTaskDateOverrides(current => Object.fromEntries(Object.entries(current).filter(([id]) => !succeeded.has(id))));
-                    setAwaitingTaskRefreshIds(current => new Set([...current, ...succeededTaskIds]));
+                succeededTaskCount = succeededRows.length;
+                if (succeededRows.length > 0) {
+                    // Keep the override (pinned to the PERSISTED dates) until the
+                    // refresh poll sees matching canonical rows — reconciliation
+                    // requires the override to exist; deleting it here would
+                    // leave awaiting ids stranded and the poll running forever.
+                    const savedById = new Map(succeededRows.map(row => [row.taskId, {
+                        startDate: row.startDate!.slice(0, 10),
+                        endDate: row.endDate!.slice(0, 10),
+                    }]));
+                    setTaskDateOverrides(current => {
+                        const next = { ...current };
+                        for (const [taskId, dates] of savedById) next[taskId] = dates;
+                        return next;
+                    });
+                    setAwaitingTaskRefreshIds(current => new Set([...current, ...savedById.keys()]));
                 }
             } catch (error) {
                 failedTaskNames = taskEntries.map(([taskId]) => canonicalTaskById.get(taskId)?.name ?? taskId);

--- a/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
+++ b/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState, useTransition } from "react";
+import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { shiftNotStartedTasksAction, updateCompanyScheduleTaskDatesAction, updateProjectStartDateAction } from "@/lib/actions";
+import { saveCompanyScheduleTaskDatesAction, shiftNotStartedTasksAction, updateProjectStartDateAction } from "@/lib/actions";
 import type { CompanyDashboardData, DashboardProjectRow, DashboardTaskRow, OverlayIncomeItem } from "@/lib/schedule-core";
 import { addDays, formatDate, getDaysBetween, parseUTCDate } from "@/app/projects/[id]/schedule/schedule-utils";
 import { MonthBarsView } from "./MonthBarsView";
@@ -12,15 +13,12 @@ import { ShiftConfirmDialog, type ProjectMoveChoice } from "./ShiftConfirmDialog
 import { UnscheduledTray } from "./UnscheduledTray";
 import {
     createProjectDropIntent,
-    getEffectivePendingProjectIds,
     getEffectiveProjectRange,
     getNewlyPendingProjectIds,
     getTimelineAutoscrollStep,
     getTimelinePointerDelta,
     previewProjectMove,
-    previewProjectWithPersistedTaskDates,
     previewProjectIncomeOverlays,
-    previewShiftedTaskIncomeOverlays,
     previewTaskDates,
     previewTaskPointerCandidate,
     projectRefreshMatches,
@@ -106,6 +104,13 @@ interface ActiveProjectPointerEdit {
     cleanup: () => void;
 }
 
+// Draft-mode: a drafted project-start move accumulated locally until Save.
+interface ProjectDraftMove {
+    originalStart: string;
+    targetStart: string;
+    deltaDays: number;
+}
+
 function hitTestScheduleDate(clientX: number, clientY: number): string | null {
     for (const element of document.elementsFromPoint(clientX, clientY)) {
         const cell = element instanceof HTMLElement ? element.closest<HTMLElement>("[data-schedule-date]") : null;
@@ -155,9 +160,11 @@ export function ScheduleBoard({
     const [projectPreviewOverrides, setProjectPreviewOverrides] = useState<Record<string, DashboardProjectRow>>({});
     const [projectIncomeOverrides, setProjectIncomeOverrides] = useState<Record<string, OverlayIncomeItem[]>>({});
     const [projectRefreshExpectations, setProjectRefreshExpectations] = useState<Record<string, ProjectRefreshExpectation>>({});
+    // Drafts accumulate here — the SAME map drives the live visual preview AND
+    // the pending-to-save payload; nothing writes to the server until Save.
     const [taskDateOverrides, setTaskDateOverrides] = useState<Record<string, TaskDateOverride>>({});
-    const [pendingProjectIds, setPendingProjectIds] = useState<Set<string>>(() => new Set());
-    const [pendingTaskIds, setPendingTaskIds] = useState<Set<string>>(() => new Set());
+    const [projectDrafts, setProjectDrafts] = useState<Record<string, ProjectDraftMove>>({});
+    const [isSaving, setIsSaving] = useState(false);
     const [awaitingTaskRefreshIds, setAwaitingTaskRefreshIds] = useState<Set<string>>(() => new Set());
     const [taskKeyboardEdit, setTaskKeyboardEdit] = useState<TaskKeyboardEditState | null>(null);
     const taskKeyboardEditRef = useRef<TaskKeyboardEditState | null>(null);
@@ -170,13 +177,11 @@ export function ScheduleBoard({
     const projectKeyboardCleanupRef = useRef<(() => void) | null>(null);
     const projectKeyboardSentinelRef = useRef<HTMLSpanElement>(null);
     const activeProjectPointerRef = useRef<ActiveProjectPointerEdit | null>(null);
-    const effectivePendingTaskIdsRef = useRef<Set<string>>(new Set());
-    const effectivePendingProjectIdsRef = useRef<Set<string>>(new Set());
     const previousExternallyPendingProjectIdsRef = useRef<ReadonlySet<string>>(new Set(externallyPendingProjectIds));
     const [confirmIntent, setConfirmIntent] = useState<ProjectDropIntent | null>(null);
-    const confirmIntentRef = useRef<ProjectDropIntent | null>(null);
-    confirmIntentRef.current = confirmIntent;
-    const [, startTransition] = useTransition();
+    // Bridges the ShiftConfirmDialog (shown at SAVE time, one project at a
+    // time) back into the sequential save loop below.
+    const confirmResolverRef = useRef<((choice: ProjectMoveChoice | "cancel") => void) | null>(null);
     useEffect(() => {
         try {
             const stored = localStorage.getItem(BOARD_VIEW_STORAGE_KEY);
@@ -198,37 +203,25 @@ export function ScheduleBoard({
     const canonicalTaskProjectById = useMemo(() => new Map(canonicalProjects.flatMap(project => (
         project.tasks.map(task => [task.id, project.id] as const)
     ))), [canonicalProjects]);
-    const effectivePendingTaskIds = useMemo(
-        () => new Set([...pendingTaskIds, ...awaitingTaskRefreshIds]),
-        [awaitingTaskRefreshIds, pendingTaskIds],
-    );
-    const effectivePendingProjectIds = useMemo(() => getEffectivePendingProjectIds(
-        [...pendingProjectIds, ...Object.keys(projectRefreshExpectations), ...externallyPendingProjectIds],
-        effectivePendingTaskIds,
-        canonicalTaskProjectById,
-    ), [canonicalTaskProjectById, effectivePendingTaskIds, externallyPendingProjectIds, pendingProjectIds, projectRefreshExpectations]);
-    effectivePendingTaskIdsRef.current = effectivePendingTaskIds;
-    effectivePendingProjectIdsRef.current = effectivePendingProjectIds;
-    const isProjectPending = (projectId: string) => (
-        effectivePendingProjectIdsRef.current.has(projectId) || isProjectExternallyPending(projectId)
-    );
-    const publishEffectivePendingProjectIds = useCallback((next: ReadonlySet<string>) => {
-        effectivePendingProjectIdsRef.current = new Set(next);
-        onEffectivePendingProjectIdsChange(next);
-    }, [onEffectivePendingProjectIdsChange]);
-    useEffect(() => {
-        publishEffectivePendingProjectIds(effectivePendingProjectIds);
-    }, [effectivePendingProjectIds, publishEffectivePendingProjectIds]);
-    useEffect(() => () => onEffectivePendingProjectIdsChange(EMPTY_PROJECT_IDS), [onEffectivePendingProjectIdsChange]);
-    const isTaskOrProjectPending = (taskId: string) => {
+    const draftTaskIds = useMemo(() => new Set(Object.keys(taskDateOverrides)), [taskDateOverrides]);
+    const draftProjectIds = useMemo(() => new Set(Object.keys(projectDrafts)), [projectDrafts]);
+    const draftCount = draftTaskIds.size + draftProjectIds.size;
+
+    // Locking during draft mode: a drafted item stays fully interactive.
+    // Only an in-flight Save (global — the whole board pauses while
+    // committing) or an externally-locked project (the legacy StartDateRow
+    // mutating that same project directly) ever blocks an edit.
+    const isProjectLocked = useCallback((projectId: string) => (
+        isSaving || isProjectExternallyPending(projectId)
+    ), [isSaving, isProjectExternallyPending]);
+    const isTaskLocked = useCallback((taskId: string) => {
+        if (isSaving) return true;
         const projectId = canonicalTaskProjectById.get(taskId);
-        return effectivePendingTaskIdsRef.current.has(taskId) || Boolean(projectId && isProjectPending(projectId));
-    };
-    const projectRefreshCount = Object.keys(projectRefreshExpectations).length;
-    const pendingRefreshKinds = [
-        projectRefreshCount > 0 ? "project" : null,
-        awaitingTaskRefreshIds.size > 0 ? "task" : null,
-    ].filter((kind): kind is string => Boolean(kind));
+        return Boolean(projectId && isProjectExternallyPending(projectId));
+    }, [isSaving, isProjectExternallyPending, canonicalTaskProjectById]);
+
+    useEffect(() => () => onEffectivePendingProjectIdsChange(EMPTY_PROJECT_IDS), [onEffectivePendingProjectIdsChange]);
+
     const applyPreview = (project: DashboardProjectRow) => {
         const projectPreview = projectPreviewOverrides[project.id] ?? project;
         return {
@@ -261,36 +254,6 @@ export function ScheduleBoard({
         overlays: data.overlays ? previewOverlays : null,
     };
 
-    function setProjectPending(projectId: string, pending: boolean) {
-        if (pending) {
-            const next = new Set(effectivePendingProjectIdsRef.current).add(projectId);
-            publishEffectivePendingProjectIds(next);
-        }
-        setPendingProjectIds(current => {
-            const next = new Set(current);
-            if (pending) next.add(projectId);
-            else next.delete(projectId);
-            return next;
-        });
-    }
-
-    function setTaskPending(taskId: string, pending: boolean) {
-        if (pending) {
-            effectivePendingTaskIdsRef.current = new Set(effectivePendingTaskIdsRef.current).add(taskId);
-            const projectId = canonicalTaskProjectById.get(taskId);
-            if (projectId) {
-                const next = new Set(effectivePendingProjectIdsRef.current).add(projectId);
-                publishEffectivePendingProjectIds(next);
-            }
-        }
-        setPendingTaskIds(current => {
-            const next = new Set(current);
-            if (pending) next.add(taskId);
-            else next.delete(taskId);
-            return next;
-        });
-    }
-
     function setTaskKeyboardState(next: TaskKeyboardEditState | null) {
         taskKeyboardEditRef.current = next;
         setTaskKeyboardEdit(next);
@@ -313,24 +276,16 @@ export function ScheduleBoard({
         const pointerEdit = activeTaskPointerRef.current;
         if (pointerEdit && projectIds.has(pointerEdit.projectId)) {
             pointerEdit.cleanup();
-            clearTaskPreview(pointerEdit.taskId);
         }
         const keyboardEdit = taskKeyboardEditRef.current;
         if (keyboardEdit && projectIds.has(keyboardEdit.projectId)) {
-            clearTaskPreview(keyboardEdit.taskId);
             taskKeyboardCleanupRef.current?.();
             setTaskKeyboardState(null);
         }
     }
 
     function cancelActiveTaskEdit() {
-        const pointerEdit = activeTaskPointerRef.current;
-        if (pointerEdit) {
-            pointerEdit.cleanup();
-            clearTaskPreview(pointerEdit.taskId);
-        }
-        const keyboardEdit = taskKeyboardEditRef.current;
-        if (keyboardEdit) clearTaskPreview(keyboardEdit.taskId);
+        activeTaskPointerRef.current?.cleanup();
         taskKeyboardCleanupRef.current?.();
         setTaskKeyboardState(null);
     }
@@ -350,14 +305,12 @@ export function ScheduleBoard({
         if (reconciledTaskIds.length === 0) return;
 
         // Prop reconciliation is intentionally deferred out of the effect body.
-        // Until refreshed canonical rows match, saved overrides stay rendered and
-        // the task remains gated against stale-base sequential edits.
+        // Until refreshed canonical rows match, saved overrides stay rendered.
         const timeoutId = window.setTimeout(() => {
             const reconciled = new Set(reconciledTaskIds);
             setTaskDateOverrides(current => Object.fromEntries(
                 Object.entries(current).filter(([taskId]) => !reconciled.has(taskId)),
             ));
-            setPendingTaskIds(current => new Set([...current].filter(taskId => !reconciled.has(taskId))));
             setAwaitingTaskRefreshIds(current => new Set([...current].filter(taskId => !reconciled.has(taskId))));
         }, 0);
         return () => window.clearTimeout(timeoutId);
@@ -374,7 +327,6 @@ export function ScheduleBoard({
             setProjectPreviewOverrides(current => Object.fromEntries(Object.entries(current).filter(([id]) => !reconciled.has(id))));
             setProjectIncomeOverrides(current => Object.fromEntries(Object.entries(current).filter(([id]) => !reconciled.has(id))));
             setProjectRefreshExpectations(current => Object.fromEntries(Object.entries(current).filter(([id]) => !reconciled.has(id))));
-            setPendingProjectIds(current => new Set([...current].filter(id => !reconciled.has(id))));
         }, 0);
         return () => window.clearTimeout(timeoutId);
     }, [canonicalProjectById, projectRefreshExpectations]);
@@ -432,25 +384,20 @@ export function ScheduleBoard({
         });
     }
 
-    function awaitProjectRefresh(
-        project: DashboardProjectRow,
-        expectation: ProjectRefreshExpectation,
-        income: OverlayIncomeItem[] | null,
-    ) {
-        setProjectPreviewOverrides(current => ({ ...current, [project.id]: project }));
-        if (income) setProjectIncomeOverrides(current => ({ ...current, [project.id]: income }));
-        else setProjectIncomeOverrides(current => {
+    function clearProjectDraft(projectId: string) {
+        setProjectDrafts(current => {
+            if (!(projectId in current)) return current;
             const next = { ...current };
-            delete next[project.id];
+            delete next[projectId];
             return next;
         });
-        setProjectRefreshExpectations(current => ({ ...current, [project.id]: expectation }));
-        router.refresh();
     }
 
-    async function commitTaskDates(taskId: string, dates: TaskDateOverride): Promise<void> {
+    // ── Draft-mode writers: accumulate locally, never touch the server. ──
+
+    function draftTaskChange(taskId: string, dates: TaskDateOverride) {
         const canonicalTask = canonicalTaskById.get(taskId);
-        if (!data.canEdit || isTaskOrProjectPending(taskId) || !canonicalTask) {
+        if (!data.canEdit || isTaskLocked(taskId) || !canonicalTask) {
             clearTaskPreview(taskId);
             return;
         }
@@ -474,164 +421,170 @@ export function ScheduleBoard({
             clearTaskPreview(taskId);
             return;
         }
-
-        dates = normalizedDates;
         setTaskPreview(taskId, normalizedDates);
-        setTaskPending(taskId, true);
-        try {
-            const saved = await updateCompanyScheduleTaskDatesAction(taskId, { startDate: dates.startDate, endDate: dates.endDate });
-            const persistedDates = { startDate: formatDate(saved.startDate), endDate: formatDate(saved.endDate) };
-            setTaskPreview(taskId, persistedDates);
-            toast.success("Task dates updated");
-            setAwaitingTaskRefreshIds(current => new Set(current).add(taskId));
-            router.refresh();
-        } catch (error) {
-            clearTaskPreview(taskId);
-            setAwaitingTaskRefreshIds(current => {
-                const next = new Set(current);
-                next.delete(taskId);
-                return next;
-            });
-            setTaskPending(taskId, false);
-            toast.error(error instanceof Error ? error.message : "Failed to update task dates");
-        }
     }
 
-    function showSuccess(message: string, notes: string[]) {
-        if (notes.length > 0) toast.success(message, { description: notes.join(" ") });
-        else toast.success(message);
-    }
-
-    function showFailure(error: unknown, fallback: string) {
-        toast.error(error instanceof Error ? error.message : fallback);
-    }
-
-    function scheduleUnscheduledProject(project: DashboardProjectRow, targetStart: string) {
+    function draftProjectMove(project: DashboardProjectRow, targetStart: string) {
         const canonicalProject = canonicalProjectById.get(project.id);
-        if (!data.canEdit || !canonicalProject || isProjectPending(project.id)) return;
-        cancelActiveTaskEdit();
-        const normalizedTarget = formatDate(parseUTCDate(targetStart));
-        setProjectPreview(canonicalProject, normalizedTarget);
-        setProjectPending(project.id, true);
-        startTransition(async () => {
-            try {
-                const result = await updateProjectStartDateAction(project.id, normalizedTarget, true);
-                toast.success("Project scheduled", result.notes.length > 0 ? { description: result.notes.join(" ") } : undefined);
-                const preview = previewProjectWithPersistedTaskDates(canonicalProject, result.startDate, result.shiftedTaskDates);
-                awaitProjectRefresh(preview, {
-                    projectStartDate: result.startDate,
-                    taskDates: result.shiftedTaskDates,
-                }, data.overlays?.income ?? null);
-            } catch (error) {
-                clearProjectPreview(project.id);
-                showFailure(error, "Failed to schedule project");
-            } finally {
-                setProjectPending(project.id, false);
-            }
-        });
-    }
-
-    function commitWaitingProjectMove(intent: ProjectDropIntent) {
-        if (!data.canEdit || isProjectPending(intent.project.id)) {
-            clearProjectPreview(intent.project.id);
-            return;
-        }
-        cancelActiveTaskEdit();
-        setProjectPending(intent.project.id, true);
-        startTransition(async () => {
-            try {
-                const result = await updateProjectStartDateAction(intent.project.id, intent.targetStart, true);
-                showSuccess("Project moved", result.notes);
-                const expected = previewProjectWithPersistedTaskDates(intent.project, result.startDate, result.shiftedTaskDates);
-                const income = data.overlays
-                    ? previewProjectIncomeOverlays(data.overlays.income, intent.project.id, intent.deltaDays)
-                    : null;
-                awaitProjectRefresh(expected, {
-                    projectStartDate: result.startDate,
-                    taskDates: result.shiftedTaskDates,
-                }, income);
-            } catch (error) {
-                clearProjectPreview(intent.project.id);
-                showFailure(error, "Failed to move project");
-            } finally {
-                setProjectPending(intent.project.id, false);
-            }
-        });
-    }
-
-    function handleProjectMovePreview(project: DashboardProjectRow, targetStart: string) {
-        const canonicalProject = canonicalProjectById.get(project.id);
-        if (!data.canEdit || !canonicalProject || isProjectPending(project.id)) {
+        if (!data.canEdit || !canonicalProject || isProjectLocked(project.id)) {
             clearProjectPreview(project.id);
             return;
         }
-        const intent = createProjectDropIntent(canonicalProject, targetStart);
-        if (!intent || intent.deltaDays === 0) clearProjectPreview(project.id);
-        else setProjectPreview(canonicalProject, intent.targetStart);
-    }
-
-    function handleProjectMoveCommit(project: DashboardProjectRow, targetStart: string) {
-        const canonicalProject = canonicalProjectById.get(project.id);
-        if (!data.canEdit || !canonicalProject || isProjectPending(project.id)) {
-            clearProjectPreview(project.id);
-            setConfirmIntent(null);
-            return;
-        }
-        cancelActiveTaskEdit();
         const intent = createProjectDropIntent(canonicalProject, targetStart);
         if (!intent || intent.deltaDays === 0) {
             clearProjectPreview(project.id);
-            setConfirmIntent(null);
+            clearProjectDraft(project.id);
             return;
         }
-
         setProjectPreview(canonicalProject, intent.targetStart);
-        if (canonicalProject.status === "In Progress") setConfirmIntent(intent);
-        else commitWaitingProjectMove(intent);
+        setProjectDrafts(current => ({
+            ...current,
+            [project.id]: { originalStart: intent.originalStart, targetStart: intent.targetStart, deltaDays: intent.deltaDays },
+        }));
     }
 
-    function handleMoveChoice(choice: ProjectMoveChoice) {
-        const intent = confirmIntent;
-        if (!data.canEdit || !intent) return;
-        if (isProjectPending(intent.project.id)) {
-            clearProjectPreview(intent.project.id);
-            setConfirmIntent(null);
-            return;
-        }
+    function discardAllDrafts() {
         cancelActiveTaskEdit();
-        setProjectPending(intent.project.id, true);
-        startTransition(async () => {
-            try {
-                if (choice === "marker-only") {
-                    const result = await updateProjectStartDateAction(intent.project.id, intent.targetStart, false);
-                    showSuccess("Start marker moved", result.notes);
-                    const preview = previewProjectWithPersistedTaskDates(intent.project, result.startDate, []);
-                    awaitProjectRefresh(preview, { projectStartDate: result.startDate, taskDates: [] }, data.overlays?.income ?? null);
-                } else {
-                    const result = await shiftNotStartedTasksAction(intent.project.id, intent.deltaDays);
-                    showSuccess("Not Started tasks shifted", result.notes);
-                    const shiftedTaskIds = new Set(result.shiftedTaskIds);
-                    const expected = previewProjectWithPersistedTaskDates(intent.project, intent.project.startDate, result.shiftedTaskDates);
-                    const income = data.overlays
-                        ? previewShiftedTaskIncomeOverlays(data.overlays.income, intent.project.id, intent.deltaDays, shiftedTaskIds)
-                        : null;
-                    awaitProjectRefresh(expected, { taskDates: result.shiftedTaskDates }, income);
-                }
-                setConfirmIntent(null);
-            } catch (error) {
-                setConfirmIntent(null);
-                clearProjectPreview(intent.project.id);
-                showFailure(error, "Failed to move project");
-            } finally {
-                setProjectPending(intent.project.id, false);
-            }
+        cancelActiveProjectEdit();
+        for (const projectId of Object.keys(projectDrafts)) clearProjectPreview(projectId);
+        setProjectDrafts({});
+        setTaskDateOverrides({});
+    }
+
+    function waitForConfirmChoice(): Promise<ProjectMoveChoice | "cancel"> {
+        return new Promise(resolve => {
+            confirmResolverRef.current = resolve;
         });
     }
 
+    function handleMoveChoice(choice: ProjectMoveChoice) {
+        confirmResolverRef.current?.(choice);
+        confirmResolverRef.current = null;
+    }
+
     function cancelConfirmedMove() {
-        if (!confirmIntent || pendingProjectIds.has(confirmIntent.project.id)) return;
-        clearProjectPreview(confirmIntent.project.id);
-        setConfirmIntent(null);
+        confirmResolverRef.current?.("cancel");
+        confirmResolverRef.current = null;
+    }
+
+    // Commits every drafted change in one Save gesture: project-start moves
+    // via the existing single-project actions (In Progress projects get their
+    // marker-only vs shift-Not-Started-tasks confirmation HERE, one project at
+    // a time — deferred from drag time), then every drafted task-date change
+    // in ONE batch call. Failures are isolated per item; only one
+    // router.refresh() fires, after everything settles.
+    async function saveAllDrafts() {
+        if (isSaving) return;
+        const projectEntries = Object.entries(projectDrafts);
+        const taskEntries = Object.entries(taskDateOverrides);
+        if (projectEntries.length === 0 && taskEntries.length === 0) return;
+
+        setIsSaving(true);
+        const lockedProjectIds = new Set<string>([
+            ...projectEntries.map(([projectId]) => projectId),
+            ...taskEntries
+                .map(([taskId]) => canonicalTaskProjectById.get(taskId))
+                .filter((id): id is string => Boolean(id)),
+        ]);
+        onEffectivePendingProjectIdsChange(lockedProjectIds);
+
+        const failedProjectNames: string[] = [];
+        const succeededProjectIds: string[] = [];
+        const projectExpectations: Record<string, ProjectRefreshExpectation> = {};
+
+        for (const [projectId, draft] of projectEntries) {
+            const canonicalProject = canonicalProjectById.get(projectId);
+            if (!canonicalProject) {
+                failedProjectNames.push(projectId);
+                continue;
+            }
+            let choice: ProjectMoveChoice = "not-started-tasks";
+            if (canonicalProject.status === "In Progress") {
+                setConfirmIntent({ project: canonicalProject, originalStart: draft.originalStart, targetStart: draft.targetStart, deltaDays: draft.deltaDays });
+                const resolved = await waitForConfirmChoice();
+                setConfirmIntent(null);
+                if (resolved === "cancel") continue; // leave this draft in place for later
+                choice = resolved;
+            }
+            try {
+                if (canonicalProject.status === "In Progress") {
+                    if (choice === "marker-only") {
+                        const result = await updateProjectStartDateAction(projectId, draft.targetStart, false);
+                        projectExpectations[projectId] = { projectStartDate: result.startDate, taskDates: [] };
+                    } else {
+                        const result = await shiftNotStartedTasksAction(projectId, draft.deltaDays);
+                        projectExpectations[projectId] = { taskDates: result.shiftedTaskDates };
+                    }
+                } else {
+                    const result = await updateProjectStartDateAction(projectId, draft.targetStart, true);
+                    projectExpectations[projectId] = { projectStartDate: result.startDate, taskDates: result.shiftedTaskDates };
+                }
+                succeededProjectIds.push(projectId);
+            } catch (error) {
+                failedProjectNames.push(canonicalProject.name);
+            }
+        }
+
+        if (succeededProjectIds.length > 0) {
+            const succeeded = new Set(succeededProjectIds);
+            setProjectDrafts(current => Object.fromEntries(Object.entries(current).filter(([id]) => !succeeded.has(id))));
+            setProjectRefreshExpectations(current => ({ ...current, ...projectExpectations }));
+        }
+
+        let failedTaskNames: string[] = [];
+        let succeededTaskCount = 0;
+        if (taskEntries.length > 0) {
+            const changes = taskEntries.map(([taskId, dates]) => ({ taskId, startDate: dates.startDate, endDate: dates.endDate }));
+            try {
+                const batchResult = await saveCompanyScheduleTaskDatesAction(changes);
+                const succeededTaskIds = batchResult.results.filter(row => row.ok).map(row => row.taskId);
+                failedTaskNames = batchResult.results
+                    .filter(row => !row.ok)
+                    .map(row => canonicalTaskById.get(row.taskId)?.name ?? row.taskId);
+                succeededTaskCount = succeededTaskIds.length;
+                if (succeededTaskIds.length > 0) {
+                    const succeeded = new Set(succeededTaskIds);
+                    setTaskDateOverrides(current => Object.fromEntries(Object.entries(current).filter(([id]) => !succeeded.has(id))));
+                    setAwaitingTaskRefreshIds(current => new Set([...current, ...succeededTaskIds]));
+                }
+            } catch (error) {
+                failedTaskNames = taskEntries.map(([taskId]) => canonicalTaskById.get(taskId)?.name ?? taskId);
+            }
+        }
+
+        setIsSaving(false);
+        onEffectivePendingProjectIdsChange(EMPTY_PROJECT_IDS);
+        router.refresh();
+
+        const totalSucceeded = succeededProjectIds.length + succeededTaskCount;
+        const totalFailed = failedProjectNames.length + failedTaskNames.length;
+        if (totalFailed === 0 && totalSucceeded > 0) {
+            toast.success(`Saved ${totalSucceeded} change${totalSucceeded === 1 ? "" : "s"}`);
+        } else if (totalFailed > 0) {
+            const failedNames = [...failedProjectNames, ...failedTaskNames];
+            toast.error(
+                `${totalFailed} change${totalFailed === 1 ? "" : "s"} failed to save: ${failedNames.join(", ")}`,
+                totalSucceeded > 0 ? { description: `${totalSucceeded} other change${totalSucceeded === 1 ? "" : "s"} saved.` } : undefined,
+            );
+        }
+    }
+
+    function cancelProjectEditsForProjects(projectIds: ReadonlySet<string>) {
+        const pointerEdit = activeProjectPointerRef.current;
+        if (pointerEdit && projectIds.has(pointerEdit.projectId)) {
+            pointerEdit.cleanup();
+        }
+        const keyboardEdit = projectKeyboardEditRef.current;
+        if (keyboardEdit && projectIds.has(keyboardEdit.projectId)) {
+            projectKeyboardCleanupRef.current?.();
+            setProjectKeyboardState(null);
+        }
+    }
+
+    function cancelActiveProjectEdit() {
+        activeProjectPointerRef.current?.cleanup();
+        projectKeyboardCleanupRef.current?.();
+        setProjectKeyboardState(null);
     }
 
     function setProjectKeyboardState(next: ProjectKeyboardEditState | null) {
@@ -639,40 +592,9 @@ export function ScheduleBoard({
         setProjectKeyboardEdit(next);
     }
 
-    function cancelProjectEditsForProjects(projectIds: ReadonlySet<string>) {
-        const pointerEdit = activeProjectPointerRef.current;
-        if (pointerEdit && projectIds.has(pointerEdit.projectId)) {
-            pointerEdit.cleanup();
-            clearProjectPreview(pointerEdit.projectId);
-        }
-        const keyboardEdit = projectKeyboardEditRef.current;
-        if (keyboardEdit && projectIds.has(keyboardEdit.projectId)) {
-            clearProjectPreview(keyboardEdit.projectId);
-            projectKeyboardCleanupRef.current?.();
-            setProjectKeyboardState(null);
-        }
-    }
-
-    function cancelActiveProjectEdit() {
-        const pointerEdit = activeProjectPointerRef.current;
-        if (pointerEdit) {
-            pointerEdit.cleanup();
-            clearProjectPreview(pointerEdit.projectId);
-        }
-        const keyboardEdit = projectKeyboardEditRef.current;
-        if (keyboardEdit) clearProjectPreview(keyboardEdit.projectId);
-        projectKeyboardCleanupRef.current?.();
-        setProjectKeyboardState(null);
-    }
-
     const cancelExternallyLockedProjectEdits = useEffectEvent((newlyPendingProjectIds: ReadonlySet<string>) => {
         cancelProjectEditsForProjects(newlyPendingProjectIds);
         cancelTaskEditsForProjects(newlyPendingProjectIds);
-        const intent = confirmIntentRef.current;
-        if (intent && newlyPendingProjectIds.has(intent.project.id)) {
-            clearProjectPreview(intent.project.id);
-            setConfirmIntent(null);
-        }
     });
 
     useEffect(() => {
@@ -688,7 +610,7 @@ export function ScheduleBoard({
 
     function handleProjectPointerEditStart(project: DashboardProjectRow, start: ProjectPointerEditStart) {
         const canonicalProject = canonicalProjectById.get(project.id);
-        if (!data.canEdit || !canonicalProject || isProjectPending(project.id)) return;
+        if (!data.canEdit || !canonicalProject || isProjectLocked(project.id)) return;
         cancelActiveProjectEdit();
         cancelActiveTaskEdit();
         const drag: ActiveProjectPointerEdit = {
@@ -750,7 +672,7 @@ export function ScheduleBoard({
                 drag.originX -= container.scrollLeft - before;
             }
             const candidate = calculateProjectPointerCandidate();
-            if (candidate) handleProjectMovePreview(drag.project, candidate);
+            if (candidate) setProjectPreview(drag.project, candidate);
             else clearProjectPreview(drag.projectId);
             if (getProjectAutoscrollStep() !== 0 && drag.animationFrameId == null) {
                 drag.animationFrameId = requestAnimationFrame(runProjectPointerFrame);
@@ -781,11 +703,12 @@ export function ScheduleBoard({
             drag.animationFrameId = null;
             const candidate = drag.active && !cancelled ? calculateProjectPointerCandidate() : null;
             drag.cleanup();
-            if (!drag.active || cancelled || !candidate) {
+            if (!drag.active) return;
+            if (cancelled || !candidate) {
                 clearProjectPreview(drag.projectId);
                 return;
             }
-            handleProjectMoveCommit(drag.project, candidate);
+            draftProjectMove(drag.project, candidate);
         };
         const onPointerUp = (event: PointerEvent) => {
             if (event.pointerId === drag.pointerId) finish(false, event);
@@ -823,7 +746,7 @@ export function ScheduleBoard({
 
     function handleProjectKeyboardStart(project: DashboardProjectRow, sourceElement: HTMLElement) {
         const canonicalProject = canonicalProjectById.get(project.id);
-        if (!data.canEdit || !canonicalProject || isProjectPending(project.id)) return;
+        if (!data.canEdit || !canonicalProject || isProjectLocked(project.id)) return;
         const range = getEffectiveProjectRange(canonicalProject);
         if (!range) return;
         const intent = createProjectDropIntent(canonicalProject, formatDate(range.start));
@@ -867,22 +790,23 @@ export function ScheduleBoard({
 
     function handleProjectKeyboardAdjust(project: DashboardProjectRow, deltaDays: number) {
         const current = projectKeyboardEditRef.current;
-        if (!current || current.projectId !== project.id || isProjectPending(project.id)) return;
+        if (!current || current.projectId !== project.id || isProjectLocked(project.id)) return;
         const targetStart = formatDate(addDays(parseUTCDate(current.targetStart), deltaDays));
         setProjectKeyboardState({ ...current, targetStart });
-        handleProjectMovePreview(project, targetStart);
+        const canonicalProject = canonicalProjectById.get(project.id);
+        if (canonicalProject) setProjectPreview(canonicalProject, targetStart);
     }
 
     function handleProjectKeyboardCommit(project: DashboardProjectRow) {
         const current = projectKeyboardEditRef.current;
         if (!current || current.projectId !== project.id) return;
-        if (isProjectPending(project.id)) {
+        if (isProjectLocked(project.id)) {
             handleProjectKeyboardCancel(project);
             return;
         }
         projectKeyboardCleanupRef.current?.();
         setProjectKeyboardState(null);
-        handleProjectMoveCommit(project, current.targetStart);
+        draftProjectMove(project, current.targetStart);
     }
 
     function handleProjectKeyboardCancel(project: DashboardProjectRow) {
@@ -895,7 +819,7 @@ export function ScheduleBoard({
     function handleTaskPointerEditStart(task: DashboardTaskRow, mode: TaskEditMode, start: TaskPointerEditStart) {
         const canonicalTask = canonicalTaskById.get(task.id);
         const projectId = canonicalTaskProjectById.get(task.id);
-        if (!data.canEdit || isTaskOrProjectPending(task.id) || !canonicalTask || !projectId) return;
+        if (!data.canEdit || isTaskLocked(task.id) || !canonicalTask || !projectId) return;
         if (canonicalTask.type === "milestone" && mode !== "move") return;
 
         cancelActiveTaskEdit();
@@ -1010,8 +934,7 @@ export function ScheduleBoard({
                 clearTaskPreview(task.id);
                 return;
             }
-            setTaskPreview(task.id, candidate);
-            void commitTaskDates(task.id, candidate);
+            draftTaskChange(task.id, candidate);
         };
         const onPointerUp = (event: PointerEvent) => {
             if (event.pointerId === drag.pointerId) finish(false, event);
@@ -1051,7 +974,7 @@ export function ScheduleBoard({
     function handleTaskKeyboardStart(task: DashboardTaskRow, mode: TaskEditMode, sourceElement: HTMLElement) {
         const canonicalTask = canonicalTaskById.get(task.id);
         const projectId = canonicalTaskProjectById.get(task.id);
-        if (!data.canEdit || isTaskOrProjectPending(task.id) || !canonicalTask || !projectId) return;
+        if (!data.canEdit || isTaskLocked(task.id) || !canonicalTask || !projectId) return;
         if (canonicalTask.type === "milestone" && mode !== "move") return;
         cancelActiveTaskEdit();
         cancelActiveProjectEdit();
@@ -1095,7 +1018,7 @@ export function ScheduleBoard({
     function handleTaskKeyboardAdjust(task: DashboardTaskRow, mode: TaskEditMode, deltaDays: number) {
         const canonicalTask = canonicalTaskById.get(task.id);
         const current = taskKeyboardEditRef.current;
-        if (!data.canEdit || isTaskOrProjectPending(task.id) || !canonicalTask || current?.taskId !== task.id || current.mode !== mode) return;
+        if (!data.canEdit || isTaskLocked(task.id) || !canonicalTask || current?.taskId !== task.id || current.mode !== mode) return;
         const nextDeltaDays = current.deltaDays + deltaDays;
         const dates = previewTaskDates(canonicalTask, mode, nextDeltaDays);
         if (!dates) return;
@@ -1108,11 +1031,11 @@ export function ScheduleBoard({
     function handleTaskKeyboardCommit(task: DashboardTaskRow, mode: TaskEditMode) {
         const canonicalTask = canonicalTaskById.get(task.id);
         const current = taskKeyboardEditRef.current;
-        if (!data.canEdit || isTaskOrProjectPending(task.id) || !canonicalTask || current?.taskId !== task.id || current.mode !== mode) return;
+        if (!data.canEdit || isTaskLocked(task.id) || !canonicalTask || current?.taskId !== task.id || current.mode !== mode) return;
         const dates = previewTaskDates(canonicalTask, mode, current.deltaDays);
         taskKeyboardCleanupRef.current?.();
         setTaskKeyboardState(null);
-        if (dates) void commitTaskDates(task.id, dates);
+        if (dates) draftTaskChange(task.id, dates);
     }
 
     function handleTaskKeyboardCancel(task: DashboardTaskRow) {
@@ -1123,25 +1046,79 @@ export function ScheduleBoard({
     }
 
     function handleTaskDatesCommit(task: DashboardTaskRow, dates: TaskDateOverride) {
-        if (!data.canEdit || isTaskOrProjectPending(task.id) || !canonicalTaskById.has(task.id)) return;
+        if (!data.canEdit || isTaskLocked(task.id) || !canonicalTaskById.has(task.id)) return;
         cancelActiveTaskEdit();
         cancelActiveProjectEdit();
-        void commitTaskDates(task.id, dates);
+        draftTaskChange(task.id, dates);
     }
 
     function handleTaskMoveBy(task: DashboardTaskRow, deltaDays: number) {
         const canonicalTask = canonicalTaskById.get(task.id);
-        if (!data.canEdit || isTaskOrProjectPending(task.id) || !canonicalTask) return;
+        if (!data.canEdit || isTaskLocked(task.id) || !canonicalTask) return;
         cancelActiveTaskEdit();
         cancelActiveProjectEdit();
         const dates = previewTaskDates(canonicalTask, "move", deltaDays);
-        if (dates) void commitTaskDates(task.id, dates);
+        if (dates) draftTaskChange(task.id, dates);
     }
+
+    // Tray drop for an unscheduled (Waiting-to-Start, no startDate yet)
+    // project — drafts the move the same as any other project drag.
+    function scheduleUnscheduledProject(project: DashboardProjectRow, targetStart: string) {
+        const canonicalProject = canonicalProjectById.get(project.id);
+        if (!data.canEdit || !canonicalProject || isProjectLocked(project.id)) return;
+        cancelActiveTaskEdit();
+        const normalizedTarget = formatDate(parseUTCDate(targetStart));
+        if (!canonicalProject.startDate) {
+            // No prior date to diff against — preview + draft directly from the
+            // unscheduled state (createProjectDropIntent needs an existing
+            // range, which an unscheduled project's task-only range still
+            // provides when tasks exist; otherwise seed a bare marker draft).
+            const preview = { ...canonicalProject, startDate: normalizedTarget };
+            setProjectPreviewOverrides(current => ({ ...current, [project.id]: preview }));
+            setProjectDrafts(current => ({
+                ...current,
+                [project.id]: { originalStart: normalizedTarget, targetStart: normalizedTarget, deltaDays: 0 },
+            }));
+            return;
+        }
+        draftProjectMove(canonicalProject, normalizedTarget);
+    }
+
+    function handleProjectMovePreview(project: DashboardProjectRow, targetStart: string) {
+        const canonicalProject = canonicalProjectById.get(project.id);
+        if (!data.canEdit || !canonicalProject || isProjectLocked(project.id)) {
+            clearProjectPreview(project.id);
+            return;
+        }
+        const intent = createProjectDropIntent(canonicalProject, targetStart);
+        if (!intent || intent.deltaDays === 0) clearProjectPreview(project.id);
+        else setProjectPreview(canonicalProject, intent.targetStart);
+    }
+
+    function handleProjectMoveCommit(project: DashboardProjectRow, targetStart: string) {
+        const canonicalProject = canonicalProjectById.get(project.id);
+        if (!data.canEdit || !canonicalProject || isProjectLocked(project.id)) {
+            clearProjectPreview(project.id);
+            return;
+        }
+        cancelActiveTaskEdit();
+        draftProjectMove(canonicalProject, targetStart);
+    }
+
+    const pendingRefreshKinds = [
+        Object.keys(projectRefreshExpectations).length > 0 ? "project" : null,
+        awaitingTaskRefreshIds.size > 0 ? "task" : null,
+    ].filter((kind): kind is string => Boolean(kind));
 
     return (
         <div className="hui-card mb-6 overflow-hidden">
             <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3 border-b border-hui-border">
-                <h2 className="text-base font-semibold text-hui-textMain">Project Schedule — {monthLabel}</h2>
+                <div className="flex items-baseline gap-3">
+                    <h2 className="text-base font-semibold text-hui-textMain">Project Schedule — {monthLabel}</h2>
+                    <Link href="/company-dashboard/guide" className="text-xs text-hui-textMuted hover:text-hui-primary underline underline-offset-2 whitespace-nowrap">
+                        How to use
+                    </Link>
+                </div>
                 <div className="flex flex-wrap items-center justify-end gap-2">
                     <div className="inline-flex rounded-md border border-hui-border bg-white p-0.5" role="group" aria-label="Schedule view">
                         <button
@@ -1174,14 +1151,26 @@ export function ScheduleBoard({
                     <button type="button" onClick={() => router.push('/company-dashboard?month=' + shiftMonth(month, 1))} className="hui-btn hui-btn-secondary text-sm">Next →</button>
                 </div>
             </div>
+            {draftCount > 0 && (
+                <div role="status" className="sticky top-0 z-40 flex flex-wrap items-center justify-between gap-3 border-b border-indigo-200 bg-indigo-50 px-4 py-2 text-sm text-indigo-900">
+                    <span>{draftCount} unsaved change{draftCount === 1 ? "" : "s"}</span>
+                    <div className="flex items-center gap-2">
+                        <button type="button" onClick={discardAllDrafts} disabled={isSaving} className="hui-btn hui-btn-secondary text-xs disabled:cursor-wait disabled:opacity-60">
+                            Discard
+                        </button>
+                        <button type="button" onClick={() => void saveAllDrafts()} disabled={isSaving} className="hui-btn hui-btn-green text-xs disabled:cursor-wait disabled:opacity-60">
+                            {isSaving ? "Saving..." : "Save"}
+                        </button>
+                    </div>
+                </div>
+            )}
             <UnscheduledTray
-                estimating={data.pipeline.estimating}
                 projects={data.pipeline.waitingToStart}
                 canEdit={data.canEdit}
-                pendingProjectIds={effectivePendingProjectIds}
+                pendingProjectIds={externallyPendingProjectIds}
                 onMoveProject={scheduleUnscheduledProject}
             />
-            {(projectRefreshCount > 0 || awaitingTaskRefreshIds.size > 0) && (
+            {(Object.keys(projectRefreshExpectations).length > 0 || awaitingTaskRefreshIds.size > 0) && (
                 <div className="flex items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-900" role="status">
                     <span>Refreshing saved {pendingRefreshKinds.join(" and ")} schedule changes...</span>
                     <button type="button" className="font-semibold underline" onClick={() => router.refresh()}>Retry now</button>
@@ -1200,8 +1189,11 @@ export function ScheduleBoard({
                     showProjectedCo={showProjectedCo}
                     showExpenses={showExpenses}
                     showHours={showHours}
-                    pendingProjectIds={effectivePendingProjectIds}
-                    pendingTaskIds={effectivePendingTaskIds}
+                    pendingProjectIds={externallyPendingProjectIds}
+                    pendingTaskIds={EMPTY_PROJECT_IDS}
+                    draftProjectIds={draftProjectIds}
+                    draftTaskIds={draftTaskIds}
+                    isSaving={isSaving}
                     activeTaskKeyboardEdit={taskKeyboardEdit}
                     onTrayProjectDrop={scheduleUnscheduledProject}
                     activeProjectKeyboardId={projectKeyboardEdit?.projectId ?? null}
@@ -1226,8 +1218,11 @@ export function ScheduleBoard({
                     showProjectedCo={showProjectedCo}
                     showExpenses={showExpenses}
                     showHours={showHours}
-                    pendingProjectIds={effectivePendingProjectIds}
-                    pendingTaskIds={effectivePendingTaskIds}
+                    pendingProjectIds={externallyPendingProjectIds}
+                    pendingTaskIds={EMPTY_PROJECT_IDS}
+                    draftProjectIds={draftProjectIds}
+                    draftTaskIds={draftTaskIds}
+                    isSaving={isSaving}
                     activeTaskKeyboardEdit={taskKeyboardEdit}
                     onTrayProjectDrop={scheduleUnscheduledProject}
                     activeProjectKeyboardId={projectKeyboardEdit?.projectId ?? null}
@@ -1248,7 +1243,7 @@ export function ScheduleBoard({
             )}
             <ShiftConfirmDialog
                 intent={confirmIntent}
-                isPending={Boolean(confirmIntent && isProjectPending(confirmIntent.project.id))}
+                isPending={false}
                 onChoice={handleMoveChoice}
                 onCancel={cancelConfirmedMove}
             />

--- a/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
+++ b/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
@@ -423,7 +423,13 @@ export function ScheduleBoard({
             startDate: canonicalTask.startDate.slice(0, 10),
             endDate: canonicalTask.endDate.slice(0, 10),
         };
-        if (normalizedDates.startDate === originalDates.startDate && normalizedDates.endDate === originalDates.endDate) {
+        // The back-to-canonical shortcut only applies to live drafts: for a
+        // saved-awaiting task the canonical props are STALE, so "back to the
+        // old date" is a real revert that must become a draft — shortcutting
+        // would delete the pinned override and strand the awaiting id.
+        if (!awaitingTaskRefreshIds.has(taskId)
+            && normalizedDates.startDate === originalDates.startDate
+            && normalizedDates.endDate === originalDates.endDate) {
             clearTaskPreview(taskId);
             return;
         }
@@ -443,6 +449,20 @@ export function ScheduleBoard({
         }
         const intent = createProjectDropIntent(canonicalProject, targetStart);
         if (!intent || intent.deltaDays === 0) {
+            // Cancelling a project draft must also UNDO the rebase it applied
+            // to this project's task drafts, or they'd save shifted for a
+            // project move that never happened.
+            const previousDelta = projectDrafts[project.id]?.deltaDays ?? 0;
+            if (previousDelta !== 0 && canonicalProject.status !== "In Progress") {
+                const projectTaskIds = new Set(canonicalProject.tasks.map(task => task.id));
+                setTaskDateOverrides(current => Object.fromEntries(Object.entries(current).map(([taskId, dates]) => {
+                    if (!projectTaskIds.has(taskId) || awaitingTaskRefreshIds.has(taskId)) return [taskId, dates];
+                    return [taskId, {
+                        startDate: formatDate(addDays(parseUTCDate(dates.startDate), -previousDelta)),
+                        endDate: formatDate(addDays(parseUTCDate(dates.endDate), -previousDelta)),
+                    }];
+                })));
+            }
             clearProjectPreview(project.id);
             clearProjectDraft(project.id);
             return;
@@ -459,7 +479,9 @@ export function ScheduleBoard({
             if (deltaChange !== 0) {
                 const projectTaskIds = new Set(canonicalProject.tasks.map(task => task.id));
                 setTaskDateOverrides(current => Object.fromEntries(Object.entries(current).map(([taskId, dates]) => {
-                    if (!projectTaskIds.has(taskId)) return [taskId, dates];
+                    // Saved-awaiting overrides are persisted state, not drafts —
+                    // never rebase them.
+                    if (!projectTaskIds.has(taskId) || awaitingTaskRefreshIds.has(taskId)) return [taskId, dates];
                     return [taskId, {
                         startDate: formatDate(addDays(parseUTCDate(dates.startDate), deltaChange)),
                         endDate: formatDate(addDays(parseUTCDate(dates.endDate), deltaChange)),
@@ -478,7 +500,12 @@ export function ScheduleBoard({
         cancelActiveProjectEdit();
         for (const projectId of Object.keys(projectDrafts)) clearProjectPreview(projectId);
         setProjectDrafts({});
-        setTaskDateOverrides({});
+        // Discard clears UNSAVED drafts only. Saved-awaiting overrides are
+        // committed state pending refresh — removing them here would strand
+        // their awaiting ids and the refresh poll forever.
+        setTaskDateOverrides(current => Object.fromEntries(
+            Object.entries(current).filter(([taskId]) => awaitingTaskRefreshIds.has(taskId)),
+        ));
     }
 
     function waitForConfirmChoice(): Promise<ProjectMoveChoice | "cancel"> {
@@ -541,12 +568,14 @@ export function ScheduleBoard({
 
         const failedProjectNames: string[] = [];
         const succeededProjectIds: string[] = [];
+        const failedProjectIds = new Set<string>();
         const projectExpectations: Record<string, ProjectRefreshExpectation> = {};
 
         for (const [projectId, draft] of projectEntries) {
             const canonicalProject = canonicalProjectById.get(projectId);
             if (!canonicalProject) {
                 failedProjectNames.push(projectId);
+                failedProjectIds.add(projectId);
                 continue;
             }
             let choice: ProjectMoveChoice = "not-started-tasks";
@@ -563,8 +592,15 @@ export function ScheduleBoard({
                         const result = await updateProjectStartDateAction(projectId, draft.targetStart, false);
                         projectExpectations[projectId] = { projectStartDate: result.startDate, taskDates: [] };
                     } else {
-                        const result = await shiftNotStartedTasksAction(projectId, draft.deltaDays);
-                        projectExpectations[projectId] = { taskDates: result.shiftedTaskDates.filter(row => !batchedTaskIds.has(row.id)) };
+                        // Owner-decided semantics: the bar drag moves the start
+                        // marker AND the not-started work — the whole future of
+                        // the job follows the drag; started work stays put.
+                        const markerResult = await updateProjectStartDateAction(projectId, draft.targetStart, false);
+                        const shiftResult = await shiftNotStartedTasksAction(projectId, draft.deltaDays);
+                        projectExpectations[projectId] = {
+                            projectStartDate: markerResult.startDate,
+                            taskDates: shiftResult.shiftedTaskDates.filter(row => !batchedTaskIds.has(row.id)),
+                        };
                     }
                 } else {
                     const result = await updateProjectStartDateAction(projectId, draft.targetStart, true);
@@ -573,6 +609,7 @@ export function ScheduleBoard({
                 succeededProjectIds.push(projectId);
             } catch (error) {
                 failedProjectNames.push(canonicalProject.name);
+                failedProjectIds.add(projectId);
             }
         }
 
@@ -584,12 +621,26 @@ export function ScheduleBoard({
 
         let failedTaskNames: string[] = [];
         let succeededTaskCount = 0;
-        if (taskEntries.length > 0) {
-            const changes = taskEntries.map(([taskId, dates]) => ({ taskId, startDate: dates.startDate, endDate: dates.endDate }));
+        // Task drafts on a project whose shift FAILED stay drafted (their
+        // overrides are stored rebased against that shift; saving them now
+        // would write post-shift dates onto an unshifted schedule). They save
+        // with the project on the next attempt.
+        const sendableTaskEntries = taskEntries.filter(([taskId]) => {
+            const projectId = canonicalTaskProjectById.get(taskId);
+            return !projectId || !failedProjectIds.has(projectId);
+        });
+        if (sendableTaskEntries.length > 0) {
+            const changes = sendableTaskEntries.map(([taskId, dates]) => ({ taskId, startDate: dates.startDate, endDate: dates.endDate }));
             try {
-                const batchResult = await saveCompanyScheduleTaskDatesAction(changes);
-                const succeededRows = batchResult.results.filter(row => row.ok);
-                failedTaskNames = batchResult.results
+                // Chunked to the server's 200-change cap so any draft count
+                // saves in one gesture.
+                const allResults = [] as Awaited<ReturnType<typeof saveCompanyScheduleTaskDatesAction>>["results"];
+                for (let offset = 0; offset < changes.length; offset += 200) {
+                    const batchResult = await saveCompanyScheduleTaskDatesAction(changes.slice(offset, offset + 200));
+                    allResults.push(...batchResult.results);
+                }
+                const succeededRows = allResults.filter(row => row.ok);
+                failedTaskNames = allResults
                     .filter(row => !row.ok)
                     .map(row => canonicalTaskById.get(row.taskId)?.name ?? row.taskId);
                 succeededTaskCount = succeededRows.length;

--- a/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
+++ b/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
@@ -52,7 +52,10 @@ interface ScheduleBoardProps {
     onEffectivePendingProjectIdsChange: (projectIds: ReadonlySet<string>) => void;
     // Persisted task shifts from sibling writers (legacy StartDateRow) so the
     // board can rewrite saved-awaiting overrides caught in an external shift.
-    externalShiftedTaskDates: { nonce: number; taskDates: { id: string; startDate: string; endDate: string }[] } | null;
+    // An append-only event queue: concurrent legacy shifts resolving in one
+    // React batch each keep their event (a single latest-payload slot would
+    // drop all but the last).
+    externalShiftEvents: { nonce: number; taskDates: { id: string; startDate: string; endDate: string }[] }[];
 }
 
 interface TaskKeyboardEditState {
@@ -152,7 +155,7 @@ export function ScheduleBoard({
     externallyPendingProjectIds,
     isProjectExternallyPending,
     onEffectivePendingProjectIdsChange,
-    externalShiftedTaskDates,
+    externalShiftEvents,
 }: ScheduleBoardProps) {
     const router = useRouter();
     const { month, isAdmin, overlays } = data;
@@ -293,14 +296,16 @@ export function ScheduleBoard({
     }
 
     // External writers (the legacy waiting-list date setter) report their
-    // persisted shifts here; each nonce is applied exactly once.
+    // persisted shifts here; every unseen nonce is applied exactly once, in
+    // order — so two shifts landing in one React batch both take effect.
     const lastExternalShiftNonceRef = useRef(0);
     useEffect(() => {
-        if (!externalShiftedTaskDates || externalShiftedTaskDates.nonce === lastExternalShiftNonceRef.current) return;
-        lastExternalShiftNonceRef.current = externalShiftedTaskDates.nonce;
-        rewriteAwaitingOverridesFromShift(externalShiftedTaskDates.taskDates);
+        const unseen = externalShiftEvents.filter(event => event.nonce > lastExternalShiftNonceRef.current);
+        if (unseen.length === 0) return;
+        lastExternalShiftNonceRef.current = Math.max(...unseen.map(event => event.nonce));
+        rewriteAwaitingOverridesFromShift(unseen.flatMap(event => event.taskDates));
         // eslint-disable-next-line react-hooks/exhaustive-deps -- rewrite reads current awaiting state by design
-    }, [externalShiftedTaskDates]);
+    }, [externalShiftEvents]);
 
     function clearTaskPreview(taskId: string) {
         // A saved-awaiting task's override IS its committed state pending

--- a/src/app/company-dashboard/schedule-board/ShiftConfirmDialog.tsx
+++ b/src/app/company-dashboard/schedule-board/ShiftConfirmDialog.tsx
@@ -40,7 +40,7 @@ export function ShiftConfirmDialog({ intent, isPending, onChoice, onCancel }: Sh
                             onClick={() => onChoice("not-started-tasks")}
                             className="hui-btn hui-btn-secondary w-full justify-center text-sm disabled:cursor-wait disabled:opacity-60"
                         >
-                            Also shift all Not Started tasks by {magnitude} day{magnitude === 1 ? "" : "s"} {direction}
+                            Move the start marker AND shift all Not Started tasks by {magnitude} day{magnitude === 1 ? "" : "s"} {direction}
                         </button>
                     </div>
                     <div className="mt-4 flex justify-end">

--- a/src/app/company-dashboard/schedule-board/TaskBlockSegment.tsx
+++ b/src/app/company-dashboard/schedule-board/TaskBlockSegment.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useId, useRef, useState, type FormEvent, type K
 import type { DashboardTaskRow } from "@/lib/schedule-core";
 import { addDays, formatDate, getDaysBetween, getDefaultColorForTaskName, parseUTCDate } from "@/app/projects/[id]/schedule/schedule-utils";
 import { clipRange, type DateRange, type TaskDateOverride, type TaskEditMode } from "./useBarLayout";
+import { FloatingPopover } from "./FloatingPopover";
 
 export interface TaskPointerEditStart {
     pointerId: number;
@@ -38,10 +39,17 @@ export interface TaskBlockSegmentProps extends TaskEditCallbacks {
     projectColor: string;
     canEdit: boolean;
     isPending: boolean;
+    // Drafted (unsaved) — dashed ring + desaturated, but still fully
+    // draggable/editable (draft mode never locks a drafted item).
+    isDraft?: boolean;
     activeTaskKeyboardEdit: ActiveTaskKeyboardEdit | null;
     timelineDayWidth?: number;
     timelineLeftInset?: number;
     timelineScrollContainerRef?: RefObject<HTMLDivElement | null>;
+    // Mini-lane placement within a project bar carrying overlapping tasks.
+    // Omitted (default) fills the parent's full height, as before.
+    laneTop?: number;
+    laneHeight?: number;
 }
 
 function readableText(color: string): string {
@@ -64,10 +72,13 @@ export function TaskBlockSegment({
     projectColor,
     canEdit,
     isPending,
+    isDraft = false,
     activeTaskKeyboardEdit,
     timelineDayWidth,
     timelineLeftInset,
     timelineScrollContainerRef,
+    laneTop,
+    laneHeight,
     onTaskPointerEditStart,
     onTaskKeyboardStart,
     onTaskKeyboardAdjust,
@@ -79,7 +90,8 @@ export function TaskBlockSegment({
     const observerRef = useRef<ResizeObserver | null>(null);
     const fragmentId = useId().replace(/:/g, "");
     const [allocatedWidth, setAllocatedWidth] = useState(0);
-    const actionDetailsRef = useRef<HTMLDetailsElement>(null);
+    const actionTriggerRef = useRef<HTMLButtonElement>(null);
+    const [menuOpen, setMenuOpen] = useState(false);
     const actionResetKey = `${isPending ? "pending" : "ready"}:${task.startDate}:${task.endDate}`;
     const [menuDraft, setMenuDraft] = useState<{ resetKey: string; dates: TaskDateOverride | null }>(() => ({
         resetKey: actionResetKey,
@@ -112,7 +124,7 @@ export function TaskBlockSegment({
 
     useEffect(() => () => observerRef.current?.disconnect(), []);
     useEffect(() => {
-        if (actionDetailsRef.current) actionDetailsRef.current.open = false;
+        setMenuOpen(false);
     }, [actionResetKey]);
 
     if (!clipped || (!isMilestone && taskEnd <= taskStart)) return null;
@@ -187,17 +199,22 @@ export function TaskBlockSegment({
             endDate: isMilestone ? menuStartDate : menuEndDate,
         });
         setMenuDraft({ resetKey: actionResetKey, dates: null });
+        setMenuOpen(false);
     }
+
+    const laneStyle = laneTop != null && laneHeight != null
+        ? { top: laneTop, height: laneHeight }
+        : undefined;
 
     return (
         <div
             ref={setMeasuredElement}
-            className={`group/task absolute inset-y-0 touch-pan-y select-none overflow-visible rounded-sm border border-black/10 text-[9px] font-semibold leading-[16px] shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white ${canEdit && !isPending ? "cursor-move" : ""}`}
-            style={{ left: `${left}%`, width: `${width}%`, backgroundColor: color, color: readableText(color) }}
+            className={`group/task absolute ${laneStyle ? "" : "inset-y-0"} touch-pan-y select-none overflow-visible rounded-sm border text-[9px] font-semibold leading-[16px] shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white ${canEdit && !isPending ? "cursor-move" : ""} ${isDraft ? "border-dashed border-2 border-white/90 saturate-[.55] brightness-95" : "border-black/10"}`}
+            style={{ left: `${left}%`, width: `${width}%`, backgroundColor: color, color: readableText(color), ...laneStyle }}
             title={title}
             role="group"
             tabIndex={0}
-            aria-label={`${title}. ${canEdit ? "Press Space or Enter to move with the keyboard." : "Read only."}`}
+            aria-label={`${title}. ${canEdit ? "Press Space or Enter to move with the keyboard." : "Read only."}${isDraft ? " Unsaved change." : ""}`}
             aria-disabled={!canEdit || isPending}
             aria-busy={isPending}
             data-task-edit-block="true"
@@ -240,49 +257,59 @@ export function TaskBlockSegment({
             )}
 
             {!mutationDisabled && (
-            <details ref={actionDetailsRef} className="absolute right-0 top-0 z-30 opacity-0 pointer-events-none transition group-hover/task:opacity-100 group-hover/task:pointer-events-auto group-focus-within/task:opacity-100 group-focus-within/task:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto">
-                <summary className="cursor-pointer list-none rounded bg-white/85 px-1 text-[8px] font-bold text-slate-800 shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" aria-label={`Task actions for ${task.name}`}>
+            <>
+                <button
+                    ref={actionTriggerRef}
+                    type="button"
+                    onClick={event => { event.stopPropagation(); setMenuOpen(value => !value); }}
+                    onPointerDown={event => event.stopPropagation()}
+                    aria-expanded={menuOpen}
+                    className="absolute right-0 top-0 z-30 cursor-pointer rounded bg-white/85 px-1 text-[8px] font-bold text-slate-800 opacity-0 shadow transition group-hover/task:opacity-100 group-focus-within/task:opacity-100 [@media(hover:none)]:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+                    aria-label={`Task actions for ${task.name}`}
+                >
                     ⋯
-                </summary>
-                <form onSubmit={handleDateSubmit} onPointerDown={event => event.stopPropagation()} className="absolute right-0 top-full z-[90] mt-1 w-60 space-y-2 rounded-md border border-hui-border bg-white p-3 text-left text-hui-textMain shadow-xl">
-                    <label className="block text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted" htmlFor={`task-start-${task.id}-${fragmentId}`}>Start date</label>
-                    <input
-                        id={`task-start-${task.id}-${fragmentId}`}
-                        type="date"
-                        value={menuStartDate}
-                        max={!isMilestone && menuEndDate ? formatDate(addDays(parseUTCDate(menuEndDate), -1)) : undefined}
-                        onChange={event => {
-                            const nextStartDate = event.target.value;
-                            setMenuDraft({
+                </button>
+                <FloatingPopover open={menuOpen} anchorRef={actionTriggerRef} onClose={() => setMenuOpen(false)} width={240}>
+                    <form onSubmit={handleDateSubmit} onPointerDown={event => event.stopPropagation()} className="space-y-2">
+                        <label className="block text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted" htmlFor={`task-start-${task.id}-${fragmentId}`}>Start date</label>
+                        <input
+                            id={`task-start-${task.id}-${fragmentId}`}
+                            type="date"
+                            value={menuStartDate}
+                            max={!isMilestone && menuEndDate ? formatDate(addDays(parseUTCDate(menuEndDate), -1)) : undefined}
+                            onChange={event => {
+                                const nextStartDate = event.target.value;
+                                setMenuDraft({
+                                    resetKey: actionResetKey,
+                                    dates: { startDate: nextStartDate, endDate: isMilestone ? nextStartDate : menuEndDate },
+                                });
+                            }}
+                            disabled={mutationDisabled}
+                            className="hui-input w-full px-2 py-1 text-xs"
+                        />
+                        <label className="block text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted" htmlFor={`task-end-${task.id}-${fragmentId}`}>End date</label>
+                        <input
+                            id={`task-end-${task.id}-${fragmentId}`}
+                            type="date"
+                            value={isMilestone ? menuStartDate : menuEndDate}
+                            min={!isMilestone && menuStartDate ? formatDate(addDays(parseUTCDate(menuStartDate), 1)) : undefined}
+                            onChange={event => setMenuDraft({
                                 resetKey: actionResetKey,
-                                dates: { startDate: nextStartDate, endDate: isMilestone ? nextStartDate : menuEndDate },
-                            });
-                        }}
-                        disabled={mutationDisabled}
-                        className="hui-input w-full px-2 py-1 text-xs"
-                    />
-                    <label className="block text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted" htmlFor={`task-end-${task.id}-${fragmentId}`}>End date</label>
-                    <input
-                        id={`task-end-${task.id}-${fragmentId}`}
-                        type="date"
-                        value={isMilestone ? menuStartDate : menuEndDate}
-                        min={!isMilestone && menuStartDate ? formatDate(addDays(parseUTCDate(menuStartDate), 1)) : undefined}
-                        onChange={event => setMenuDraft({
-                            resetKey: actionResetKey,
-                            dates: { startDate: menuStartDate, endDate: event.target.value },
-                        })}
-                        disabled={mutationDisabled || isMilestone}
-                        className="hui-input w-full px-2 py-1 text-xs"
-                    />
-                    <div className="grid grid-cols-2 gap-2">
-                        <button type="button" disabled={mutationDisabled} onClick={() => onTaskMoveBy(task, -1)} className="hui-btn hui-btn-secondary text-[10px] disabled:opacity-60">Move Earlier</button>
-                        <button type="button" disabled={mutationDisabled} onClick={() => onTaskMoveBy(task, 1)} className="hui-btn hui-btn-secondary text-[10px] disabled:opacity-60">Move Later</button>
-                    </div>
-                    <button type="submit" disabled={mutationDisabled || !menuStartDate || (!isMilestone && !menuEndDate)} className="hui-btn hui-btn-primary w-full text-xs disabled:opacity-60">
-                        Save task dates
-                    </button>
-                </form>
-            </details>
+                                dates: { startDate: menuStartDate, endDate: event.target.value },
+                            })}
+                            disabled={mutationDisabled || isMilestone}
+                            className="hui-input w-full px-2 py-1 text-xs"
+                        />
+                        <div className="grid grid-cols-2 gap-2">
+                            <button type="button" disabled={mutationDisabled} onClick={() => onTaskMoveBy(task, -1)} className="hui-btn hui-btn-secondary text-[10px] disabled:opacity-60">Move Earlier</button>
+                            <button type="button" disabled={mutationDisabled} onClick={() => onTaskMoveBy(task, 1)} className="hui-btn hui-btn-secondary text-[10px] disabled:opacity-60">Move Later</button>
+                        </div>
+                        <button type="submit" disabled={mutationDisabled || !menuStartDate || (!isMilestone && !menuEndDate)} className="hui-btn hui-btn-primary w-full text-xs disabled:opacity-60">
+                            Save task dates
+                        </button>
+                    </form>
+                </FloatingPopover>
+            </>
             )}
         </div>
     );

--- a/src/app/company-dashboard/schedule-board/TimelineView.tsx
+++ b/src/app/company-dashboard/schedule-board/TimelineView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, type DragEvent } from "react";
+import { useEffect, useRef, useState, type DragEvent } from "react";
 import Link from "next/link";
 import type { CompanyDashboardData, DashboardProjectRow } from "@/lib/schedule-core";
 import {
@@ -15,16 +15,17 @@ import {
     todayUTC,
 } from "@/app/projects/[id]/schedule/schedule-utils";
 import { MilestoneMarker } from "./MilestoneMarker";
-import { ProjectBar, ProjectBarGridStartContext, type ProjectEditCallbacks } from "./ProjectBar";
+import { ProjectBar, ProjectBarGridStartContext, computeTaskLaneLayout, type ProjectEditCallbacks } from "./ProjectBar";
 import { TaskBlockSegment, type ActiveTaskKeyboardEdit, type TaskEditCallbacks } from "./TaskBlockSegment";
 import { PROJECT_DRAG_MIME } from "./UnscheduledTray";
-import { clipRange, getEffectiveProjectRange, toTimelineRect, type WeekSegment } from "./useBarLayout";
+import { assignTaskLanes, clipRange, getEffectiveProjectRange, toTimelineRect, type WeekSegment } from "./useBarLayout";
 
 const DAY_WIDTH = 20;
 const TIMELINE_DAYS = 42;
 const LABEL_WIDTH = 240;
 const CANVAS_WIDTH = DAY_WIDTH * TIMELINE_DAYS;
 const FALLBACK_COLORS = ["#2563eb", "#7c3aed", "#0f766e", "#c2410c", "#be123c", "#4338ca", "#047857", "#a21caf"];
+const CREW_MODE_STORAGE_KEY = "gtr-company-schedule-board-crew-mode";
 
 interface TimelineViewProps extends TaskEditCallbacks, ProjectEditCallbacks {
     data: CompanyDashboardData;
@@ -34,8 +35,90 @@ interface TimelineViewProps extends TaskEditCallbacks, ProjectEditCallbacks {
     showHours: boolean;
     pendingProjectIds: ReadonlySet<string>;
     pendingTaskIds: ReadonlySet<string>;
+    draftProjectIds: ReadonlySet<string>;
+    draftTaskIds: ReadonlySet<string>;
+    isSaving: boolean;
     activeTaskKeyboardEdit: ActiveTaskKeyboardEdit | null;
     onTrayProjectDrop: (_project: DashboardProjectRow, _targetStart: string) => void;
+}
+
+interface CrewTaskBlock {
+    taskId: string;
+    projectId: string;
+    projectName: string;
+    projectColor: string;
+    name: string;
+    start: Date;
+    end: Date;
+}
+
+interface CrewCoverageBlock {
+    projectId: string;
+    projectName: string;
+    projectColor: string;
+    start: Date;
+    end: Date;
+}
+
+interface CrewTimelineRow {
+    userId: string;
+    name: string;
+    taskBlocks: CrewTaskBlock[];
+    coverageBlocks: CrewCoverageBlock[];
+}
+
+/**
+ * One row per ACTIVATED crew member with task assignments or project-crew
+ * membership in range (item 8). Reuses the already-serialized
+ * DashboardTaskRow.assignments and project.crew — no new money/data fetch.
+ * A project a member is on the crew of but has NO task assignment on renders
+ * as hollow coverage over the project's window (same source data as
+ * getCrewConflicts' P2 project-window fallback, just for display here).
+ */
+function buildCrewTimelineRows(projects: DashboardProjectRow[], colorFor: (project: DashboardProjectRow) => string): CrewTimelineRow[] {
+    const rowsByUser = new Map<string, CrewTimelineRow>();
+    const assignedProjectIdsByUser = new Map<string, Set<string>>();
+    const rowFor = (userId: string, name: string): CrewTimelineRow => {
+        let row = rowsByUser.get(userId);
+        if (!row) {
+            row = { userId, name, taskBlocks: [], coverageBlocks: [] };
+            rowsByUser.set(userId, row);
+        }
+        return row;
+    };
+
+    for (const project of projects) {
+        const projectColor = colorFor(project);
+        for (const task of project.tasks) {
+            for (const assignment of task.assignments) {
+                if (assignment.status !== "ACTIVATED") continue;
+                const start = parseUTCDate(task.startDate.slice(0, 10));
+                const end = task.type === "milestone" ? addDays(start, 1) : parseUTCDate(task.endDate.slice(0, 10));
+                if (end <= start) continue;
+                rowFor(assignment.userId, assignment.name).taskBlocks.push({
+                    taskId: task.id, projectId: project.id, projectName: project.name, projectColor,
+                    name: task.name, start, end,
+                });
+                const assignedSet = assignedProjectIdsByUser.get(assignment.userId) ?? new Set<string>();
+                assignedSet.add(project.id);
+                assignedProjectIdsByUser.set(assignment.userId, assignedSet);
+            }
+        }
+    }
+    for (const project of projects) {
+        const range = getEffectiveProjectRange(project);
+        if (!range) continue;
+        const projectColor = colorFor(project);
+        for (const member of project.crew) {
+            if (member.status !== "ACTIVATED") continue;
+            if (assignedProjectIdsByUser.get(member.id)?.has(project.id)) continue;
+            rowFor(member.id, member.name).coverageBlocks.push({
+                projectId: project.id, projectName: project.name, projectColor,
+                start: range.start, end: range.end,
+            });
+        }
+    }
+    return [...rowsByUser.values()].sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export function TimelineView({
@@ -46,6 +129,9 @@ export function TimelineView({
     showHours,
     pendingProjectIds,
     pendingTaskIds,
+    draftProjectIds,
+    draftTaskIds,
+    isSaving,
     activeTaskKeyboardEdit,
     onTrayProjectDrop,
     onProjectMoveCommit,
@@ -65,6 +151,26 @@ export function TimelineView({
 }: TimelineViewProps) {
     const scrollContainerRef = useRef<HTMLDivElement>(null);
     const [dragOverDate, setDragOverDate] = useState<string | null>(null);
+    const [groupByCrew, setGroupByCrew] = useState(false);
+    useEffect(() => {
+        try {
+            const stored = localStorage.getItem(CREW_MODE_STORAGE_KEY);
+            if (stored === "true") setGroupByCrew(true);
+        } catch {
+            // Storage can be unavailable in privacy-restricted browser contexts.
+        }
+    }, []);
+    function toggleGroupByCrew() {
+        setGroupByCrew(value => {
+            const next = !value;
+            try {
+                localStorage.setItem(CREW_MODE_STORAGE_KEY, String(next));
+            } catch {
+                // The selected mode still applies for this session when persistence fails.
+            }
+            return next;
+        });
+    }
     const anchor = parseUTCDate(`${data.month}-01`);
     const days = getMonthGrid(anchor).slice(0, TIMELINE_DAYS);
     const gridStart = days[0];
@@ -77,6 +183,8 @@ export function TimelineView({
         ...data.pipeline.inProgress,
         ...data.pipeline.substantialCompletion,
     ];
+    const colorForProject = (project: DashboardProjectRow) => project.color || FALLBACK_COLORS[projects.indexOf(project) % FALLBACK_COLORS.length];
+    const crewRows = groupByCrew ? buildCrewTimelineRows(projects, colorForProject) : [];
     const adminOverlays = data.isAdmin ? data.overlays : null;
     const visibleIncomeMilestones = adminOverlays && showIncome ? adminOverlays.income : [];
     const visibleChangeOrderMilestones = adminOverlays && showProjectedCo ? adminOverlays.changeOrders : [];
@@ -128,8 +236,16 @@ export function TimelineView({
             <div ref={scrollContainerRef} className="overflow-x-auto" aria-label="Project schedule timeline">
                 <div style={{ width: LABEL_WIDTH + CANVAS_WIDTH }}>
                     <div className="flex border-b border-hui-border bg-white">
-                        <div data-timeline-sticky-label="true" className="sticky left-0 z-50 flex shrink-0 items-end border-r border-hui-border bg-white px-3 pb-2 text-[10px] font-semibold uppercase tracking-wide text-slate-500" style={{ width: LABEL_WIDTH }}>
-                            Project
+                        <div data-timeline-sticky-label="true" className="sticky left-0 z-50 flex shrink-0 items-end justify-between gap-2 border-r border-hui-border bg-white px-3 pb-2 text-[10px] font-semibold uppercase tracking-wide text-slate-500" style={{ width: LABEL_WIDTH }}>
+                            <span>{groupByCrew ? "Crew" : "Project"}</span>
+                            <button
+                                type="button"
+                                onClick={toggleGroupByCrew}
+                                aria-pressed={groupByCrew}
+                                className={`rounded-full border px-2 py-0.5 text-[9px] font-semibold normal-case tracking-normal transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary ${groupByCrew ? "border-indigo-300 bg-indigo-100 text-indigo-700" : "border-hui-border bg-white text-hui-textMuted hover:bg-slate-50"}`}
+                            >
+                                By crew
+                            </button>
                         </div>
                         <div className="shrink-0" style={{ width: CANVAS_WIDTH }}>
                             <div className="grid grid-cols-6 border-b border-hui-border">
@@ -192,6 +308,66 @@ export function TimelineView({
                         </div>
                     )}
 
+                    {groupByCrew ? (
+                        crewRows.length === 0 ? (
+                            <div className="px-4 py-8 text-center text-sm text-hui-textMuted">No active crew coverage in this window.</div>
+                        ) : crewRows.map(row => {
+                            const { laneByTaskId, laneCount: rawLaneCount } = assignTaskLanes(row.taskBlocks.map(block => ({ id: block.taskId, start: block.start, end: block.end })));
+                            const laneCount = Math.max(1, rawLaneCount);
+                            const TASK_LANE_TOP = 20;
+                            const TASK_LANE_HEIGHT = 16;
+                            const coverageTop = TASK_LANE_TOP + laneCount * TASK_LANE_HEIGHT + 4;
+                            const rowHeight = Math.max(64, coverageTop + (row.coverageBlocks.length > 0 ? TASK_LANE_HEIGHT + 8 : 8));
+                            return (
+                                <div key={row.userId} className="flex border-b border-hui-border last:border-b-0" style={{ minHeight: rowHeight }}>
+                                    <div data-timeline-sticky-label="true" className="sticky left-0 z-40 flex shrink-0 items-center border-r border-hui-border bg-white px-3 py-2" style={{ width: LABEL_WIDTH }}>
+                                        <span className="truncate text-xs font-semibold text-hui-textMain" title={row.name}>{row.name}</span>
+                                    </div>
+                                    <div className="relative shrink-0" style={{ width: CANVAS_WIDTH, height: rowHeight }}>
+                                        <div className="absolute inset-0 grid" style={{ gridTemplateColumns: `repeat(${TIMELINE_DAYS}, ${DAY_WIDTH}px)` }} aria-hidden="true">
+                                            {days.map(day => (
+                                                <div key={formatDate(day)} className={`border-r border-hui-border ${isWeekend(day) ? "bg-slate-100/70" : "bg-white"}`} />
+                                            ))}
+                                        </div>
+                                        {today >= gridStart && today < gridEnd && (
+                                            <span className="pointer-events-none absolute inset-y-0 z-20 w-px bg-indigo-500" style={{ left: toTimelineRect({ start: today, end: addDays(today, 1) }, gridStart, DAY_WIDTH).left + DAY_WIDTH / 2 }} aria-hidden="true" />
+                                        )}
+                                        {row.taskBlocks.filter(block => laneByTaskId.has(block.taskId)).map(block => {
+                                            const clipped = clipRange({ start: block.start, end: block.end }, visibleRange);
+                                            if (!clipped) return null;
+                                            const rect = toTimelineRect(clipped, gridStart, DAY_WIDTH);
+                                            const lane = laneByTaskId.get(block.taskId)!;
+                                            return (
+                                                <div
+                                                    key={block.taskId}
+                                                    className="absolute z-10 overflow-hidden rounded-sm text-[9px] font-semibold leading-[15px] text-white shadow-sm"
+                                                    style={{ left: rect.left, top: TASK_LANE_TOP + lane * TASK_LANE_HEIGHT, width: Math.max(rect.width, DAY_WIDTH), height: TASK_LANE_HEIGHT - 2, backgroundColor: block.projectColor }}
+                                                    title={`${block.projectName} — ${block.name} — UTC ${formatDate(block.start)} → ${formatDate(block.end)}`}
+                                                >
+                                                    <span className="block truncate px-1">{block.name}</span>
+                                                </div>
+                                            );
+                                        })}
+                                        {row.coverageBlocks.map(block => {
+                                            const clipped = clipRange({ start: block.start, end: block.end }, visibleRange);
+                                            if (!clipped) return null;
+                                            const rect = toTimelineRect(clipped, gridStart, DAY_WIDTH);
+                                            return (
+                                                <div
+                                                    key={`coverage-${block.projectId}`}
+                                                    className="absolute z-10 overflow-hidden rounded-sm border-2 border-dashed text-[9px] font-semibold leading-[13px]"
+                                                    style={{ left: rect.left, top: coverageTop, width: Math.max(rect.width, DAY_WIDTH), height: TASK_LANE_HEIGHT - 2, borderColor: block.projectColor, backgroundColor: `${block.projectColor}22`, color: block.projectColor }}
+                                                    title={`${block.projectName} — on the project crew, no task assignment in range`}
+                                                >
+                                                    <span className="block truncate px-1">{block.projectName}</span>
+                                                </div>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
+                            );
+                        })
+                    ) : (<>
                     {projects.map((project, projectIndex) => {
                         const range = getEffectiveProjectRange(project);
                         const clipped = range ? clipRange(range, visibleRange) : null;
@@ -224,6 +400,9 @@ export function TimelineView({
                                 : [],
                         ))];
                         const crewLabel = project.crew.length > 0 ? project.crew.map(member => member.name).join(", ") : "No project crew";
+                        // Row must fit the bar: wrapper sits at top 8 + py-1 (4),
+                        // so a laneCount-3 bar (60px) needs 12 + 60 + 8 = 80px.
+                        const rowHeight = Math.max(64, 12 + computeTaskLaneLayout(project.tasks).barHeight + 8);
                         const milestoneRows = [
                             ...visibleIncomeMilestones.filter(item => item.projectId === project.id).map(item => ({
                                 key: `income-${item.id}`,
@@ -261,7 +440,7 @@ export function TimelineView({
                                         </span>
                                     )}
                                 </div>
-                                <div data-timeline-schedule-grid="true" className="relative h-16 shrink-0" style={{ width: CANVAS_WIDTH }}>
+                                <div data-timeline-schedule-grid="true" className="relative shrink-0" style={{ width: CANVAS_WIDTH, height: rowHeight }}>
                                     <div className="absolute inset-0 grid" style={{ gridTemplateColumns: `repeat(${TIMELINE_DAYS}, ${DAY_WIDTH}px)` }} aria-hidden="true">
                                         {days.map(day => {
                                             const dayKey = formatDate(day);
@@ -291,8 +470,10 @@ export function TimelineView({
                                                 changeOrderMilestones={[]}
                                                 canEdit={data.canEdit}
                                                 canMoveProject={data.canEdit && (project.status === "Waiting to Start" || project.status === "In Progress")}
-                                                isPending={pendingProjectIds.has(project.id)}
+                                                isPending={isSaving || pendingProjectIds.has(project.id)}
+                                                isDraft={draftProjectIds.has(project.id)}
                                                 pendingTaskIds={pendingTaskIds}
+                                                draftTaskIds={draftTaskIds}
                                                 activeTaskKeyboardEdit={activeTaskKeyboardEdit}
                                                 activeProjectKeyboardId={activeProjectKeyboardId}
                                                 timelineDayWidth={DAY_WIDTH}
@@ -325,7 +506,8 @@ export function TimelineView({
                                                     visibleRange={milestoneRange}
                                                     projectColor={project.color || FALLBACK_COLORS[projectIndex % FALLBACK_COLORS.length]}
                                                     canEdit={data.canEdit}
-                                                    isPending={pendingProjectIds.has(project.id) || pendingTaskIds.has(task.id)}
+                                                    isPending={isSaving || pendingProjectIds.has(project.id) || pendingTaskIds.has(task.id)}
+                                                    isDraft={draftProjectIds.has(project.id) || draftTaskIds.has(task.id)}
                                                     activeTaskKeyboardEdit={activeTaskKeyboardEdit}
                                                     timelineDayWidth={DAY_WIDTH}
                                                     timelineLeftInset={LABEL_WIDTH}
@@ -363,6 +545,7 @@ export function TimelineView({
                         );
                     })}
                     {projects.length === 0 && <div className="px-4 py-8 text-center text-sm text-hui-textMuted">No scheduled projects in this window.</div>}
+                    </>)}
                 </div>
             </div>
         </ProjectBarGridStartContext.Provider>

--- a/src/app/company-dashboard/schedule-board/UnscheduledTray.tsx
+++ b/src/app/company-dashboard/schedule-board/UnscheduledTray.tsx
@@ -2,12 +2,11 @@
 
 import { useState, type DragEvent, type FormEvent } from "react";
 import Link from "next/link";
-import type { CompanyDashboardData, DashboardProjectRow } from "@/lib/schedule-core";
+import type { DashboardProjectRow } from "@/lib/schedule-core";
 
 export const PROJECT_DRAG_MIME = "application/x-gtr-project-id";
 
 interface UnscheduledTrayProps {
-    estimating: CompanyDashboardData["pipeline"]["estimating"];
     projects: DashboardProjectRow[];
     canEdit: boolean;
     pendingProjectIds: ReadonlySet<string>;
@@ -54,7 +53,7 @@ function ProjectActions({
     );
 }
 
-export function UnscheduledTray({ estimating, projects, canEdit, pendingProjectIds, onMoveProject }: UnscheduledTrayProps) {
+export function UnscheduledTray({ projects, canEdit, pendingProjectIds, onMoveProject }: UnscheduledTrayProps) {
     function handleDragStart(project: DashboardProjectRow, event: DragEvent<HTMLElement>) {
         if (!canEdit || pendingProjectIds.has(project.id)) {
             event.preventDefault();
@@ -64,8 +63,6 @@ export function UnscheduledTray({ estimating, projects, canEdit, pendingProjectI
         event.dataTransfer.setData(PROJECT_DRAG_MIME, project.id);
     }
 
-    if (projects.length === 0 && estimating.length === 0) return null;
-
     return (
         <section className="border-b border-hui-border bg-slate-50/70 px-4 py-3" aria-labelledby="unscheduled-projects-heading">
             <div className="mb-2 flex items-center justify-between gap-3">
@@ -74,34 +71,32 @@ export function UnscheduledTray({ estimating, projects, canEdit, pendingProjectI
                     {canEdit ? "Drag a Waiting-to-Start project onto a day or use Project actions." : "Unscheduled projects are read-only for your role."}
                 </p>
             </div>
-            <div className="flex flex-wrap gap-2">
-                {projects.map(project => {
-                    const pending = pendingProjectIds.has(project.id);
-                    return (
-                        <article
-                            key={project.id}
-                            draggable={canEdit && !pending ? true : undefined}
-                            onDragStart={event => handleDragStart(project, event)}
-                            aria-busy={pending}
-                            className={`group flex min-w-52 items-center gap-2 rounded-md border border-indigo-200 bg-white px-3 py-2 shadow-sm ${canEdit && !pending ? "cursor-grab active:cursor-grabbing" : "opacity-60"}`}
-                        >
-                            <div className="min-w-0 flex-1">
-                                <Link href={`/projects/${project.id}`} className="block truncate text-xs font-semibold text-hui-textMain hover:text-hui-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
-                                    {project.name}
-                                </Link>
-                                <span className="block truncate text-[10px] text-hui-textMuted">{project.client ?? "No client"} · Waiting to Start</span>
-                            </div>
-                            {canEdit && <ProjectActions project={project} disabled={pending} onMoveProject={onMoveProject} />}
-                        </article>
-                    );
-                })}
-                {estimating.map(lead => (
-                    <div key={lead.id} aria-disabled="true" className="min-w-44 rounded-md border border-dashed border-slate-300 bg-slate-100 px-3 py-2 opacity-60">
-                        <span className="block truncate text-xs font-semibold text-slate-600">{lead.name}</span>
-                        <span className="block truncate text-[10px] text-slate-500">{lead.client ?? "Lead"} · Estimating</span>
-                    </div>
-                ))}
-            </div>
+            {projects.length === 0 ? (
+                <p className="text-xs text-hui-textMuted">No Waiting-to-Start projects to schedule.</p>
+            ) : (
+                <div className="flex flex-wrap gap-2">
+                    {projects.map(project => {
+                        const pending = pendingProjectIds.has(project.id);
+                        return (
+                            <article
+                                key={project.id}
+                                draggable={canEdit && !pending ? true : undefined}
+                                onDragStart={event => handleDragStart(project, event)}
+                                aria-busy={pending}
+                                className={`group flex min-w-52 items-center gap-2 rounded-md border border-indigo-200 bg-white px-3 py-2 shadow-sm ${canEdit && !pending ? "cursor-grab active:cursor-grabbing" : "opacity-60"}`}
+                            >
+                                <div className="min-w-0 flex-1">
+                                    <Link href={`/projects/${project.id}`} className="block truncate text-xs font-semibold text-hui-textMain hover:text-hui-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
+                                        {project.name}
+                                    </Link>
+                                    <span className="block truncate text-[10px] text-hui-textMuted">{project.client ?? "No client"} · Waiting to Start</span>
+                                </div>
+                                {canEdit && <ProjectActions project={project} disabled={pending} onMoveProject={onMoveProject} />}
+                            </article>
+                        );
+                    })}
+                </div>
+            )}
         </section>
     );
 }

--- a/src/app/company-dashboard/schedule-board/useBarLayout.ts
+++ b/src/app/company-dashboard/schedule-board/useBarLayout.ts
@@ -434,6 +434,48 @@ export function assignMonthProjectLanes(
     return { visibleWork, visibleMilestoneHosts, hiddenProjectIdsByWeek };
 }
 
+export const MAX_TASK_LANES = 3;
+
+export interface TaskLaneRange {
+    id: string;
+    start: Date;
+    end: Date;
+}
+
+export interface TaskLaneLayout {
+    laneByTaskId: Map<string, number>;
+    hiddenTaskIds: string[];
+    laneCount: number;
+}
+
+/**
+ * Stack a project's own tasks into overlap-free mini-lanes (a project can
+ * carry concurrent phases — e.g. concrete + deck). Same greedy
+ * interval-partition idea as assignProjectLanes, capped at MAX_TASK_LANES;
+ * tasks beyond the cap are reported as hidden for a "+N" affordance. Sorted
+ * by start (tie-broken by id) for a deterministic, stable assignment.
+ */
+export function assignTaskLanes(tasks: TaskLaneRange[]): TaskLaneLayout {
+    const sorted = [...tasks].sort((a, b) => a.start.getTime() - b.start.getTime() || a.id.localeCompare(b.id));
+    const laneEnds: Date[] = [];
+    const laneByTaskId = new Map<string, number>();
+    const hiddenTaskIds: string[] = [];
+
+    for (const task of sorted) {
+        let lane = laneEnds.findIndex(end => end <= task.start);
+        if (lane === -1) lane = laneEnds.length;
+        if (lane >= MAX_TASK_LANES) {
+            hiddenTaskIds.push(task.id);
+            continue;
+        }
+        laneEnds[lane] = task.end;
+        laneByTaskId.set(task.id, lane);
+    }
+
+    const laneCount = laneByTaskId.size === 0 ? 0 : Math.max(...laneByTaskId.values()) + 1;
+    return { laneByTaskId, hiddenTaskIds, laneCount };
+}
+
 export function toTimelineRect(range: DateRange, origin: Date, dayWidth: number): TimelineRect {
     const normalizedOrigin = toUTCDay(origin);
     const start = toUTCDay(range.start);

--- a/src/app/company-dashboard/schedule-board/useBarLayout.ts
+++ b/src/app/company-dashboard/schedule-board/useBarLayout.ts
@@ -121,6 +121,12 @@ export function previewProjectMove(project: DashboardProjectRow, targetStart: st
     const normalizedTarget = formatDate(parseSerializedUTCDay(targetStart));
     if (!project.startDate) return { ...project, startDate: normalizedTarget };
 
+    // In Progress: the preview moves the start marker ONLY. Neither save
+    // choice shifts started work, and the "also shift" choice (marker +
+    // Not Started tasks) is explicitly consented to in the confirm dialog —
+    // the preview shows the minimum guaranteed effect, never more.
+    if (project.status === "In Progress") return { ...project, startDate: normalizedTarget };
+
     const range = getEffectiveProjectRange(project);
     if (!range) return { ...project, startDate: normalizedTarget };
 

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -7305,6 +7305,67 @@ export async function updateTaskCrewAction(taskId: string, userIds: string[]) {
     return result;
 }
 
+export interface SaveCompanyScheduleTaskDatesInput {
+    taskId: string;
+    startDate: string; // YYYY-MM-DD
+    endDate: string;   // YYYY-MM-DD
+}
+
+export interface SaveCompanyScheduleTaskDateResult {
+    taskId: string;
+    ok: boolean;
+    startDate?: string;
+    endDate?: string;
+    error?: string;
+}
+
+export interface SaveCompanyScheduleTaskDatesResult {
+    results: SaveCompanyScheduleTaskDateResult[];
+    succeeded: number;
+    failed: number;
+}
+
+// Commit the company schedule board's draft-mode edits in one batch. ADMIN/
+// MANAGER only, same gate as the other dashboard batch actions. Loops the
+// canonical updateScheduleTask per task — deliberately NOT a second mutation
+// core — so every existing lock/validation/ActivityLog path applies
+// unchanged. One task's failure never blocks the rest: each change is applied
+// independently and reported in `results`, so the client can clear succeeded
+// drafts and keep failed ones pending for retry.
+export async function saveCompanyScheduleTaskDatesAction(
+    changes: SaveCompanyScheduleTaskDatesInput[],
+): Promise<SaveCompanyScheduleTaskDatesResult> {
+    const session = await getServerSession(authOptions);
+    const caller = session?.user?.email
+        ? await prisma.user.findUnique({ where: { email: session.user.email }, select: { role: true, name: true, email: true } })
+        : null;
+    if (!caller || !["ADMIN", "MANAGER"].includes(caller.role)) throw new Error("Forbidden");
+
+    const results: SaveCompanyScheduleTaskDateResult[] = [];
+    for (const change of changes) {
+        try {
+            const task = await updateScheduleTask(change.taskId, {
+                startDate: change.startDate,
+                endDate: change.endDate,
+            });
+            results.push({
+                taskId: change.taskId,
+                ok: true,
+                startDate: task.startDate.toISOString(),
+                endDate: task.endDate.toISOString(),
+            });
+        } catch (err: any) {
+            results.push({ taskId: change.taskId, ok: false, error: err?.message ?? String(err) });
+        }
+    }
+
+    return {
+        results,
+        succeeded: results.filter(r => r.ok).length,
+        failed: results.filter(r => !r.ok).length,
+    };
+}
+
 export async function updateProjectColor(projectId: string, color: string) {
     await prisma.project.update({
         where: { id: projectId },

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -7340,9 +7340,13 @@ export async function saveCompanyScheduleTaskDatesAction(
         ? await prisma.user.findUnique({ where: { email: session.user.email }, select: { role: true, name: true, email: true } })
         : null;
     if (!caller || !["ADMIN", "MANAGER"].includes(caller.role)) throw new Error("Forbidden");
+    if (changes.length > 200) throw new Error("Too many schedule changes in one save (max 200) — save in smaller batches");
+    // Deterministic dedupe: the LAST occurrence of a taskId wins and is applied
+    // exactly once (no duplicate activity records or inflated success counts).
+    const deduped = [...new Map(changes.map(change => [change.taskId, change])).values()];
 
     const results: SaveCompanyScheduleTaskDateResult[] = [];
-    for (const change of changes) {
+    for (const change of deduped) {
         try {
             const task = await updateScheduleTask(change.taskId, {
                 startDate: change.startDate,

--- a/src/lib/schedule-core.ts
+++ b/src/lib/schedule-core.ts
@@ -48,6 +48,9 @@ export interface PipelineCrewMember {
     // User status (PENDING/ACTIVATED/DISABLED) — the dashboard picker renders
     // assigned non-ACTIVATED members as removable "(inactive)" entries.
     status: string;
+    // User role — the picker renders an assigned FINANCE user (excluded from
+    // the pickable teamMembers list) as a removable "(finance)" entry.
+    role: string;
 }
 
 export interface PipelineProject {
@@ -109,7 +112,7 @@ export async function getCompanyPipeline(): Promise<CompanyPipeline> {
             select: {
                 id: true, name: true, status: true, startDate: true, color: true,
                 client: { select: { name: true } },
-                crew: { select: { id: true, name: true, email: true, status: true } },
+                crew: { select: { id: true, name: true, email: true, status: true, role: true } },
                 estimates: {
                     where: { status: { in: CONTRACT_ESTIMATE_STATUSES } },
                     orderBy: { createdAt: "desc" },
@@ -128,7 +131,7 @@ export async function getCompanyPipeline(): Promise<CompanyPipeline> {
         startDate: p.startDate ? p.startDate.toISOString() : null,
         color: p.color,
         contractValue: p.estimates[0] ? Number(p.estimates[0].totalAmount) : null,
-        crew: p.crew.map(u => ({ id: u.id, name: u.name || u.email, status: u.status })),
+        crew: p.crew.map(u => ({ id: u.id, name: u.name || u.email, status: u.status, role: u.role })),
     });
 
     const waitingToStart: PipelineProject[] = [];
@@ -1377,14 +1380,18 @@ export async function setProjectCrew(input: {
         const byId = new Map(users.map(u => [u.id, u]));
         const missing = wanted.filter(id => !byId.has(id));
         if (missing.length > 0) throw new Error(`Unknown user id(s): ${missing.join(", ")}`);
-        const notActivated = users.filter(u => u.status !== "ACTIVATED");
-        if (notActivated.length > 0) {
-            throw new Error(`Crew members must be ACTIVATED users: ${notActivated.map(u => u.name || u.email).join(", ")}`);
-        }
 
         const current = project.crew.map(u => u.id);
         const toConnect = wanted.filter(id => !current.includes(id));
         const toDisconnect = current.filter(id => !wanted.includes(id));
+
+        // ACTIVATED is required only for users being ADDED — a project already
+        // carrying a legacy inactive/finance crew member (kept or removed) must
+        // never throw; only a NEW non-ACTIVATED addition is rejected.
+        const notActivated = toConnect.map(id => byId.get(id)!).filter(u => u.status !== "ACTIVATED");
+        if (notActivated.length > 0) {
+            throw new Error(`Crew members must be ACTIVATED users: ${notActivated.map(u => u.name || u.email).join(", ")}`);
+        }
         await tx.project.update({
             where: { id: input.projectId },
             data: {
@@ -1840,6 +1847,7 @@ export interface DashboardTaskAssignment {
     userId: string;
     name: string;
     status: string;
+    role: string;
 }
 
 export interface DashboardTaskRow {
@@ -2077,7 +2085,7 @@ export async function getCompanyDashboardData(
                 id: true, projectId: true, name: true, startDate: true, endDate: true, color: true, parentId: true, progress: true, status: true, type: true,
                 assignments: {
                     orderBy: { createdAt: "asc" },
-                    select: { id: true, userId: true, user: { select: { name: true, email: true, status: true } } },
+                    select: { id: true, userId: true, user: { select: { name: true, email: true, status: true, role: true } } },
                 },
             },
         }),
@@ -2103,6 +2111,7 @@ export async function getCompanyDashboardData(
                 userId: a.userId,
                 name: a.user.name || a.user.email,
                 status: a.user.status,
+                role: a.user.role,
             })),
         });
         tasksByProject.set(task.projectId, rows);
@@ -2116,14 +2125,25 @@ export async function getCompanyDashboardData(
         unappliedChangeOrders: unappliedByProject[p.id] ?? { count: 0, items: [] },
     });
 
-    // Picker list is pre-filtered to ACTIVATED (getTeamMembers stays unchanged
-    // for other callers) and only sent to roles that can edit.
-    const teamMembers = canEdit
-        ? (await prisma.user.findMany({
-            where: { status: "ACTIVATED" },
+    // Picker list is pre-filtered to ACTIVATED, non-FINANCE (getTeamMembers
+    // stays unchanged for other callers) and only sent to roles that can edit
+    // — bookkeeper accounts must never be offered as job crew. Display names
+    // that collide (e.g. two "Justin Adkins" accounts) get their email
+    // appended so the picker stays unambiguous.
+    const teamMembersRaw = canEdit
+        ? await prisma.user.findMany({
+            where: { status: "ACTIVATED", role: { not: "FINANCE" } },
             orderBy: { name: "asc" },
             select: { id: true, name: true, email: true },
-        })).map(u => ({ id: u.id, name: u.name || u.email, email: u.email }))
+        })
+        : [];
+    const teamMembers = canEdit
+        ? (() => {
+            const rows = teamMembersRaw.map(u => ({ id: u.id, name: u.name || u.email, email: u.email }));
+            const nameCounts = new Map<string, number>();
+            for (const r of rows) nameCounts.set(r.name, (nameCounts.get(r.name) ?? 0) + 1);
+            return rows.map(r => (nameCounts.get(r.name)! > 1 ? { ...r, name: `${r.name} (${r.email})` } : r));
+        })()
         : null;
 
     // Money redaction for schedules-only viewers: null out pipeline dollar
@@ -2738,14 +2758,18 @@ export async function setTaskCrew(input: {
         const byId = new Map(users.map(u => [u.id, u]));
         const missing = wanted.filter(id => !byId.has(id));
         if (missing.length > 0) throw new Error(`Unknown user id(s): ${missing.join(", ")}`);
-        const notActivated = users.filter(u => u.status !== "ACTIVATED");
-        if (notActivated.length > 0) {
-            throw new Error(`Task crew members must be ACTIVATED users: ${notActivated.map(u => u.name || u.email).join(", ")}`);
-        }
 
         const current = task.assignments.map(a => a.userId);
         const toAdd = wanted.filter(id => !current.includes(id));
         const toRemove = current.filter(id => !wanted.includes(id));
+
+        // ACTIVATED is required only for users being ADDED — same added-only
+        // rule as setProjectCrew, so a task already carrying an inactive
+        // assignee never blocks unrelated edits.
+        const notActivated = toAdd.map(id => byId.get(id)!).filter(u => u.status !== "ACTIVATED");
+        if (notActivated.length > 0) {
+            throw new Error(`Task crew members must be ACTIVATED users: ${notActivated.map(u => u.name || u.email).join(", ")}`);
+        }
         if (toRemove.length > 0) {
             await tx.taskAssignment.deleteMany({ where: { taskId: input.taskId, userId: { in: toRemove } } });
         }


### PR DESCRIPTION
First-walkthrough feedback on the schedule board (PR #218), plus the prod crew-edit bug it surfaced.

## Bug fix (the prod error toast)
`setProjectCrew`/`setTaskCrew` rejected the whole submitted list if ANY already-assigned member was non-ACTIVATED — projects carrying a legacy inactive crew member threw on every edit. Now only newly-ADDED members must be ACTIVATED; keep/remove never throws.

## UX changes (owner decisions)
- **Draft-mode editing**: drags accumulate locally with a pending style and stay re-editable; sticky "N unsaved changes — Save / Discard" bar; Save runs one batch action (per-task results, partial failures stay drafted) + one refresh; In Progress confirm dialog moves to save time. The per-drag freeze and stuck refresh banner are gone.
- **Popovers** portal to the viewport (flip/clamp) — no more clipping in either view.
- **In Progress only**: Estimating lead chips removed from the tray.
- **Overlapping phases** stack into mini-lanes (cap 3, "+N"); shared `computeTaskLaneLayout` sizes bars and rows in both views.
- **Bar click opens the menu** (never navigates); "Open project" is a menu item.
- **Crew hygiene**: FINANCE users excluded from pickers; duplicate names disambiguated by email.
- **Timeline "By crew"** grouping (read-only): a row per member across all projects.
- **/company-dashboard/guide**: how-to page for onboarding (linked in the board header).

## Verification
- DB verifier extended (crew added-only validation incl. live inactive-member case, FINANCE exclusion, batch-action gate + partial failure): ALL PASS, fixtures cleaned
- Layout + render-contract suites PASS (new row-height source contract); `tsc` 0 errors; build clean
- Independent checker agent verified all 8 items and caught a Timeline row-height overflow (3-lane bars), fixed in this PR
- Money rules audited: no payment/QB writes anywhere; milestone rendering stays ADMIN-gated; canSeeFinancials redaction untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)