### PR TITLE
fix(schedule): crew pickers list FIELD_CREW only, no email decorations

### DIFF
--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -256,8 +256,8 @@ assert.match(coreSource, /where: \{ status: "ACTIVATED", role: "FIELD_CREW" \}/)
 // Owner call 2026-07-23: names stay bare — no email decoration ever (full
 // addresses wrapped across six lines in the crew checklist).
 assert.doesNotMatch(coreSource, /name: `\$\{r\.name\} \(\$\{r\.email\}\)`/, "picker names must never carry email decorations");
-assert.match(crewPickersSource, /c\.role === "FINANCE" \? "finance" : "inactive"/, "CrewPicker (now in CrewPickers.tsx) must still label removable FINANCE crew entries");
-assert.match(crewPickersSource, /a\.role === "FINANCE" \? "finance" : "inactive"/, "TaskCrewPicker (now in CrewPickers.tsx) must still label removable FINANCE task-crew entries");
+assert.match(crewPickersSource, /c\.status !== "ACTIVATED" \? "inactive" : c\.role\.toLowerCase\(\)\.replace\("_", " "\)/, "CrewPicker labels removable non-crew entries by role (or inactive)");
+assert.match(crewPickersSource, /a\.status !== "ACTIVATED" \? "inactive" : a\.role\.toLowerCase\(\)\.replace\("_", " "\)/, "TaskCrewPicker labels removable non-crew entries by role (or inactive)");
 assert.match(companyDashboardSource, /a\.role === "FINANCE" \? " \(finance\)"/, "the Schedule & crew task-row display keeps its own FINANCE label");
 assert.match(companyDashboardSource, /import \{ CrewPicker, TaskCrewPicker \} from "\.\/schedule-board\/CrewPickers"/, "the Schedule & crew table must reuse the extracted pickers, not redefine them");
 
@@ -430,8 +430,8 @@ assert.match(popoverSource, /overflowX: "hidden",/, "FloatingPopover must clip h
 assert.match(popoverSource, /maxWidth: `calc\(100vw - \$\{2 \* VIEWPORT_MARGIN_PX\}px\)`,/, "FloatingPopover must clamp its own width into the viewport");
 // FINANCE/inactive labeling and FloatingPopover's existing maxHeight/overflowY
 // contract stay exactly as before the rebuild.
-assert.match(crewPickersSource, /c\.role === "FINANCE" \? "finance" : "inactive"/, "CrewPicker must still label removable FINANCE crew entries");
-assert.match(crewPickersSource, /a\.role === "FINANCE" \? "finance" : "inactive"/, "TaskCrewPicker must still label removable FINANCE task-crew entries");
+
+
 assert.match(popoverSource, /maxHeight: position\?\.maxHeight,/);
 assert.match(popoverSource, /overflowY: "auto",/);
 

--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -250,8 +250,12 @@ assert.doesNotMatch(projectBarSource, /onClick=\{.*router\.push|onClick=\{.*navi
 assert.match(projectBarSource, />\s*Open project\s*<\/Link>/, "Open project must be a menu item inside the Actions dropdown");
 
 // ── Item 7: crew picker hygiene (FINANCE exclusion + name disambiguation) ──
-assert.match(coreSource, /where: \{ status: "ACTIVATED", role: \{ not: "FINANCE" \} \}/);
-assert.match(coreSource, /nameCounts\.get\(r\.name\)! > 1 \? \{ \.\.\.r, name: `\$\{r\.name\} \(\$\{r\.email\}\)` \} : r/);
+// Owner call 2026-07-23: schedulable people = FIELD_CREW only (no admins or
+// office in pickers/availability). Stricter than the earlier FINANCE-exclusion.
+assert.match(coreSource, /where: \{ status: "ACTIVATED", role: "FIELD_CREW" \}/);
+// Owner call 2026-07-23: names stay bare — no email decoration ever (full
+// addresses wrapped across six lines in the crew checklist).
+assert.doesNotMatch(coreSource, /name: `\$\{r\.name\} \(\$\{r\.email\}\)`/, "picker names must never carry email decorations");
 assert.match(crewPickersSource, /c\.role === "FINANCE" \? "finance" : "inactive"/, "CrewPicker (now in CrewPickers.tsx) must still label removable FINANCE crew entries");
 assert.match(crewPickersSource, /a\.role === "FINANCE" \? "finance" : "inactive"/, "TaskCrewPicker (now in CrewPickers.tsx) must still label removable FINANCE task-crew entries");
 assert.match(companyDashboardSource, /a\.role === "FINANCE" \? " \(finance\)"/, "the Schedule & crew task-row display keeps its own FINANCE label");

--- a/scripts/verify-schedule-board.ts
+++ b/scripts/verify-schedule-board.ts
@@ -695,8 +695,11 @@ async function main() {
         check("assigned DISABLED user still appears as a removable crew entry", !!inactiveCrewEntry && inactiveCrewEntry.status !== "ACTIVATED");
 
         const dupeEntries = (dashboardForCrew.teamMembers ?? []).filter(u => u.id === dupeUserA.id || u.id === dupeUserB.id);
-        check("teamMembers disambiguates identical display names with the email",
-            dupeEntries.length === 2 && dupeEntries.every(u => u.name.includes(u.email)) && dupeEntries[0].name !== dupeEntries[1].name);
+        // Owner call 2026-07-23: NO email decoration in picker names ever —
+        // full addresses wrapped across six lines in the crew checklist.
+        // Duplicate display names render as-is (email stays in its own field).
+        check("teamMembers never decorates names with emails, even for duplicates",
+            dupeEntries.length === 2 && dupeEntries.every(u => !u.name.includes("@")) && dupeEntries[0].name === dupeEntries[1].name);
         const soloNamedEntry = (dashboardForCrew.teamMembers ?? []).find(u => u.id === activeUser.id);
         check("teamMembers leaves unique display names unmodified",
             soloNamedEntry?.name === (activeUser.name ?? activeUser.email) && !soloNamedEntry.name.includes("@"));
@@ -712,7 +715,7 @@ async function main() {
         const scheduleCoreTaskCrewBody = scheduleCoreSource.slice(scheduleCoreTaskCrewStart);
         check("source validates ACTIVATED only for users being added to task crew",
             scheduleCoreTaskCrewBody.includes("toAdd.map(id => byId.get(id)!).filter(u => u.status !== \"ACTIVATED\")"));
-        check("teamMembers query excludes FINANCE role", scheduleCoreSource.includes('role: { not: "FINANCE" }'));
+        check("teamMembers query is FIELD_CREW-only (no admins/office/finance schedulable)", scheduleCoreSource.includes('where: { status: "ACTIVATED", role: "FIELD_CREW" }'));
 
         // Batch task-date save (fix 2) — ADMIN/MANAGER gated, loops the ONE
         // canonical updateScheduleTask (not a second mutation core), isolates

--- a/src/app/company-dashboard/schedule-board/AvailabilityPanel.tsx
+++ b/src/app/company-dashboard/schedule-board/AvailabilityPanel.tsx
@@ -169,10 +169,10 @@ export function AvailabilityPanel({ data, onDrillDown }: AvailabilityPanelProps)
     ];
     // Rows = FIELD_CREW, plus any ADMIN who actually does field work (shows
     // up on a project crew) — Richard, not Marge/Justin.
-    const crewMemberIds = new Set(projects.flatMap(project => project.crew.map(member => member.id)));
-    const members: AvailabilityMember[] = (teamMembers ?? []).filter(member => (
-        member.role === "FIELD_CREW" || (member.role === "ADMIN" && crewMemberIds.has(member.id))
-    ));
+    // Owner call 2026-07-23: only members DESIGNATED as crew are planned here
+    // — no admins/office on the availability grid (teamMembers is already
+    // FIELD_CREW-only at serialization; this filter just states the rule).
+    const members: AvailabilityMember[] = (teamMembers ?? []).filter(member => member.role === "FIELD_CREW");
 
     const today = todayUTC();
     const days = Array.from({ length: AVAILABILITY_DAYS }, (_, i) => addDays(today, i));

--- a/src/app/company-dashboard/schedule-board/CrewPickers.tsx
+++ b/src/app/company-dashboard/schedule-board/CrewPickers.tsx
@@ -157,7 +157,7 @@ export function CrewPicker({
     const unlistedAssigned = crew.filter(c => !teamMembers.some(m => m.id === c.id));
     const options = [
         ...teamMembers.map(m => ({ id: m.id, label: m.name || m.email })),
-        ...unlistedAssigned.map(c => ({ id: c.id, label: `${c.name} (${c.role === "FINANCE" ? "finance" : "inactive"})` })),
+        ...unlistedAssigned.map(c => ({ id: c.id, label: `${c.name} (${c.status !== "ACTIVATED" ? "inactive" : c.role.toLowerCase().replace("_", " ")})` })),
     ];
     const legend = `Project crew — ${selected.length} assigned`;
 
@@ -205,7 +205,7 @@ export function TaskCrewPicker({
     const unlisted = task.assignments.filter(a => !teamMembers.some(m => m.id === a.userId));
     const options = [
         ...teamMembers.map(member => ({ id: member.id, label: member.name || member.email })),
-        ...unlisted.map(a => ({ id: a.userId, label: `${a.name} (${a.role === "FINANCE" ? "finance" : "inactive"})` })),
+        ...unlisted.map(a => ({ id: a.userId, label: `${a.name} (${a.status !== "ACTIVATED" ? "inactive" : a.role.toLowerCase().replace("_", " ")})` })),
     ];
     const legend = `Task crew — ${selected.length} assigned`;
 

--- a/src/lib/schedule-core.ts
+++ b/src/lib/schedule-core.ts
@@ -2232,7 +2232,10 @@ export async function getCompanyDashboardData(
     // appended so the picker stays unambiguous.
     const teamMembersRaw = canEdit
         ? await prisma.user.findMany({
-            where: { status: "ACTIVATED", role: { not: "FINANCE" } },
+            // Owner call 2026-07-23: only people DESIGNATED as crew are
+            // schedulable — no admins/office in the pickers or availability.
+            // Already-assigned non-crew still render as removable entries.
+            where: { status: "ACTIVATED", role: "FIELD_CREW" },
             orderBy: { name: "asc" },
             select: { id: true, name: true, email: true, role: true, hourlyRate: true, burdenRate: true },
         })
@@ -2249,9 +2252,12 @@ export async function getCompanyDashboardData(
                 // ignores the extra field).
                 ...(canSeeFinancials ? { burdenedHourlyRate: round2(Number(u.hourlyRate) + Number(u.burdenRate)) } : {}),
             }));
-            const nameCounts = new Map<string, number>();
-            for (const r of rows) nameCounts.set(r.name, (nameCounts.get(r.name) ?? 0) + 1);
-            return rows.map(r => (nameCounts.get(r.name)! > 1 ? { ...r, name: `${r.name} (${r.email})` } : r));
+            // Names stay bare — no email disambiguation (owner call 2026-07-23:
+            // full addresses wrapped across six lines in the crew checklist and
+            // a 9-person crew knows who's who; duplicate-name accounts simply
+            // render twice, and the email remains in the serialized field for
+            // any UI that ever needs a tooltip).
+            return rows;
         })()
         : null;
 


### PR DESCRIPTION
Owner feedback: crew pickers/availability now offer ACTIVATED FIELD_CREW only (admins/office aren't schedulable — already-assigned non-crew stay as removable role-labeled entries), and picker names never carry email decorations (they wrapped across six lines). Verifier + contract assertions updated to pin both rules. All suites green; build 96/96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)