### PR TITLE
fix(schedule): findable grab zone for the end-date resize handle

### DIFF
--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -352,7 +352,9 @@ assert.match(projectBarSource, /opacity-0 transition group-hover\/project:opacit
 // Confined to the title strip's own 18px band — this is what keeps it from
 // EVER vertically overlapping a task block's own resize-right handle, which
 // lives only inside the task strip below.
-assert.match(projectBarSource, /className="absolute right-0 top-0 z-20 h-\[18px\] w-1\.5/, "the edge-resize handle must be confined to the title strip's 18px band, never the task strip");
+// 16px grab zone with a 4px overhang past the bar edge (a 6px sliver was
+// unhittable in practice) — still confined to the title strip's 18px band.
+assert.match(projectBarSource, /className="absolute -right-1 top-0 z-20 h-\[18px\] w-4/, "the edge-resize handle must be a findable-width target confined to the title strip's 18px band, never the task strip");
 // ScheduleBoard: a SEPARATE drag machine from the whole-bar move, live local
 // preview via the SAME projectPreviewOverrides mechanism the move-drag/item-3
 // preview already uses, immediate commit (never draftProjectMove).

--- a/src/app/company-dashboard/schedule-board/ProjectBar.tsx
+++ b/src/app/company-dashboard/schedule-board/ProjectBar.tsx
@@ -573,11 +573,14 @@ export function ProjectBar({
                     role="presentation"
                     aria-hidden="true"
                     title={`Drag to change ${project.name}'s end date`}
-                    className="absolute right-0 top-0 z-20 h-[18px] w-1.5 touch-pan-y cursor-ew-resize opacity-0 transition group-hover/project:opacity-100 group-focus-within/project:opacity-100 [@media(hover:none)]:opacity-100"
+                    // 16px grab zone with a 4px overhang past the bar edge — a
+                    // 6px sliver was practically unhittable next to the bar's
+                    // own move/click cursor (owner couldn't find it).
+                    className="absolute -right-1 top-0 z-20 h-[18px] w-4 touch-pan-y cursor-ew-resize opacity-0 transition group-hover/project:opacity-100 group-focus-within/project:opacity-100 [@media(hover:none)]:opacity-100"
                     onPointerDown={handleEndResizePointerDown}
                 >
-                    <span className="absolute inset-y-1 left-0 w-px bg-white/90" />
-                    <span className="absolute inset-y-1 right-0 w-px bg-white/90" />
+                    <span className="absolute inset-y-1 left-[5px] w-px bg-white/90" />
+                    <span className="absolute inset-y-1 left-[9px] w-px bg-white/90" />
                 </div>
             )}
             {hiddenTasks.length > 0 && (


### PR DESCRIPTION
The edge-resize handle was a 6px sliver — correct cursor and tooltip, but practically unhittable next to the bar's move cursor (owner couldn't find it). Now a 16px grab zone with a 4px overhang past the bar edge, grips centered, still confined to the title band so it can't collide with task-strip interactions. Styling-only; contract assertion updated to pin the new geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)