### PR TITLE
chore(db): ship the missing PaymentNotification apply script

### DIFF
--- a/scripts/apply-payment-notification-schema.mjs
+++ b/scripts/apply-payment-notification-schema.mjs
@@ -1,0 +1,58 @@
+// One-off additive migration for the payment-notification outbox
+// (model PaymentNotification in prisma/schema.prisma, drained by
+// src/lib/payment-outbox.ts). This script should have shipped with the model:
+// prod was missing the table until 2026-07-23 and every settle that enqueued a
+// milestone_paid notification rolled back with "table does not exist". The
+// table was created manually in prod that day — running this again is a no-op.
+// Safe to run against the live DB while the deployed (old) client is in use.
+// Mirrors scripts/apply-schedule-provenance-schema.mjs.
+//
+// Run:  node scripts/apply-payment-notification-schema.mjs
+// (DDL via $executeRawUnsafe over the Supabase transaction pooler — the working
+//  path in this project; psql / prisma db push / migrate dev do not work here.)
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+function resolveDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const f of [".env", ".env.local"]) {
+    if (!fs.existsSync(f)) continue;
+    const m = fs.readFileSync(f, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+    if (m) return m[1];
+  }
+  throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const prisma = new PrismaClient({ datasources: { db: { url: resolveDatabaseUrl() } } });
+
+const statements = [
+  `CREATE TABLE IF NOT EXISTS "PaymentNotification" (
+     "id" TEXT NOT NULL,
+     "scheduleId" TEXT NOT NULL,
+     "scheduleType" TEXT NOT NULL,
+     "kind" TEXT NOT NULL DEFAULT 'milestone_paid',
+     "status" TEXT NOT NULL DEFAULT 'PENDING',
+     "attempts" INTEGER NOT NULL DEFAULT 0,
+     "lastError" TEXT,
+     "claimToken" TEXT,
+     "processingStartedAt" TIMESTAMP(3),
+     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+     "processedAt" TIMESTAMP(3),
+     CONSTRAINT "PaymentNotification_pkey" PRIMARY KEY ("id")
+   )`,
+  `CREATE INDEX IF NOT EXISTS "PaymentNotification_status_idx" ON "PaymentNotification" ("status")`,
+  `CREATE INDEX IF NOT EXISTS "PaymentNotification_scheduleId_idx" ON "PaymentNotification" ("scheduleId")`,
+];
+
+try {
+  for (const sql of statements) {
+    await prisma.$executeRawUnsafe(sql);
+    console.log("✔ applied:", sql.split("\n")[0]);
+  }
+  console.log("Done.");
+} catch (e) {
+  console.error("Migration failed:", e);
+  process.exitCode = 1;
+} finally {
+  await prisma.$disconnect();
+}


### PR DESCRIPTION
## Summary
- Adds `scripts/apply-payment-notification-schema.mjs` — the apply script that should have shipped with the `PaymentNotification` outbox model (drained by `src/lib/payment-outbox.ts`). Prod was missing the table until 2026-07-23; every QuickBooks payment settle that enqueued a milestone_paid notification rolled back with "table public.PaymentNotification does not exist", leaving milestones stuck Pending.
- The table was created manually in prod on 2026-07-23. This script matches the Prisma model and that manual DDL exactly (`IF NOT EXISTS` guards, Prisma-convention index names) — **re-running it was verified as a clean no-op against prod**.

## Verification
- `npm run build` passes with 0 errors (script is standalone Node, not part of the Next bundle).
- Script executed against prod: no-op, all guards held.
- Read-only schema-drift audit (information_schema vs prisma/schema.prisma): no other missing tables/columns. Orphaned prod tables noted for later: `HelpRequest`, `AuditLog`, `Notification`.
- Codex peer review at xhigh reasoning: no blockers; DDL matches the model exactly. Two pattern-level notes (env resolution order, no pgbouncer assert) apply to all sibling apply scripts and are deferred as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)