### PR TITLE
feat(invoices): rebalance pending milestones with QuickBooks re-staging

### DIFF
--- a/e2e/milestone-rebalance.spec.ts
+++ b/e2e/milestone-rebalance.spec.ts
@@ -17,8 +17,10 @@ import {
  *
  * No live QuickBooks connection exists in this test DB (no Integration row),
  * so `getFreshQBTokens()` throws `QBNotConnectedError` for any row that carries
- * a `qbInvoiceId` — the QB-touching test below exercises the DB-side unlink
- * claim and asserts a warning comes back, but never reaches a live QBO call.
+ * a `qbInvoiceId` — the QB-touching test below asserts the row KEEPS its link
+ * (unlinking only ever happens after the old QBO invoice is confirmed deleted,
+ * which can't be reached here) and a warning comes back; no live QBO call is
+ * ever made.
  */
 
 const prisma = new PrismaClient();
@@ -86,14 +88,21 @@ test.describe.serial("updatePendingMilestoneAmountsCore", () => {
         const estimateId = `${PFX}-est-${suffix}`;
         const invoiceId = `${PFX}-inv-${suffix}`;
         const epsA = `${PFX}-eps-a-${suffix}`;
+        const epsB = `${PFX}-eps-b-${suffix}`;
         const psA = `${PFX}-ps-a-${suffix}`;
         const psB = `${PFX}-ps-b-${suffix}`;
 
+        // Both rows are estimate-mirrored: rebalancing may only move money WITHIN
+        // a pool (mirrored ↔ mirrored), so a fully-mirrored schedule is the
+        // canonical happy path (this matches Mesplay/Berg's real shape).
         await prisma.estimate.create({
             data: { id: estimateId, title: "MR Estimate", code: `EST-MR-${suffix}`, projectId: `${PFX}-project`, status: "Approved", totalAmount: 1000, balanceDue: 1000 },
         });
         await prisma.estimatePaymentSchedule.create({
             data: { id: epsA, estimateId, name: "Deposit", percentage: 40, amount: 400, status: "Pending", order: 1 },
+        });
+        await prisma.estimatePaymentSchedule.create({
+            data: { id: epsB, estimateId, name: "Final", percentage: 60, amount: 600, status: "Pending", order: 2 },
         });
         await prisma.invoice.create({
             data: { id: invoiceId, code: `INV-MR-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, estimateId, status: "Issued", totalAmount: 1000, balanceDue: 1000 },
@@ -101,7 +110,9 @@ test.describe.serial("updatePendingMilestoneAmountsCore", () => {
         await prisma.paymentSchedule.create({
             data: { id: psA, invoiceId, name: "Deposit", amount: 400, status: "Pending", sourceScheduleId: epsA, dueDate: new Date("2026-01-01") },
         });
-        await prisma.paymentSchedule.create({ data: { id: psB, invoiceId, name: "Final", amount: 600, status: "Pending" } });
+        await prisma.paymentSchedule.create({
+            data: { id: psB, invoiceId, name: "Final", amount: 600, status: "Pending", sourceScheduleId: epsB },
+        });
 
         const res = await updatePendingMilestoneAmountsCore(invoiceId, [
             { scheduleId: psA, name: "Deposit (revised)", amount: 350, dueDate: "2026-02-01" },
@@ -153,7 +164,7 @@ test.describe.serial("updatePendingMilestoneAmountsCore", () => {
         expect(num(paid!.amount)).toBe(400); // unchanged
     });
 
-    test("QB-linked row: unlinks locally and reports a warning (no live QuickBooks in this env)", async () => {
+    test("QB-linked row: keeps its link and reports a warning when QuickBooks is unreachable", async () => {
         await ensureClientAndProject();
         const suffix = "qblinked";
         const invoiceId = `${PFX}-inv-${suffix}`;
@@ -173,12 +184,51 @@ test.describe.serial("updatePendingMilestoneAmountsCore", () => {
             { scheduleId: psOther, name: "Final", amount: 650 },
         ]);
         expect(res.success).toBe(true);
-        expect(res.warnings.length).toBeGreaterThan(0); // no QuickBooks connection to re-stage against
+        expect(res.warnings.length).toBeGreaterThan(0); // no QuickBooks connection to replace the staged invoice
 
+        // Amounts update locally, but the QB link is deliberately KEPT: unlinking
+        // only happens after the old QBO invoice is confirmed deleted, and this
+        // env can never reach QBO — so the payment poller keeps watching the old
+        // invoice instead of stranding any payment behind a cleared link.
         const qbRow = await prisma.paymentSchedule.findUnique({ where: { id: psQB } });
-        expect(num(qbRow!.amount)).toBe(350); // amount still updated
-        expect(qbRow!.qbInvoiceId).toBeNull(); // unlinked locally, safely
-        expect(qbRow!.qbInvoiceLink).toBeNull();
+        expect(num(qbRow!.amount)).toBe(350);
+        expect(qbRow!.qbInvoiceId).toBe("fake-qbo-1");
+        expect(qbRow!.qbInvoiceLink).toBe("https://qbo.example/fake-1");
+    });
+
+    test("rejects moving money between estimate-mirrored rows and extras", async () => {
+        await ensureClientAndProject();
+        const suffix = "crosspool";
+        const estimateId = `${PFX}-est-${suffix}`;
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const eps = `${PFX}-eps-${suffix}`;
+        const psMirrored = `${PFX}-ps-m-${suffix}`;
+        const psExtra = `${PFX}-ps-x-${suffix}`;
+
+        await prisma.estimate.create({
+            data: { id: estimateId, title: "MR Estimate", code: `EST-MR-${suffix}`, projectId: `${PFX}-project`, status: "Approved", totalAmount: 400, balanceDue: 400 },
+        });
+        await prisma.estimatePaymentSchedule.create({ data: { id: eps, estimateId, name: "Deposit", amount: 400, status: "Pending", order: 1 } });
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-MR-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, estimateId, status: "Issued", totalAmount: 1000, balanceDue: 1000 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psMirrored, invoiceId, name: "Deposit", amount: 400, status: "Pending", sourceScheduleId: eps } });
+        await prisma.paymentSchedule.create({ data: { id: psExtra, invoiceId, name: "Extra", amount: 600, status: "Pending" } });
+
+        // Invoice-wide total is preserved (1000) but $50 slides from the mirrored
+        // row to the extra — that would desync the estimate schedule from the
+        // estimate total, so it must be rejected.
+        await expect(
+            updatePendingMilestoneAmountsCore(invoiceId, [
+                { scheduleId: psMirrored, name: "Deposit", amount: 350 },
+                { scheduleId: psExtra, name: "Extra", amount: 650 },
+            ]),
+        ).rejects.toThrow(/estimate-linked/i);
+
+        const m = await prisma.paymentSchedule.findUnique({ where: { id: psMirrored } });
+        const x = await prisma.paymentSchedule.findUnique({ where: { id: psExtra } });
+        expect(num(m!.amount)).toBe(400); // unchanged
+        expect(num(x!.amount)).toBe(600); // unchanged
     });
 });
 
@@ -251,6 +301,28 @@ test.describe.serial("deleteInvoiceMilestoneCore", () => {
         expect(num(invoice!.totalAmount)).toBe(400);
         expect(num(invoice!.balanceDue)).toBe(0);
         expect(invoice!.status).toBe("Paid");
+    });
+
+    test("keeps a Draft invoice Draft when deleting its only pending extra", async () => {
+        await ensureClientAndProject();
+        const suffix = "delete-draft";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psExtra = `${PFX}-ps-extra-${suffix}`;
+
+        // No payments at all — a zero balance reached purely by deletion must not
+        // read as "Paid".
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-MR-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Draft", totalAmount: 600, balanceDue: 600 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psExtra, invoiceId, name: "Extra Charge", amount: 600, status: "Pending" } });
+
+        const res = await deleteInvoiceMilestoneCore(psExtra);
+        expect(res.success).toBe(true);
+
+        const invoice = await prisma.invoice.findUnique({ where: { id: invoiceId } });
+        expect(num(invoice!.totalAmount)).toBe(0);
+        expect(num(invoice!.balanceDue)).toBe(0);
+        expect(invoice!.status).toBe("Draft");
     });
 });
 

--- a/e2e/milestone-rebalance.spec.ts
+++ b/e2e/milestone-rebalance.spec.ts
@@ -128,11 +128,14 @@ test.describe.serial("updatePendingMilestoneAmountsCore", () => {
         expect(a!.dueDate?.toISOString().slice(0, 10)).toBe("2026-02-01");
         expect(num(b!.amount)).toBe(650);
 
-        // Estimate-side mirror follows, percentage cleared (no longer a fixed share).
+        // Estimate-side mirrors follow, percentage cleared (no longer a fixed share).
         const eps = await prisma.estimatePaymentSchedule.findUnique({ where: { id: epsA } });
         expect(eps!.name).toBe("Deposit (revised)");
         expect(num(eps!.amount)).toBe(350);
         expect(eps!.percentage).toBeNull();
+        const epsB2 = await prisma.estimatePaymentSchedule.findUnique({ where: { id: epsB } });
+        expect(num(epsB2!.amount)).toBe(650);
+        expect(epsB2!.percentage).toBeNull();
 
         // Invoice total/balance are untouched by a rebalance.
         const invoice = await prisma.invoice.findUnique({ where: { id: invoiceId } });

--- a/e2e/milestone-rebalance.spec.ts
+++ b/e2e/milestone-rebalance.spec.ts
@@ -1,0 +1,298 @@
+import { test, expect } from "@playwright/test";
+import { PrismaClient } from "@prisma/client";
+import {
+    updatePendingMilestoneAmountsCore,
+    deleteInvoiceMilestoneCore,
+    splitInvoiceMilestonesCore,
+} from "../src/lib/billing-core";
+
+/**
+ * Milestone rebalance + QBO resync regression net.
+ *
+ * Covers the three session-free cores behind the "Edit amounts" / delete-extra
+ * / split flows on the invoice editor (actions.ts wraps these with
+ * `assertInvoicePermission()`, which needs a real Next.js request scope — see
+ * `reconcile-to-qbo.spec.ts` for the established precedent of testing the
+ * auth-free core directly against the throwaway CI Postgres).
+ *
+ * No live QuickBooks connection exists in this test DB (no Integration row),
+ * so `getFreshQBTokens()` throws `QBNotConnectedError` for any row that carries
+ * a `qbInvoiceId` — the QB-touching test below exercises the DB-side unlink
+ * claim and asserts a warning comes back, but never reaches a live QBO call.
+ */
+
+const prisma = new PrismaClient();
+const PFX = "mr-e2e";
+const num = (v: unknown) => Number(v);
+
+async function afterAllCleanup() {
+    try {
+        await prisma.paymentSchedule.deleteMany({ where: { id: { startsWith: PFX } } });
+        await prisma.invoice.deleteMany({ where: { id: { startsWith: PFX } } });
+        await prisma.estimatePaymentSchedule.deleteMany({ where: { id: { startsWith: PFX } } });
+        await prisma.estimate.deleteMany({ where: { id: { startsWith: PFX } } });
+        await prisma.project.deleteMany({ where: { id: { startsWith: PFX } } });
+        await prisma.client.deleteMany({ where: { id: { startsWith: PFX } } });
+    } finally {
+        await prisma.$disconnect();
+    }
+}
+
+async function ensureClientAndProject() {
+    await prisma.client.upsert({
+        where: { id: `${PFX}-client` },
+        update: {},
+        create: { id: `${PFX}-client`, name: "MR Client", initials: "MR" },
+    });
+    await prisma.project.upsert({
+        where: { id: `${PFX}-project` },
+        update: {},
+        create: { id: `${PFX}-project`, name: "MR Project", clientId: `${PFX}-client` },
+    });
+}
+
+test.describe.serial("updatePendingMilestoneAmountsCore", () => {
+    test.afterAll(afterAllCleanup);
+
+    test("rejects a mismatched total", async () => {
+        await ensureClientAndProject();
+        const suffix = "mismatch";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psA = `${PFX}-ps-a-${suffix}`;
+        const psB = `${PFX}-ps-b-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-MR-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 1000, balanceDue: 1000 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psA, invoiceId, name: "Deposit", amount: 400, status: "Pending" } });
+        await prisma.paymentSchedule.create({ data: { id: psB, invoiceId, name: "Final", amount: 600, status: "Pending" } });
+
+        await expect(
+            updatePendingMilestoneAmountsCore(invoiceId, [
+                { scheduleId: psA, name: "Deposit", amount: 400 },
+                { scheduleId: psB, name: "Final", amount: 500 }, // 900 total, not 1000
+            ]),
+        ).rejects.toThrow();
+
+        const a = await prisma.paymentSchedule.findUnique({ where: { id: psA } });
+        const b = await prisma.paymentSchedule.findUnique({ where: { id: psB } });
+        expect(num(a!.amount)).toBe(400); // unchanged
+        expect(num(b!.amount)).toBe(600); // unchanged
+    });
+
+    test("successful rebalance updates rows + estimate mirrors and leaves totalAmount/balanceDue unchanged", async () => {
+        await ensureClientAndProject();
+        const suffix = "success";
+        const estimateId = `${PFX}-est-${suffix}`;
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const epsA = `${PFX}-eps-a-${suffix}`;
+        const psA = `${PFX}-ps-a-${suffix}`;
+        const psB = `${PFX}-ps-b-${suffix}`;
+
+        await prisma.estimate.create({
+            data: { id: estimateId, title: "MR Estimate", code: `EST-MR-${suffix}`, projectId: `${PFX}-project`, status: "Approved", totalAmount: 1000, balanceDue: 1000 },
+        });
+        await prisma.estimatePaymentSchedule.create({
+            data: { id: epsA, estimateId, name: "Deposit", percentage: 40, amount: 400, status: "Pending", order: 1 },
+        });
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-MR-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, estimateId, status: "Issued", totalAmount: 1000, balanceDue: 1000 },
+        });
+        await prisma.paymentSchedule.create({
+            data: { id: psA, invoiceId, name: "Deposit", amount: 400, status: "Pending", sourceScheduleId: epsA, dueDate: new Date("2026-01-01") },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psB, invoiceId, name: "Final", amount: 600, status: "Pending" } });
+
+        const res = await updatePendingMilestoneAmountsCore(invoiceId, [
+            { scheduleId: psA, name: "Deposit (revised)", amount: 350, dueDate: "2026-02-01" },
+            { scheduleId: psB, name: "Final", amount: 650 },
+        ]);
+        expect(res.success).toBe(true);
+        expect(res.warnings).toEqual([]);
+
+        const a = await prisma.paymentSchedule.findUnique({ where: { id: psA } });
+        const b = await prisma.paymentSchedule.findUnique({ where: { id: psB } });
+        expect(a!.name).toBe("Deposit (revised)");
+        expect(num(a!.amount)).toBe(350);
+        expect(a!.dueDate?.toISOString().slice(0, 10)).toBe("2026-02-01");
+        expect(num(b!.amount)).toBe(650);
+
+        // Estimate-side mirror follows, percentage cleared (no longer a fixed share).
+        const eps = await prisma.estimatePaymentSchedule.findUnique({ where: { id: epsA } });
+        expect(eps!.name).toBe("Deposit (revised)");
+        expect(num(eps!.amount)).toBe(350);
+        expect(eps!.percentage).toBeNull();
+
+        // Invoice total/balance are untouched by a rebalance.
+        const invoice = await prisma.invoice.findUnique({ where: { id: invoiceId } });
+        expect(num(invoice!.totalAmount)).toBe(1000);
+        expect(num(invoice!.balanceDue)).toBe(1000);
+    });
+
+    test("rejects a submitted row that is already Paid", async () => {
+        await ensureClientAndProject();
+        const suffix = "paidrow";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psPaid = `${PFX}-ps-paid-${suffix}`;
+        const psPending = `${PFX}-ps-pending-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-MR-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Partially Paid", totalAmount: 1000, balanceDue: 600 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psPaid, invoiceId, name: "Deposit", amount: 400, status: "Paid" } });
+        await prisma.paymentSchedule.create({ data: { id: psPending, invoiceId, name: "Final", amount: 600, status: "Pending" } });
+
+        await expect(
+            updatePendingMilestoneAmountsCore(invoiceId, [
+                { scheduleId: psPaid, name: "Deposit", amount: 350 },
+                { scheduleId: psPending, name: "Final", amount: 650 },
+            ]),
+        ).rejects.toThrow(/not Pending/i);
+
+        const paid = await prisma.paymentSchedule.findUnique({ where: { id: psPaid } });
+        expect(num(paid!.amount)).toBe(400); // unchanged
+    });
+
+    test("QB-linked row: unlinks locally and reports a warning (no live QuickBooks in this env)", async () => {
+        await ensureClientAndProject();
+        const suffix = "qblinked";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psQB = `${PFX}-ps-qb-${suffix}`;
+        const psOther = `${PFX}-ps-other-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-MR-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 1000, balanceDue: 1000 },
+        });
+        await prisma.paymentSchedule.create({
+            data: { id: psQB, invoiceId, name: "Deposit", amount: 400, status: "Pending", qbInvoiceId: "fake-qbo-1", qbInvoiceLink: "https://qbo.example/fake-1" },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psOther, invoiceId, name: "Final", amount: 600, status: "Pending" } });
+
+        const res = await updatePendingMilestoneAmountsCore(invoiceId, [
+            { scheduleId: psQB, name: "Deposit", amount: 350 },
+            { scheduleId: psOther, name: "Final", amount: 650 },
+        ]);
+        expect(res.success).toBe(true);
+        expect(res.warnings.length).toBeGreaterThan(0); // no QuickBooks connection to re-stage against
+
+        const qbRow = await prisma.paymentSchedule.findUnique({ where: { id: psQB } });
+        expect(num(qbRow!.amount)).toBe(350); // amount still updated
+        expect(qbRow!.qbInvoiceId).toBeNull(); // unlinked locally, safely
+        expect(qbRow!.qbInvoiceLink).toBeNull();
+    });
+});
+
+test.describe.serial("deleteInvoiceMilestoneCore", () => {
+    test.afterAll(afterAllCleanup);
+
+    test("rejects a mirrored row (sourceScheduleId set)", async () => {
+        await ensureClientAndProject();
+        const suffix = "mirrored";
+        const estimateId = `${PFX}-est-${suffix}`;
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const eps = `${PFX}-eps-${suffix}`;
+        const ps = `${PFX}-ps-${suffix}`;
+
+        await prisma.estimate.create({
+            data: { id: estimateId, title: "MR Estimate", code: `EST-MR-${suffix}`, projectId: `${PFX}-project`, status: "Approved", totalAmount: 500, balanceDue: 500 },
+        });
+        await prisma.estimatePaymentSchedule.create({ data: { id: eps, estimateId, name: "Deposit", amount: 500, status: "Pending", order: 1 } });
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-MR-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, estimateId, status: "Issued", totalAmount: 500, balanceDue: 500 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: ps, invoiceId, name: "Deposit", amount: 500, status: "Pending", sourceScheduleId: eps } });
+
+        await expect(deleteInvoiceMilestoneCore(ps)).rejects.toThrow(/linked to the estimate/i);
+
+        const row = await prisma.paymentSchedule.findUnique({ where: { id: ps } });
+        expect(row).not.toBeNull(); // not deleted
+    });
+
+    test("rejects a QuickBooks-linked row", async () => {
+        await ensureClientAndProject();
+        const suffix = "qblinked";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const ps = `${PFX}-ps-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-MR-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 500, balanceDue: 500 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: ps, invoiceId, name: "Extra", amount: 500, status: "Pending", qbInvoiceId: "fake-qbo-2" } });
+
+        await expect(deleteInvoiceMilestoneCore(ps)).rejects.toThrow(/QuickBooks invoice staged/i);
+
+        const row = await prisma.paymentSchedule.findUnique({ where: { id: ps } });
+        expect(row).not.toBeNull(); // not deleted
+    });
+
+    test("deletes a pending extra and decrements the invoice total/balance", async () => {
+        await ensureClientAndProject();
+        const suffix = "delete-success";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psPaid = `${PFX}-ps-paid-${suffix}`;
+        const psExtra = `${PFX}-ps-extra-${suffix}`;
+
+        // 400 already paid, 600 pending extra with nothing else outstanding —
+        // deleting the extra should fully settle the invoice (balance → 0, Paid).
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-MR-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Partially Paid", totalAmount: 1000, balanceDue: 600 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psPaid, invoiceId, name: "Deposit", amount: 400, status: "Paid" } });
+        await prisma.paymentSchedule.create({ data: { id: psExtra, invoiceId, name: "Extra Charge", amount: 600, status: "Pending" } });
+
+        const res = await deleteInvoiceMilestoneCore(psExtra);
+        expect(res.success).toBe(true);
+        expect(res.invoiceId).toBe(invoiceId);
+
+        const deleted = await prisma.paymentSchedule.findUnique({ where: { id: psExtra } });
+        expect(deleted).toBeNull();
+
+        const invoice = await prisma.invoice.findUnique({ where: { id: invoiceId } });
+        expect(num(invoice!.totalAmount)).toBe(400);
+        expect(num(invoice!.balanceDue)).toBe(0);
+        expect(invoice!.status).toBe("Paid");
+    });
+});
+
+test.describe.serial("splitInvoiceMilestonesCore partially-paid total fix", () => {
+    test.afterAll(afterAllCleanup);
+
+    test("totalAmount = paid + newTotal, balanceDue = newTotal", async () => {
+        await ensureClientAndProject();
+        const suffix = "split-partial";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psPaid = `${PFX}-ps-paid-${suffix}`;
+        const psPending = `${PFX}-ps-pending-${suffix}`;
+
+        // 400 paid, 600 pending (old total 1000). Re-split the pending portion
+        // into a NEW total of 700 (not equal to the old pending total) so the
+        // fix is unambiguous: the old buggy code would have produced
+        // totalAmount=700 (dropping the paid 400) and balanceDue=300
+        // (max(0, 700-400)) instead of the correct 1100 / 700.
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-MR-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Partially Paid", totalAmount: 1000, balanceDue: 600 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psPaid, invoiceId, name: "Deposit", amount: 400, status: "Paid" } });
+        await prisma.paymentSchedule.create({ data: { id: psPending, invoiceId, name: "Final", amount: 600, status: "Pending" } });
+
+        const projectId = await splitInvoiceMilestonesCore(invoiceId, [
+            { name: "Progress 1", amount: 350 },
+            { name: "Progress 2", amount: 350 },
+        ]);
+        expect(projectId).toBe(`${PFX}-project`);
+
+        const invoice = await prisma.invoice.findUnique({ where: { id: invoiceId } });
+        expect(num(invoice!.totalAmount)).toBe(1100); // paid(400) + newTotal(700)
+        expect(num(invoice!.balanceDue)).toBe(700); // exactly the fresh pending total
+        expect(invoice!.status).toBe("Partially Paid");
+
+        // Paid row survives untouched; pending rows were replaced.
+        const paid = await prisma.paymentSchedule.findUnique({ where: { id: psPaid } });
+        expect(paid).not.toBeNull();
+        expect(num(paid!.amount)).toBe(400);
+
+        const remaining = await prisma.paymentSchedule.findMany({ where: { invoiceId, status: "Pending" } });
+        expect(remaining.length).toBe(2);
+        expect(remaining.reduce((sum, r) => sum + num(r.amount), 0)).toBe(700);
+    });
+});

--- a/src/app/projects/[id]/invoices/[invoiceId]/InvoiceEditor.tsx
+++ b/src/app/projects/[id]/invoices/[invoiceId]/InvoiceEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { recordPayment, issueInvoice, deleteInvoice, updateInvoiceNotes, addInvoiceMilestone, unrecordPayment, splitInvoiceMilestones, sendPaymentReceipt, createQBPaymentLink, refreshQBPayments, breakQBInvoiceLink, emailInvoiceCopyToMe } from "@/lib/actions";
+import { recordPayment, issueInvoice, deleteInvoice, updateInvoiceNotes, addInvoiceMilestone, unrecordPayment, splitInvoiceMilestones, sendPaymentReceipt, createQBPaymentLink, refreshQBPayments, breakQBInvoiceLink, emailInvoiceCopyToMe, updatePendingMilestoneAmounts, deleteInvoiceMilestone } from "@/lib/actions";
 import { useRouter } from "next/navigation";
 import StatusBadge from "@/components/StatusBadge";
 import SendInvoiceModal from "@/components/SendInvoiceModal";
@@ -49,6 +49,21 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
     const [qbBusy, setQbBusy] = useState<string | null>(null);
     const [isEmailingCopy, setIsEmailingCopy] = useState(false);
 
+    // Break QB Link confirm dialog (replaces window.confirm so the "also delete
+    // in QuickBooks" checkbox has somewhere to live).
+    const [breakQBTarget, setBreakQBTarget] = useState<{ id: string; name: string } | null>(null);
+    const [breakQBDeleteInQBO, setBreakQBDeleteInQBO] = useState(false);
+
+    // Edit amounts (rebalance Pending milestones without changing the invoice total)
+    type EditRow = { name: string; amount: string; dueDate: string };
+    const [editMode, setEditMode] = useState(false);
+    const [editRows, setEditRows] = useState<Record<string, EditRow>>({});
+    const [isSavingEdit, setIsSavingEdit] = useState(false);
+
+    // Delete a non-mirrored, non-QB-linked Pending milestone
+    const [deleteMilestoneTarget, setDeleteMilestoneTarget] = useState<{ id: string; name: string } | null>(null);
+    const [isDeletingMilestone, setIsDeletingMilestone] = useState(false);
+
     // On view: if any pending milestone is on the QuickBooks rail, pull settled
     // payments right now (the hourly cron is the backstop, this is the fast path).
     const qbCheckedRef = useRef(false);
@@ -94,25 +109,27 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
     }
 
     // Recover a milestone whose QuickBooks invoice was voided/deleted: clear the
-    // stale link so it can be re-created fresh. Money state is untouched.
-    async function handleBreakQBLink(payment: { id: string; name: string }) {
-        const ok = window.confirm(
-            `Break the QuickBooks link for "${payment.name}"?\n\n` +
-            `Use this when the QuickBooks invoice was voided or deleted and this milestone ` +
-            `is stuck on "Pending". It clears the QuickBooks link in ProBuild so you can ` +
-            `re-create it fresh with "QuickBooks Link".\n\n` +
-            `It does NOT change the paid/unpaid status, and does NOT delete the invoice in QuickBooks.`
-        );
-        if (!ok) return;
-        setQbBusy(payment.id);
+    // stale link so it can be re-created fresh. Money state is untouched. Opens
+    // the confirm dialog below (with the optional "also delete in QuickBooks"
+    // checkbox) instead of firing immediately.
+    function handleBreakQBLink(payment: { id: string; name: string }) {
+        setBreakQBDeleteInQBO(false);
+        setBreakQBTarget(payment);
+    }
+
+    async function confirmBreakQBLink() {
+        if (!breakQBTarget) return;
+        const target = breakQBTarget;
+        setQbBusy(target.id);
         try {
-            const res = await breakQBInvoiceLink(payment.id);
+            const res = await breakQBInvoiceLink(target.id, { deleteInQBO: breakQBDeleteInQBO });
             if (!res.success) {
                 toast.error(res.error);
                 return;
             }
             if (res.warning) toast.warning(res.warning);
             else toast.success("QuickBooks link cleared — you can now re-create it.");
+            setBreakQBTarget(null);
             router.refresh();
         } finally {
             setQbBusy(null);
@@ -205,6 +222,68 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
             toast.error(e?.message || "Failed to update payment schedule");
         } finally {
             setIsSplitting(false);
+        }
+    }
+
+    const pendingPayments = (initialInvoice.payments || []).filter((p: any) => p.status === "Pending");
+    const requiredRemaining = pendingPayments.reduce((sum: number, p: any) => sum + Number(p.amount || 0), 0);
+
+    function handleEnterEditMode() {
+        const rows: Record<string, EditRow> = {};
+        for (const p of pendingPayments) {
+            rows[p.id] = {
+                name: p.name,
+                amount: String(Number(p.amount)),
+                dueDate: p.dueDate ? new Date(p.dueDate).toISOString().slice(0, 10) : "",
+            };
+        }
+        setEditRows(rows);
+        setEditMode(true);
+        setShowSplit(false);
+        setShowAddMilestone(false);
+    }
+
+    function handleCancelEditMode() {
+        setEditMode(false);
+        setEditRows({});
+    }
+
+    const enteredSum = Object.values(editRows).reduce((sum, r) => sum + (parseFloat(r.amount) || 0), 0);
+    const editTotalsMatch = Math.abs(enteredSum - requiredRemaining) < 0.005;
+
+    async function handleSaveEdit() {
+        setIsSavingEdit(true);
+        try {
+            const rows = Object.entries(editRows).map(([scheduleId, r]) => ({
+                scheduleId,
+                name: r.name.trim(),
+                amount: parseFloat(r.amount) || 0,
+                dueDate: r.dueDate || null,
+            }));
+            const res = await updatePendingMilestoneAmounts(initialInvoice.id, rows);
+            for (const warning of res.warnings || []) toast.warning(warning);
+            if (!res.warnings || res.warnings.length === 0) toast.success("Payment schedule updated");
+            handleCancelEditMode();
+            router.refresh();
+        } catch (e: any) {
+            toast.error(e?.message || "Failed to update milestone amounts");
+        } finally {
+            setIsSavingEdit(false);
+        }
+    }
+
+    async function handleDeleteMilestone() {
+        if (!deleteMilestoneTarget) return;
+        setIsDeletingMilestone(true);
+        try {
+            await deleteInvoiceMilestone(deleteMilestoneTarget.id);
+            toast.success("Milestone deleted");
+            setDeleteMilestoneTarget(null);
+            router.refresh();
+        } catch (e: any) {
+            toast.error(e?.message || "Failed to delete milestone");
+        } finally {
+            setIsDeletingMilestone(false);
         }
     }
 
@@ -495,19 +574,33 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                                     {paidCount} of {totalCount} paid
                                 </span>
                                 <button
-                                    onClick={() => { setShowSplit(v => !v); setShowAddMilestone(false); }}
+                                    onClick={() => { setShowSplit(v => !v); setShowAddMilestone(false); if (editMode) handleCancelEditMode(); }}
                                     className="hui-btn hui-btn-secondary text-xs py-1 px-3 flex items-center gap-1"
                                 >
                                     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/></svg>
                                     {showSplit ? "Cancel" : "Split payments"}
                                 </button>
                                 <button
-                                    onClick={() => { setShowAddMilestone(v => !v); setShowSplit(false); }}
+                                    onClick={() => { setShowAddMilestone(v => !v); setShowSplit(false); if (editMode) handleCancelEditMode(); }}
                                     className="hui-btn hui-btn-secondary text-xs py-1 px-3 flex items-center gap-1"
                                 >
                                     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M12 5v14M5 12h14" /></svg>
                                     {showAddMilestone ? "Cancel" : "Add extra charge"}
                                 </button>
+                                {pendingPayments.length > 0 && (
+                                    <button
+                                        onClick={() => {
+                                            if (editMode) { handleCancelEditMode(); return; }
+                                            setShowSplit(false);
+                                            setShowAddMilestone(false);
+                                            handleEnterEditMode();
+                                        }}
+                                        className="hui-btn hui-btn-secondary text-xs py-1 px-3 flex items-center gap-1"
+                                    >
+                                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                                        {editMode ? "Cancel" : "Edit amounts"}
+                                    </button>
+                                )}
                             </div>
                         </div>
                         {showSplit && (
@@ -619,6 +712,33 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                                 </p>
                             </div>
                         )}
+                        {editMode && (
+                            <div className="px-6 py-3 border-b border-hui-border bg-indigo-50/40 flex items-center justify-between gap-4">
+                                <p className="text-xs text-hui-textMuted">
+                                    Edit the name, amount, or due date of the pending milestones below. The total must stay
+                                    the same — use "Add extra charge" or a change order to change the invoice total.
+                                </p>
+                                <div className="flex items-center gap-3 shrink-0">
+                                    <span className={`text-xs font-medium whitespace-nowrap ${editTotalsMatch ? "text-emerald-600" : "text-red-600"}`}>
+                                        Entered {formatCurrency(enteredSum)} / Required {formatCurrency(requiredRemaining)}
+                                    </span>
+                                    <button
+                                        onClick={handleCancelEditMode}
+                                        disabled={isSavingEdit}
+                                        className="hui-btn hui-btn-secondary text-sm disabled:opacity-50"
+                                    >
+                                        Cancel
+                                    </button>
+                                    <button
+                                        onClick={handleSaveEdit}
+                                        disabled={isSavingEdit || !editTotalsMatch}
+                                        className="hui-btn hui-btn-primary text-sm disabled:opacity-50"
+                                    >
+                                        {isSavingEdit ? "Saving..." : "Save"}
+                                    </button>
+                                </div>
+                            </div>
+                        )}
                         <div className="overflow-x-auto">
                         <table className="w-full min-w-[34rem] text-sm text-left">
                             <thead className="bg-white text-hui-textMuted border-b border-hui-border">
@@ -688,19 +808,44 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                                                 ) : null}
                                             </td>
                                             <td className="px-6 py-4 font-medium text-hui-textMain">
-                                                <div>{payment.name}</div>
-                                                {payment.status === 'Paid' && methodLabel && (
-                                                    <div className="text-[11px] text-hui-textMuted font-normal mt-0.5">{methodLabel}</div>
-                                                )}
-                                                {payment.status !== 'Paid' && sentLabel && (
-                                                    <div className="text-[11px] text-emerald-600 font-semibold mt-0.5 flex items-center gap-1">
-                                                        <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2.5"><path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>
-                                                        {sentLabel}
-                                                    </div>
+                                                {editMode && payment.status === 'Pending' ? (
+                                                    <>
+                                                        <input
+                                                            type="text"
+                                                            value={editRows[payment.id]?.name ?? ""}
+                                                            onChange={(e) => setEditRows(prev => ({ ...prev, [payment.id]: { ...prev[payment.id], name: e.target.value } }))}
+                                                            className="hui-input text-sm w-full"
+                                                        />
+                                                        {payment.qbInvoiceId && (
+                                                            <p className="text-[11px] text-amber-700 mt-1">
+                                                                QuickBooks invoice will be re-staged at the new amount.
+                                                            </p>
+                                                        )}
+                                                    </>
+                                                ) : (
+                                                    <>
+                                                        <div>{payment.name}</div>
+                                                        {payment.status === 'Paid' && methodLabel && (
+                                                            <div className="text-[11px] text-hui-textMuted font-normal mt-0.5">{methodLabel}</div>
+                                                        )}
+                                                        {payment.status !== 'Paid' && sentLabel && (
+                                                            <div className="text-[11px] text-emerald-600 font-semibold mt-0.5 flex items-center gap-1">
+                                                                <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2.5"><path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>
+                                                                {sentLabel}
+                                                            </div>
+                                                        )}
+                                                    </>
                                                 )}
                                             </td>
                                             <td className="px-6 py-4 text-hui-textMuted">
-                                                {payment.dueDate ? (
+                                                {editMode && payment.status === 'Pending' ? (
+                                                    <input
+                                                        type="date"
+                                                        value={editRows[payment.id]?.dueDate ?? ""}
+                                                        onChange={(e) => setEditRows(prev => ({ ...prev, [payment.id]: { ...prev[payment.id], dueDate: e.target.value } }))}
+                                                        className="hui-input text-sm w-full"
+                                                    />
+                                                ) : payment.dueDate ? (
                                                     <span className={isPastDue ? 'text-red-600 font-medium' : ''}>
                                                         {new Date(payment.dueDate).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })}
                                                         {isPastDue && <span className="ml-1 text-[10px] uppercase font-bold">overdue</span>}
@@ -721,7 +866,21 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                                                 </div>
                                             </td>
                                             <td className="px-6 py-4 text-right font-medium text-hui-textMain">
-                                                {formatCurrency(payment.amount)}
+                                                {editMode && payment.status === 'Pending' ? (
+                                                    <div className="relative">
+                                                        <span className="absolute left-3 top-1/2 -translate-y-1/2 text-hui-textMuted text-sm">$</span>
+                                                        <input
+                                                            type="number"
+                                                            min="0"
+                                                            step="0.01"
+                                                            value={editRows[payment.id]?.amount ?? ""}
+                                                            onChange={(e) => setEditRows(prev => ({ ...prev, [payment.id]: { ...prev[payment.id], amount: e.target.value } }))}
+                                                            className="hui-input text-sm pl-6 w-32 text-right"
+                                                        />
+                                                    </div>
+                                                ) : (
+                                                    formatCurrency(payment.amount)
+                                                )}
                                             </td>
                                             <td className="px-6 py-4 text-right text-hui-textMuted">
                                                 {payment.paymentDate
@@ -730,7 +889,10 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                                             </td>
                                             <td className="px-6 py-4 text-right">
                                                 <div className="flex items-center justify-end gap-2 flex-wrap">
-                                                    {payment.status !== 'Paid' && (
+                                                    {editMode && payment.status === 'Pending' && (
+                                                        <span className="text-xs text-hui-textMuted italic">Editing…</span>
+                                                    )}
+                                                    {!editMode && payment.status !== 'Paid' && (
                                                         <>
                                                         <button
                                                             onClick={() => handleQBLink(payment)}
@@ -768,6 +930,15 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                                                                 {qbBusy === payment.id ? "Working…" : "Break QB Link"}
                                                             </button>
                                                         )}
+                                                        {payment.status === 'Pending' && !payment.sourceScheduleId && !payment.qbInvoiceId && (
+                                                            <button
+                                                                onClick={() => setDeleteMilestoneTarget({ id: payment.id, name: payment.name })}
+                                                                title="Delete this milestone"
+                                                                className="p-1.5 rounded text-hui-textMuted hover:text-red-600 hover:bg-red-50 transition"
+                                                            >
+                                                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg>
+                                                            </button>
+                                                        )}
                                                         </>
                                                     )}
                                                     {payment.status === 'Paid' && (
@@ -803,6 +974,90 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
 
                 </div>
             </div>
+
+            {/* Break QB Link confirm dialog */}
+            {breakQBTarget && (
+                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4" onClick={() => setBreakQBTarget(null)}>
+                    <div className="bg-white rounded-xl shadow-2xl w-full max-w-md" onClick={e => e.stopPropagation()}>
+                        <div className="px-6 py-4 border-b border-slate-200 flex items-center justify-between bg-amber-50/50 rounded-t-xl">
+                            <h3 className="text-lg font-semibold text-slate-900">Break QuickBooks Link</h3>
+                            <button type="button" onClick={() => setBreakQBTarget(null)} className="text-slate-400 hover:text-slate-600 transition rounded-lg p-1 hover:bg-slate-100">
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6 6 18M6 6l12 12" /></svg>
+                            </button>
+                        </div>
+                        <div className="px-6 py-4 space-y-3">
+                            <p className="text-sm text-slate-700">
+                                Break the QuickBooks link for <strong>"{breakQBTarget.name}"</strong>?
+                            </p>
+                            <p className="text-xs text-slate-500">
+                                Use this when the QuickBooks invoice was voided or deleted and this milestone is stuck
+                                on "Pending". It clears the QuickBooks link in ProBuild so you can re-create it fresh
+                                with "QuickBooks Link". It does NOT change the paid/unpaid status.
+                            </p>
+                            <label className="flex items-start gap-2 text-sm text-slate-700 bg-slate-50 border border-slate-200 rounded-lg px-3 py-2.5 cursor-pointer">
+                                <input
+                                    type="checkbox"
+                                    checked={breakQBDeleteInQBO}
+                                    onChange={(e) => setBreakQBDeleteInQBO(e.target.checked)}
+                                    className="mt-0.5 rounded border-gray-300 text-emerald-600 focus:ring-emerald-500"
+                                />
+                                <span>
+                                    Also delete the staged invoice in QuickBooks.
+                                    {breakQBDeleteInQBO
+                                        ? " This WILL delete it in QuickBooks (if it has no linked payment)."
+                                        : " Leave unchecked to keep the QuickBooks invoice as-is (e.g. a voided invoice kept for audit)."}
+                                </span>
+                            </label>
+                        </div>
+                        <div className="px-6 py-4 border-t border-slate-200 flex items-center justify-end gap-2 bg-slate-50/50 rounded-b-xl">
+                            <button type="button" onClick={() => setBreakQBTarget(null)} disabled={qbBusy === breakQBTarget.id} className="hui-btn hui-btn-secondary">
+                                Cancel
+                            </button>
+                            <button
+                                type="button"
+                                onClick={confirmBreakQBLink}
+                                disabled={qbBusy === breakQBTarget.id}
+                                className="hui-btn bg-red-600 text-white hover:bg-red-700 disabled:opacity-40 disabled:cursor-not-allowed transition"
+                            >
+                                {qbBusy === breakQBTarget.id ? "Working…" : "Break Link"}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Delete Milestone confirm dialog */}
+            {deleteMilestoneTarget && (
+                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4" onClick={() => setDeleteMilestoneTarget(null)}>
+                    <div className="bg-white rounded-xl shadow-2xl w-full max-w-md" onClick={e => e.stopPropagation()}>
+                        <div className="px-6 py-4 border-b border-slate-200 flex items-center justify-between bg-red-50/50 rounded-t-xl">
+                            <h3 className="text-lg font-semibold text-slate-900">Delete Milestone</h3>
+                            <button type="button" onClick={() => setDeleteMilestoneTarget(null)} className="text-slate-400 hover:text-slate-600 transition rounded-lg p-1 hover:bg-slate-100">
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6 6 18M6 6l12 12" /></svg>
+                            </button>
+                        </div>
+                        <div className="px-6 py-4">
+                            <p className="text-sm text-slate-700">
+                                Delete <strong>"{deleteMilestoneTarget.name}"</strong>? This removes the milestone and
+                                lowers the invoice total by its amount. This cannot be undone.
+                            </p>
+                        </div>
+                        <div className="px-6 py-4 border-t border-slate-200 flex items-center justify-end gap-2 bg-slate-50/50 rounded-b-xl">
+                            <button type="button" onClick={() => setDeleteMilestoneTarget(null)} disabled={isDeletingMilestone} className="hui-btn hui-btn-secondary">
+                                Cancel
+                            </button>
+                            <button
+                                type="button"
+                                onClick={handleDeleteMilestone}
+                                disabled={isDeletingMilestone}
+                                className="hui-btn bg-red-600 text-white hover:bg-red-700 disabled:opacity-40 disabled:cursor-not-allowed transition"
+                            >
+                                {isDeletingMilestone ? "Deleting…" : "Delete Milestone"}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
 
             {/* Send Invoice Modal */}
             {showSendModal && (

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -3614,27 +3614,11 @@ export async function breakQBInvoiceLink(
         return { success: false, error: "This milestone has no QuickBooks link to break." };
     }
 
-    // Claim the unlink atomically: the guard fields go in the WHERE, so if the QB
-    // sync settles this milestone (status→Paid, qbPaymentId set) between the read
-    // above and this write, the claim matches 0 rows and we never strip QB fields
-    // off a now-paid row. `qbInvoiceId` is pinned to the value we read so a
-    // concurrent re-push (new id) can't be clobbered either.
-    const cleared = await prisma.paymentSchedule.updateMany({
-        where: {
-            id: schedule.id,
-            status: { not: "Paid" },
-            qbPaymentId: null,
-            qbInvoiceId: schedule.qbInvoiceId,
-        },
-        data: {
-            qbInvoiceId: null,
-            qbInvoiceLink: null,
-            qbInvoiceSentAt: null,
-            qbSyncedAt: null,
-            qbSyncError: null,
-        },
-    });
-    if (cleared.count !== 1) {
+    // Claim the unlink atomically via the shared helper (also used by
+    // updatePendingMilestoneAmountsCore) — see its doc comment for the race it closes.
+    const { claimQBInvoiceUnlink } = await import("./quickbooks-payments");
+    const cleared = await claimQBInvoiceUnlink(prisma, schedule.id, schedule.qbInvoiceId);
+    if (!cleared) {
         return { success: false, error: "This milestone changed while unlinking (it may have just been paid or re-synced). Refresh and try again." };
     }
 
@@ -4145,81 +4129,57 @@ export async function splitInvoiceMilestones(
 ) {
     await assertInvoicePermission();
 
-    if (!milestones.length) throw new Error("At least one milestone is required");
-
-    const validated = milestones.map((m, i) => {
-        const name = (m.name || "").trim();
-        const amount = Math.round(Number(m.amount) * 100) / 100;
-        if (!name) throw new Error(`Milestone ${i + 1}: name is required`);
-        if (!Number.isFinite(amount) || amount <= 0) throw new Error(`Milestone ${i + 1}: amount must be greater than zero`);
-        return { name, amount, dueDate: m.dueDate || null };
-    });
-
-    const newTotal = Math.round(validated.reduce((s, m) => s + m.amount, 0) * 100) / 100;
-
-    // Interactive tx, invoice locked FIRST (canonical Estimate → Invoice order; this flow touches
-    // only the invoice). The paid portion is re-read from the LOCKED invoice, so a concurrent
-    // settle on a surviving Paid milestone can't leave paidAmount stale and get its balance
-    // overwritten. Arithmetic is otherwise unchanged from the original array-form transaction.
-    const projectId = await withTxRetry(() => prisma.$transaction(async (tx) => {
-        await lockMoneyParents(tx, { invoiceId });
-        const invoice = await tx.invoice.findUnique({ where: { id: invoiceId } });
-        if (!invoice) throw new Error("Invoice not found");
-
-        // Refuse to re-split while a payment is in flight on a non-Paid milestone. The delete
-        // below drops every non-Paid schedule; if one has an open Stripe checkout or a sent
-        // QuickBooks invoice, a settlement landing afterward would find no row to claim and the
-        // customer would be charged with nothing to reconcile against. Checked under the invoice
-        // lock so a checkout/QB-send starting concurrently can't slip in after this guard.
-        const inFlight = await tx.paymentSchedule.findFirst({
-            where: {
-                invoiceId,
-                status: { not: "Paid" },
-                OR: [
-                    { stripeSessionId: { not: null } },
-                    { stripePaymentIntentId: { not: null } },
-                    { qbInvoiceId: { not: null } },
-                ],
-            },
-            select: { name: true },
-        });
-        if (inFlight) {
-            throw new Error(
-                `A payment is in progress on this invoice (milestone "${inFlight.name}"). Wait for it to finish or void it before re-splitting the milestones.`,
-            );
-        }
-
-        // Recalculate balanceDue: paid amount stays the same, only pending changes
-        const paidAmount = Math.round(
-            (Number(invoice.totalAmount) - Number(invoice.balanceDue)) * 100,
-        ) / 100;
-        const newBalance = Math.max(0, Math.round((newTotal - paidAmount) * 100) / 100);
-        const newStatus =
-            newBalance <= 0 ? "Paid"
-            : invoice.status === "Draft" ? "Draft"
-            : invoice.status === "Overdue" ? "Overdue"
-            : "Issued";
-
-        await tx.paymentSchedule.deleteMany({ where: { invoiceId, status: { not: "Paid" } } });
-        await tx.paymentSchedule.createMany({
-            data: validated.map((m) => ({
-                invoiceId,
-                name: m.name,
-                amount: m.amount,
-                status: "Pending",
-                dueDate: m.dueDate ? new Date(m.dueDate) : null,
-            })),
-        });
-        await tx.invoice.update({
-            where: { id: invoiceId },
-            data: { totalAmount: newTotal, balanceDue: newBalance, status: newStatus },
-        });
-        return invoice.projectId;
-    }));
+    const { splitInvoiceMilestonesCore } = await import("./billing-core");
+    const projectId = await splitInvoiceMilestonesCore(invoiceId, milestones);
 
     revalidatePath(`/projects/${projectId}/invoices`);
     revalidatePath(`/projects/${projectId}/invoices/${invoiceId}`);
     revalidatePath(`/invoices`);
+
+    return { success: true };
+}
+
+/**
+ * Re-price the Pending milestones on an invoice without changing the invoice
+ * total ("Edit amounts"). See `updatePendingMilestoneAmountsCore` for the
+ * validation, mirror-sync, and QuickBooks re-stage details.
+ */
+export async function updatePendingMilestoneAmounts(
+    invoiceId: string,
+    rows: { scheduleId: string; name: string; amount: number; dueDate?: string | null }[],
+) {
+    await assertInvoicePermission();
+
+    const { updatePendingMilestoneAmountsCore } = await import("./billing-core");
+    const result = await updatePendingMilestoneAmountsCore(invoiceId, rows);
+
+    // Same paths splitInvoiceMilestones revalidates.
+    const invoice = await prisma.invoice.findUnique({ where: { id: invoiceId }, select: { projectId: true } });
+    if (invoice) {
+        revalidatePath(`/projects/${invoice.projectId}/invoices`);
+        revalidatePath(`/projects/${invoice.projectId}/invoices/${invoiceId}`);
+    }
+    revalidatePath(`/invoices`);
+
+    return result;
+}
+
+/**
+ * Delete a Pending, non-mirrored, non-QB-linked "extra charge" milestone —
+ * the inverse of `addInvoiceMilestone`. QB-linked rows must be unlinked via
+ * Break QB Link first; this action is DB-only.
+ */
+export async function deleteInvoiceMilestone(scheduleId: string) {
+    await assertInvoicePermission();
+
+    const { deleteInvoiceMilestoneCore } = await import("./billing-core");
+    const result = await deleteInvoiceMilestoneCore(scheduleId);
+
+    revalidatePath(`/projects/${result.projectId}/invoices`);
+    revalidatePath(`/projects/${result.projectId}/invoices/${result.invoiceId}`);
+    revalidatePath(`/invoices`);
+    revalidatePath(`/portal`);
+    revalidatePath(`/reports/open-invoices`);
 
     return { success: true };
 }

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -2275,8 +2275,15 @@ async function ensureProjectAndDepositInvoiceForEstimate(estimateId: string): Pr
         try {
             const { pushMilestoneToQuickBooks } = await import("./quickbooks-payments");
             for (const milestone of pendingMilestones) {
-                const pushed = await pushMilestoneToQuickBooks(milestone.id);
-                if (milestone.id === deposit?.id) payLink = pushed.payLink;
+                // Per-milestone catch: one milestone failing (e.g. it changed mid-push
+                // and the conditional link claim refused) must not stop the remaining
+                // milestones from getting their QuickBooks links.
+                try {
+                    const pushed = await pushMilestoneToQuickBooks(milestone.id);
+                    if (milestone.id === deposit?.id) payLink = pushed.payLink;
+                } catch (e) {
+                    console.warn(`[approveEstimate] QuickBooks push skipped for milestone "${milestone.name}":`, e instanceof Error ? e.message : e);
+                }
             }
         } catch (e) {
             // QuickBooks not connected or unreachable — Stripe portal payment and

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -1586,7 +1586,11 @@ export async function updatePendingMilestoneAmountsCore(
     type QBAffected = { scheduleId: string; name: string; oldQbInvoiceId: string };
 
     const qbAffected = await withTxRetry(() => prisma.$transaction(async (tx) => {
-        await lockMoneyParents(tx, { invoiceId });
+        // Canonical lock order: Estimate → Invoice → schedules. The mirror sync
+        // below writes estimate-side rows, so read the estimate link (non-locking)
+        // and lock the Estimate before the Invoice — same pattern as unrecordPayment.
+        const invLink = await tx.invoice.findUnique({ where: { id: invoiceId }, select: { estimateId: true } });
+        await lockMoneyParents(tx, { estimateId: invLink?.estimateId, invoiceId });
 
         const existing = await tx.paymentSchedule.findMany({ where: { invoiceId } });
         const existingMap = new Map(existing.map((s) => [s.id, s]));

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -1554,12 +1554,14 @@ export type RebalanceMilestoneRow = { scheduleId: string; name: string; amount: 
  * in `rows` (the new amounts must sum to the same pending balance they replace);
  * `invoice.totalAmount`/`balanceDue` are never touched here.
  *
- * Rows whose amount changes while carrying a QuickBooks invoice are unlinked
- * atomically (via `claimQBInvoiceUnlink`, shared with `breakQBInvoiceLink` — a
- * concurrent settle wins and aborts the whole rebalance) and re-staged at the
- * new amount post-commit, sequentially, on one shared token fetch. A recreate
- * failure is reported as a warning, not rolled back — the row is already safely
- * unlinked locally and can be re-staged later via "QuickBooks Link".
+ * Rows that change while carrying a QuickBooks invoice have that QBO invoice
+ * replaced post-commit, sequentially, on one shared token fetch: probe (refuse
+ * if a not-yet-pulled payment exists), delete in QBO, then atomically unlink
+ * (via `claimQBInvoiceUnlink`, shared with `breakQBInvoiceLink` — a concurrent
+ * settle wins the claim) and re-stage at the new amount. The link is only ever
+ * cleared AFTER the old QBO invoice is confirmed gone, so a QBO-side payment
+ * can never be stranded behind a cleared link. Every failure mode degrades to
+ * a per-row warning; the DB changes are never rolled back.
  */
 export async function updatePendingMilestoneAmountsCore(
     invoiceId: string,
@@ -1621,17 +1623,39 @@ export async function updatePendingMilestoneAmountsCore(
             );
         }
 
+        // Total-preserving PER POOL, not just invoice-wide: estimate-mirrored rows
+        // and invoice-only extras must each keep their own sum. A single invoice
+        // total check would let money slide between the pools — the per-row mirror
+        // below would then desync the estimate-side schedule from the estimate
+        // total (e.g. the invoice reads paid while the estimate still shows a
+        // balance due).
+        const sumCents = (vals: number[]) => Math.round(vals.reduce((s, v) => s + v, 0) * 100) / 100;
+        const currentMirrored = sumCents(pendingRows.filter((s) => s.sourceScheduleId).map((s) => toNum(s.amount)));
+        const newMirrored = sumCents(parsed.filter((r) => existingMap.get(r.scheduleId)!.sourceScheduleId).map((r) => r.amount));
+        if (Math.abs(newMirrored - currentMirrored) > 0.005) {
+            throw new Error(
+                `New amounts move money between estimate-linked milestones and extra charges. ` +
+                `Estimate-linked milestones must still total ${formatCurrency(currentMirrored)} ` +
+                `(entered: ${formatCurrency(newMirrored)}) so the estimate's payment schedule stays in sync.`
+            );
+        }
+
         const affected: QBAffected[] = [];
         for (const r of parsed) {
             const row = existingMap.get(r.scheduleId)!;
             const amountChanged = Math.abs(toNum(row.amount) - r.amount) > 0.005;
+            const nameChanged = row.name !== r.name;
+            const dueDateChanged =
+                (row.dueDate ? row.dueDate.toISOString().slice(0, 10) : null) !==
+                (r.dueDate ? r.dueDate.slice(0, 10) : null);
 
-            if (row.qbInvoiceId && amountChanged) {
-                const { claimQBInvoiceUnlink } = await import("./quickbooks-payments");
-                const claimed = await claimQBInvoiceUnlink(tx, row.id, row.qbInvoiceId);
-                if (!claimed) {
-                    throw new Error(`"${row.name}"'s QuickBooks invoice was just settled — reload and try again.`);
-                }
+            // A QB-linked row whose content changes needs its staged QBO invoice
+            // replaced (QBO invoices are create-only here — no update path). The
+            // link is deliberately KEPT through this transaction: unlinking happens
+            // post-commit only AFTER the old QBO invoice is confirmed payment-free
+            // and actually deleted, so a payment that landed in QBO but hasn't been
+            // pulled yet can never be orphaned behind a cleared link.
+            if (row.qbInvoiceId && (amountChanged || nameChanged || dueDateChanged)) {
                 affected.push({ scheduleId: row.id, name: r.name, oldQbInvoiceId: row.qbInvoiceId });
             }
 
@@ -1665,23 +1689,40 @@ export async function updatePendingMilestoneAmountsCore(
     }));
 
     // Post-commit QBO resync: one shared token fetch, sequential per affected row.
+    // Order per row is deliberate — probe, refuse if paid, delete in QBO, and only
+    // THEN unlink locally (atomic claim) and re-stage. Unlinking last means a QBO
+    // payment the poller hasn't pulled yet can never be stranded behind a cleared
+    // link: until the old invoice is confirmed gone, the row keeps pointing at it
+    // and the payment poller keeps watching it.
     const warnings: string[] = [];
     if (qbAffected.length > 0) {
         try {
-            const { getFreshQBTokens, pushMilestoneToQuickBooks } = await import("./quickbooks-payments");
+            const { getFreshQBTokens, pushMilestoneToQuickBooks, claimQBInvoiceUnlink } = await import("./quickbooks-payments");
             const { deleteQBInvoice, probeQBInvoice } = await import("./quickbooks");
             const tokens = await getFreshQBTokens();
             for (const row of qbAffected) {
                 try {
-                    // Tolerate a QBO invoice that's already gone/voided; only an "ok"
-                    // invoice needs an actual delete call. Anything else (a genuine
-                    // refusal, or an inconclusive probe) stops the re-stage for this
-                    // row — it stays safely unlinked locally.
                     const probe = await probeQBInvoice(tokens, row.oldQbInvoiceId);
+                    if (probe.state === "error") {
+                        warnings.push(`"${row.name}": couldn't reach QuickBooks to replace the staged invoice — it still shows the old details. Retry, or use "Break QB Link" and re-stage.`);
+                        continue;
+                    }
+                    if (probe.state === "ok" && (probe.paymentTxnIds.length > 0 || Math.abs(probe.balance - probe.total) > 0.005)) {
+                        // A payment already exists on the old QBO invoice that ProBuild
+                        // hasn't pulled yet. Do NOT delete or unlink — leave the link so
+                        // the poller settles it — and tell the user to reconcile first.
+                        warnings.push(`"${row.name}": a payment exists on its QuickBooks invoice that ProBuild hasn't pulled yet — run "Refresh QB payments" and review before changing this milestone.`);
+                        continue;
+                    }
                     const alreadyGone = probe.state === "voided" || probe.state === "notFound";
-                    const deleted = alreadyGone || (probe.state === "ok" && await deleteQBInvoice(tokens, row.oldQbInvoiceId));
-                    if (!deleted) {
-                        warnings.push(`"${row.name}": couldn't delete the old QuickBooks invoice — re-stage it via "QuickBooks Link".`);
+                    if (!alreadyGone && !(await deleteQBInvoice(tokens, row.oldQbInvoiceId))) {
+                        warnings.push(`"${row.name}": couldn't delete the old QuickBooks invoice — it still shows the old details. Retry, or use "Break QB Link" and re-stage.`);
+                        continue;
+                    }
+                    // Old QBO invoice is confirmed gone — now clear the link, atomically
+                    // (a concurrent settle still wins the claim and we stop here).
+                    if (!(await claimQBInvoiceUnlink(prisma, row.scheduleId, row.oldQbInvoiceId))) {
+                        warnings.push(`"${row.name}": milestone changed while replacing its QuickBooks invoice — refresh and review before re-staging.`);
                         continue;
                     }
                     await pushMilestoneToQuickBooks(row.scheduleId, tokens);
@@ -1690,11 +1731,12 @@ export async function updatePendingMilestoneAmountsCore(
                 }
             }
         } catch (e) {
-            // Token fetch itself failed (QB not connected/unreachable) — every
-            // affected row is already unlinked locally, so warn once per row.
+            // Token fetch itself failed (QB not connected/unreachable). Nothing was
+            // unlinked — every affected row still points at its old QBO invoice,
+            // which now shows outdated details. Warn once per row.
             const reason = e instanceof Error ? e.message : "QuickBooks unavailable";
             for (const row of qbAffected) {
-                warnings.push(`"${row.name}": QuickBooks unavailable (${reason}) — re-stage it via "QuickBooks Link".`);
+                warnings.push(`"${row.name}": QuickBooks unavailable (${reason}) — its staged QuickBooks invoice still shows the old details. Use "Break QB Link" and re-stage once QuickBooks is back.`);
             }
         }
     }
@@ -1740,12 +1782,13 @@ export async function deleteInvoiceMilestoneCore(
         const newTotal = Math.round((toNum(invoice.totalAmount) - amount) * 100) / 100;
         const newBalance = Math.max(0, Math.round((toNum(invoice.balanceDue) - amount) * 100) / 100);
         // Inverse of addInvoiceMilestone's ladder: a pure decrement can only ever
-        // free up balance, so the only possible transitions are Paid (fully
-        // settled once this pending extra is gone) or Paid→Partially Paid (this
-        // extra was the only thing keeping a fully-paid invoice open); everything
-        // else (Draft/Issued/Overdue/Partially Paid) is unaffected by a decrement.
+        // free up balance. "Paid" requires actual money received — a zero balance
+        // reached by deleting the only pending row on an invoice with no payments
+        // (e.g. a Draft whose sole extra is removed) keeps its current status
+        // rather than reading as settled.
+        const paidAmount = Math.round((toNum(invoice.totalAmount) - toNum(invoice.balanceDue)) * 100) / 100;
         const nextStatus =
-            newBalance <= 0 ? "Paid"
+            newBalance <= 0 ? (paidAmount > 0.005 ? "Paid" : invoice.status)
             : invoice.status === "Paid" ? "Partially Paid"
             : invoice.status;
 

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -1540,3 +1540,317 @@ export async function createChangeOrderDraft(input: ChangeOrderDraftInput) {
         note: "Draft only — review and send it to the customer from ProBuild.",
     };
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Invoice milestone rebalance / delete / split — session-free cores for the
+// permission-gated actions in actions.ts (addInvoiceMilestone's siblings).
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type RebalanceMilestoneRow = { scheduleId: string; name: string; amount: number; dueDate?: string | null };
+
+/**
+ * Re-price the Pending milestones on an invoice without changing the invoice
+ * total — the "Edit amounts" flow. Every currently-Pending row must be present
+ * in `rows` (the new amounts must sum to the same pending balance they replace);
+ * `invoice.totalAmount`/`balanceDue` are never touched here.
+ *
+ * Rows whose amount changes while carrying a QuickBooks invoice are unlinked
+ * atomically (via `claimQBInvoiceUnlink`, shared with `breakQBInvoiceLink` — a
+ * concurrent settle wins and aborts the whole rebalance) and re-staged at the
+ * new amount post-commit, sequentially, on one shared token fetch. A recreate
+ * failure is reported as a warning, not rolled back — the row is already safely
+ * unlinked locally and can be re-staged later via "QuickBooks Link".
+ */
+export async function updatePendingMilestoneAmountsCore(
+    invoiceId: string,
+    rows: RebalanceMilestoneRow[],
+): Promise<{ success: true; warnings: string[] }> {
+    if (!rows.length) throw new Error("At least one milestone row is required");
+
+    const parsed = rows.map((r) => ({
+        scheduleId: r.scheduleId,
+        name: (r.name || "").trim(),
+        amount: Math.round(Number(r.amount) * 100) / 100,
+        dueDate: r.dueDate || null,
+    }));
+    for (const r of parsed) {
+        if (!r.scheduleId) throw new Error("Missing milestone id");
+        if (!r.name) throw new Error("Milestone name is required");
+        if (!Number.isFinite(r.amount) || r.amount <= 0) {
+            throw new Error(`"${r.name || r.scheduleId}": amount must be greater than zero`);
+        }
+    }
+    const seenIds = new Set(parsed.map((r) => r.scheduleId));
+    if (seenIds.size !== parsed.length) throw new Error("Duplicate milestone in the same request");
+
+    type QBAffected = { scheduleId: string; name: string; oldQbInvoiceId: string };
+
+    const qbAffected = await withTxRetry(() => prisma.$transaction(async (tx) => {
+        await lockMoneyParents(tx, { invoiceId });
+
+        const existing = await tx.paymentSchedule.findMany({ where: { invoiceId } });
+        const existingMap = new Map(existing.map((s) => [s.id, s]));
+
+        for (const r of parsed) {
+            const row = existingMap.get(r.scheduleId);
+            if (!row) throw new Error(`Milestone not found: ${r.scheduleId}`);
+            if (row.status !== "Pending") throw new Error(`"${row.name}" is not Pending — only pending milestones can be rebalanced`);
+            if (row.stripeSessionId || row.stripePaymentIntentId) {
+                throw new Error(`A payment is in progress on "${row.name}". Wait for it to finish or void it before rebalancing.`);
+            }
+        }
+
+        // Every currently-Pending row must be accounted for — a partial submission
+        // can't total-preserve since the rows left out would be silently excluded
+        // from both sides of the comparison below.
+        const pendingRows = existing.filter((s) => s.status === "Pending");
+        if (pendingRows.length !== parsed.length || !pendingRows.every((s) => seenIds.has(s.id))) {
+            throw new Error("All pending milestones must be included in the rebalance");
+        }
+
+        const currentPendingTotal = Math.round(pendingRows.reduce((sum, s) => sum + toNum(s.amount), 0) * 100) / 100;
+        const newTotal = Math.round(parsed.reduce((sum, r) => sum + r.amount, 0) * 100) / 100;
+        if (Math.abs(newTotal - currentPendingTotal) > 0.005) {
+            throw new Error(
+                `New amounts total ${formatCurrency(newTotal)}, but the pending balance is ${formatCurrency(currentPendingTotal)}. ` +
+                `Rebalancing can't change the invoice total — use "Add extra charge" or a change order for that.`
+            );
+        }
+
+        const affected: QBAffected[] = [];
+        for (const r of parsed) {
+            const row = existingMap.get(r.scheduleId)!;
+            const amountChanged = Math.abs(toNum(row.amount) - r.amount) > 0.005;
+
+            if (row.qbInvoiceId && amountChanged) {
+                const { claimQBInvoiceUnlink } = await import("./quickbooks-payments");
+                const claimed = await claimQBInvoiceUnlink(tx, row.id, row.qbInvoiceId);
+                if (!claimed) {
+                    throw new Error(`"${row.name}"'s QuickBooks invoice was just settled — reload and try again.`);
+                }
+                affected.push({ scheduleId: row.id, name: r.name, oldQbInvoiceId: row.qbInvoiceId });
+            }
+
+            await tx.paymentSchedule.update({
+                where: { id: r.scheduleId },
+                data: {
+                    name: r.name,
+                    amount: r.amount,
+                    dueDate: r.dueDate ? new Date(r.dueDate) : null,
+                },
+            });
+
+            // Mirror onto the linked estimate-side row (unpaid only). The new amount
+            // is no longer necessarily the same share of the estimate total, so clear
+            // `percentage` rather than guess one — consistent with saveEstimate's
+            // differential upsert, which nulls `percentage` whenever the incoming
+            // payload doesn't carry one for the row's new amount.
+            if (row.sourceScheduleId) {
+                await tx.estimatePaymentSchedule.updateMany({
+                    where: { id: row.sourceScheduleId, status: { not: "Paid" } },
+                    data: {
+                        name: r.name,
+                        amount: r.amount,
+                        dueDate: r.dueDate ? new Date(r.dueDate) : null,
+                        percentage: null,
+                    },
+                });
+            }
+        }
+        return affected;
+    }));
+
+    // Post-commit QBO resync: one shared token fetch, sequential per affected row.
+    const warnings: string[] = [];
+    if (qbAffected.length > 0) {
+        try {
+            const { getFreshQBTokens, pushMilestoneToQuickBooks } = await import("./quickbooks-payments");
+            const { deleteQBInvoice, probeQBInvoice } = await import("./quickbooks");
+            const tokens = await getFreshQBTokens();
+            for (const row of qbAffected) {
+                try {
+                    // Tolerate a QBO invoice that's already gone/voided; only an "ok"
+                    // invoice needs an actual delete call. Anything else (a genuine
+                    // refusal, or an inconclusive probe) stops the re-stage for this
+                    // row — it stays safely unlinked locally.
+                    const probe = await probeQBInvoice(tokens, row.oldQbInvoiceId);
+                    const alreadyGone = probe.state === "voided" || probe.state === "notFound";
+                    const deleted = alreadyGone || (probe.state === "ok" && await deleteQBInvoice(tokens, row.oldQbInvoiceId));
+                    if (!deleted) {
+                        warnings.push(`"${row.name}": couldn't delete the old QuickBooks invoice — re-stage it via "QuickBooks Link".`);
+                        continue;
+                    }
+                    await pushMilestoneToQuickBooks(row.scheduleId, tokens);
+                } catch (e) {
+                    warnings.push(`"${row.name}": QuickBooks re-stage failed (${e instanceof Error ? e.message : "unknown error"}) — re-stage it via "QuickBooks Link".`);
+                }
+            }
+        } catch (e) {
+            // Token fetch itself failed (QB not connected/unreachable) — every
+            // affected row is already unlinked locally, so warn once per row.
+            const reason = e instanceof Error ? e.message : "QuickBooks unavailable";
+            for (const row of qbAffected) {
+                warnings.push(`"${row.name}": QuickBooks unavailable (${reason}) — re-stage it via "QuickBooks Link".`);
+            }
+        }
+    }
+
+    return { success: true, warnings };
+}
+
+/**
+ * Delete a Pending, non-mirrored, non-QB-linked "extra charge" milestone —
+ * the exact inverse of `addInvoiceMilestone`. QB-linked rows must go through
+ * Break QB Link first (this is DB-only, no QBO call).
+ */
+export async function deleteInvoiceMilestoneCore(
+    scheduleId: string,
+): Promise<{ success: true; projectId: string; invoiceId: string }> {
+    return withTxRetry(() => prisma.$transaction(async (tx) => {
+        const row = await tx.paymentSchedule.findUnique({ where: { id: scheduleId } });
+        if (!row) throw new Error("Milestone not found");
+
+        await lockMoneyParents(tx, { invoiceId: row.invoiceId });
+
+        // Re-read under the invoice lock — a concurrent write between the first
+        // read and the lock could have changed status/links.
+        const locked = await tx.paymentSchedule.findUnique({ where: { id: scheduleId } });
+        if (!locked) throw new Error("Milestone not found");
+        if (locked.status !== "Pending") throw new Error("Only pending milestones can be deleted");
+        if (locked.sourceScheduleId) {
+            throw new Error("This milestone is linked to the estimate — remove it from the estimate's payment schedule instead");
+        }
+        if (locked.qbInvoiceId) {
+            throw new Error(`This milestone has a QuickBooks invoice staged — break the QuickBooks link first, then delete.`);
+        }
+        if (locked.stripeSessionId || locked.stripePaymentIntentId) {
+            throw new Error("A payment is in progress on this milestone — wait for it to finish or void it before deleting");
+        }
+
+        await tx.paymentSchedule.delete({ where: { id: scheduleId } });
+
+        const invoice = await tx.invoice.findUnique({ where: { id: locked.invoiceId } });
+        if (!invoice) throw new Error("Invoice not found");
+
+        const amount = toNum(locked.amount);
+        const newTotal = Math.round((toNum(invoice.totalAmount) - amount) * 100) / 100;
+        const newBalance = Math.max(0, Math.round((toNum(invoice.balanceDue) - amount) * 100) / 100);
+        // Inverse of addInvoiceMilestone's ladder: a pure decrement can only ever
+        // free up balance, so the only possible transitions are Paid (fully
+        // settled once this pending extra is gone) or Paid→Partially Paid (this
+        // extra was the only thing keeping a fully-paid invoice open); everything
+        // else (Draft/Issued/Overdue/Partially Paid) is unaffected by a decrement.
+        const nextStatus =
+            newBalance <= 0 ? "Paid"
+            : invoice.status === "Paid" ? "Partially Paid"
+            : invoice.status;
+
+        await tx.invoice.update({
+            where: { id: invoice.id },
+            data: {
+                totalAmount: newTotal,
+                balanceDue: newBalance,
+                ...(nextStatus !== invoice.status ? { status: nextStatus } : {}),
+            },
+        });
+
+        return { success: true as const, projectId: invoice.projectId, invoiceId: invoice.id };
+    }));
+}
+
+/**
+ * Replace every non-Paid milestone on an invoice with a fresh set — the
+ * "Split payments" flow. Moved from actions.ts verbatim except the arithmetic
+ * fix below; behavior for the caller is unchanged.
+ *
+ * KNOWN LIMITATION: this deletes and recreates every non-Paid row, so any
+ * `sourceScheduleId` link to an estimate-side mirror is dropped — the new rows
+ * are unlinked extras. `updatePendingMilestoneAmountsCore` (re-price in place)
+ * is the correct tool when the mirror link must survive.
+ */
+export async function splitInvoiceMilestonesCore(
+    invoiceId: string,
+    milestones: { name: string; amount: number; dueDate?: string | null }[],
+): Promise<string> {
+    if (!milestones.length) throw new Error("At least one milestone is required");
+
+    const validated = milestones.map((m, i) => {
+        const name = (m.name || "").trim();
+        const amount = Math.round(Number(m.amount) * 100) / 100;
+        if (!name) throw new Error(`Milestone ${i + 1}: name is required`);
+        if (!Number.isFinite(amount) || amount <= 0) throw new Error(`Milestone ${i + 1}: amount must be greater than zero`);
+        return { name, amount, dueDate: m.dueDate || null };
+    });
+
+    const newTotal = Math.round(validated.reduce((s, m) => s + m.amount, 0) * 100) / 100;
+
+    // Interactive tx, invoice locked FIRST (canonical Estimate → Invoice order; this flow touches
+    // only the invoice). The paid portion is re-read from the LOCKED invoice, so a concurrent
+    // settle on a surviving Paid milestone can't leave paidAmount stale and get its balance
+    // overwritten. Arithmetic is otherwise unchanged from the original array-form transaction.
+    const projectId = await withTxRetry(() => prisma.$transaction(async (tx) => {
+        await lockMoneyParents(tx, { invoiceId });
+        const invoice = await tx.invoice.findUnique({ where: { id: invoiceId } });
+        if (!invoice) throw new Error("Invoice not found");
+
+        // Refuse to re-split while a payment is in flight on a non-Paid milestone. The delete
+        // below drops every non-Paid schedule; if one has an open Stripe checkout or a sent
+        // QuickBooks invoice, a settlement landing afterward would find no row to claim and the
+        // customer would be charged with nothing to reconcile against. Checked under the invoice
+        // lock so a checkout/QB-send starting concurrently can't slip in after this guard.
+        const inFlight = await tx.paymentSchedule.findFirst({
+            where: {
+                invoiceId,
+                status: { not: "Paid" },
+                OR: [
+                    { stripeSessionId: { not: null } },
+                    { stripePaymentIntentId: { not: null } },
+                    { qbInvoiceId: { not: null } },
+                ],
+            },
+            select: { name: true },
+        });
+        if (inFlight) {
+            throw new Error(
+                `A payment is in progress on this invoice (milestone "${inFlight.name}"). Wait for it to finish or void it before re-splitting the milestones.`,
+            );
+        }
+
+        // Recalculate: the paid portion survives untouched, and only the pending
+        // portion is replaced. totalAmount must keep counting the surviving paid
+        // rows (paidAmount + newTotal) — a prior version dropped paidAmount from
+        // totalAmount here, undercounting the invoice whenever the split ran on a
+        // partially-paid invoice. balanceDue is exactly the fresh pending total.
+        const paidAmount = Math.round(
+            (Number(invoice.totalAmount) - Number(invoice.balanceDue)) * 100,
+        ) / 100;
+        const newInvoiceTotal = Math.round((paidAmount + newTotal) * 100) / 100;
+        const newBalance = newTotal; // validated milestones are all > 0, so this is always positive
+        const newStatus =
+            invoice.status === "Draft" ? "Draft"
+            : invoice.status === "Overdue" ? "Overdue"
+            : paidAmount > 0 ? "Partially Paid"
+            : "Issued";
+
+        await tx.paymentSchedule.deleteMany({ where: { invoiceId, status: { not: "Paid" } } });
+        // NOTE: this drops sourceScheduleId links on any replaced row — see the
+        // KNOWN LIMITATION above. Rebalancing amounts in place (without touching
+        // links) should go through updatePendingMilestoneAmountsCore instead.
+        await tx.paymentSchedule.createMany({
+            data: validated.map((m) => ({
+                invoiceId,
+                name: m.name,
+                amount: m.amount,
+                status: "Pending",
+                dueDate: m.dueDate ? new Date(m.dueDate) : null,
+            })),
+        });
+        await tx.invoice.update({
+            where: { id: invoiceId },
+            data: { totalAmount: newInvoiceTotal, balanceDue: newBalance, status: newStatus },
+        });
+        return invoice.projectId;
+    }));
+
+    return projectId;
+}

--- a/src/lib/quickbooks-payments.ts
+++ b/src/lib/quickbooks-payments.ts
@@ -26,6 +26,7 @@ import {
     getQBInvoiceStatus,
     probeQBInvoice,
     getQBPayment,
+    deleteQBInvoice,
 } from "./quickbooks";
 import type { QBSyncIssue } from "./payment-notifications";
 
@@ -196,11 +197,24 @@ export async function pushMilestoneToQuickBooks(paymentScheduleId: string, passe
 
     const payLink = await getQBInvoicePaymentLink(tokens, qbId);
 
-    await prisma.paymentSchedule.update({
-        where: { id: schedule.id },
+    // Conditional link write: the milestone was read as unlinked and not Paid at
+    // the top, but this function does several remote calls in between — a manual
+    // "Record Payment", a QB settle, or a concurrent push can land in that window.
+    // The guards go in the WHERE so a changed row loses nothing: if the claim
+    // misses, the just-created QBO invoice is deleted (compensation) instead of
+    // being attached to a row the payment poller would never watch again.
+    const linked = await prisma.paymentSchedule.updateMany({
+        where: { id: schedule.id, status: { not: "Paid" }, qbPaymentId: null, qbInvoiceId: null },
         // qbSyncError: null — a fresh invoice clears any prior voided/notFound flag (self-heal).
         data: { qbInvoiceId: qbId, qbInvoiceLink: payLink, qbSyncedAt: new Date(), qbSyncError: null },
     });
+    if (linked.count !== 1) {
+        const compensated = await deleteQBInvoice(tokens, qbId).catch(() => false);
+        if (!compensated) {
+            console.error(`[quickbooks-payments] milestone ${schedule.id} changed mid-push and compensating delete of QBO invoice ${qbId} (${docNumber}) failed — delete it in QuickBooks manually`);
+        }
+        throw new Error("This milestone changed while staging its QuickBooks invoice — refresh and try again.");
+    }
 
     return { qbInvoiceId: qbId, payLink, qbTotal: total };
 }

--- a/src/lib/quickbooks-payments.ts
+++ b/src/lib/quickbooks-payments.ts
@@ -10,6 +10,7 @@
  * milestone Paid exactly like the Stripe webhook does. That keeps ProBuild,
  * QuickBooks, and the bank in sync, and keeps the sales-tax report truthful.
  */
+import { Prisma } from "@prisma/client";
 import { prisma } from "./prisma";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { enqueueMilestonePaid, drainPaymentNotifications } from "./payment-outbox";
@@ -49,6 +50,41 @@ export async function getFreshQBTokens(): Promise<QBTokens> {
         // Refresh can fail transiently; the old access token may still be valid.
         return { accessToken: qb.accessToken, refreshToken: qb.refreshToken, realmId: qb.realmId };
     }
+}
+
+/**
+ * Atomically clear a milestone's QuickBooks link fields. The guard fields
+ * (`status`, `qbPaymentId`, and the exact `qbInvoiceId` the caller read) all go
+ * in the WHERE, so if a QB settlement lands on this milestone between the
+ * caller's read and this write, the claim matches 0 rows and the settle wins —
+ * we never strip QB fields off a now-paid row, and a concurrent re-push (new
+ * id) can't be clobbered either.
+ *
+ * Accepts either a bare `prisma` client or an in-flight `tx` — shared by
+ * `breakQBInvoiceLink` (standalone) and `updatePendingMilestoneAmountsCore`
+ * (inside its rebalance transaction) so both go through the same claim.
+ */
+export async function claimQBInvoiceUnlink(
+    client: Prisma.TransactionClient,
+    scheduleId: string,
+    expectedQbInvoiceId: string,
+): Promise<boolean> {
+    const cleared = await client.paymentSchedule.updateMany({
+        where: {
+            id: scheduleId,
+            status: { not: "Paid" },
+            qbPaymentId: null,
+            qbInvoiceId: expectedQbInvoiceId,
+        },
+        data: {
+            qbInvoiceId: null,
+            qbInvoiceLink: null,
+            qbInvoiceSentAt: null,
+            qbSyncedAt: null,
+            qbSyncError: null,
+        },
+    });
+    return cleared.count === 1;
 }
 
 async function resolveCustomerAndItem(tokens: QBTokens, clientId: string): Promise<{ customerId: string; itemId: string }> {

--- a/src/lib/quickbooks-payments.ts
+++ b/src/lib/quickbooks-payments.ts
@@ -197,14 +197,27 @@ export async function pushMilestoneToQuickBooks(paymentScheduleId: string, passe
 
     const payLink = await getQBInvoicePaymentLink(tokens, qbId);
 
-    // Conditional link write: the milestone was read as unlinked and not Paid at
+    // Conditional link write: the milestone was read as unlinked and unpaid at
     // the top, but this function does several remote calls in between — a manual
-    // "Record Payment", a QB settle, or a concurrent push can land in that window.
-    // The guards go in the WHERE so a changed row loses nothing: if the claim
-    // misses, the just-created QBO invoice is deleted (compensation) instead of
-    // being attached to a row the payment poller would never watch again.
+    // "Record Payment", a QB settle, a cancellation, a concurrent push, or a
+    // rebalance changing the row's content can all land in that window. The
+    // guards go in the WHERE — status pinned to Pending (a Canceled row must
+    // never get a fresh collectible invoice: the payment poller only watches
+    // Pending) and the content snapshot (amount/name/dueDate) pinned to what the
+    // QBO invoice was actually created from, so a mid-push edit can't leave QBO
+    // silently out of sync. If the claim misses, the just-created QBO invoice is
+    // deleted (compensation) instead of being attached to a row it no longer
+    // describes.
     const linked = await prisma.paymentSchedule.updateMany({
-        where: { id: schedule.id, status: { not: "Paid" }, qbPaymentId: null, qbInvoiceId: null },
+        where: {
+            id: schedule.id,
+            status: "Pending",
+            qbPaymentId: null,
+            qbInvoiceId: null,
+            amount: schedule.amount,
+            name: schedule.name,
+            dueDate: schedule.dueDate,
+        },
         // qbSyncError: null — a fresh invoice clears any prior voided/notFound flag (self-heal).
         data: { qbInvoiceId: qbId, qbInvoiceLink: payLink, qbSyncedAt: new Date(), qbSyncError: null },
     });
@@ -212,6 +225,7 @@ export async function pushMilestoneToQuickBooks(paymentScheduleId: string, passe
         const compensated = await deleteQBInvoice(tokens, qbId).catch(() => false);
         if (!compensated) {
             console.error(`[quickbooks-payments] milestone ${schedule.id} changed mid-push and compensating delete of QBO invoice ${qbId} (${docNumber}) failed — delete it in QuickBooks manually`);
+            throw new Error(`This milestone changed while staging its QuickBooks invoice, and the abandoned QuickBooks invoice ${docNumber} (id ${qbId}) could not be deleted — remove it in QuickBooks, then retry.`);
         }
         throw new Error("This milestone changed while staging its QuickBooks invoice — refresh and try again.");
     }


### PR DESCRIPTION
## What

Adds the milestone rebalance feature needed to adjust remaining amounts on partially-paid invoices whose milestones have staged QuickBooks invoices (Mesplay INV-00171, Berg INV-00177).

- **Edit amounts** on the invoice Payment Schedule: total-preserving re-pricing of all Pending milestones (per pool — estimate-mirrored rows and extras each keep their own sum), mirrored to the estimate-side schedule. QB-linked rows get their staged QBO invoice replaced at the new amount: probe → refuse if a not-yet-pulled payment exists → delete in QBO → atomic unlink (settle-wins claim) → re-stage. The local link is only ever cleared after the old QBO invoice is confirmed gone, so a QBO-side payment can never be stranded.
- **Delete milestone** for Pending, non-mirrored, non-QB-linked extras (inverse of Add extra charge), with a Draft-preserving status ladder.
- **Split payments fix**: partially-paid invoices no longer lose the paid portion from `totalAmount` (was: `totalAmount = sum(new pending)`; now: `paid + newTotal`).
- **Break QB Link dialog** replaces `window.confirm`, adding the "also delete the staged invoice in QuickBooks" option (backend `deleteInQBO` already existed, never exposed).
- **pushMilestoneToQuickBooks** hardening (pre-existing race): final link write is now a conditional claim pinning status=Pending + the content snapshot the QBO invoice was created from; a miss deletes the just-created QBO invoice as compensation.

## Review

Two Codex review rounds (money-path protocol): round 1 found 3 blockers (QBO payment orphan on unlink-first ordering, mid-push settle race, cross-pool transfer desyncing the estimate) — all fixed by reordering the resync, the conditional claim, and per-pool total preservation. Round 2 confirmed the fixes and found 1 blocker (content-drift race on the link claim) + 3 real issues (Canceled rows linkable, silent orphan on failed compensation, approveEstimate whole-loop catch) — all addressed in `8ccc780`.

## Tests

`e2e/milestone-rebalance.spec.ts`: 9 tests over the three session-free cores — total/pool preservation, mirror sync, paid-row rejection, QB link retention when QBO unreachable, delete guards + Draft preservation, split arithmetic. Known gap: the concurrency races (settle-wins claim, conditional link claim) have no deterministic e2e coverage, same as the codebase's other claim-based races.

## Deploy notes

No schema changes. Deploy via `vercel --prod` from the main checkout after merge; then rebalance Mesplay INV-00171 / clean up Berg INV-00177 via the new UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)