### PR TITLE
fix(billing): QBO preflight before rebalance commits repriced amounts [P1 from #225]

### DIFF
--- a/e2e/milestone-rebalance.spec.ts
+++ b/e2e/milestone-rebalance.spec.ts
@@ -167,7 +167,7 @@ test.describe.serial("updatePendingMilestoneAmountsCore", () => {
         expect(num(paid!.amount)).toBe(400); // unchanged
     });
 
-    test("QB-linked row: keeps its link and reports a warning when QuickBooks is unreachable", async () => {
+    test("QB-linked row: aborts with NO changes when QuickBooks is unreachable (preflight)", async () => {
         await ensureClientAndProject();
         const suffix = "qblinked";
         const invoiceId = `${PFX}-inv-${suffix}`;
@@ -182,21 +182,33 @@ test.describe.serial("updatePendingMilestoneAmountsCore", () => {
         });
         await prisma.paymentSchedule.create({ data: { id: psOther, invoiceId, name: "Final", amount: 600, status: "Pending" } });
 
-        const res = await updatePendingMilestoneAmountsCore(invoiceId, [
-            { scheduleId: psQB, name: "Deposit", amount: 350 },
-            { scheduleId: psOther, name: "Final", amount: 650 },
-        ]);
-        expect(res.success).toBe(true);
-        expect(res.warnings.length).toBeGreaterThan(0); // no QuickBooks connection to replace the staged invoice
+        // The preflight must verify the staged QBO invoice is reachable and
+        // payment-free BEFORE any DB write. This env has no QuickBooks
+        // connection, so the whole rebalance aborts and NOTHING changes — a
+        // payment sitting unpulled on the old QBO invoice can therefore never be
+        // settled against a silently repriced milestone.
+        await expect(
+            updatePendingMilestoneAmountsCore(invoiceId, [
+                { scheduleId: psQB, name: "Deposit", amount: 350 },
+                { scheduleId: psOther, name: "Final", amount: 650 },
+            ]),
+        ).rejects.toThrow(/QuickBooks is unreachable/i);
 
-        // Amounts update locally, but the QB link is deliberately KEPT: unlinking
-        // only happens after the old QBO invoice is confirmed deleted, and this
-        // env can never reach QBO — so the payment poller keeps watching the old
-        // invoice instead of stranding any payment behind a cleared link.
         const qbRow = await prisma.paymentSchedule.findUnique({ where: { id: psQB } });
-        expect(num(qbRow!.amount)).toBe(350);
+        const other = await prisma.paymentSchedule.findUnique({ where: { id: psOther } });
+        expect(num(qbRow!.amount)).toBe(400); // untouched
         expect(qbRow!.qbInvoiceId).toBe("fake-qbo-1");
         expect(qbRow!.qbInvoiceLink).toBe("https://qbo.example/fake-1");
+        expect(num(other!.amount)).toBe(600); // untouched
+
+        // A rebalance that does NOT touch the QB-linked row's content sails
+        // through without needing QuickBooks at all.
+        const res = await updatePendingMilestoneAmountsCore(invoiceId, [
+            { scheduleId: psQB, name: "Deposit", amount: 400 },
+            { scheduleId: psOther, name: "Final", amount: 600 },
+        ]);
+        expect(res.success).toBe(true);
+        expect(res.warnings).toEqual([]);
     });
 
     test("rejects moving money between estimate-mirrored rows and extras", async () => {

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -1585,6 +1585,56 @@ export async function updatePendingMilestoneAmountsCore(
     const seenIds = new Set(parsed.map((r) => r.scheduleId));
     if (seenIds.size !== parsed.length) throw new Error("Duplicate milestone in the same request");
 
+    // Content-change test shared by the QBO preflight below and the in-tx
+    // collection: any of amount/name/dueDate differing means the staged QBO
+    // invoice (if one exists) no longer matches and must be replaced.
+    const contentChanged = (
+        row: { amount: unknown; name: string; dueDate: Date | null },
+        r: { name: string; amount: number; dueDate: string | null },
+    ) =>
+        Math.abs(toNum(row.amount) - r.amount) > 0.005 ||
+        row.name !== r.name ||
+        (row.dueDate ? row.dueDate.toISOString().slice(0, 10) : null) !== (r.dueDate ? r.dueDate.slice(0, 10) : null);
+
+    // PREFLIGHT (before any DB write): a QB-linked row may only be repriced if
+    // its staged QBO invoice is reachable and payment-free RIGHT NOW. Committing
+    // new amounts first and checking later leaves a window where a payment that
+    // already landed in QBO (possibly hours before the poller's next pull)
+    // settles the milestone at the NEW local amount while the client actually
+    // paid the OLD one — a silent cash/records mismatch. Aborting here costs
+    // nothing: no row has been touched yet. The post-commit loop re-probes
+    // before the delete, so the residual race is only the seconds between this
+    // check and the delete — and QBO refuses to delete a paid invoice even then.
+    const preflightRows = await prisma.paymentSchedule.findMany({
+        where: { invoiceId, id: { in: parsed.map((r) => r.scheduleId) }, qbInvoiceId: { not: null } },
+    });
+    const preflightChanged = preflightRows.filter((row) => contentChanged(row, parsed.find((p) => p.scheduleId === row.id)!));
+    if (preflightChanged.length > 0) {
+        const { getFreshQBTokens } = await import("./quickbooks-payments");
+        const { probeQBInvoice } = await import("./quickbooks");
+        let tokens;
+        try {
+            tokens = await getFreshQBTokens();
+        } catch (e) {
+            throw new Error(
+                `QuickBooks is unreachable (${e instanceof Error ? e.message : "unknown error"}) and this rebalance changes milestones with staged QuickBooks invoices. ` +
+                `Nothing was changed — retry when QuickBooks is back, or use "Break QB Link" first.`
+            );
+        }
+        for (const row of preflightChanged) {
+            const probe = await probeQBInvoice(tokens, row.qbInvoiceId!);
+            if (probe.state === "error") {
+                throw new Error(`Couldn't verify "${row.name}"'s staged QuickBooks invoice — nothing was changed. Retry in a moment.`);
+            }
+            if (probe.state === "ok" && (probe.paymentTxnIds.length > 0 || Math.abs(probe.balance - probe.total) > 0.005)) {
+                throw new Error(
+                    `A payment already exists on "${row.name}"'s QuickBooks invoice that ProBuild hasn't pulled yet. ` +
+                    `Nothing was changed — run "Refresh QB payments" first, then rebalance.`
+                );
+            }
+        }
+    }
+
     type QBAffected = { scheduleId: string; name: string; oldQbInvoiceId: string };
 
     const qbAffected = await withTxRetry(() => prisma.$transaction(async (tx) => {
@@ -1643,19 +1693,15 @@ export async function updatePendingMilestoneAmountsCore(
         const affected: QBAffected[] = [];
         for (const r of parsed) {
             const row = existingMap.get(r.scheduleId)!;
-            const amountChanged = Math.abs(toNum(row.amount) - r.amount) > 0.005;
-            const nameChanged = row.name !== r.name;
-            const dueDateChanged =
-                (row.dueDate ? row.dueDate.toISOString().slice(0, 10) : null) !==
-                (r.dueDate ? r.dueDate.slice(0, 10) : null);
 
             // A QB-linked row whose content changes needs its staged QBO invoice
             // replaced (QBO invoices are create-only here — no update path). The
-            // link is deliberately KEPT through this transaction: unlinking happens
-            // post-commit only AFTER the old QBO invoice is confirmed payment-free
-            // and actually deleted, so a payment that landed in QBO but hasn't been
-            // pulled yet can never be orphaned behind a cleared link.
-            if (row.qbInvoiceId && (amountChanged || nameChanged || dueDateChanged)) {
+            // preflight above already verified these invoices are reachable and
+            // payment-free. The link is deliberately KEPT through this transaction:
+            // unlinking happens post-commit only AFTER the old QBO invoice is
+            // confirmed still payment-free and actually deleted, so a payment that
+            // landed in QBO can never be orphaned behind a cleared link.
+            if (row.qbInvoiceId && contentChanged(row, r)) {
                 affected.push({ scheduleId: row.id, name: r.name, oldQbInvoiceId: row.qbInvoiceId });
             }
 
@@ -1708,10 +1754,11 @@ export async function updatePendingMilestoneAmountsCore(
                         continue;
                     }
                     if (probe.state === "ok" && (probe.paymentTxnIds.length > 0 || Math.abs(probe.balance - probe.total) > 0.005)) {
-                        // A payment already exists on the old QBO invoice that ProBuild
-                        // hasn't pulled yet. Do NOT delete or unlink — leave the link so
-                        // the poller settles it — and tell the user to reconcile first.
-                        warnings.push(`"${row.name}": a payment exists on its QuickBooks invoice that ProBuild hasn't pulled yet — run "Refresh QB payments" and review before changing this milestone.`);
+                        // A payment landed on the old QBO invoice in the seconds since
+                        // the preflight passed. Do NOT delete or unlink — leave the link
+                        // so the poller settles it — but the local amount has already
+                        // changed, so tell the user to reconcile this milestone now.
+                        warnings.push(`"${row.name}": a payment just landed on its old QuickBooks invoice, but the milestone amount here already changed — run "Refresh QB payments" and reconcile this milestone before sending anything.`);
                         continue;
                     }
                     const alreadyGone = probe.state === "voided" || probe.state === "notFound";


### PR DESCRIPTION
Hotfix for the P1 posted on #225 after it merged: the rebalance tx committed new amounts before the old staged QBO invoice was checked, so a payment sitting unpulled in QBO could settle a milestone at the new local amount while the client paid the old one.

Fix: preflight before any DB write — every QB-linked row whose content changes must probe reachable + payment-free, else the whole rebalance aborts with zero changes. Post-commit probe/delete/unlink/re-stage unchanged (still guards the residual seconds-wide race; QBO refuses deleting a paid invoice).

P2 (crash between QBO delete and unlink) is answered on #225: the existing `qbSyncError` probe flag + Break QB Link flow is the documented recovery for a link to a deleted QBO invoice; window is a single statement wide and self-surfaces in the UI.

e2e updated: unreachable QBO now asserts full abort with zero changes; content-untouched QB rows rebalance without QuickBooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)