### PR TITLE
feat(schedule): board polish — unified dates, edge-drag end dates, hover notes, no-scroll crew picker

### DIFF
--- a/scripts/verify-schedule-board-layout.ts
+++ b/scripts/verify-schedule-board-layout.ts
@@ -16,8 +16,8 @@ const project = {
     startDate: null, endDate: null, color: "#123456", contractValue: null, crew: [],
     taskCount: 2, hasQualifyingEstimate: false, unappliedChangeOrders: { count: 0, items: [] },
     tasks: [
-        { id: "t1", name: "Frame", startDate: "2037-01-03T00:00:00.000Z", endDate: "2037-01-06T00:00:00.000Z", color: "#111111", parentId: null, progress: 0, status: "Not Started", type: "task", assignments: [] },
-        { id: "t2", name: "Billing", startDate: "2037-01-20T00:00:00.000Z", endDate: "2037-01-20T00:00:00.000Z", color: "#222222", parentId: null, progress: 0, status: "Not Started", type: "milestone", assignments: [] },
+        { id: "t1", name: "Frame", startDate: "2037-01-03T00:00:00.000Z", endDate: "2037-01-06T00:00:00.000Z", color: "#111111", parentId: null, progress: 0, status: "Not Started", type: "task", assignments: [], latestComments: [] },
+        { id: "t2", name: "Billing", startDate: "2037-01-20T00:00:00.000Z", endDate: "2037-01-20T00:00:00.000Z", color: "#222222", parentId: null, progress: 0, status: "Not Started", type: "milestone", assignments: [], latestComments: [] },
     ],
 };
 
@@ -421,5 +421,19 @@ const fourOverlapping = assignTaskLanes([
 assert.equal(fourOverlapping.laneCount, 3, "lane assignment caps at MAX_TASK_LANES");
 assert.equal(fourOverlapping.hiddenTaskIds.length, 1, "the 4th concurrent task is reported hidden for the +N chip");
 assert.deepEqual([...fourOverlapping.laneByTaskId.values()].sort(), [0, 1, 2]);
+
+// Owner-feedback round (2026-07-22), item 2: project-bar right-edge resize
+// preview clamp — a candidate end may never land on or before the project's
+// start; it clamps to start+1 instead of going negative/zero-width.
+assert.equal(typeof (barLayout as Record<string, unknown>).computeProjectEndResizeCandidate, "function", "computeProjectEndResizeCandidate must be exported");
+const computeProjectEndResizeCandidate = (barLayout as unknown as {
+    computeProjectEndResizeCandidate: (originalEnd: Date, startDate: Date, deltaDays: number) => Date;
+}).computeProjectEndResizeCandidate;
+const resizeStart = parseUTCDate("2037-01-03");
+const resizeOriginalEnd = parseUTCDate("2037-01-06");
+assert.deepEqual(computeProjectEndResizeCandidate(resizeOriginalEnd, resizeStart, 2), parseUTCDate("2037-01-08"), "a positive drag extends the end by exactly the dragged days");
+assert.deepEqual(computeProjectEndResizeCandidate(resizeOriginalEnd, resizeStart, -2), parseUTCDate("2037-01-04"), "a negative drag shortens the end while it stays past the start");
+assert.deepEqual(computeProjectEndResizeCandidate(resizeOriginalEnd, resizeStart, -10), addDays(resizeStart, 1), "dragging past the start clamps to start+1, never to or before the start");
+assert.deepEqual(computeProjectEndResizeCandidate(resizeOriginalEnd, resizeStart, -3), addDays(resizeStart, 1), "the clamp boundary itself (candidate === start) also clamps to start+1");
 
 console.log("schedule-board layout verification: PASS");

--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -361,7 +361,11 @@ assert.match(layoutSource, /candidate < minEnd \? minEnd : candidate/, "the clam
 assert.match(boardSource, /function measureMonthDayWidth\(clientX: number, clientY: number\): number \| null \{/, "Month's day width must be measured from the underlying week-grid day cell, not hardcoded");
 assert.match(boardSource, /function handleProjectEndResizeStart\(project: DashboardProjectRow, start: ProjectEndResizePointerStart\) \{/);
 assert.match(boardSource, /const dayWidth = drag\.start\.timelineDayWidth \?\? drag\.monthDayWidth;/, "px->day math must read the CURRENT day width — Timeline's zoom-driven prop or Month's measured value — never a hardcoded constant");
-assert.match(boardSource, /computeProjectEndResizeCandidate\(\s*\n\s*parseUTCDate\(drag\.originalEnd\),\s*\n\s*parseUTCDate\(drag\.originalStart\),/, "the live preview must run through the shared pure clamp helper");
+// The clamp floor is the PERSISTED start marker when one exists (the effective
+// range can begin at an earlier task after marker-only moves, and the server
+// rejects end <= persisted startDate) — falling back to the range start.
+assert.match(boardSource, /const clampStart = drag\.project\.startDate\s*\n\s*\? parseUTCDate\(drag\.project\.startDate\.slice\(0, 10\)\)\s*\n\s*: parseUTCDate\(drag\.originalStart\);/, "the resize clamp must floor at the persisted start marker");
+assert.match(boardSource, /computeProjectEndResizeCandidate\(\s*\n\s*parseUTCDate\(drag\.originalEnd\),\s*\n\s*clampStart,/, "the live preview must run through the shared pure clamp helper");
 assert.match(boardSource, /function commitProjectEndResize\(project: DashboardProjectRow, candidateEnd: string\) \{/);
 assert.doesNotMatch(
     boardSource.slice(boardSource.indexOf("function commitProjectEndResize("), boardSource.indexOf("function handleProjectEndResizeStart(")),

--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -56,8 +56,11 @@ assert.match(boardSource, /draftProjectMove\(project, current\.targetStart\)/, "
 assert.doesNotMatch(boardSource, /updateCompanyScheduleTaskDatesAction/, "the board no longer calls the single-task write action directly");
 
 // The batch save is the ONLY place these three server actions are called,
-// and it fires exactly once per Save click.
-assert.match(boardSource, /import \{ saveCompanyScheduleTaskDatesAction, shiftNotStartedTasksAction, updateProjectStartDateAction \} from "@\/lib\/actions"/);
+// and it fires exactly once per Save click. (updateProjectEndDateAction
+// joined this import in the owner-feedback round — item 2's edge-resize
+// commit — but it is NOT part of the batch/draft system below; see its own
+// assertions further down.)
+assert.match(boardSource, /import \{ saveCompanyScheduleTaskDatesAction, shiftNotStartedTasksAction, updateProjectEndDateAction, updateProjectStartDateAction \} from "@\/lib\/actions"/);
 const saveAllDraftsStart = boardSource.indexOf("async function saveAllDrafts()");
 const saveAllDraftsEnd = boardSource.indexOf("function cancelProjectEditsForProjects", saveAllDraftsStart);
 const saveAllDraftsBody = boardSource.slice(saveAllDraftsStart, saveAllDraftsEnd);
@@ -216,7 +219,7 @@ assert.match(monthSource, /No unscheduled projects/, "Month's Schedule-here must
 assert.match(timelineSource, /No unscheduled projects/, "Timeline's Schedule-here must show a disabled line when there is nothing to schedule");
 // Task block: Delete task is an immediate action (not draft-mode) through
 // the existing deleteScheduleTask, with explicit non-draft copy in the confirm.
-assert.match(taskBlockSource, /import \{ deleteScheduleTask \} from "@\/lib\/actions"/);
+assert.match(taskBlockSource, /import \{ addTaskComment, deleteScheduleTask \} from "@\/lib\/actions"/);
 assert.match(taskBlockSource, /await deleteScheduleTask\(task\.id\)/);
 assert.match(taskBlockSource, /Deletes now — not part of unsaved changes/, "Delete task's confirm copy must explicitly say it is immediate, not draft-mode");
 // Project bar: Remove from schedule only for Waiting to Start, through the
@@ -229,10 +232,13 @@ assert.match(projectBarSource, /import \{ addDays, formatDate, parseUTCDate, PRE
 assert.match(projectBarSource, /PRESET_COLORS\.map\(swatch =>/, "the Color… grid must be built from PRESET_COLORS");
 // Project crew…/Task crew… reuse the SAME pickers as the Schedule & crew
 // table (via the extracted CrewPickers module), never a rebuilt picker.
+// Crew-picker rebuild (item 5): the schedule-board menu instances render the
+// shared CrewChecklist INLINE (variant="inline") — no nested popover inside
+// the bar/block's own FloatingPopover menu, which was the double-scrollbar bug.
 assert.match(projectBarSource, /import \{ CrewPicker \} from "\.\/CrewPickers"/);
-assert.match(projectBarSource, /<CrewPicker projectId=\{project\.id\} crew=\{project\.crew\} teamMembers=\{teamMembers\} \/>/);
+assert.match(projectBarSource, /<CrewPicker projectId=\{project\.id\} crew=\{project\.crew\} teamMembers=\{teamMembers\} variant="inline" \/>/);
 assert.match(taskBlockSource, /import \{ TaskCrewPicker \} from "\.\/CrewPickers"/);
-assert.match(taskBlockSource, /<TaskCrewPicker task=\{task\} teamMembers=\{teamMembers\} \/>/);
+assert.match(taskBlockSource, /<TaskCrewPicker task=\{task\} teamMembers=\{teamMembers\} variant="inline" \/>/);
 
 // ── Item 6: a bar click toggles its menu, never navigates ──
 assert.match(projectBarSource, /function handleBarClick\(/);
@@ -302,5 +308,121 @@ assert.match(timelineSource, /export const CREW_MODE_STORAGE_KEY/);
 assert.match(boardSource, /import \{ TimelineView, CREW_MODE_STORAGE_KEY \} from "\.\/TimelineView"/);
 assert.match(boardSource, /function drillDownToCrewTimeline\(/);
 assert.match(boardSource, /onDrillDown=\{drillDownToCrewTimeline\}/);
+
+// ── Owner-feedback round (2026-07-22), item 1: end date merged into
+// "Edit dates…" — the standalone "Set end date…" item and its own menu view
+// are GONE; the "dates" view now carries both fields. ──
+assert.doesNotMatch(projectBarSource, /Set end date…/, "the standalone \"Set end date…\" menu item must be removed");
+assert.doesNotMatch(projectBarSource, /"main" \| "dates" \| "crew" \| "color" \| "end-date"/, "BarMenuView must no longer carry a separate end-date view");
+assert.match(projectBarSource, /type BarMenuView = "main" \| "dates" \| "crew" \| "color";/);
+// "Edit dates…" is no longer canMoveProject-gated at the menu-item level (a
+// Substantial Completion project can't move its start, but must still be
+// able to set an end date) — the Start FIELD inside the view stays gated.
+assert.doesNotMatch(projectBarSource, /\{canMoveProject && \(\s*<button type="button" onClick=\{\(\) => setMenuView\("dates"\)\}/, "the Edit dates… menu item itself must not be canMoveProject-gated");
+assert.match(projectBarSource, /\{menuView === "dates" && \(/, "the merged dates view must not require canMoveProject to render at all");
+assert.match(projectBarSource, /\{canMoveProject && \(\s*<div>\s*<label[\s\S]{0,300}Start date/, "the Start date FIELD inside the merged view stays canMoveProject-gated");
+assert.match(projectBarSource, /htmlFor=\{`bar-project-enddate-\$\{project\.id\}`\}>End date/, "the merged view must contain an End date field");
+assert.match(projectBarSource, /Joins unsaved changes — Save to commit\./, "the Start field needs a caption distinguishing it from the immediate End write");
+assert.match(projectBarSource, /Saves immediately\./, "the End field needs a caption distinguishing it from the draft Start write");
+assert.match(projectBarSource, /Clear end date/, "the merged view keeps a Clear end date affordance");
+// Submit behavior: Start routes through the EXISTING draft path
+// (onMoveCommit -> draftProjectMove); End calls updateProjectEndDateAction
+// (via submitEndDate) immediately and ONLY when it actually changed.
+const handleDateSubmitStart = projectBarSource.indexOf("function handleDateSubmit(");
+const handleDateSubmitEnd = projectBarSource.indexOf("function submitColor(", handleDateSubmitStart);
+const handleDateSubmitBody = projectBarSource.slice(handleDateSubmitStart, handleDateSubmitEnd);
+assert.ok(handleDateSubmitStart >= 0, "handleDateSubmit must exist");
+assert.match(handleDateSubmitBody, /onMoveCommit\(project, targetStart\)/, "a start change must route through the existing draft path");
+assert.match(handleDateSubmitBody, /if \(endDateValue !== projectEndDate\) \{\s*\n\s*submitEndDate\(endDateValue \|\| null\);/, "an end change must fire submitEndDate ONLY when the value actually changed");
+assert.match(projectBarSource, /await updateProjectEndDateAction\(project\.id, value\);/, "the merged End field still routes through the existing updateProjectEndDateAction — no new action");
+assert.match(projectBarSource, /toast\.error\(err\?\.message \|\| "Failed to update end date"\)/, "end-date validation errors stay toasts");
+
+// ── Item 2: project-bar right-edge resize -> end date ──
+assert.match(projectBarSource, /onProjectEndResizeStart: ProjectEditCallbacks\["onProjectEndResizeStart"\]/, "ProjectBarProps must carry the end-resize callback");
+assert.match(projectBarSource, /export interface ProjectEndResizePointerStart \{/, "a dedicated pointer-start payload type must exist for the edge-resize drag");
+assert.match(projectBarSource, /function handleEndResizePointerDown\(event: ReactPointerEvent<HTMLDivElement>\) \{/);
+assert.match(projectBarSource, /event\.stopPropagation\(\);\s*\n\s*onProjectEndResizeStart\(project, \{/, "the edge-resize pointerdown must stop propagation so it wins over the whole-bar move drag");
+// The handle only renders on the segment that actually ENDS the project
+// (never a continuation), is canEdit-gated independent of canMoveProject
+// (matches item 1's End-date access boundary), and follows the standard
+// hover-reveal + [@media(hover:none)] always-visible pattern.
+assert.match(projectBarSource, /\{canEdit && !isPending && !segment\.continuesAfter && \(/, "the edge-resize handle must only render on the segment ending the project, canEdit-gated, independent of canMoveProject");
+assert.match(projectBarSource, /onPointerDown=\{handleEndResizePointerDown\}/);
+assert.match(projectBarSource, /opacity-0 transition group-hover\/project:opacity-100 group-focus-within\/project:opacity-100 \[@media\(hover:none\)\]:opacity-100/, "the edge-resize handle must use the standard hover/focus/touch-always-visible pattern");
+// Confined to the title strip's own 18px band — this is what keeps it from
+// EVER vertically overlapping a task block's own resize-right handle, which
+// lives only inside the task strip below.
+assert.match(projectBarSource, /className="absolute right-0 top-0 z-20 h-\[18px\] w-1\.5/, "the edge-resize handle must be confined to the title strip's 18px band, never the task strip");
+// ScheduleBoard: a SEPARATE drag machine from the whole-bar move, live local
+// preview via the SAME projectPreviewOverrides mechanism the move-drag/item-3
+// preview already uses, immediate commit (never draftProjectMove).
+assert.match(layoutSource, /export function computeProjectEndResizeCandidate\(originalEnd: Date, startDate: Date, deltaDays: number\): Date \{/, "the resize-preview clamp must be an exported PURE helper (testable, reused by both views)");
+assert.match(layoutSource, /candidate < minEnd \? minEnd : candidate/, "the clamp must floor the candidate at start+1, never at or before the start");
+assert.match(boardSource, /function measureMonthDayWidth\(clientX: number, clientY: number\): number \| null \{/, "Month's day width must be measured from the underlying week-grid day cell, not hardcoded");
+assert.match(boardSource, /function handleProjectEndResizeStart\(project: DashboardProjectRow, start: ProjectEndResizePointerStart\) \{/);
+assert.match(boardSource, /const dayWidth = drag\.start\.timelineDayWidth \?\? drag\.monthDayWidth;/, "px->day math must read the CURRENT day width — Timeline's zoom-driven prop or Month's measured value — never a hardcoded constant");
+assert.match(boardSource, /computeProjectEndResizeCandidate\(\s*\n\s*parseUTCDate\(drag\.originalEnd\),\s*\n\s*parseUTCDate\(drag\.originalStart\),/, "the live preview must run through the shared pure clamp helper");
+assert.match(boardSource, /function commitProjectEndResize\(project: DashboardProjectRow, candidateEnd: string\) \{/);
+assert.doesNotMatch(
+    boardSource.slice(boardSource.indexOf("function commitProjectEndResize("), boardSource.indexOf("function handleProjectEndResizeStart(")),
+    /draftProjectMove|setProjectDrafts/,
+    "the edge-resize commit must NEVER join the draft/Save system — it writes immediately",
+);
+assert.match(boardSource, /await updateProjectEndDateAction\(project\.id, candidateEnd\);/, "the edge-resize commit must call the existing updateProjectEndDateAction — no new action");
+assert.match(boardSource, /const taskDerivedRange = getEffectiveProjectRange\(\{ \.\.\.project, endDate: null \}\);/, "the 'still shows through' toast must compare against the pure task/marker-derived range (endDate ignored)");
+assert.match(boardSource, /End date saved — the bar still shows through \$\{formatDate\(addDays\(taskDerivedRange\.end, -1\)\)\} because tasks run that long\./, "a released end shorter than the last task's end must still save, with an info toast explaining the bar's visible length");
+assert.match(boardSource, /activeProjectEndResizeRef\.current\?\.cleanup\(\);/, "starting another project/task edit must cancel an active end-resize drag");
+assert.match(boardSource, /const combinedPendingProjectIds = useMemo\(\s*\n\s*\(\) => mergeProjectPendingIds\(externallyPendingProjectIds, endResizeSavingProjectIds\),/, "an in-flight end-resize save must lock the project the SAME way the legacy externally-pending mechanism does");
+assert.equal((boardSource.match(/pendingProjectIds=\{combinedPendingProjectIds\}/g) ?? []).length, 2, "both views must receive the combined (legacy + end-resize) pending-project set");
+assert.match(monthSource, /onProjectEndResizeStart=\{onProjectEndResizeStart\}/);
+assert.match(timelineSource, /onProjectEndResizeStart=\{onProjectEndResizeStart\}/);
+assert.match(boardSource, /onProjectEndResizeStart=\{handleProjectEndResizeStart\}/, "the board must wire the end-resize handler into at least one view");
+
+// ── Item 3: hover notes on task blocks ──
+assert.match(coreSource, /latestComments: DashboardTaskComment\[\];/, "DashboardTaskRow must carry the hover-card's latestComments");
+assert.match(coreSource, /comments: \{\s*\n\s*orderBy: \{ createdAt: "desc" \},\s*\n\s*take: 2,/, "the task select must cap comments at 2, newest first");
+assert.match(coreSource, /authorName: c\.user\?\.name \?\? c\.user\?\.email \?\? c\.subcontractorName \?\? "Unknown",/, "author fallback chain must be user.name -> user.email -> subcontractorName -> Unknown");
+const addTaskCommentStart = actionsSource.indexOf("export async function addTaskComment(");
+const addTaskCommentEnd = actionsSource.indexOf("export async function getTaskComments(", addTaskCommentStart);
+const addTaskCommentBody = actionsSource.slice(addTaskCommentStart, addTaskCommentEnd);
+assert.ok(addTaskCommentStart >= 0, "addTaskComment must exist");
+assert.match(addTaskCommentBody, /await assertScheduleTaskAccess\(taskId\);/, "addTaskComment previously had NO auth check — hardened to the same schedule-task gate every other per-task mutation uses");
+assert.match(taskBlockSource, /import \{ addTaskComment, deleteScheduleTask \} from "@\/lib\/actions"/);
+assert.match(taskBlockSource, /Add note…/, "the task context menu must offer Add note…");
+assert.match(taskBlockSource, /await addTaskComment\(task\.id, text\);/, "Add note must go through the existing (now hardened) addTaskComment action");
+assert.match(taskBlockSource, /task\.latestComments\.map\(\(comment, index\) => \(/, "the hover card must render latestComments");
+assert.match(taskBlockSource, /truncateNote\(comment\.text\)/, "note text in the hover card must be truncated");
+assert.match(taskBlockSource, /const NOTE_TRUNCATE_LENGTH = 140;/);
+assert.match(taskBlockSource, /isAnyDragActive: boolean;/, "TaskBlockSegmentProps must accept the cross-board drag-active flag");
+assert.match(taskBlockSource, /if \(!isAnyDragActive && !menuOpen\) return;[\s\S]{0,300}setHoverCardOpen\(false\);/, "an active drag (or the click/context menu) must force-close an already-open hover card");
+assert.match(taskBlockSource, /if \(isAnyDragActive \|\| menuOpen(?: \|\| hoverOpenTimeoutRef\.current != null)?\) return;/, "opening the hover card must be gated on isAnyDragActive");
+assert.match(popoverSource, /pointerEventsNone\?: boolean;/, "FloatingPopover must support a non-interactive hover-card mode");
+assert.match(popoverSource, /pointerEventsNone \? "pointer-events-none" : ""/);
+assert.match(taskBlockSource, /pointerEventsNone/, "the hover card FloatingPopover instance must opt into pointer-events-none");
+for (const source of [monthSource, timelineSource, projectBarSource]) {
+    assert.match(source, /isAnyDragActive=\{isAnyDragActive\}/, "every TaskBlockSegment/ProjectBar render site must thread isAnyDragActive through");
+}
+
+// ── Item 5: crew-picker rebuild (owner-flagged double scrollbar) ──
+// CrewChecklist owns NO scroll/width of its own — FloatingPopover (width=320
+// for the standalone popover variant) is the ONLY scroll owner anywhere a
+// picker renders, including the "inline" variant nested inside an ALREADY-
+// open schedule-board menu.
+assert.doesNotMatch(crewPickersSource, /max-h-64/, "CrewPickers must not bring its own max-height scroller — FloatingPopover owns scrolling");
+assert.doesNotMatch(crewPickersSource, /overflow-y-auto/, "CrewPickers must not bring its own scroll region — double scrollbar was the bug");
+assert.match(crewPickersSource, /function CrewChecklist\(/, "a single shared checklist presentation must exist");
+assert.match(crewPickersSource, /grid grid-cols-1 gap-1 sm:grid-cols-2/, "the checklist must be a two-column grid, not a single vertical list");
+assert.match(crewPickersSource, /variant\?: "inline" \| "popover";/, "CrewPicker/TaskCrewPicker must accept the inline/popover variant");
+assert.match(crewPickersSource, /if \(variant === "inline"\) \{\s*\n\s*return <CrewChecklist/, "the inline variant must render the checklist directly with no nested trigger/popover of its own");
+assert.match(crewPickersSource, /<FloatingPopover open=\{open\} anchorRef=\{triggerRef\} onClose=\{\(\) => setOpen\(false\)\} width=\{320\}>/, "the popover variant (Schedule & crew table) must use FloatingPopover at width 320");
+assert.doesNotMatch(crewPickersSource, /w-56/, "the old fixed w-56 picker panel must be gone");
+assert.match(popoverSource, /overflowX: "hidden",/, "FloatingPopover must clip horizontally so nested content can never reintroduce a second scroll axis");
+assert.match(popoverSource, /maxWidth: `calc\(100vw - \$\{2 \* VIEWPORT_MARGIN_PX\}px\)`,/, "FloatingPopover must clamp its own width into the viewport");
+// FINANCE/inactive labeling and FloatingPopover's existing maxHeight/overflowY
+// contract stay exactly as before the rebuild.
+assert.match(crewPickersSource, /c\.role === "FINANCE" \? "finance" : "inactive"/, "CrewPicker must still label removable FINANCE crew entries");
+assert.match(crewPickersSource, /a\.role === "FINANCE" \? "finance" : "inactive"/, "TaskCrewPicker must still label removable FINANCE task-crew entries");
+assert.match(popoverSource, /maxHeight: position\?\.maxHeight,/);
+assert.match(popoverSource, /overflowY: "auto",/);
 
 console.log("schedule-board render contract verification: PASS");

--- a/scripts/verify-schedule-board.ts
+++ b/scripts/verify-schedule-board.ts
@@ -7,7 +7,7 @@ import { prisma } from "../src/lib/prisma";
 import { getCompanyDashboardData, setProjectCrew, setProjectStartDate, setTaskCrew, shiftNotStartedTasks } from "../src/lib/schedule-core";
 import { canAccessProject, hasPermission } from "../src/lib/permissions";
 import { withTxRetry } from "../src/lib/tx-retry";
-import { saveCompanyScheduleTaskDatesAction, updateProjectEndDateAction } from "../src/lib/actions";
+import { addTaskComment, saveCompanyScheduleTaskDatesAction, updateProjectEndDateAction } from "../src/lib/actions";
 
 type Check = [label: string, passed: boolean];
 
@@ -295,6 +295,56 @@ async function main() {
             .find(candidate => candidate.id === waitingProject.id);
         check("dashboard computes distanceMilesFromShop for a known 1-degree-latitude offset (~69 mi)",
             waitingRowForDistance?.distanceMilesFromShop === 69);
+
+        // ── Owner-feedback round (2026-07-22), item 3: hover-card notes ──
+        // latestComments serialization — newest-first, capped at 2, author
+        // fallback chain (user.name -> user.email -> subcontractorName ->
+        // "Unknown"). Explicit createdAt values keep ordering deterministic
+        // regardless of DB clock precision.
+        const commentNamedUser = await prisma.user.create({
+            data: { email: `board-comment-named-${tag}@example.invalid`, name: `Board Commenter ${tag}`, role: "FIELD_CREW", status: "ACTIVATED" },
+        });
+        const commentUnnamedUser = await prisma.user.create({
+            data: { email: `board-comment-unnamed-${tag}@example.invalid`, name: null, role: "FIELD_CREW", status: "ACTIVATED" },
+        });
+        userIds.push(commentNamedUser.id, commentUnnamedUser.id);
+        const oldestComment = await prisma.taskComment.create({
+            data: { taskId: notStarted.id, text: `Oldest note ${tag} — capped out of latestComments`, subcontractorName: `Sub Crew ${tag}`, createdAt: at(-3) },
+        });
+        const middleComment = await prisma.taskComment.create({
+            data: { taskId: notStarted.id, text: `Middle note ${tag}`, userId: commentUnnamedUser.id, createdAt: at(-2) },
+        });
+        const newestComment = await prisma.taskComment.create({
+            data: { taskId: notStarted.id, text: `Newest note ${tag}`, userId: commentNamedUser.id, createdAt: at(-1) },
+        });
+        const commentsDashboard = await getCompanyDashboardData({ role: "ADMIN" }, month);
+        const commentsRow = commentsDashboard.pipeline.inProgress.find(candidate => candidate.id === project.id);
+        const commentsTask = commentsRow?.tasks.find(candidate => candidate.id === notStarted.id);
+        check("latestComments is capped at 2, newest first",
+            commentsTask?.latestComments.length === 2
+            && commentsTask.latestComments[0].text === newestComment.text
+            && commentsTask.latestComments[1].text === middleComment.text
+            && commentsTask.latestComments.every(c => c.text !== oldestComment.text));
+        check("latestComments falls back to user.email when the user has no name",
+            commentsTask?.latestComments[1].authorName === commentUnnamedUser.email);
+        check("latestComments uses user.name when present",
+            commentsTask?.latestComments[0].authorName === commentNamedUser.name);
+
+        // addTaskComment previously had NO auth check at all — hardened to
+        // assertScheduleTaskAccess (same gate updateScheduleTask/every other
+        // per-task mutation in this file uses). Reachability asserted the
+        // same way as the other actions above: this script runs outside a
+        // request scope, so a real auth wall is the expected outcome.
+        let addTaskCommentRan = false;
+        let addTaskCommentErr = "";
+        try {
+            await addTaskComment(notStarted.id, `Reachability probe ${tag}`);
+            addTaskCommentRan = true;
+        } catch (error) {
+            addTaskCommentErr = String((error as Error)?.message ?? error);
+        }
+        check("addTaskComment is reachable (runs, or hits the expected script auth wall outside a request scope)",
+            addTaskCommentRan || /Forbidden|Unauthorized|outside a request scope|headers/i.test(addTaskCommentErr));
 
         const allTasksBeforeZero = snapshot(await prisma.scheduleTask.findMany({
             where: { projectId: project.id },

--- a/src/app/company-dashboard/guide/page.tsx
+++ b/src/app/company-dashboard/guide/page.tsx
@@ -52,7 +52,8 @@ export default async function CompanyDashboardGuidePage() {
                     <p>Jobs that are ready but have no start date sit in the <strong>Unscheduled</strong> shelf above the calendar. Drag one onto the day it starts — its whole task schedule comes with it.</p>
                 </Step>
                 <Step n={2} title="Adjust dates by dragging">
-                    <p>Drag a whole bar to move the job. Drag a single phase block to move just that phase. Drag a block&apos;s edge to make it longer or shorter. Nothing is saved yet while you do this — pending moves show with a dashed outline.</p>
+                    <p>Drag a whole bar to move the job. Drag a single phase block to move just that phase, or its edge to make it longer or shorter. None of that is saved yet while you do this — pending moves show with a dashed outline.</p>
+                    <p>Drag the <strong>bar&apos;s own right edge</strong> to change the job&apos;s finish date — that one saves right away, no Save click needed.</p>
                 </Step>
                 <Step n={3} title="Hit Save when it looks right">
                     <p>A bar appears showing how many unsaved changes you have — <strong>Save</strong> writes them all at once, <strong>Discard</strong> puts everything back. If you move a job that&apos;s already In Progress, it asks whether to move just the start marker or also shift the work that hasn&apos;t started yet.</p>
@@ -65,7 +66,8 @@ export default async function CompanyDashboardGuidePage() {
             <div className="hui-card p-6 mb-6">
                 <h2 className="text-base font-semibold text-hui-textMain mb-4">Good to know</h2>
                 <ul className="text-sm text-hui-textMuted space-y-2 list-disc pl-5">
-                    <li>Clicking a bar opens its menu (dates, crew, <em>Open project</em>). It never jumps you into the project by accident.</li>
+                    <li>Clicking a bar opens its menu (dates, crew, <em>Open project</em>). It never jumps you into the project by accident. Right-click anywhere for the same menus a click opens.</li>
+                    <li>Hover any phase block to see its latest notes. Add one from its menu with <em>Add note…</em>.</li>
                     <li>Every move is logged on the project&apos;s activity feed — nothing here emails a customer.</li>
                     <li>Diamond markers and the money toggles (Income, Expenses, Projected CO, Hours) only appear for admin logins.</li>
                     <li>Anything more detailed — dependencies, baselines, punch lists — lives on the job&apos;s own Schedule page (menu → Open project → Schedule).</li>

--- a/src/app/company-dashboard/schedule-board/CrewPickers.tsx
+++ b/src/app/company-dashboard/schedule-board/CrewPickers.tsx
@@ -37,6 +37,38 @@ interface CrewOption {
 // popover of its own) and `variant="popover"` (the Schedule & crew table's
 // own trigger + FloatingPopover). No selected-initials chip here — the
 // table/bar trigger button keeps summarizing initials on its own.
+// Serializes full-list crew writes: instant optimistic UI, but requests go
+// out strictly in order (a later toggle's list can never be overtaken by an
+// earlier one racing through the locked server transaction). While one write
+// is in flight, newer lists coalesce into a single queued follow-up.
+function useSerializedCrewSubmit(send: (ids: string[]) => Promise<void>, onError: (message: string) => void) {
+    const [, startTransition] = useTransition();
+    const inFlightRef = useRef(false);
+    const queuedRef = useRef<string[] | null>(null);
+    return (ids: string[]) => {
+        if (inFlightRef.current) {
+            queuedRef.current = ids;
+            return;
+        }
+        inFlightRef.current = true;
+        startTransition(async () => {
+            try {
+                let current: string[] | null = ids;
+                while (current) {
+                    await send(current);
+                    current = queuedRef.current;
+                    queuedRef.current = null;
+                }
+            } catch (err: any) {
+                queuedRef.current = null;
+                onError(err?.message ?? "Failed to update crew");
+            } finally {
+                inFlightRef.current = false;
+            }
+        });
+    };
+}
+
 function CrewChecklist({
     legend,
     options,
@@ -99,18 +131,20 @@ export function CrewPicker({
     const [override, setOverride] = useState<{ key: string; ids: string[] } | null>(null);
     const selected = override && override.key === crewKey ? override.ids : crew.map(c => c.id);
 
+    const submitCrew = useSerializedCrewSubmit(
+        async ids => {
+            await updateProjectCrewAction(projectId, ids);
+            router.refresh();
+        },
+        message => {
+            toast.error(message || "Failed to update crew");
+            setOverride(null);
+        },
+    );
     function toggle(userId: string) {
         const next = selected.includes(userId) ? selected.filter(id => id !== userId) : [...selected, userId];
         setOverride({ key: crewKey, ids: next });
-        startTransition(async () => {
-            try {
-                await updateProjectCrewAction(projectId, next);
-                router.refresh();
-            } catch (err: any) {
-                toast.error(err?.message || "Failed to update crew");
-                setOverride(null);
-            }
-        });
+        submitCrew(next);
     }
 
     // Option list: the picker team list PLUS any currently-assigned member who
@@ -175,18 +209,20 @@ export function TaskCrewPicker({
     ];
     const legend = `Task crew — ${selected.length} assigned`;
 
+    const submitCrew = useSerializedCrewSubmit(
+        async ids => {
+            await updateTaskCrewAction(task.id, ids);
+            router.refresh();
+        },
+        message => {
+            toast.error(message || "Failed to update task crew");
+            setOverride(null);
+        },
+    );
     function toggle(userId: string) {
         const next = selected.includes(userId) ? selected.filter(id => id !== userId) : [...selected, userId];
         setOverride({ key: assignmentKey, ids: next });
-        startTransition(async () => {
-            try {
-                await updateTaskCrewAction(task.id, next);
-                router.refresh();
-            } catch (err: any) {
-                toast.error(err?.message || "Failed to update task crew");
-                setOverride(null);
-            }
-        });
+        submitCrew(next);
     }
 
     if (variant === "inline") {

--- a/src/app/company-dashboard/schedule-board/CrewPickers.tsx
+++ b/src/app/company-dashboard/schedule-board/CrewPickers.tsx
@@ -6,31 +6,93 @@
 // import (CompanyDashboardClient -> ScheduleBoard -> …View -> ProjectBar
 // would import back into CompanyDashboardClient otherwise). Behavior is
 // byte-identical to the original inline components.
+//
+// Rebuild (owner-feedback round, item 5): the picker used to bring its own
+// fixed-width, fixed-height, self-scrolling inner panel, nested inside the
+// schedule board's ALREADY-scrollable FloatingPopover menus (ProjectBar/
+// TaskBlockSegment's "crew" view) — a double scrollbar + horizontal overflow.
+// CrewChecklist is now a plain two-column grid with NO scroll/width of its
+// own — FloatingPopover is the one and only scroll owner everywhere a picker
+// renders.
 
-import { useState, useTransition } from "react";
+import { useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import type { DashboardTaskRow, PipelineCrewMember } from "@/lib/schedule-core";
 import { updateProjectCrewAction, updateTaskCrewAction } from "@/lib/actions";
+import { FloatingPopover } from "./FloatingPopover";
 
 function initials(name: string): string {
     const parts = name.trim().split(/\s+/);
     return parts.map(p => p[0]).join("").toUpperCase().slice(0, 2) || "?";
 }
 
-// Compact crew picker (checkbox popover) — the list is pre-filtered to
-// ACTIVATED users server-side; every toggle replaces the crew idempotently.
+interface CrewOption {
+    id: string;
+    label: string;
+}
+
+// Shared checklist presentation — used both `variant="inline"` (rendered
+// directly inside an ALREADY-open schedule-board FloatingPopover, no nested
+// popover of its own) and `variant="popover"` (the Schedule & crew table's
+// own trigger + FloatingPopover). No selected-initials chip here — the
+// table/bar trigger button keeps summarizing initials on its own.
+function CrewChecklist({
+    legend,
+    options,
+    selected,
+    disabled,
+    onToggle,
+}: {
+    legend: string;
+    options: CrewOption[];
+    selected: string[];
+    disabled: boolean;
+    onToggle: (userId: string) => void;
+}) {
+    return (
+        <fieldset className="m-0 min-w-0 border-0 p-0" disabled={disabled}>
+            <legend className="mb-1 px-0 text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted">{legend}</legend>
+            {options.length === 0 ? (
+                <p className="px-2 py-1 text-xs text-hui-textMuted">No active team members.</p>
+            ) : (
+                <div className="grid grid-cols-1 gap-1 sm:grid-cols-2">
+                    {options.map(option => (
+                        <label key={option.id} className="flex min-h-11 min-w-0 items-center gap-2 rounded-md px-2 py-2 hover:bg-slate-50 focus-within:ring-2 focus-within:ring-hui-primary">
+                            <input
+                                type="checkbox"
+                                checked={selected.includes(option.id)}
+                                onChange={() => onToggle(option.id)}
+                                className="h-4 w-4 shrink-0 accent-hui-primary"
+                            />
+                            <span className="min-w-0 break-words text-sm text-hui-textMain">{option.label}</span>
+                        </label>
+                    ))}
+                </div>
+            )}
+        </fieldset>
+    );
+}
+
+// Compact crew picker — the list is pre-filtered to ACTIVATED users
+// server-side; every toggle replaces the crew idempotently.
 export function CrewPicker({
     projectId,
     crew,
     teamMembers,
+    variant = "popover",
 }: {
     projectId: string;
     crew: PipelineCrewMember[];
     teamMembers: { id: string; name: string; email: string }[];
+    // "inline" (ProjectBar's "Project crew…" menu view — already inside a
+    // FloatingPopover) vs "popover" (Schedule & crew table — owns its own
+    // trigger + FloatingPopover).
+    variant?: "inline" | "popover";
 }) {
     const router = useRouter();
     const [open, setOpen] = useState(false);
+    const triggerRef = useRef<HTMLButtonElement>(null);
     const [isPending, startTransition] = useTransition();
 
     // Selection mirrors the server crew unless the user just toggled (the
@@ -64,44 +126,45 @@ export function CrewPicker({
         ...teamMembers.map(m => ({ id: m.id, label: m.name || m.email })),
         ...unlistedAssigned.map(c => ({ id: c.id, label: `${c.name} (${c.role === "FINANCE" ? "finance" : "inactive"})` })),
     ];
+    const legend = `Project crew — ${selected.length} assigned`;
+
+    if (variant === "inline") {
+        return <CrewChecklist legend={legend} options={options} selected={selected} disabled={isPending} onToggle={toggle} />;
+    }
+
     const selectedNames = options.filter(o => selected.includes(o.id));
     return (
-        <div className="relative">
+        <>
             <button
+                ref={triggerRef}
                 type="button"
                 onClick={() => setOpen(o => !o)}
                 disabled={isPending}
+                aria-expanded={open}
                 className="hui-btn hui-btn-secondary text-xs px-2 py-1"
                 title="Assign crew"
             >
                 {selectedNames.length === 0 ? "Assign crew" : selectedNames.map(o => initials(o.label)).join(" ")}
             </button>
-            {open && (
-                <>
-                    <div className="fixed inset-0 z-20" onClick={() => setOpen(false)} />
-                    <div className="absolute z-30 mt-1 w-56 bg-white border border-hui-border rounded-lg shadow-lg p-2 max-h-64 overflow-y-auto">
-                        {options.length === 0 && <p className="text-xs text-hui-textMuted px-2 py-1">No active team members.</p>}
-                        {options.map(o => (
-                            <label key={o.id} className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-slate-50 cursor-pointer">
-                                <input
-                                    type="checkbox"
-                                    checked={selected.includes(o.id)}
-                                    onChange={() => toggle(o.id)}
-                                    className="accent-hui-primary"
-                                />
-                                <span className="text-sm text-hui-textMain">{o.label}</span>
-                            </label>
-                        ))}
-                    </div>
-                </>
-            )}
-        </div>
+            <FloatingPopover open={open} anchorRef={triggerRef} onClose={() => setOpen(false)} width={320}>
+                <CrewChecklist legend={legend} options={options} selected={selected} disabled={isPending} onToggle={toggle} />
+            </FloatingPopover>
+        </>
     );
 }
 
-export function TaskCrewPicker({ task, teamMembers }: { task: DashboardTaskRow; teamMembers: { id: string; name: string; email: string }[] }) {
+export function TaskCrewPicker({
+    task,
+    teamMembers,
+    variant = "popover",
+}: {
+    task: DashboardTaskRow;
+    teamMembers: { id: string; name: string; email: string }[];
+    variant?: "inline" | "popover";
+}) {
     const router = useRouter();
     const [open, setOpen] = useState(false);
+    const triggerRef = useRef<HTMLButtonElement>(null);
     const [isPending, startTransition] = useTransition();
     const assignedIds = task.assignments.map(a => a.userId);
     const assignmentKey = [...assignedIds].sort().join(",");
@@ -112,6 +175,7 @@ export function TaskCrewPicker({ task, teamMembers }: { task: DashboardTaskRow; 
         ...teamMembers.map(member => ({ id: member.id, label: member.name || member.email })),
         ...unlisted.map(a => ({ id: a.userId, label: `${a.name} (${a.role === "FINANCE" ? "finance" : "inactive"})` })),
     ];
+    const legend = `Task crew — ${selected.length} assigned`;
 
     function toggle(userId: string) {
         const next = selected.includes(userId) ? selected.filter(id => id !== userId) : [...selected, userId];
@@ -127,25 +191,18 @@ export function TaskCrewPicker({ task, teamMembers }: { task: DashboardTaskRow; 
         });
     }
 
+    if (variant === "inline") {
+        return <CrewChecklist legend={legend} options={options} selected={selected} disabled={isPending} onToggle={toggle} />;
+    }
+
     return (
-        <div className="relative inline-block">
-            <button type="button" onClick={() => setOpen(value => !value)} disabled={isPending} className="hui-btn hui-btn-secondary text-xs px-2 py-1" aria-expanded={open}>
+        <>
+            <button ref={triggerRef} type="button" onClick={() => setOpen(value => !value)} disabled={isPending} className="hui-btn hui-btn-secondary text-xs px-2 py-1" aria-expanded={open}>
                 {selected.length === 0 ? "Assign task crew" : task.assignments.filter(a => selected.includes(a.userId)).map(a => initials(a.name)).join(" ") || `${selected.length} assigned`}
             </button>
-            {open && (
-                <>
-                    <div className="fixed inset-0 z-20" onClick={() => setOpen(false)} />
-                    <div className="absolute right-0 z-30 mt-1 w-56 bg-white border border-hui-border rounded-lg shadow-lg p-2 max-h-64 overflow-y-auto">
-                        {options.length === 0 && <p className="text-xs text-hui-textMuted px-2 py-1">No active team members.</p>}
-                        {options.map(option => (
-                            <label key={option.id} className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-slate-50 cursor-pointer">
-                                <input type="checkbox" checked={selected.includes(option.id)} onChange={() => toggle(option.id)} className="accent-hui-primary" />
-                                <span className="text-sm text-hui-textMain">{option.label}</span>
-                            </label>
-                        ))}
-                    </div>
-                </>
-            )}
-        </div>
+            <FloatingPopover open={open} anchorRef={triggerRef} onClose={() => setOpen(false)} width={320}>
+                <CrewChecklist legend={legend} options={options} selected={selected} disabled={isPending} onToggle={toggle} />
+            </FloatingPopover>
+        </>
     );
 }

--- a/src/app/company-dashboard/schedule-board/CrewPickers.tsx
+++ b/src/app/company-dashboard/schedule-board/CrewPickers.tsx
@@ -42,10 +42,10 @@ interface CrewOption {
 // earlier one racing through the locked server transaction). While one write
 // is in flight, newer lists coalesce into a single queued follow-up.
 function useSerializedCrewSubmit(send: (ids: string[]) => Promise<void>, onError: (message: string) => void) {
-    const [, startTransition] = useTransition();
+    const [isPending, startTransition] = useTransition();
     const inFlightRef = useRef(false);
     const queuedRef = useRef<string[] | null>(null);
-    return (ids: string[]) => {
+    const submit = (ids: string[]) => {
         if (inFlightRef.current) {
             queuedRef.current = ids;
             return;
@@ -67,6 +67,7 @@ function useSerializedCrewSubmit(send: (ids: string[]) => Promise<void>, onError
             }
         });
     };
+    return { submit, isPending };
 }
 
 function CrewChecklist({
@@ -123,7 +124,7 @@ export function CrewPicker({
     const router = useRouter();
     const [open, setOpen] = useState(false);
     const triggerRef = useRef<HTMLButtonElement>(null);
-    const [isPending, startTransition] = useTransition();
+
 
     // Selection mirrors the server crew unless the user just toggled (the
     // override keys on the crew contents, so refreshed props take back over).
@@ -131,7 +132,7 @@ export function CrewPicker({
     const [override, setOverride] = useState<{ key: string; ids: string[] } | null>(null);
     const selected = override && override.key === crewKey ? override.ids : crew.map(c => c.id);
 
-    const submitCrew = useSerializedCrewSubmit(
+    const { submit: submitCrew, isPending } = useSerializedCrewSubmit(
         async ids => {
             await updateProjectCrewAction(projectId, ids);
             router.refresh();
@@ -197,7 +198,6 @@ export function TaskCrewPicker({
     const router = useRouter();
     const [open, setOpen] = useState(false);
     const triggerRef = useRef<HTMLButtonElement>(null);
-    const [isPending, startTransition] = useTransition();
     const assignedIds = task.assignments.map(a => a.userId);
     const assignmentKey = [...assignedIds].sort().join(",");
     const [override, setOverride] = useState<{ key: string; ids: string[] } | null>(null);
@@ -209,7 +209,7 @@ export function TaskCrewPicker({
     ];
     const legend = `Task crew — ${selected.length} assigned`;
 
-    const submitCrew = useSerializedCrewSubmit(
+    const { submit: submitCrew, isPending } = useSerializedCrewSubmit(
         async ids => {
             await updateTaskCrewAction(task.id, ids);
             router.refresh();

--- a/src/app/company-dashboard/schedule-board/CrewPickers.tsx
+++ b/src/app/company-dashboard/schedule-board/CrewPickers.tsx
@@ -41,17 +41,15 @@ function CrewChecklist({
     legend,
     options,
     selected,
-    disabled,
     onToggle,
 }: {
     legend: string;
     options: CrewOption[];
     selected: string[];
-    disabled: boolean;
     onToggle: (userId: string) => void;
 }) {
     return (
-        <fieldset className="m-0 min-w-0 border-0 p-0" disabled={disabled}>
+        <fieldset className="m-0 min-w-0 border-0 p-0">
             <legend className="mb-1 px-0 text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted">{legend}</legend>
             {options.length === 0 ? (
                 <p className="px-2 py-1 text-xs text-hui-textMuted">No active team members.</p>
@@ -129,7 +127,7 @@ export function CrewPicker({
     const legend = `Project crew — ${selected.length} assigned`;
 
     if (variant === "inline") {
-        return <CrewChecklist legend={legend} options={options} selected={selected} disabled={isPending} onToggle={toggle} />;
+        return <CrewChecklist legend={legend} options={options} selected={selected} onToggle={toggle} />;
     }
 
     const selectedNames = options.filter(o => selected.includes(o.id));
@@ -147,7 +145,7 @@ export function CrewPicker({
                 {selectedNames.length === 0 ? "Assign crew" : selectedNames.map(o => initials(o.label)).join(" ")}
             </button>
             <FloatingPopover open={open} anchorRef={triggerRef} onClose={() => setOpen(false)} width={320}>
-                <CrewChecklist legend={legend} options={options} selected={selected} disabled={isPending} onToggle={toggle} />
+                <CrewChecklist legend={legend} options={options} selected={selected} onToggle={toggle} />
             </FloatingPopover>
         </>
     );
@@ -192,7 +190,7 @@ export function TaskCrewPicker({
     }
 
     if (variant === "inline") {
-        return <CrewChecklist legend={legend} options={options} selected={selected} disabled={isPending} onToggle={toggle} />;
+        return <CrewChecklist legend={legend} options={options} selected={selected} onToggle={toggle} />;
     }
 
     return (
@@ -201,7 +199,7 @@ export function TaskCrewPicker({
                 {selected.length === 0 ? "Assign task crew" : task.assignments.filter(a => selected.includes(a.userId)).map(a => initials(a.name)).join(" ") || `${selected.length} assigned`}
             </button>
             <FloatingPopover open={open} anchorRef={triggerRef} onClose={() => setOpen(false)} width={320}>
-                <CrewChecklist legend={legend} options={options} selected={selected} disabled={isPending} onToggle={toggle} />
+                <CrewChecklist legend={legend} options={options} selected={selected} onToggle={toggle} />
             </FloatingPopover>
         </>
     );

--- a/src/app/company-dashboard/schedule-board/FloatingPopover.tsx
+++ b/src/app/company-dashboard/schedule-board/FloatingPopover.tsx
@@ -21,6 +21,8 @@ export interface FloatingPopoverProps {
     children: ReactNode;
     /** Panel width in px — the panel right-aligns to the trigger by default (matching the prior `absolute right-0` menus), then clamps into the viewport. */
     width?: number;
+    /** Non-interactive hover card mode (schedule-board task hover notes): the panel never captures pointer events, so it can never trap the mouse mid-hover. Default false (normal click/context menu). */
+    pointerEventsNone?: boolean;
 }
 
 /**
@@ -33,7 +35,7 @@ export interface FloatingPopoverProps {
  * horizontally with an 8px viewport margin. Escape closes and returns focus
  * to the trigger; a pointerdown outside the panel and trigger also closes it.
  */
-export function FloatingPopover({ open, anchorRef, anchorPoint, onClose, children, width = 224 }: FloatingPopoverProps) {
+export function FloatingPopover({ open, anchorRef, anchorPoint, onClose, children, width = 224, pointerEventsNone = false }: FloatingPopoverProps) {
     const panelRef = useRef<HTMLDivElement | null>(null);
     const [position, setPosition] = useState<{ top: number; left: number; maxHeight: number } | null>(null);
 
@@ -131,10 +133,19 @@ export function FloatingPopover({ open, anchorRef, anchorPoint, onClose, childre
                 maxHeight: position?.maxHeight,
                 overflowY: "auto",
                 width,
+                // Crew-picker rebuild (item 5): FloatingPopover is now the ONLY
+                // scroll owner any schedule-board menu ever nests — content
+                // (e.g. CrewChecklist) must never bring its own w-*/max-h-*
+                // scroller, and a viewport narrower than `width` must clip
+                // horizontally rather than overflow the screen.
+                maxWidth: `calc(100vw - ${2 * VIEWPORT_MARGIN_PX}px)`,
+                boxSizing: "border-box",
+                overflowX: "hidden",
+                overscrollBehaviorY: "contain",
                 visibility: position ? "visible" : "hidden",
             }}
-            className="z-[200] space-y-2 rounded-md border border-hui-border bg-white p-3 text-left text-hui-textMain shadow-xl"
-            onPointerDown={event => event.stopPropagation()}
+            className={`z-[200] space-y-2 rounded-md border border-hui-border bg-white p-3 text-left text-hui-textMain shadow-xl ${pointerEventsNone ? "pointer-events-none" : ""}`}
+            onPointerDown={pointerEventsNone ? undefined : event => event.stopPropagation()}
         >
             {children}
         </div>,

--- a/src/app/company-dashboard/schedule-board/FloatingPopover.tsx
+++ b/src/app/company-dashboard/schedule-board/FloatingPopover.tsx
@@ -93,9 +93,17 @@ export function FloatingPopover({ open, anchorRef, anchorPoint, onClose, childre
         place();
         window.addEventListener("resize", place);
         window.addEventListener("scroll", place, true);
+        // Re-measure when the PANEL's content changes size (e.g. a menu view
+        // switching to the taller inline crew checklist) — placement computed
+        // for the short view would otherwise keep constraining the tall one.
+        const panelObserver = typeof ResizeObserver !== "undefined" && panelRef.current
+            ? new ResizeObserver(() => place())
+            : null;
+        if (panelObserver && panelRef.current) panelObserver.observe(panelRef.current);
         return () => {
             window.removeEventListener("resize", place);
             window.removeEventListener("scroll", place, true);
+            panelObserver?.disconnect();
         };
     }, [open, anchorRef, anchorPoint, width]);
 
@@ -105,7 +113,9 @@ export function FloatingPopover({ open, anchorRef, anchorPoint, onClose, childre
             if (event.key !== "Escape") return;
             event.preventDefault();
             onClose();
-            anchorRef?.current?.focus();
+            // Hover cards open on focus — restoring focus to the anchor would
+            // immediately reopen the card Escape just dismissed.
+            if (!pointerEventsNone) anchorRef?.current?.focus();
         }
         function onPointerDownOutside(event: PointerEvent) {
             const target = event.target as Node;
@@ -119,7 +129,7 @@ export function FloatingPopover({ open, anchorRef, anchorPoint, onClose, childre
             window.removeEventListener("keydown", onKeyDown);
             window.removeEventListener("pointerdown", onPointerDownOutside, true);
         };
-    }, [open, onClose, anchorRef]);
+    }, [open, onClose, anchorRef, pointerEventsNone]);
 
     if (!open || typeof document === "undefined") return null;
 

--- a/src/app/company-dashboard/schedule-board/FloatingPopover.tsx
+++ b/src/app/company-dashboard/schedule-board/FloatingPopover.tsx
@@ -37,6 +37,7 @@ export interface FloatingPopoverProps {
  */
 export function FloatingPopover({ open, anchorRef, anchorPoint, onClose, children, width = 224, pointerEventsNone = false }: FloatingPopoverProps) {
     const panelRef = useRef<HTMLDivElement | null>(null);
+    const contentRef = useRef<HTMLDivElement | null>(null);
     const [position, setPosition] = useState<{ top: number; left: number; maxHeight: number } | null>(null);
 
     useLayoutEffect(() => {
@@ -54,7 +55,11 @@ export function FloatingPopover({ open, anchorRef, anchorPoint, onClose, childre
             const viewportWidth = window.innerWidth;
             const viewportHeight = window.innerHeight;
             const panelWidth = panelRef.current?.offsetWidth ?? width;
-            const panelHeight = panelRef.current?.offsetHeight ?? 0;
+            // scrollHeight, not offsetHeight: once a maxHeight is applied the
+            // box stops growing, so a menu switching to taller content (the
+            // inline crew checklist) would keep measuring the SHORT view and
+            // never re-place. scrollHeight always reflects the content.
+            const panelHeight = Math.max(panelRef.current?.scrollHeight ?? 0, panelRef.current?.offsetHeight ?? 0);
 
             // Clamp order matters: the left-edge floor is applied LAST so a
             // viewport narrower than the panel pins to the margin instead of
@@ -96,10 +101,14 @@ export function FloatingPopover({ open, anchorRef, anchorPoint, onClose, childre
         // Re-measure when the PANEL's content changes size (e.g. a menu view
         // switching to the taller inline crew checklist) — placement computed
         // for the short view would otherwise keep constraining the tall one.
-        const panelObserver = typeof ResizeObserver !== "undefined" && panelRef.current
+        // Observe the CONTENT wrapper, not the panel: a maxHeight-capped panel
+        // box never changes size when its content grows, so panel observation
+        // misses the menu→taller-checklist switch entirely.
+        const observed = contentRef.current ?? panelRef.current;
+        const panelObserver = typeof ResizeObserver !== "undefined" && observed
             ? new ResizeObserver(() => place())
             : null;
-        if (panelObserver && panelRef.current) panelObserver.observe(panelRef.current);
+        if (panelObserver && observed) panelObserver.observe(observed);
         return () => {
             window.removeEventListener("resize", place);
             window.removeEventListener("scroll", place, true);
@@ -157,7 +166,10 @@ export function FloatingPopover({ open, anchorRef, anchorPoint, onClose, childre
             className={`z-[200] space-y-2 rounded-md border border-hui-border bg-white p-3 text-left text-hui-textMain shadow-xl ${pointerEventsNone ? "pointer-events-none" : ""}`}
             onPointerDown={pointerEventsNone ? undefined : event => event.stopPropagation()}
         >
-            {children}
+            {/* Content wrapper: observed for size changes — the panel box
+                itself stops growing once maxHeight caps it, so observing the
+                panel alone misses menu→taller-view switches. */}
+            <div ref={contentRef}>{children}</div>
         </div>,
         document.body,
     );

--- a/src/app/company-dashboard/schedule-board/MonthBarsView.tsx
+++ b/src/app/company-dashboard/schedule-board/MonthBarsView.tsx
@@ -51,6 +51,9 @@ interface MonthBarsViewProps extends TaskEditCallbacks, ProjectEditCallbacks {
     // pickers (item 1) — reuses the exact CrewPicker/TaskCrewPicker the
     // Schedule & crew table uses.
     teamMembers: { id: string; name: string; email: string }[];
+    // Suppresses every task hover card while ANY schedule-board drag is
+    // active (item 3).
+    isAnyDragActive: boolean;
 }
 
 // window: badges only reflect conflicts intersecting the visible grid — the
@@ -112,6 +115,7 @@ export function MonthBarsView({
     activeTaskKeyboardEdit,
     onTrayProjectDrop,
     teamMembers,
+    isAnyDragActive,
     onProjectMoveCommit,
     activeProjectKeyboardId,
     onProjectPointerEditStart,
@@ -119,6 +123,7 @@ export function MonthBarsView({
     onProjectKeyboardAdjust,
     onProjectKeyboardCommit,
     onProjectKeyboardCancel,
+    onProjectEndResizeStart,
     onTaskPointerEditStart,
     onTaskKeyboardStart,
     onTaskKeyboardAdjust,
@@ -322,12 +327,14 @@ export function MonthBarsView({
                                                     activeTaskKeyboardEdit={activeTaskKeyboardEdit}
                                                     activeProjectKeyboardId={activeProjectKeyboardId}
                                                     teamMembers={teamMembers}
+                                                    isAnyDragActive={isAnyDragActive}
                                                     onProjectPointerEditStart={onProjectPointerEditStart}
                                                     onProjectKeyboardStart={onProjectKeyboardStart}
                                                     onProjectKeyboardAdjust={onProjectKeyboardAdjust}
                                                     onProjectKeyboardCommit={onProjectKeyboardCommit}
                                                     onProjectKeyboardCancel={onProjectKeyboardCancel}
                                                     onMoveCommit={onProjectMoveCommit}
+                                                    onProjectEndResizeStart={onProjectEndResizeStart}
                                                     onTaskPointerEditStart={onTaskPointerEditStart}
                                                     onTaskKeyboardStart={onTaskKeyboardStart}
                                                     onTaskKeyboardAdjust={onTaskKeyboardAdjust}
@@ -376,6 +383,7 @@ export function MonthBarsView({
                                                                     isDraft={draftProjectIds.has(project.id) || draftTaskIds.has(task.id)}
                                                                     activeTaskKeyboardEdit={activeTaskKeyboardEdit}
                                                                     teamMembers={teamMembers}
+                                                                    isAnyDragActive={isAnyDragActive}
                                                                     onTaskPointerEditStart={onTaskPointerEditStart}
                                                                     onTaskKeyboardStart={onTaskKeyboardStart}
                                                                     onTaskKeyboardAdjust={onTaskKeyboardAdjust}

--- a/src/app/company-dashboard/schedule-board/ProjectBar.tsx
+++ b/src/app/company-dashboard/schedule-board/ProjectBar.tsx
@@ -50,6 +50,10 @@ export interface ProjectEditCallbacks {
     onProjectKeyboardCommit: (_project: DashboardProjectRow) => void;
     onProjectKeyboardCancel: (_project: DashboardProjectRow) => void;
     onProjectMoveCommit: (_project: DashboardProjectRow, _targetStart: string) => void;
+    // Right-edge drag-to-resize the project's end date (item 2) — a SEPARATE
+    // pointer-drag from the whole-bar move above; it never joins the draft
+    // system, it commits immediately via updateProjectEndDateAction.
+    onProjectEndResizeStart: (_project: DashboardProjectRow, _start: ProjectEndResizePointerStart) => void;
 }
 
 export interface ProjectBarProps extends TaskEditCallbacks {
@@ -74,6 +78,9 @@ export interface ProjectBarProps extends TaskEditCallbacks {
     // Context-menu "Project crew…" / TaskBlockSegment's "Task crew…" (item 1)
     // reuse the exact CrewPicker/TaskCrewPicker the Schedule & crew table uses.
     teamMembers: { id: string; name: string; email: string }[];
+    // Suppresses every task's hover card while ANY schedule-board drag is
+    // active (item 3) — threaded through to this bar's own task renders.
+    isAnyDragActive: boolean;
     activeProjectKeyboardId: ProjectEditCallbacks["activeProjectKeyboardId"];
     onProjectPointerEditStart: ProjectEditCallbacks["onProjectPointerEditStart"];
     onProjectKeyboardStart: ProjectEditCallbacks["onProjectKeyboardStart"];
@@ -81,6 +88,7 @@ export interface ProjectBarProps extends TaskEditCallbacks {
     onProjectKeyboardCommit: ProjectEditCallbacks["onProjectKeyboardCommit"];
     onProjectKeyboardCancel: ProjectEditCallbacks["onProjectKeyboardCancel"];
     onMoveCommit: ProjectEditCallbacks["onProjectMoveCommit"];
+    onProjectEndResizeStart: ProjectEditCallbacks["onProjectEndResizeStart"];
 }
 
 export const ProjectBarGridStartContext = createContext<Date | null>(null);
@@ -97,6 +105,23 @@ export interface ProjectPointerEditStart {
     timelineScrollContainerRef?: RefObject<HTMLDivElement | null>;
 }
 
+// Right-edge resize drag (item 2) — deliberately separate from
+// ProjectPointerEditStart: no fallbackGrabDate (px→day math only, never
+// cell hit-testing), and it carries the project's CURRENT end so the drag
+// can compute a delta without re-deriving it from segment geometry.
+export interface ProjectEndResizePointerStart {
+    pointerId: number;
+    pointerType: string;
+    clientX: number;
+    clientY: number;
+    sourceElement: HTMLElement;
+    originalStart: string;
+    originalEnd: string;
+    timelineDayWidth?: number;
+    timelineLeftInset?: number;
+    timelineScrollContainerRef?: RefObject<HTMLDivElement | null>;
+}
+
 function initials(name: string): string {
     return name.trim().split(/\s+/).map(part => part[0]).join("").toUpperCase().slice(0, 2) || "?";
 }
@@ -105,7 +130,7 @@ function initials(name: string): string {
 // CONTENT switches between a top-level list and each item's own sub-view
 // (item 1) — simpler and more robust than nesting flyout panels, and keeps
 // every item reachable by keyboard from the same panel.
-type BarMenuView = "main" | "dates" | "crew" | "color" | "end-date";
+type BarMenuView = "main" | "dates" | "crew" | "color";
 
 export function ProjectBar({
     project,
@@ -125,6 +150,7 @@ export function ProjectBar({
     timelineLeftInset,
     timelineScrollContainerRef,
     teamMembers,
+    isAnyDragActive,
     activeProjectKeyboardId,
     onProjectPointerEditStart,
     onProjectKeyboardStart,
@@ -132,6 +158,7 @@ export function ProjectBar({
     onProjectKeyboardCommit,
     onProjectKeyboardCancel,
     onMoveCommit,
+    onProjectEndResizeStart,
     onTaskPointerEditStart,
     onTaskKeyboardStart,
     onTaskKeyboardAdjust,
@@ -235,6 +262,29 @@ export function ProjectBar({
         });
     }
 
+    // Right-edge grab handle (item 2): a SEPARATE pointer-drag from the
+    // whole-bar move above — stopPropagation so it wins over handlePointerDown
+    // within its own hit area instead of also starting a move-drag. Available
+    // whenever the bar's Actions menu is (canEdit), independent of
+    // canMoveProject — a Substantial Completion project can't have its START
+    // dragged, but its finish date is still editable, same as "Edit dates…".
+    function handleEndResizePointerDown(event: ReactPointerEvent<HTMLDivElement>) {
+        if (!canEdit || isPending || !event.isPrimary || (event.pointerType === "mouse" && event.button !== 0)) return;
+        event.stopPropagation();
+        onProjectEndResizeStart(project, {
+            pointerId: event.pointerId,
+            pointerType: event.pointerType,
+            clientX: event.clientX,
+            clientY: event.clientY,
+            sourceElement: event.currentTarget,
+            originalStart: formatDate(projectRange!.start),
+            originalEnd: formatDate(projectRange!.end),
+            timelineDayWidth,
+            timelineLeftInset,
+            timelineScrollContainerRef,
+        });
+    }
+
     function openMenu(anchorPoint: { x: number; y: number } | null) {
         setMenuAnchorPoint(anchorPoint);
         setMenuView("main");
@@ -284,10 +334,20 @@ export function ProjectBar({
         openMenu({ x: event.clientX, y: event.clientY });
     }
 
+    // Merged "Edit dates…" submit (item 1): a Start change and an End change
+    // are TWO INDEPENDENT writers fired from the same form. Start joins the
+    // existing draft system (onMoveCommit -> draftProjectMove — unsaved until
+    // Save); End calls updateProjectEndDateAction immediately and ONLY when
+    // it actually changed (the Clear button below fires the same action
+    // directly, unconditionally).
     function handleDateSubmit(event: FormEvent<HTMLFormElement>) {
         event.preventDefault();
-        if (!targetStart || isPending) return;
-        onMoveCommit(project, targetStart);
+        if (canMoveProject && targetStart && !isPending) {
+            onMoveCommit(project, targetStart);
+        }
+        if (endDateValue !== projectEndDate) {
+            submitEndDate(endDateValue || null);
+        }
         setMenuOpen(false);
     }
 
@@ -408,19 +468,14 @@ export function ProjectBar({
                                     {project.distanceMilesFromShop != null && (
                                         <p className="px-2 text-[10px] text-hui-textMuted">≈{project.distanceMilesFromShop} mi from shop</p>
                                     )}
-                                    {canMoveProject && (
-                                        <button type="button" onClick={() => setMenuView("dates")} className="block w-full rounded px-2 py-1.5 text-left text-xs text-hui-textMain hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary">
-                                            Edit dates…
-                                        </button>
-                                    )}
+                                    <button type="button" onClick={() => setMenuView("dates")} className="block w-full rounded px-2 py-1.5 text-left text-xs text-hui-textMain hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary">
+                                        Edit dates…
+                                    </button>
                                     <button type="button" onClick={() => setMenuView("crew")} className="block w-full rounded px-2 py-1.5 text-left text-xs text-hui-textMain hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary">
                                         Project crew…
                                     </button>
                                     <button type="button" onClick={() => setMenuView("color")} className="block w-full rounded px-2 py-1.5 text-left text-xs text-hui-textMain hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary">
                                         Color…
-                                    </button>
-                                    <button type="button" onClick={() => setMenuView("end-date")} className="block w-full rounded px-2 py-1.5 text-left text-xs text-hui-textMain hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary">
-                                        Set end date…
                                     </button>
                                     {project.status === "Waiting to Start" && (
                                         <button
@@ -434,20 +489,40 @@ export function ProjectBar({
                                     )}
                                 </div>
                             )}
-                            {menuView === "dates" && canMoveProject && (
+                            {menuView === "dates" && (
                                 <form onSubmit={handleDateSubmit} className="space-y-2">
                                     <button type="button" onClick={() => setMenuView("main")} className="text-[10px] font-semibold text-hui-textMuted hover:text-hui-primary">← Back</button>
-                                    <label className="block text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted" htmlFor={`bar-project-date-${project.id}-${segment.weekIndex}`}>Start date</label>
-                                    <input
-                                        id={`bar-project-date-${project.id}-${segment.weekIndex}`}
-                                        type="date"
-                                        value={targetStart}
-                                        onChange={event => setTargetStartDraft({ resetKey: actionResetKey, value: event.target.value })}
-                                        disabled={isPending}
-                                        className="hui-input w-full px-2 py-1 text-xs"
-                                    />
-                                    <button type="submit" disabled={isPending || !targetStart} className="hui-btn hui-btn-primary w-full text-xs disabled:cursor-wait disabled:opacity-60">
-                                        Move project
+                                    {canMoveProject && (
+                                        <div>
+                                            <label className="block text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted" htmlFor={`bar-project-date-${project.id}-${segment.weekIndex}`}>Start date</label>
+                                            <input
+                                                id={`bar-project-date-${project.id}-${segment.weekIndex}`}
+                                                type="date"
+                                                value={targetStart}
+                                                onChange={event => setTargetStartDraft({ resetKey: actionResetKey, value: event.target.value })}
+                                                disabled={isPending}
+                                                className="hui-input w-full px-2 py-1 text-xs"
+                                            />
+                                            <p className="mt-0.5 text-[9px] text-hui-textMuted">Joins unsaved changes — Save to commit.</p>
+                                        </div>
+                                    )}
+                                    <div>
+                                        <label className="block text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted" htmlFor={`bar-project-enddate-${project.id}`}>End date</label>
+                                        <input
+                                            id={`bar-project-enddate-${project.id}`}
+                                            type="date"
+                                            value={endDateValue}
+                                            onChange={event => setEndDateDraft({ resetKey: actionResetKey, value: event.target.value })}
+                                            disabled={isEndDatePending}
+                                            className="hui-input w-full px-2 py-1 text-xs"
+                                        />
+                                        <p className="mt-0.5 text-[9px] text-hui-textMuted">Saves immediately.</p>
+                                    </div>
+                                    <button type="button" disabled={isEndDatePending || !project.endDate} onClick={() => submitEndDate(null)} className="hui-btn hui-btn-secondary w-full text-[10px] disabled:opacity-60">
+                                        Clear end date
+                                    </button>
+                                    <button type="submit" disabled={isEndDatePending || (canMoveProject && (isPending || !targetStart))} className="hui-btn hui-btn-primary w-full text-xs disabled:cursor-wait disabled:opacity-60">
+                                        {isEndDatePending ? "Saving..." : "Save"}
                                     </button>
                                 </form>
                             )}
@@ -455,7 +530,7 @@ export function ProjectBar({
                                 <div className="space-y-2">
                                     <button type="button" onClick={() => setMenuView("main")} className="text-[10px] font-semibold text-hui-textMuted hover:text-hui-primary">← Back</button>
                                     <p className="text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted">Project crew</p>
-                                    <CrewPicker projectId={project.id} crew={project.crew} teamMembers={teamMembers} />
+                                    <CrewPicker projectId={project.id} crew={project.crew} teamMembers={teamMembers} variant="inline" />
                                 </div>
                             )}
                             {menuView === "color" && (
@@ -481,34 +556,30 @@ export function ProjectBar({
                                     </div>
                                 </div>
                             )}
-                            {menuView === "end-date" && (
-                                <div className="space-y-2">
-                                    <button type="button" onClick={() => setMenuView("main")} className="text-[10px] font-semibold text-hui-textMuted hover:text-hui-primary">← Back</button>
-                                    <p className="text-[10px] text-hui-textMuted">Immediate — not part of unsaved changes.</p>
-                                    <label className="block text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted" htmlFor={`bar-project-enddate-${project.id}`}>End date</label>
-                                    <input
-                                        id={`bar-project-enddate-${project.id}`}
-                                        type="date"
-                                        value={endDateValue}
-                                        onChange={event => setEndDateDraft({ resetKey: actionResetKey, value: event.target.value })}
-                                        disabled={isEndDatePending}
-                                        className="hui-input w-full px-2 py-1 text-xs"
-                                    />
-                                    <div className="grid grid-cols-2 gap-2">
-                                        <button type="button" disabled={isEndDatePending || !project.endDate} onClick={() => submitEndDate(null)} className="hui-btn hui-btn-secondary text-[10px] disabled:opacity-60">
-                                            Clear
-                                        </button>
-                                        <button type="button" disabled={isEndDatePending || !endDateValue} onClick={() => submitEndDate(endDateValue)} className="hui-btn hui-btn-primary text-[10px] disabled:opacity-60">
-                                            {isEndDatePending ? "Saving..." : "Save"}
-                                        </button>
-                                    </div>
-                                </div>
-                            )}
                         </FloatingPopover>
                     </>
                 )}
                 {segment.continuesAfter && <span aria-hidden="true">›</span>}
             </div>
+            {/* Right-edge resize handle (item 2) — confined to the title strip's
+            own 18px band (top-0, h-[18px]) so it can NEVER vertically overlap a
+            task block's own resize-right handle, which lives only inside the
+            task strip below (18px..barHeight). Only rendered on the segment
+            that actually ENDS the project (not a continuation into a future
+            week/timeline clip) — canEdit-gated like every other end-date
+            affordance (item 1), independent of canMoveProject. */}
+            {canEdit && !isPending && !segment.continuesAfter && (
+                <div
+                    role="presentation"
+                    aria-hidden="true"
+                    title={`Drag to change ${project.name}'s end date`}
+                    className="absolute right-0 top-0 z-20 h-[18px] w-1.5 touch-pan-y cursor-ew-resize opacity-0 transition group-hover/project:opacity-100 group-focus-within/project:opacity-100 [@media(hover:none)]:opacity-100"
+                    onPointerDown={handleEndResizePointerDown}
+                >
+                    <span className="absolute inset-y-1 left-0 w-px bg-white/90" />
+                    <span className="absolute inset-y-1 right-0 w-px bg-white/90" />
+                </div>
+            )}
             {hiddenTasks.length > 0 && (
                 <>
                     <button
@@ -549,6 +620,7 @@ export function ProjectBar({
                         timelineLeftInset={timelineLeftInset}
                         timelineScrollContainerRef={timelineScrollContainerRef}
                         teamMembers={teamMembers}
+                        isAnyDragActive={isAnyDragActive}
                         onTaskPointerEditStart={onTaskPointerEditStart}
                         onTaskKeyboardStart={onTaskKeyboardStart}
                         onTaskKeyboardAdjust={onTaskKeyboardAdjust}

--- a/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
+++ b/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
@@ -335,6 +335,14 @@ export function ScheduleBoard({
     const isAnyDragActive = pointerDragActive || projectKeyboardEdit !== null || taskKeyboardEdit !== null;
 
     useEffect(() => () => onEffectivePendingProjectIdsChange(EMPTY_PROJECT_IDS), [onEffectivePendingProjectIdsChange]);
+    // Edge-resize saves must lock the project PAGE-WIDE: without publishing,
+    // the legacy StartDateRow can mutate the same project mid-save and reject
+    // or clobber the new end date. (saveAllDrafts publishes its own set
+    // in-line; this effect only speaks while no batch save is running.)
+    useEffect(() => {
+        if (isSaving) return;
+        onEffectivePendingProjectIdsChange(endResizeSavingProjectIds);
+    }, [endResizeSavingProjectIds, isSaving, onEffectivePendingProjectIdsChange]);
 
     const applyPreview = (project: DashboardProjectRow) => {
         const projectPreview = projectPreviewOverrides[project.id] ?? project;
@@ -1046,6 +1054,14 @@ export function ScheduleBoard({
         void (async () => {
             try {
                 await updateProjectEndDateAction(project.id, candidateEnd);
+                // Reconcile the resize preview through the expectation system —
+                // it clears the override once canonical endDate matches;
+                // leaving the override unmanaged would mask ALL later
+                // refreshed data for this project.
+                setProjectRefreshExpectations(current => ({
+                    ...current,
+                    [project.id]: { projectEndDate: candidateEnd, taskDates: [] },
+                }));
                 router.refresh();
                 if (taskDerivedRange && parseUTCDate(candidateEnd) < taskDerivedRange.end) {
                     toast.info(`End date saved — the bar still shows through ${formatDate(addDays(taskDerivedRange.end, -1))} because tasks run that long.`);
@@ -1097,9 +1113,15 @@ export function ScheduleBoard({
             const dayWidth = drag.start.timelineDayWidth ?? drag.monthDayWidth;
             if (!dayWidth) return null;
             const deltaDays = getTimelinePointerDelta(drag.latestClientX, drag.originX, dayWidth);
+            // Clamp against the PERSISTED start marker when one exists — the
+            // effective range can start at an earlier task (marker-only moves),
+            // and the server rejects end <= persisted startDate.
+            const clampStart = drag.project.startDate
+                ? parseUTCDate(drag.project.startDate.slice(0, 10))
+                : parseUTCDate(drag.originalStart);
             const candidateEnd = computeProjectEndResizeCandidate(
                 parseUTCDate(drag.originalEnd),
-                parseUTCDate(drag.originalStart),
+                clampStart,
                 deltaDays,
             );
             return formatDate(candidateEnd);

--- a/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
+++ b/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
@@ -223,6 +223,12 @@ export function ScheduleBoard({
     // the pending-to-save payload; nothing writes to the server until Save.
     const [taskDateOverrides, setTaskDateOverrides] = useState<Record<string, TaskDateOverride>>({});
     const [projectDrafts, setProjectDrafts] = useState<Record<string, ProjectDraftMove>>({});
+    // Read at reconciliation-timeout FIRE time (an effect-render snapshot can
+    // miss a just-added draft or resurrect a just-discarded one).
+    const projectDraftsRef = useRef(projectDrafts);
+    useEffect(() => { projectDraftsRef.current = projectDrafts; }, [projectDrafts]);
+    // Batch-save lock set feeding the single derived page-wide publisher.
+    const [saveLockedProjectIds, setSaveLockedProjectIds] = useState<ReadonlySet<string>>(EMPTY_PROJECT_IDS);
     const [isSaving, setIsSaving] = useState(false);
     const [awaitingTaskRefreshIds, setAwaitingTaskRefreshIds] = useState<Set<string>>(() => new Set());
     const [taskKeyboardEdit, setTaskKeyboardEdit] = useState<TaskKeyboardEditState | null>(null);
@@ -335,14 +341,13 @@ export function ScheduleBoard({
     const isAnyDragActive = pointerDragActive || projectKeyboardEdit !== null || taskKeyboardEdit !== null;
 
     useEffect(() => () => onEffectivePendingProjectIdsChange(EMPTY_PROJECT_IDS), [onEffectivePendingProjectIdsChange]);
-    // Edge-resize saves must lock the project PAGE-WIDE: without publishing,
-    // the legacy StartDateRow can mutate the same project mid-save and reject
-    // or clobber the new end date. (saveAllDrafts publishes its own set
-    // in-line; this effect only speaks while no batch save is running.)
+    // ONE derived publisher for the page-wide lock: the live union of the
+    // running batch save's locked projects and every in-flight end-resize
+    // save. Snapshot-based inline publications left windows where a resize
+    // starting mid-batch went unpublished.
     useEffect(() => {
-        if (isSaving) return;
-        onEffectivePendingProjectIdsChange(endResizeSavingProjectIds);
-    }, [endResizeSavingProjectIds, isSaving, onEffectivePendingProjectIdsChange]);
+        onEffectivePendingProjectIdsChange(mergeProjectPendingIds(saveLockedProjectIds, endResizeSavingProjectIds));
+    }, [saveLockedProjectIds, endResizeSavingProjectIds, onEffectivePendingProjectIdsChange]);
 
     const applyPreview = (project: DashboardProjectRow) => {
         const projectPreview = projectPreviewOverrides[project.id] ?? project;
@@ -488,13 +493,12 @@ export function ScheduleBoard({
             // visual preview of a still-UNSAVED start draft on the same
             // project — rebuild that preview from fresh canonical data.
             for (const projectId of reconciled) {
-                const draft = projectDrafts[projectId];
+                const draft = projectDraftsRef.current[projectId];
                 const canonical = canonicalProjectById.get(projectId);
                 if (draft && canonical) setProjectPreview(canonical, draft.targetStart);
             }
         }, 0);
         return () => window.clearTimeout(timeoutId);
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- projectDrafts read at fire time by design
     }, [canonicalProjectById, projectRefreshExpectations]);
 
     useEffect(() => {
@@ -725,9 +729,7 @@ export function ScheduleBoard({
                 .map(([taskId]) => canonicalTaskProjectById.get(taskId))
                 .filter((id): id is string => Boolean(id)),
         ]);
-        // The batch's page-wide lock must UNION any in-flight end-resize saves
-        // — replacing the set would unlock a project mid-resize-save.
-        onEffectivePendingProjectIdsChange(mergeProjectPendingIds(lockedProjectIds, endResizeSavingProjectIds));
+        setSaveLockedProjectIds(lockedProjectIds); // the derived publisher unions live resize saves
 
         const failedProjectNames: string[] = [];
         const succeededProjectIds: string[] = [];
@@ -855,10 +857,7 @@ export function ScheduleBoard({
         }
 
         setIsSaving(false);
-        // Reset to the still-in-flight end-resize saves, not blindly to empty
-        // (the isSaving-gated effect re-publishes on the next change anyway,
-        // but the window between here and that effect must not unlock them).
-        onEffectivePendingProjectIdsChange(endResizeSavingProjectIds.size > 0 ? endResizeSavingProjectIds : EMPTY_PROJECT_IDS);
+        setSaveLockedProjectIds(EMPTY_PROJECT_IDS); // derived publisher keeps live resize saves locked
         router.refresh();
 
         if (saveNotes.length > 0) toast.info(saveNotes.join(" "));

--- a/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
+++ b/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
@@ -484,8 +484,17 @@ export function ScheduleBoard({
             setProjectPreviewOverrides(current => Object.fromEntries(Object.entries(current).filter(([id]) => !reconciled.has(id))));
             setProjectIncomeOverrides(current => Object.fromEntries(Object.entries(current).filter(([id]) => !reconciled.has(id))));
             setProjectRefreshExpectations(current => Object.fromEntries(Object.entries(current).filter(([id]) => !reconciled.has(id))));
+            // A reconciled refresh (e.g. an end-resize save) must not eat the
+            // visual preview of a still-UNSAVED start draft on the same
+            // project — rebuild that preview from fresh canonical data.
+            for (const projectId of reconciled) {
+                const draft = projectDrafts[projectId];
+                const canonical = canonicalProjectById.get(projectId);
+                if (draft && canonical) setProjectPreview(canonical, draft.targetStart);
+            }
         }, 0);
         return () => window.clearTimeout(timeoutId);
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- projectDrafts read at fire time by design
     }, [canonicalProjectById, projectRefreshExpectations]);
 
     useEffect(() => {
@@ -716,7 +725,9 @@ export function ScheduleBoard({
                 .map(([taskId]) => canonicalTaskProjectById.get(taskId))
                 .filter((id): id is string => Boolean(id)),
         ]);
-        onEffectivePendingProjectIdsChange(lockedProjectIds);
+        // The batch's page-wide lock must UNION any in-flight end-resize saves
+        // — replacing the set would unlock a project mid-resize-save.
+        onEffectivePendingProjectIdsChange(mergeProjectPendingIds(lockedProjectIds, endResizeSavingProjectIds));
 
         const failedProjectNames: string[] = [];
         const succeededProjectIds: string[] = [];
@@ -844,7 +855,10 @@ export function ScheduleBoard({
         }
 
         setIsSaving(false);
-        onEffectivePendingProjectIdsChange(EMPTY_PROJECT_IDS);
+        // Reset to the still-in-flight end-resize saves, not blindly to empty
+        // (the isSaving-gated effect re-publishes on the next change anyway,
+        // but the window between here and that effect must not unlock them).
+        onEffectivePendingProjectIdsChange(endResizeSavingProjectIds.size > 0 ? endResizeSavingProjectIds : EMPTY_PROJECT_IDS);
         router.refresh();
 
         if (saveNotes.length > 0) toast.info(saveNotes.join(" "));

--- a/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
+++ b/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } fro
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { saveCompanyScheduleTaskDatesAction, shiftNotStartedTasksAction, updateProjectStartDateAction } from "@/lib/actions";
+import { saveCompanyScheduleTaskDatesAction, shiftNotStartedTasksAction, updateProjectEndDateAction, updateProjectStartDateAction } from "@/lib/actions";
 import type { CompanyDashboardData, DashboardProjectRow, DashboardTaskRow, OverlayIncomeItem } from "@/lib/schedule-core";
 import { addDays, formatDate, getDaysBetween, parseUTCDate } from "@/app/projects/[id]/schedule/schedule-utils";
 import { MonthBarsView } from "./MonthBarsView";
@@ -13,11 +13,13 @@ import { AvailabilityPanel } from "./AvailabilityPanel";
 import { ShiftConfirmDialog, type ProjectMoveChoice } from "./ShiftConfirmDialog";
 import { UnscheduledTray } from "./UnscheduledTray";
 import {
+    computeProjectEndResizeCandidate,
     createProjectDropIntent,
     getEffectiveProjectRange,
     getNewlyPendingProjectIds,
     getTimelineAutoscrollStep,
     getTimelinePointerDelta,
+    mergeProjectPendingIds,
     previewProjectMove,
     previewProjectIncomeOverlays,
     previewTaskDates,
@@ -30,7 +32,7 @@ import {
     type TaskEditMode,
 } from "./useBarLayout";
 import type { TaskPointerEditStart } from "./TaskBlockSegment";
-import type { ProjectPointerEditStart } from "./ProjectBar";
+import type { ProjectEndResizePointerStart, ProjectPointerEditStart } from "./ProjectBar";
 
 export type { ProjectMoveChoice } from "./ShiftConfirmDialog";
 export type { ProjectDropIntent } from "./useBarLayout";
@@ -111,6 +113,36 @@ interface ActiveProjectPointerEdit {
     cleanup: () => void;
 }
 
+// Right-edge resize drag (item 2) — a SEPARATE pointer-drag from
+// ActiveProjectPointerEdit above: it previews via the SAME projectPreviewOverrides
+// slot (only one project edit can be active at a time — see cancelActiveProjectEdit)
+// but commits immediately (updateProjectEndDateAction), never joining the
+// draft/Save system.
+interface ActiveProjectEndResizeEdit {
+    projectId: string;
+    project: DashboardProjectRow;
+    pointerId: number;
+    pointerType: string;
+    startX: number;
+    startY: number;
+    originX: number;
+    latestClientX: number;
+    latestClientY: number;
+    originalStart: string;
+    originalEnd: string;
+    // Month has no fixed per-day pixel width (Timeline's zoom-driven
+    // timelineDayWidth) — measured once at drag start from the underlying
+    // week-grid day cell (see measureMonthDayWidth).
+    monthDayWidth: number | null;
+    active: boolean;
+    currentCandidate: string | null;
+    animationFrameId: number | null;
+    sourceElement: HTMLElement;
+    previousTouchAction: string;
+    start: ProjectEndResizePointerStart;
+    cleanup: () => void;
+}
+
 // Draft-mode: a drafted project-start move accumulated locally until Save.
 interface ProjectDraftMove {
     originalStart: string;
@@ -137,6 +169,19 @@ function hitTestTimelineScheduleGrid(clientX: number, clientY: number): boolean 
             && clientY >= bounds.top && clientY <= bounds.bottom;
     }
     return false;
+}
+
+// Project-bar right-edge resize (item 2), Month view only: there is no fixed
+// per-day pixel width the way Timeline has (its zoom-driven timelineDayWidth)
+// — the week grid's day-cell width is measured directly from whichever
+// [data-schedule-date] cell sits under the pointer at drag start (every cell
+// in a week row is exactly one day wide by construction).
+function measureMonthDayWidth(clientX: number, clientY: number): number | null {
+    for (const element of document.elementsFromPoint(clientX, clientY)) {
+        const cell = element instanceof HTMLElement ? element.closest<HTMLElement>("[data-schedule-date]") : null;
+        if (cell) return cell.getBoundingClientRect().width;
+    }
+    return null;
 }
 
 function isInteractiveTaskFallbackTarget(target: EventTarget | null): boolean {
@@ -191,6 +236,17 @@ export function ScheduleBoard({
     const projectKeyboardCleanupRef = useRef<(() => void) | null>(null);
     const projectKeyboardSentinelRef = useRef<HTMLSpanElement>(null);
     const activeProjectPointerRef = useRef<ActiveProjectPointerEdit | null>(null);
+    // Right-edge resize (item 2): a SEPARATE active-drag ref from the
+    // whole-bar move above, plus the set of projects with an in-flight
+    // updateProjectEndDateAction save (merged into pendingProjectIds below so
+    // it participates in the SAME isPending gating as every other lock).
+    const activeProjectEndResizeRef = useRef<ActiveProjectEndResizeEdit | null>(null);
+    const [endResizeSavingProjectIds, setEndResizeSavingProjectIds] = useState<ReadonlySet<string>>(EMPTY_PROJECT_IDS);
+    // True for the duration of ANY pointer drag whose threshold has been
+    // crossed (project move, project end-resize, task move/resize) —
+    // combined with the keyboard-edit states below to gate task hover cards
+    // off while an edit is in progress (item 3).
+    const [pointerDragActive, setPointerDragActive] = useState(false);
     const previousExternallyPendingProjectIdsRef = useRef<ReadonlySet<string>>(new Set(externallyPendingProjectIds));
     const [confirmIntent, setConfirmIntent] = useState<ProjectDropIntent | null>(null);
     // Bumped on every "Today" click so TimelineView re-scrolls to today even
@@ -266,6 +322,17 @@ export function ScheduleBoard({
         const projectId = canonicalTaskProjectById.get(taskId);
         return Boolean(projectId && isProjectExternallyPending(projectId));
     }, [isSaving, isProjectExternallyPending, canonicalTaskProjectById]);
+
+    // End-resize saves are a SECOND source of "externally" pending, alongside
+    // the legacy StartDateRow (item 2) — merged so both views' isPending gate
+    // (isSaving || pendingProjectIds.has(id)) sees either lock the same way.
+    const combinedPendingProjectIds = useMemo(
+        () => mergeProjectPendingIds(externallyPendingProjectIds, endResizeSavingProjectIds),
+        [externallyPendingProjectIds, endResizeSavingProjectIds],
+    );
+    // Hover cards go quiet the moment ANY drag — pointer or keyboard, project
+    // or task — is in progress (item 3).
+    const isAnyDragActive = pointerDragActive || projectKeyboardEdit !== null || taskKeyboardEdit !== null;
 
     useEffect(() => () => onEffectivePendingProjectIdsChange(EMPTY_PROJECT_IDS), [onEffectivePendingProjectIdsChange]);
 
@@ -421,6 +488,7 @@ export function ScheduleBoard({
 
     useEffect(() => () => {
         activeProjectPointerRef.current?.cleanup();
+        activeProjectEndResizeRef.current?.cleanup();
         projectKeyboardCleanupRef.current?.();
         activeTaskPointerRef.current?.cleanup();
         taskKeyboardCleanupRef.current?.();
@@ -790,6 +858,10 @@ export function ScheduleBoard({
         if (pointerEdit && projectIds.has(pointerEdit.projectId)) {
             pointerEdit.cleanup();
         }
+        const endResizeEdit = activeProjectEndResizeRef.current;
+        if (endResizeEdit && projectIds.has(endResizeEdit.projectId)) {
+            endResizeEdit.cleanup();
+        }
         const keyboardEdit = projectKeyboardEditRef.current;
         if (keyboardEdit && projectIds.has(keyboardEdit.projectId)) {
             projectKeyboardCleanupRef.current?.();
@@ -799,6 +871,7 @@ export function ScheduleBoard({
 
     function cancelActiveProjectEdit() {
         activeProjectPointerRef.current?.cleanup();
+        activeProjectEndResizeRef.current?.cleanup();
         projectKeyboardCleanupRef.current?.();
         setProjectKeyboardState(null);
     }
@@ -906,6 +979,7 @@ export function ScheduleBoard({
                 if (Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY) < threshold) return;
                 drag.active = true;
                 drag.sourceElement.style.touchAction = "none";
+                setPointerDragActive(true);
             }
             event.preventDefault();
             requestProjectPointerFrame();
@@ -935,6 +1009,7 @@ export function ScheduleBoard({
         const onWindowBlur = () => finish(true);
         drag.cleanup = () => {
             if (activeProjectPointerRef.current === drag) activeProjectPointerRef.current = null;
+            setPointerDragActive(false);
             window.removeEventListener("pointermove", onPointerMove);
             window.removeEventListener("pointerup", onPointerUp);
             window.removeEventListener("pointercancel", onPointerCancel);
@@ -949,6 +1024,182 @@ export function ScheduleBoard({
             }
         };
         activeProjectPointerRef.current = drag;
+        try {
+            start.sourceElement.setPointerCapture(start.pointerId);
+        } catch {
+            // Window listeners keep ownership stable when capture is unavailable.
+        }
+        window.addEventListener("pointermove", onPointerMove, { passive: false });
+        window.addEventListener("pointerup", onPointerUp);
+        window.addEventListener("pointercancel", onPointerCancel);
+        window.addEventListener("blur", onWindowBlur);
+    }
+
+    // Immediate server write for a released end-resize drag (item 2) — NOT
+    // part of the draft system. getEffectiveProjectRange treats endDate as an
+    // EXTEND-ONLY candidate, so a released end shorter than the last task's
+    // end still saves (owner-approved semantics) but the bar keeps showing
+    // through the task-derived date — surfaced here as an info toast.
+    function commitProjectEndResize(project: DashboardProjectRow, candidateEnd: string) {
+        const taskDerivedRange = getEffectiveProjectRange({ ...project, endDate: null });
+        setEndResizeSavingProjectIds(current => new Set([...current, project.id]));
+        void (async () => {
+            try {
+                await updateProjectEndDateAction(project.id, candidateEnd);
+                router.refresh();
+                if (taskDerivedRange && parseUTCDate(candidateEnd) < taskDerivedRange.end) {
+                    toast.info(`End date saved — the bar still shows through ${formatDate(addDays(taskDerivedRange.end, -1))} because tasks run that long.`);
+                } else {
+                    toast.success("End date saved");
+                }
+            } catch (error: any) {
+                clearProjectPreview(project.id);
+                toast.error(error?.message || "Failed to update end date");
+            } finally {
+                setEndResizeSavingProjectIds(current => {
+                    if (!current.has(project.id)) return current;
+                    const next = new Set(current);
+                    next.delete(project.id);
+                    return next;
+                });
+            }
+        })();
+    }
+
+    function handleProjectEndResizeStart(project: DashboardProjectRow, start: ProjectEndResizePointerStart) {
+        const canonicalProject = canonicalProjectById.get(project.id);
+        if (!data.canEdit || !canonicalProject || isProjectLocked(project.id)) return;
+        cancelActiveProjectEdit();
+        cancelActiveTaskEdit();
+        const drag: ActiveProjectEndResizeEdit = {
+            projectId: project.id,
+            project: canonicalProject,
+            pointerId: start.pointerId,
+            pointerType: start.pointerType,
+            startX: start.clientX,
+            startY: start.clientY,
+            originX: start.clientX,
+            latestClientX: start.clientX,
+            latestClientY: start.clientY,
+            originalStart: start.originalStart,
+            originalEnd: start.originalEnd,
+            monthDayWidth: start.timelineDayWidth ? null : measureMonthDayWidth(start.clientX, start.clientY),
+            active: false,
+            currentCandidate: null,
+            animationFrameId: null,
+            sourceElement: start.sourceElement,
+            previousTouchAction: start.sourceElement.style.touchAction,
+            start,
+            cleanup: () => undefined,
+        };
+
+        const calculateEndResizeCandidate = (): string | null => {
+            const dayWidth = drag.start.timelineDayWidth ?? drag.monthDayWidth;
+            if (!dayWidth) return null;
+            const deltaDays = getTimelinePointerDelta(drag.latestClientX, drag.originX, dayWidth);
+            const candidateEnd = computeProjectEndResizeCandidate(
+                parseUTCDate(drag.originalEnd),
+                parseUTCDate(drag.originalStart),
+                deltaDays,
+            );
+            return formatDate(candidateEnd);
+        };
+        const getEndResizeAutoscrollStep = () => {
+            const container = drag.start.timelineScrollContainerRef?.current;
+            if (!container || !drag.start.timelineDayWidth) return 0;
+            const bounds = container.getBoundingClientRect();
+            return getTimelineAutoscrollStep({
+                clientX: drag.latestClientX,
+                containerLeft: bounds.left,
+                containerRight: bounds.right,
+                timelineLeftInset: drag.start.timelineLeftInset ?? 0,
+                scrollLeft: container.scrollLeft,
+                scrollWidth: container.scrollWidth,
+                clientWidth: container.clientWidth,
+                threshold: EDGE_AUTOSCROLL_THRESHOLD_PX,
+                maxStep: MAX_AUTOSCROLL_PX_PER_FRAME,
+            });
+        };
+        const applyEndResizeCandidate = () => {
+            const candidate = calculateEndResizeCandidate();
+            drag.currentCandidate = candidate;
+            if (!candidate || candidate === drag.originalEnd) {
+                clearProjectPreview(drag.projectId);
+                return;
+            }
+            setProjectPreviewOverrides(current => ({
+                ...current,
+                [drag.projectId]: { ...drag.project, endDate: `${candidate}T00:00:00.000Z` },
+            }));
+        };
+        const runEndResizeFrame = () => {
+            drag.animationFrameId = null;
+            if (!drag.active) return;
+            const container = drag.start.timelineScrollContainerRef?.current;
+            const scrollDelta = getEndResizeAutoscrollStep();
+            if (container && scrollDelta !== 0) {
+                const before = container.scrollLeft;
+                container.scrollLeft += scrollDelta;
+                drag.originX -= container.scrollLeft - before;
+            }
+            applyEndResizeCandidate();
+            if (getEndResizeAutoscrollStep() !== 0 && drag.animationFrameId == null) {
+                drag.animationFrameId = requestAnimationFrame(runEndResizeFrame);
+            }
+        };
+        const onPointerMove = (event: PointerEvent) => {
+            if (event.pointerId !== drag.pointerId) return;
+            drag.latestClientX = event.clientX;
+            drag.latestClientY = event.clientY;
+            if (!drag.active) {
+                const threshold = drag.pointerType === "touch" ? PROJECT_TOUCH_DRAG_THRESHOLD_PX : PROJECT_MOUSE_DRAG_THRESHOLD_PX;
+                if (Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY) < threshold) return;
+                drag.active = true;
+                drag.sourceElement.style.touchAction = "none";
+                setPointerDragActive(true);
+            }
+            event.preventDefault();
+            if (drag.animationFrameId == null) drag.animationFrameId = requestAnimationFrame(runEndResizeFrame);
+        };
+        const finish = (cancelled: boolean, releaseEvent?: PointerEvent) => {
+            if (releaseEvent) {
+                drag.latestClientX = releaseEvent.clientX;
+                drag.latestClientY = releaseEvent.clientY;
+            }
+            if (drag.animationFrameId != null) cancelAnimationFrame(drag.animationFrameId);
+            drag.animationFrameId = null;
+            const candidate = drag.active && !cancelled ? calculateEndResizeCandidate() : null;
+            drag.cleanup();
+            if (!drag.active || cancelled || !candidate || candidate === drag.originalEnd) {
+                clearProjectPreview(drag.projectId);
+                return;
+            }
+            commitProjectEndResize(drag.project, candidate);
+        };
+        const onPointerUp = (event: PointerEvent) => {
+            if (event.pointerId === drag.pointerId) finish(false, event);
+        };
+        const onPointerCancel = (event: PointerEvent) => {
+            if (event.pointerId === drag.pointerId) finish(true);
+        };
+        const onWindowBlur = () => finish(true);
+        drag.cleanup = () => {
+            if (activeProjectEndResizeRef.current === drag) activeProjectEndResizeRef.current = null;
+            setPointerDragActive(false);
+            window.removeEventListener("pointermove", onPointerMove);
+            window.removeEventListener("pointerup", onPointerUp);
+            window.removeEventListener("pointercancel", onPointerCancel);
+            window.removeEventListener("blur", onWindowBlur);
+            if (drag.animationFrameId != null) cancelAnimationFrame(drag.animationFrameId);
+            drag.animationFrameId = null;
+            drag.sourceElement.style.touchAction = drag.previousTouchAction;
+            try {
+                if (drag.sourceElement.hasPointerCapture(drag.pointerId)) drag.sourceElement.releasePointerCapture(drag.pointerId);
+            } catch {
+                // The optimistic preview may re-key the originating segment.
+            }
+        };
+        activeProjectEndResizeRef.current = drag;
         try {
             start.sourceElement.setPointerCapture(start.pointerId);
         } catch {
@@ -1130,6 +1381,7 @@ export function ScheduleBoard({
                 if (Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY) < threshold) return;
                 drag.active = true;
                 drag.sourceElement.style.touchAction = "none";
+                setPointerDragActive(true);
             }
             event.preventDefault();
             if (drag.animationFrameId == null) drag.animationFrameId = requestAnimationFrame(runTaskPointerFrame);
@@ -1162,6 +1414,7 @@ export function ScheduleBoard({
 
         drag.cleanup = () => {
             if (activeTaskPointerRef.current === drag) activeTaskPointerRef.current = null;
+            setPointerDragActive(false);
             window.removeEventListener("pointermove", onPointerMove);
             window.removeEventListener("pointerup", onPointerUp);
             window.removeEventListener("pointercancel", onPointerCancel);
@@ -1405,7 +1658,7 @@ export function ScheduleBoard({
                     showProjectedCo={showProjectedCo}
                     showExpenses={showExpenses}
                     showHours={showHours}
-                    pendingProjectIds={externallyPendingProjectIds}
+                    pendingProjectIds={combinedPendingProjectIds}
                     pendingTaskIds={EMPTY_PROJECT_IDS}
                     draftProjectIds={draftProjectIds}
                     draftTaskIds={draftTaskIds}
@@ -1413,6 +1666,7 @@ export function ScheduleBoard({
                     activeTaskKeyboardEdit={taskKeyboardEdit}
                     onTrayProjectDrop={scheduleUnscheduledProject}
                     teamMembers={data.teamMembers ?? []}
+                    isAnyDragActive={isAnyDragActive}
                     activeProjectKeyboardId={projectKeyboardEdit?.projectId ?? null}
                     onProjectPointerEditStart={handleProjectPointerEditStart}
                     onProjectKeyboardStart={handleProjectKeyboardStart}
@@ -1420,6 +1674,7 @@ export function ScheduleBoard({
                     onProjectKeyboardCommit={handleProjectKeyboardCommit}
                     onProjectKeyboardCancel={handleProjectKeyboardCancel}
                     onProjectMoveCommit={handleProjectMoveCommit}
+                    onProjectEndResizeStart={handleProjectEndResizeStart}
                     onTaskPointerEditStart={handleTaskPointerEditStart}
                     onTaskKeyboardStart={handleTaskKeyboardStart}
                     onTaskKeyboardAdjust={handleTaskKeyboardAdjust}
@@ -1435,7 +1690,7 @@ export function ScheduleBoard({
                     showProjectedCo={showProjectedCo}
                     showExpenses={showExpenses}
                     showHours={showHours}
-                    pendingProjectIds={externallyPendingProjectIds}
+                    pendingProjectIds={combinedPendingProjectIds}
                     pendingTaskIds={EMPTY_PROJECT_IDS}
                     draftProjectIds={draftProjectIds}
                     draftTaskIds={draftTaskIds}
@@ -1446,6 +1701,7 @@ export function ScheduleBoard({
                     onToggleGroupByCrew={() => setGroupByCrewMode(!groupByCrew)}
                     scrollToTodayNonce={scrollToTodayNonce}
                     teamMembers={data.teamMembers ?? []}
+                    isAnyDragActive={isAnyDragActive}
                     activeProjectKeyboardId={projectKeyboardEdit?.projectId ?? null}
                     onProjectPointerEditStart={handleProjectPointerEditStart}
                     onProjectKeyboardStart={handleProjectKeyboardStart}
@@ -1453,6 +1709,7 @@ export function ScheduleBoard({
                     onProjectKeyboardCommit={handleProjectKeyboardCommit}
                     onProjectKeyboardCancel={handleProjectKeyboardCancel}
                     onProjectMoveCommit={handleProjectMoveCommit}
+                    onProjectEndResizeStart={handleProjectEndResizeStart}
                     onTaskPointerEditStart={handleTaskPointerEditStart}
                     onTaskKeyboardStart={handleTaskKeyboardStart}
                     onTaskKeyboardAdjust={handleTaskKeyboardAdjust}

--- a/src/app/company-dashboard/schedule-board/TaskBlockSegment.tsx
+++ b/src/app/company-dashboard/schedule-board/TaskBlockSegment.tsx
@@ -4,8 +4,8 @@ import { useCallback, useEffect, useId, useRef, useState, useTransition, type Fo
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import type { DashboardTaskRow } from "@/lib/schedule-core";
-import { deleteScheduleTask } from "@/lib/actions";
-import { addDays, formatDate, getDaysBetween, getDefaultColorForTaskName, parseUTCDate } from "@/app/projects/[id]/schedule/schedule-utils";
+import { addTaskComment, deleteScheduleTask } from "@/lib/actions";
+import { addDays, formatDate, getDaysBetween, getDefaultColorForTaskName, parseUTCDate, todayUTC } from "@/app/projects/[id]/schedule/schedule-utils";
 import { clipRange, type DateRange, type TaskDateOverride, type TaskEditMode } from "./useBarLayout";
 import { FloatingPopover } from "./FloatingPopover";
 import { TaskCrewPicker } from "./CrewPickers";
@@ -58,6 +58,10 @@ export interface TaskBlockSegmentProps extends TaskEditCallbacks {
     // Context-menu "Task crew…" (item 1) reuses the exact TaskCrewPicker the
     // Schedule & crew table uses.
     teamMembers: { id: string; name: string; email: string }[];
+    // Suppresses the hover card while ANY schedule-board drag (project move,
+    // project end-resize, task move/resize, or either's keyboard mode) is in
+    // progress — a hover card popping up mid-drag would be pure noise.
+    isAnyDragActive: boolean;
 }
 
 function readableText(color: string): string {
@@ -73,6 +77,23 @@ function initials(name: string): string {
     return name.trim().split(/\s+/).map(part => part[0]).join("").toUpperCase().slice(0, 2) || "?";
 }
 
+// Hover-card notes (owner-feedback round, item 3).
+const HOVER_CARD_OPEN_DELAY_MS = 300;
+const NOTE_TRUNCATE_LENGTH = 140;
+
+function relativeDayLabel(iso: string): string {
+    const createdDay = parseUTCDate(iso.slice(0, 10));
+    const diffDays = getDaysBetween(createdDay, todayUTC());
+    if (diffDays <= 0) return "Today";
+    if (diffDays === 1) return "Yesterday";
+    if (diffDays < 7) return `${diffDays} days ago`;
+    return formatDate(createdDay);
+}
+
+function truncateNote(text: string): string {
+    return text.length > NOTE_TRUNCATE_LENGTH ? `${text.slice(0, NOTE_TRUNCATE_LENGTH)}…` : text;
+}
+
 // Readability pass (2026-07-22): a task chip only shows its text label once
 // it's wide enough for roughly 3 characters at the bumped 11px label font —
 // narrower than that, the label is dropped in favor of the milestone's own
@@ -82,7 +103,7 @@ const MIN_LABEL_WIDTH_PX = 28;
 // Same single-popover, view-switching pattern as ProjectBar (item 1): one
 // FloatingPopover instance whose content swaps between the top-level menu
 // list and each item's own sub-view.
-type TaskMenuView = "main" | "dates" | "crew";
+type TaskMenuView = "main" | "dates" | "crew" | "notes";
 
 export function TaskBlockSegment({
     task,
@@ -99,6 +120,7 @@ export function TaskBlockSegment({
     laneTop,
     laneHeight,
     teamMembers,
+    isAnyDragActive,
     onTaskPointerEditStart,
     onTaskKeyboardStart,
     onTaskKeyboardAdjust,
@@ -109,6 +131,7 @@ export function TaskBlockSegment({
 }: TaskBlockSegmentProps) {
     const router = useRouter();
     const observerRef = useRef<ResizeObserver | null>(null);
+    const rootRef = useRef<HTMLDivElement | null>(null);
     const fragmentId = useId().replace(/:/g, "");
     const [allocatedWidth, setAllocatedWidth] = useState(0);
     const actionTriggerRef = useRef<HTMLButtonElement>(null);
@@ -116,6 +139,13 @@ export function TaskBlockSegment({
     const [menuAnchorPoint, setMenuAnchorPoint] = useState<{ x: number; y: number } | null>(null);
     const [menuView, setMenuView] = useState<TaskMenuView>("main");
     const [isDeletePending, startDeleteTransition] = useTransition();
+    const [isNotePending, startNoteTransition] = useTransition();
+    const [noteDraft, setNoteDraft] = useState("");
+    // Hover card (item 3): mouseenter opens after a short delay; focus opens
+    // immediately. Suppressed while the click/context menu is open or ANY
+    // board drag is active.
+    const [hoverCardOpen, setHoverCardOpen] = useState(false);
+    const hoverOpenTimeoutRef = useRef<number | null>(null);
     const actionResetKey = `${isPending ? "pending" : "ready"}:${task.startDate}:${task.endDate}`;
     const [menuDraft, setMenuDraft] = useState<{ resetKey: string; dates: TaskDateOverride | null }>(() => ({
         resetKey: actionResetKey,
@@ -136,6 +166,7 @@ export function TaskBlockSegment({
     const activeMode = activeTaskKeyboardEdit?.taskId === task.id ? activeTaskKeyboardEdit.mode : null;
 
     const setMeasuredElement = useCallback((element: HTMLDivElement | null) => {
+        rootRef.current = element;
         observerRef.current?.disconnect();
         observerRef.current = null;
         if (!element) return;
@@ -150,6 +181,9 @@ export function TaskBlockSegment({
     useEffect(() => {
         setMenuOpen(false);
     }, [actionResetKey]);
+    useEffect(() => {
+        if (!menuOpen) setNoteDraft("");
+    }, [menuOpen]);
     // Only one schedule-board menu open at a time (item 1) — including across
     // a right-click/context menu vs the click-triggered "⋯" menu.
     useEffect(() => {
@@ -162,6 +196,43 @@ export function TaskBlockSegment({
         activateExclusiveMenu(close);
         return () => deactivateExclusiveMenu(close);
     }, [menuOpen]);
+    // Hover card: a drag starting anywhere on the board (or the click/context
+    // menu opening) force-closes an already-open card — never left floating
+    // over an active edit.
+    useEffect(() => {
+        if (!isAnyDragActive && !menuOpen) return;
+        if (hoverOpenTimeoutRef.current != null) {
+            window.clearTimeout(hoverOpenTimeoutRef.current);
+            hoverOpenTimeoutRef.current = null;
+        }
+        setHoverCardOpen(false);
+    }, [isAnyDragActive, menuOpen]);
+    useEffect(() => () => {
+        if (hoverOpenTimeoutRef.current != null) window.clearTimeout(hoverOpenTimeoutRef.current);
+    }, []);
+
+    function handleHoverCardMouseEnter() {
+        if (isAnyDragActive || menuOpen || hoverOpenTimeoutRef.current != null) return;
+        hoverOpenTimeoutRef.current = window.setTimeout(() => {
+            hoverOpenTimeoutRef.current = null;
+            setHoverCardOpen(true);
+        }, HOVER_CARD_OPEN_DELAY_MS);
+    }
+    function handleHoverCardFocus() {
+        if (isAnyDragActive || menuOpen) return;
+        if (hoverOpenTimeoutRef.current != null) {
+            window.clearTimeout(hoverOpenTimeoutRef.current);
+            hoverOpenTimeoutRef.current = null;
+        }
+        setHoverCardOpen(true);
+    }
+    function closeHoverCard() {
+        if (hoverOpenTimeoutRef.current != null) {
+            window.clearTimeout(hoverOpenTimeoutRef.current);
+            hoverOpenTimeoutRef.current = null;
+        }
+        setHoverCardOpen(false);
+    }
 
     if (!clipped || (!isMilestone && taskEnd <= taskStart)) return null;
 
@@ -279,6 +350,26 @@ export function TaskBlockSegment({
         setMenuOpen(false);
     }
 
+    // Add note (item 3): an IMMEDIATE action through the existing task-comment
+    // creation action (addTaskComment, now hardened with assertScheduleTaskAccess)
+    // — not part of the board's draft-mode/Save system. The new note shows up
+    // in the hover card after the refresh below re-serializes latestComments.
+    function submitNote() {
+        const text = noteDraft.trim();
+        if (mutationDisabled || isNotePending || !text) return;
+        startNoteTransition(async () => {
+            try {
+                await addTaskComment(task.id, text);
+                router.refresh();
+                toast.success("Note added");
+            } catch (err: any) {
+                toast.error(err?.message || "Failed to add note");
+            }
+        });
+        setNoteDraft("");
+        setMenuOpen(false);
+    }
+
     const laneStyle = laneTop != null && laneHeight != null
         ? { top: laneTop, height: laneHeight }
         : undefined;
@@ -300,6 +391,10 @@ export function TaskBlockSegment({
             onPointerDown={event => beginPointerEdit(event, "move")}
             onKeyDown={event => handleKeyboard(event, "move")}
             onContextMenu={handleContextMenu}
+            onMouseEnter={handleHoverCardMouseEnter}
+            onMouseLeave={closeHoverCard}
+            onFocus={handleHoverCardFocus}
+            onBlur={closeHoverCard}
         >
             <div className="absolute inset-0 overflow-hidden rounded-sm">
                 <span className="absolute inset-y-0 left-0 bg-white/25" style={{ width: `${progress}%` }} aria-hidden="true" />
@@ -358,6 +453,9 @@ export function TaskBlockSegment({
                             <button type="button" onClick={() => setMenuView("crew")} className="block w-full rounded px-2 py-1.5 text-left text-xs text-hui-textMain hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary">
                                 Task crew…
                             </button>
+                            <button type="button" onClick={() => setMenuView("notes")} className="block w-full rounded px-2 py-1.5 text-left text-xs text-hui-textMain hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary">
+                                Add note…
+                            </button>
                             <button
                                 type="button"
                                 disabled={isDeletePending}
@@ -414,12 +512,49 @@ export function TaskBlockSegment({
                         <div className="space-y-2" onPointerDown={event => event.stopPropagation()}>
                             <button type="button" onClick={() => setMenuView("main")} className="text-[10px] font-semibold text-hui-textMuted hover:text-hui-primary">← Back</button>
                             <p className="text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted">Task crew</p>
-                            <TaskCrewPicker task={task} teamMembers={teamMembers} />
+                            <TaskCrewPicker task={task} teamMembers={teamMembers} variant="inline" />
+                        </div>
+                    )}
+                    {menuView === "notes" && (
+                        <div className="space-y-2" onPointerDown={event => event.stopPropagation()}>
+                            <button type="button" onClick={() => setMenuView("main")} className="text-[10px] font-semibold text-hui-textMuted hover:text-hui-primary">← Back</button>
+                            <label className="block text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted" htmlFor={`task-note-${task.id}-${fragmentId}`}>Note</label>
+                            <textarea
+                                id={`task-note-${task.id}-${fragmentId}`}
+                                value={noteDraft}
+                                onChange={event => setNoteDraft(event.target.value)}
+                                disabled={mutationDisabled || isNotePending}
+                                rows={3}
+                                className="hui-input w-full px-2 py-1 text-xs"
+                            />
+                            <button type="button" disabled={mutationDisabled || isNotePending || !noteDraft.trim()} onClick={submitNote} className="hui-btn hui-btn-primary w-full text-xs disabled:opacity-60">
+                                {isNotePending ? "Saving..." : "Add note"}
+                            </button>
+                            <p className="px-2 text-[9px] text-hui-textMuted">Saves immediately — not part of unsaved changes.</p>
                         </div>
                     )}
                 </FloatingPopover>
             </>
             )}
+            <FloatingPopover open={hoverCardOpen} anchorRef={rootRef} onClose={closeHoverCard} width={220} pointerEventsNone>
+                <div className="space-y-1">
+                    <p className="text-xs font-semibold text-hui-textMain">{isMilestone ? `◆ ${task.name}` : task.name}</p>
+                    <p className="text-[10px] text-hui-textMuted">UTC {formatDate(taskStart)} → {formatDate(isMilestone ? taskStart : taskEnd)}</p>
+                    <p className="text-[10px] text-hui-textMuted">Crew: {crew}</p>
+                    {task.latestComments.length > 0 && (
+                        <div className="space-y-1 border-t border-hui-border pt-1">
+                            {task.latestComments.map((comment, index) => (
+                                <p key={index} className="text-[10px] text-hui-textMain">
+                                    <span className="font-semibold">{comment.authorName}</span>{" "}
+                                    <span className="text-hui-textMuted">{relativeDayLabel(comment.createdAt)}</span>
+                                    {" — "}
+                                    {truncateNote(comment.text)}
+                                </p>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </FloatingPopover>
         </div>
     );
 }

--- a/src/app/company-dashboard/schedule-board/TimelineView.tsx
+++ b/src/app/company-dashboard/schedule-board/TimelineView.tsx
@@ -74,6 +74,9 @@ interface TimelineViewProps extends TaskEditCallbacks, ProjectEditCallbacks {
     // pickers (item 1) — reuses the exact CrewPicker/TaskCrewPicker the
     // Schedule & crew table uses.
     teamMembers: { id: string; name: string; email: string }[];
+    // Suppresses every task hover card while ANY schedule-board drag is
+    // active (item 3).
+    isAnyDragActive: boolean;
 }
 
 interface CrewTaskBlock {
@@ -172,6 +175,7 @@ export function TimelineView({
     onToggleGroupByCrew,
     scrollToTodayNonce,
     teamMembers,
+    isAnyDragActive,
     onProjectMoveCommit,
     activeProjectKeyboardId,
     onProjectPointerEditStart,
@@ -179,6 +183,7 @@ export function TimelineView({
     onProjectKeyboardAdjust,
     onProjectKeyboardCommit,
     onProjectKeyboardCancel,
+    onProjectEndResizeStart,
     onTaskPointerEditStart,
     onTaskKeyboardStart,
     onTaskKeyboardAdjust,
@@ -595,12 +600,14 @@ export function TimelineView({
                                                 timelineLeftInset={LABEL_WIDTH}
                                                 timelineScrollContainerRef={scrollContainerRef}
                                                 teamMembers={teamMembers}
+                                                isAnyDragActive={isAnyDragActive}
                                                 onProjectPointerEditStart={onProjectPointerEditStart}
                                                 onProjectKeyboardStart={onProjectKeyboardStart}
                                                 onProjectKeyboardAdjust={onProjectKeyboardAdjust}
                                                 onProjectKeyboardCommit={onProjectKeyboardCommit}
                                                 onProjectKeyboardCancel={onProjectKeyboardCancel}
                                                 onMoveCommit={onProjectMoveCommit}
+                                                onProjectEndResizeStart={onProjectEndResizeStart}
                                                 onTaskPointerEditStart={onTaskPointerEditStart}
                                                 onTaskKeyboardStart={onTaskKeyboardStart}
                                                 onTaskKeyboardAdjust={onTaskKeyboardAdjust}
@@ -629,6 +636,7 @@ export function TimelineView({
                                                     timelineLeftInset={LABEL_WIDTH}
                                                     timelineScrollContainerRef={scrollContainerRef}
                                                     teamMembers={teamMembers}
+                                                    isAnyDragActive={isAnyDragActive}
                                                     onTaskPointerEditStart={onTaskPointerEditStart}
                                                     onTaskKeyboardStart={onTaskKeyboardStart}
                                                     onTaskKeyboardAdjust={onTaskKeyboardAdjust}

--- a/src/app/company-dashboard/schedule-board/useBarLayout.ts
+++ b/src/app/company-dashboard/schedule-board/useBarLayout.ts
@@ -488,6 +488,19 @@ export function assignTaskLanes(tasks: TaskLaneRange[]): TaskLaneLayout {
     return { laneByTaskId, hiddenTaskIds, laneCount };
 }
 
+// Project-bar right-edge resize (owner-feedback round, item 2): the dragged
+// END date, clamped so the live preview (and the value actually saved on
+// release) never lands on or before the project's start — a project must
+// span at least one day. This is a PREVIEW-time clamp only; the persisted
+// value can still end up earlier than the last task's end (getEffectiveProjectRange
+// treats endDate as an extend-only candidate — see the ScheduleBoard commit
+// handler's "still shows through" info toast).
+export function computeProjectEndResizeCandidate(originalEnd: Date, startDate: Date, deltaDays: number): Date {
+    const candidate = addDays(originalEnd, deltaDays);
+    const minEnd = addDays(startDate, 1);
+    return candidate < minEnd ? minEnd : candidate;
+}
+
 export function toTimelineRect(range: DateRange, origin: Date, dayWidth: number): TimelineRect {
     const normalizedOrigin = toUTCDay(origin);
     const start = toUTCDay(range.start);

--- a/src/app/company-dashboard/schedule-board/useBarLayout.ts
+++ b/src/app/company-dashboard/schedule-board/useBarLayout.ts
@@ -51,6 +51,9 @@ export type PersistedTaskDate = PersistedScheduleTaskDate;
 
 export interface ProjectRefreshExpectation {
     projectStartDate?: string | null;
+    // Edge-resize end saves reconcile through the same expectation system —
+    // without this the resize preview override masks refreshed data forever.
+    projectEndDate?: string | null;
     taskDates: PersistedTaskDate[];
 }
 
@@ -209,6 +212,8 @@ export function projectRefreshMatches(
     if (!canonical) return false;
     if (expected.projectStartDate !== undefined
         && canonical.startDate?.slice(0, 10) !== expected.projectStartDate?.slice(0, 10)) return false;
+    if (expected.projectEndDate !== undefined
+        && (canonical.endDate?.slice(0, 10) ?? null) !== (expected.projectEndDate?.slice(0, 10) ?? null)) return false;
     const canonicalTasks = new Map(canonical.tasks.map(task => [task.id, task]));
     return expected.taskDates.every(task => {
         const canonicalTask = canonicalTasks.get(task.id);

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -6809,6 +6809,12 @@ export async function importEstimateToSchedule(projectId: string, estimateId: st
 // ========== TASK COMMENTS ==========
 
 export async function addTaskComment(taskId: string, text: string, photoUrls?: string[]) {
+    // Hardened (owner-feedback round, item 3): this action had no auth check
+    // at all — any caller could comment on any task. Same gate every other
+    // per-task schedule mutation in this file uses (schedules permission +
+    // project access), now also the entry point for the schedule board's
+    // hover-card "Add note…".
+    await assertScheduleTaskAccess(taskId);
     // Derive identity from the session — never trust a client-supplied userId.
     const session = await getSessionOrDev();
     const sessionUserId = (session?.user as any)?.id as string | null | undefined;

--- a/src/lib/schedule-core.ts
+++ b/src/lib/schedule-core.ts
@@ -1889,6 +1889,12 @@ export interface DashboardTaskAssignment {
     role: string;
 }
 
+export interface DashboardTaskComment {
+    text: string;
+    authorName: string;
+    createdAt: string;
+}
+
 export interface DashboardTaskRow {
     id: string;
     name: string;
@@ -1900,6 +1906,10 @@ export interface DashboardTaskRow {
     status: string;
     type: string;
     assignments: DashboardTaskAssignment[];
+    // Hover-card notes (owner-feedback round, item 3): most recent 2 task
+    // comments, newest first — same TaskComment source the project schedule
+    // page already shows, no new writes/schema.
+    latestComments: DashboardTaskComment[];
 }
 
 export interface DashboardProjectRow extends PipelineProject {
@@ -2164,6 +2174,14 @@ export async function getCompanyDashboardData(
                     orderBy: { createdAt: "asc" },
                     select: { id: true, userId: true, user: { select: { name: true, email: true, status: true, role: true } } },
                 },
+                // Hover-card notes (item 3): capped at 2, newest first — same
+                // audience as the project schedule page's own comment thread
+                // (not money, no extra gate).
+                comments: {
+                    orderBy: { createdAt: "desc" },
+                    take: 2,
+                    select: { text: true, createdAt: true, subcontractorName: true, user: { select: { name: true, email: true } } },
+                },
             },
         }),
         prisma.estimate.groupBy({ by: ["projectId"], where: { projectId: { in: rowIds }, status: { in: CONTRACT_ESTIMATE_STATUSES } }, _count: { id: true } }),
@@ -2189,6 +2207,11 @@ export async function getCompanyDashboardData(
                 name: a.user.name || a.user.email,
                 status: a.user.status,
                 role: a.user.role,
+            })),
+            latestComments: task.comments.map(c => ({
+                text: c.text,
+                authorName: c.user?.name ?? c.user?.email ?? c.subcontractorName ?? "Unknown",
+                createdAt: c.createdAt.toISOString(),
             })),
         });
         tasksByProject.set(task.projectId, rows);


### PR DESCRIPTION
Owner-feedback polish on the schedule board (follows #224).

- **Unified "Edit dates…"**: Start + End in one form (start drafts, end saves immediately — labeled); standalone "Set end date…" removed.
- **Edge-drag end dates**: grab the bar's right edge (both views) — live preview, day snap, immediate save; info toast when tasks outrun the new end (bars are extend-only by design).
- **Hover notes**: task blocks get a hover/focus card with dates, crew, and the latest 2 notes from the existing TaskComment system; "Add note…" in the task menu. **Security: `addTaskComment` previously had NO auth check — now gated by `assertScheduleTaskAccess`.**
- **Crew picker rebuild** (Codex design debate winner): shared two-column CrewChecklist fieldset — whole crew visible, zero scrollbars, 44px touch rows; inline in bar menus (no nested popover), 320px popover from the table; FloatingPopover is the sole scroll owner with contract guardrails against the old double-scroll classes.

Verification: all three board suites green (DB verifier incl. latestComments serialization + comment-auth checks, fixture cleanup), `tsc` 0, build 96/96. No payment/QB writes; money gates untouched; draft-mode invariants preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)