### PR TITLE
Security foundation for the dispatch arc

### DIFF
--- a/scripts/migrate-takeoffs.mjs
+++ b/scripts/migrate-takeoffs.mjs
@@ -2,7 +2,11 @@
 import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = process.env.SUPABASE_URL || 'https://ghzdbzdnwjxazvmcefbh.supabase.co';
-const supabaseKey = process.env.SUPABASE_SERVICE_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdoemRiemRud2p4YXp2bWNlZmJoIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc3MjA3NTQyMiwiZXhwIjoyMDg3NjUxNDIyfQ.7TmN0axLB6zwSwO07kCaPlhmcCjY6Vz9vaPadzsGNMM';
+const supabaseKey = process.env.SUPABASE_SERVICE_KEY;
+if (!supabaseKey) {
+    console.error('SUPABASE_SERVICE_KEY is required to run scripts/migrate-takeoffs.mjs');
+    process.exit(1);
+}
 
 const supabase = createClient(supabaseUrl, supabaseKey);
 

--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -257,8 +257,8 @@ assert.match(coreSource, /where: \{ status: "ACTIVATED", role: "FIELD_CREW" \}/)
 // addresses wrapped across six lines in the crew checklist).
 assert.doesNotMatch(coreSource, /name: `\$\{r\.name\} \(\$\{r\.email\}\)`/, "picker names must never carry email decorations");
 assert.match(crewPickersSource, /c\.status !== "ACTIVATED" \? "inactive" : c\.role\.toLowerCase\(\)\.replace\("_", " "\)/, "CrewPicker labels removable non-crew entries by role (or inactive)");
-assert.match(crewPickersSource, /a\.status !== "ACTIVATED" \? "inactive" : a\.role\.toLowerCase\(\)\.replace\("_", " "\)/, "TaskCrewPicker labels removable non-crew entries by role (or inactive)");
-assert.match(companyDashboardSource, /a\.role === "FINANCE" \? " \(finance\)"/, "the Schedule & crew task-row display keeps its own FINANCE label");
+assert.match(crewPickersSource, /a\.status !== "ACTIVATED" \? "inactive" : a\.userRole\.toLowerCase\(\)\.replace\("_", " "\)/, "TaskCrewPicker labels removable non-crew entries by role (or inactive)");
+assert.match(companyDashboardSource, /a\.userRole === "FINANCE" \? " \(finance\)"/, "the Schedule & crew task-row display keeps its own FINANCE label");
 assert.match(companyDashboardSource, /import \{ CrewPicker, TaskCrewPicker \} from "\.\/schedule-board\/CrewPickers"/, "the Schedule & crew table must reuse the extracted pickers, not redefine them");
 
 // ── Item 8: crew-grouped Timeline toggle ──

--- a/scripts/verify-schedule-board.ts
+++ b/scripts/verify-schedule-board.ts
@@ -1,3 +1,4 @@
+// Usage: set ALLOW_PROD_VERIFY=1 when DATABASE_URL targets Supabase; this verifier creates and deletes fixtures.
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 
@@ -36,6 +37,16 @@ function withoutTaskDates(value: Record<string, unknown>): string {
 }
 
 async function main() {
+    const databaseUrl = process.env.DATABASE_URL ?? "";
+    if (databaseUrl.includes("supabase.c") && process.env.ALLOW_PROD_VERIFY !== "1") {
+        console.error(
+            "[verify-schedule-board] REFUSING TO RUN: DATABASE_URL points at Supabase.\n" +
+            "This script creates and deletes verification fixtures in the target database.\n" +
+            "Set ALLOW_PROD_VERIFY=1 to opt in."
+        );
+        process.exit(1);
+    }
+
     const checks: Check[] = [];
     const check = (label: string, passed: boolean) => checks.push([label, passed]);
     const tag = randomUUID();

--- a/src/app/company-dashboard/CompanyDashboardClient.tsx
+++ b/src/app/company-dashboard/CompanyDashboardClient.tsx
@@ -417,7 +417,7 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
                                                                 <div className="text-xs text-hui-textMuted">
                                                                     {task.assignments.length === 0
                                                                         ? "No task crew"
-                                                                        : task.assignments.map(a => `${a.name}${a.role === "FINANCE" ? " (finance)" : a.status === "ACTIVATED" ? "" : " (inactive)"}`).join(", ")}
+                                                                        : task.assignments.map(a => `${a.name}${a.userRole === "FINANCE" ? " (finance)" : a.status === "ACTIVATED" ? "" : " (inactive)"}`).join(", ")}
                                                                 </div>
                                                                 {canEdit && teamMembers && <TaskCrewPicker task={task} teamMembers={teamMembers} />}
                                                             </div>

--- a/src/app/company-dashboard/schedule-board/CrewPickers.tsx
+++ b/src/app/company-dashboard/schedule-board/CrewPickers.tsx
@@ -205,7 +205,7 @@ export function TaskCrewPicker({
     const unlisted = task.assignments.filter(a => !teamMembers.some(m => m.id === a.userId));
     const options = [
         ...teamMembers.map(member => ({ id: member.id, label: member.name || member.email })),
-        ...unlisted.map(a => ({ id: a.userId, label: `${a.name} (${a.status !== "ACTIVATED" ? "inactive" : a.role.toLowerCase().replace("_", " ")})` })),
+        ...unlisted.map(a => ({ id: a.userId, label: `${a.name} (${a.status !== "ACTIVATED" ? "inactive" : a.userRole.toLowerCase().replace("_", " ")})` })),
     ];
     const legend = `Task crew — ${selected.length} assigned`;
 

--- a/src/app/portal/projects/[id]/page.tsx
+++ b/src/app/portal/projects/[id]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from "next/navigation";
 import StatusBadge, { StatusType } from "@/components/StatusBadge";
 import PortalPayButton from "@/components/PortalPayButton";
 import PortalProjectTabs, { type PortalTab } from "@/components/PortalProjectTabs";
-import { getPortalVisibility, getScheduleTasks } from "@/lib/actions";
+import { getPortalScheduleTasks, getPortalVisibility } from "@/lib/actions";
 import { formatCurrency } from "@/lib/utils";
 import PortalVisitTracker from "@/components/PortalVisitTracker";
 import { resolveSessionClientId } from "@/lib/portal-auth";
@@ -90,7 +90,7 @@ export default async function PortalProjectDetail(props: {
     const [settings, visibility, scheduleTasks, sharedRooms] = await Promise.all([
         prisma.companySettings.findUnique({ where: { id: "singleton" } }),
         getPortalVisibility(projectId),
-        getScheduleTasks(projectId).catch(() => [] as any[]),
+        getPortalScheduleTasks(projectId).catch(() => [] as any[]),
         prisma.roomDesign.findMany({
             where: { projectId, shareEnabled: true, shareToken: { not: null } },
             select: { id: true, name: true, shareToken: true, thumbnail: true, updatedAt: true },

--- a/src/app/portal/projects/[id]/schedule/PortalGanttChart.tsx
+++ b/src/app/portal/projects/[id]/schedule/PortalGanttChart.tsx
@@ -4,8 +4,8 @@ import { useState, useRef, type Dispatch, type SetStateAction } from "react";
 import { addTaskCommentAsSub, updateTaskStatusAsSub } from "@/lib/actions";
 
 type Dependency = { id: string; predecessorId: string; dependentId: string };
-type TeamMember = { id: string; name: string | null; email: string };
-type Assignment = { id: string; userId: string; user: TeamMember };
+type Assignment = { id: string; userId: string; firstName: string };
+type SubAssignment = { id: string; companyName: string };
 type Comment = { id: string; text: string; createdAt: string; authorName: string };
 
 type Task = {
@@ -20,6 +20,7 @@ type Task = {
     order: number;
     dependencies: Dependency[];
     assignments?: Assignment[];
+    subAssignments?: SubAssignment[];
     comments?: Comment[];
 };
 
@@ -278,10 +279,13 @@ export default function PortalGanttChart({
                                 )}
                                 <div className="flex-1 min-w-0 pr-2">
                                     <div className="text-xs font-medium text-slate-800 truncate" title={task.name}>{task.name}</div>
-                                    {(task.assignments || []).length > 0 && (
+                                    {((task.assignments || []).length > 0 || (task.subAssignments || []).length > 0) && (
                                         <div className="flex items-center gap-1 mt-0.5">
-                                            {(task.assignments || []).slice(0, 2).map(a => (
-                                                <span key={a.userId} className="text-[9px] text-slate-500 truncate">{a.user.name || a.user.email}</span>
+                                            {[
+                                                ...(task.assignments || []).map(a => ({ id: `crew-${a.id}`, label: a.firstName })),
+                                                ...(task.subAssignments || []).map(a => ({ id: `sub-${a.id}`, label: a.companyName })),
+                                            ].slice(0, 2).map(assignee => (
+                                                <span key={assignee.id} className="text-[9px] text-slate-500 truncate">{assignee.label}</span>
                                             ))}
                                         </div>
                                     )}

--- a/src/app/portal/projects/[id]/schedule/PortalScheduleView.tsx
+++ b/src/app/portal/projects/[id]/schedule/PortalScheduleView.tsx
@@ -5,8 +5,8 @@ import PortalGanttChart from "./PortalGanttChart";
 import PortalCalendarView from "./PortalCalendarView";
 
 type Dependency = { id: string; predecessorId: string; dependentId: string };
-type TeamMember = { id: string; name: string | null; email: string };
-type Assignment = { id: string; userId: string; user: TeamMember };
+type Assignment = { id: string; userId: string; firstName: string };
+type SubAssignment = { id: string; companyName: string };
 type Comment = { id: string; text: string; createdAt: string; authorName: string };
 
 export type PortalTask = {
@@ -21,6 +21,7 @@ export type PortalTask = {
     order: number;
     dependencies: Dependency[];
     assignments?: Assignment[];
+    subAssignments?: SubAssignment[];
     comments?: Comment[];
 };
 

--- a/src/app/portal/projects/[id]/schedule/page.tsx
+++ b/src/app/portal/projects/[id]/schedule/page.tsx
@@ -1,9 +1,12 @@
 import { notFound } from "next/navigation";
 import { prisma } from "@/lib/prisma";
-import { getPortalVisibility, getScheduleTasks, getScheduleTasksForSub } from "@/lib/actions";
+import { getPortalScheduleTasks, getPortalVisibility, getScheduleTasksForSub } from "@/lib/actions";
 import PortalScheduleView from "./PortalScheduleView";
 import Link from "next/link";
 import { getSubPortalSession } from "@/lib/sub-portal-auth";
+import { resolveSessionClientId } from "@/lib/portal-auth";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth";
 
 export const dynamic = "force-dynamic";
 
@@ -15,17 +18,31 @@ export default async function PortalSchedulePage(props: { params: Promise<{ id: 
     const subSession = await getSubPortalSession();
     const subcontractorId = subSession?.id ?? null;
 
+    let project;
+    if (subcontractorId) {
+        project = await prisma.project.findUnique({ where: { id } });
+    } else {
+        const staffSession = await getServerSession(authOptions);
+        const isStaff = ["ADMIN", "MANAGER"].includes((staffSession?.user as any)?.role);
+
+        if (isStaff) {
+            project = await prisma.project.findFirst({ where: { id } });
+        } else {
+            const sessionClientId = await resolveSessionClientId();
+            if (!sessionClientId) return notFound();
+            project = await prisma.project.findFirst({ where: { id, clientId: sessionClientId } });
+        }
+    }
+    if (!project) return notFound();
+
     const visibility = await getPortalVisibility(id);
     if (!subcontractorId && (!visibility.isPortalEnabled || !visibility.showSchedule)) {
         return notFound();
     }
 
-    const project = await prisma.project.findUnique({ where: { id } });
-    if (!project) return notFound();
-
     const rawTasks = subcontractorId
         ? await getScheduleTasksForSub(id, subcontractorId)
-        : await getScheduleTasks(id);
+        : await getPortalScheduleTasks(id);
 
     const tasks = rawTasks.map((t: any) => ({
         id: t.id,
@@ -45,7 +62,11 @@ export default async function PortalSchedulePage(props: { params: Promise<{ id: 
         assignments: (t.assignments || []).map((a: any) => ({
             id: a.id,
             userId: a.userId,
-            user: { name: a.user.name, email: a.user.email }
+            firstName: a.firstName || a.user?.name?.trim().split(/\s+/)[0] || "Crew",
+        })),
+        subAssignments: (t.subAssignments || []).map((a: any) => ({
+            id: a.id,
+            companyName: a.companyName || a.subcontractor?.companyName || "Subcontractor",
         })),
         comments: (t.comments || []).map((c: any) => ({
             id: c.id,

--- a/src/app/projects/[id]/dailylogs/DailyLogsClient.tsx
+++ b/src/app/projects/[id]/dailylogs/DailyLogsClient.tsx
@@ -245,7 +245,6 @@ export default function DailyLogsClient({ projectId, projectName, logs, currentU
                         workPerformed: formWork,
                         materialsDelivered: formMaterials || undefined,
                         issues: formIssues || undefined,
-                        createdById: currentUserId,
                         photoUrls: photoUrls.length > 0 ? photoUrls : undefined,
                     });
                     toast.success("Daily log created!");

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -6486,6 +6486,9 @@ export async function countersignContractAsCompany(contractId: string, signerNam
 // ────────────────────────────────────────────────
 
 export async function getScheduleTasks(projectId: string) {
+    // Hardened (dispatch-arc foundation): internal schedule details require an authenticated team session.
+    const session = await getSessionOrDev();
+    if (!session?.user) throw new Error("Unauthorized");
     return prisma.scheduleTask.findMany({
         where: { projectId },
         orderBy: { order: "asc" },
@@ -6501,7 +6504,88 @@ export async function getScheduleTasks(projectId: string) {
     });
 }
 
+export async function getPortalScheduleTasks(projectId: string) {
+    // Hardened (dispatch-arc foundation): portal schedule details require staff access or an owning client with schedule visibility.
+    const session = await getSessionOrDev();
+    const role = ((session?.user as any)?.role as string | null) ?? null;
+    const isStaff = role === "ADMIN" || role === "MANAGER";
+
+    if (!isStaff) {
+        const sessionClientId = await resolveSessionClientId();
+        if (!sessionClientId) throw new Error("Unauthorized");
+
+        const project = await prisma.project.findFirst({
+            where: { id: projectId, clientId: sessionClientId },
+            select: { id: true },
+        });
+        if (!project) throw new Error("Unauthorized");
+
+        const visibility = await prisma.portalVisibility.findUnique({
+            where: { projectId },
+        });
+        // Match getPortalVisibility defaults: a missing record enables the portal and schedule.
+        if (visibility && (!visibility.isPortalEnabled || !visibility.showSchedule)) {
+            throw new Error("Unauthorized");
+        }
+    }
+
+    const tasks = await prisma.scheduleTask.findMany({
+        where: { projectId },
+        orderBy: { order: "asc" },
+        select: {
+            id: true,
+            name: true,
+            startDate: true,
+            endDate: true,
+            color: true,
+            progress: true,
+            status: true,
+            type: true,
+            order: true,
+            dependencies: { select: { id: true, predecessorId: true, dependentId: true } },
+            assignments: {
+                select: {
+                    id: true,
+                    userId: true,
+                    user: { select: { name: true } },
+                },
+            },
+            subAssignments: {
+                select: {
+                    id: true,
+                    subcontractor: { select: { companyName: true } },
+                },
+            },
+        },
+    });
+
+    return tasks.map(task => ({
+        id: task.id,
+        name: task.name,
+        startDate: task.startDate,
+        endDate: task.endDate,
+        color: task.color,
+        progress: task.progress,
+        status: task.status,
+        type: task.type,
+        order: task.order,
+        dependencies: task.dependencies,
+        assignments: task.assignments.map(assignment => ({
+            id: assignment.id,
+            userId: assignment.userId,
+            firstName: assignment.user.name?.trim().split(/\s+/)[0] || "Crew",
+        })),
+        subAssignments: task.subAssignments.map(assignment => ({
+            id: assignment.id,
+            companyName: assignment.subcontractor.companyName,
+        })),
+    }));
+}
+
 export async function getDashboardTasks(projectId: string) {
+    // Hardened (dispatch-arc foundation): dashboard task summaries require an authenticated team session.
+    const session = await getSessionOrDev();
+    if (!session?.user) throw new Error("Unauthorized");
     return prisma.scheduleTask.findMany({
         where: { projectId },
         orderBy: { order: "asc" },
@@ -7646,6 +7730,10 @@ export async function markClientMessagesRead(entityId: string, entityType: "lead
 
 
 export async function toggleSchedulePublished(projectId: string, published: boolean) {
+    // Hardened (dispatch-arc foundation): only ADMIN/MANAGER sessions may change client schedule visibility.
+    const session = await getSessionOrDev();
+    const role = ((session?.user as any)?.role as string | null) ?? null;
+    if (!role || !["ADMIN", "MANAGER"].includes(role)) throw new Error("Forbidden");
     const existing = await prisma.portalVisibility.findUnique({ where: { projectId } });
     if (existing) {
         await prisma.portalVisibility.update({ where: { projectId }, data: { showSchedule: published } });
@@ -9146,7 +9234,27 @@ export async function getSelectionBoardsForPortal(projectId: string) {
 // Daily Logs CRUD
 // =============================================
 
+async function assertDailyLogAccess(projectId: string) {
+    const session = await getSessionOrDev();
+    const sessionUserId = (session?.user as any)?.id as string | null | undefined;
+    if (!sessionUserId) throw new Error("Unauthorized");
+
+    const user = await prisma.user.findUnique({
+        where: { id: sessionUserId },
+        include: {
+            permissions: true,
+            projectAccess: { select: { projectId: true } },
+            assignedProjects: { select: { id: true } },
+        },
+    });
+    if (!user || user.status === "DISABLED") throw new Error("Unauthorized");
+    if (!hasPermission(user, "dailyLogs") || !canAccessProject(user, projectId)) throw new Error("Forbidden");
+    return user;
+}
+
 export async function getDailyLogs(projectId: string) {
+    // Hardened (dispatch-arc foundation): require daily-log permission and project access before reading logs.
+    await assertDailyLogAccess(projectId);
     return await prisma.dailyLog.findMany({
         where: { projectId },
         orderBy: { date: "desc" },
@@ -9158,6 +9266,10 @@ export async function getDailyLogs(projectId: string) {
 }
 
 export async function getDailyLog(id: string) {
+    // Hardened (dispatch-arc foundation): resolve the log's project before authorizing the read.
+    const target = await prisma.dailyLog.findUnique({ where: { id }, select: { projectId: true } });
+    if (!target) return null;
+    await assertDailyLogAccess(target.projectId);
     return await prisma.dailyLog.findUnique({
         where: { id },
         include: {
@@ -9175,9 +9287,10 @@ export async function createDailyLog(projectId: string, data: {
     workPerformed: string;
     materialsDelivered?: string;
     issues?: string;
-    createdById: string;
     photoUrls?: { url: string; caption?: string }[];
 }) {
+    // Hardened (dispatch-arc foundation): derive the author from an authorized staff session.
+    const author = await assertDailyLogAccess(projectId);
     const log = await prisma.dailyLog.create({
         data: {
             projectId,
@@ -9187,7 +9300,7 @@ export async function createDailyLog(projectId: string, data: {
             workPerformed: data.workPerformed,
             materialsDelivered: data.materialsDelivered || null,
             issues: data.issues || null,
-            createdById: data.createdById,
+            createdById: author.id,
             photos: data.photoUrls && data.photoUrls.length > 0 ? {
                 create: data.photoUrls.map(p => ({
                     url: p.url,
@@ -9210,6 +9323,10 @@ export async function updateDailyLog(id: string, data: {
     materialsDelivered?: string;
     issues?: string;
 }) {
+    // Hardened (dispatch-arc foundation): authorize against the persisted log project before updating.
+    const target = await prisma.dailyLog.findUnique({ where: { id }, select: { projectId: true } });
+    if (!target) throw new Error("Daily log not found");
+    await assertDailyLogAccess(target.projectId);
     const updateData: any = {};
     if (data.date !== undefined) updateData.date = new Date(data.date);
     if (data.weather !== undefined) updateData.weather = data.weather || null;
@@ -9228,8 +9345,10 @@ export async function updateDailyLog(id: string, data: {
 }
 
 export async function deleteDailyLog(id: string) {
+    // Hardened (dispatch-arc foundation): authorize against the persisted log project before deleting.
     const log = await prisma.dailyLog.findUnique({ where: { id }, select: { projectId: true } });
     if (!log) return { success: false };
+    await assertDailyLogAccess(log.projectId);
 
     await prisma.dailyLog.delete({ where: { id } });
     revalidatePath(`/projects/${log.projectId}/dailylogs`);
@@ -9237,8 +9356,10 @@ export async function deleteDailyLog(id: string) {
 }
 
 export async function addDailyLogPhotos(dailyLogId: string, photos: { url: string; caption?: string }[]) {
+    // Hardened (dispatch-arc foundation): authorize against the persisted log project before adding photos.
     const log = await prisma.dailyLog.findUnique({ where: { id: dailyLogId }, select: { projectId: true } });
     if (!log) throw new Error("Daily log not found");
+    await assertDailyLogAccess(log.projectId);
 
     await prisma.dailyLogPhoto.createMany({
         data: photos.map(p => ({
@@ -9253,11 +9374,13 @@ export async function addDailyLogPhotos(dailyLogId: string, photos: { url: strin
 }
 
 export async function deleteDailyLogPhoto(photoId: string) {
+    // Hardened (dispatch-arc foundation): authorize against the photo's persisted log project before deleting.
     const photo = await prisma.dailyLogPhoto.findUnique({
         where: { id: photoId },
         include: { dailyLog: { select: { projectId: true } } },
     });
     if (!photo) return { success: false };
+    await assertDailyLogAccess(photo.dailyLog.projectId);
 
     await prisma.dailyLogPhoto.delete({ where: { id: photoId } });
     revalidatePath(`/projects/${photo.dailyLog.projectId}/dailylogs`);

--- a/src/lib/schedule-core.ts
+++ b/src/lib/schedule-core.ts
@@ -1886,7 +1886,8 @@ export interface DashboardTaskAssignment {
     userId: string;
     name: string;
     status: string;
-    role: string;
+    userRole: string;
+    assignmentRole: string;
 }
 
 export interface DashboardTaskComment {
@@ -2172,7 +2173,7 @@ export async function getCompanyDashboardData(
                 id: true, projectId: true, name: true, startDate: true, endDate: true, color: true, parentId: true, progress: true, status: true, type: true,
                 assignments: {
                     orderBy: { createdAt: "asc" },
-                    select: { id: true, userId: true, user: { select: { name: true, email: true, status: true, role: true } } },
+                    select: { id: true, userId: true, role: true, user: { select: { name: true, email: true, status: true, role: true } } },
                 },
                 // Hover-card notes (item 3): capped at 2, newest first — same
                 // audience as the project schedule page's own comment thread
@@ -2206,7 +2207,8 @@ export async function getCompanyDashboardData(
                 userId: a.userId,
                 name: a.user.name || a.user.email,
                 status: a.user.status,
-                role: a.user.role,
+                userRole: a.user.role,
+                assignmentRole: a.role,
             })),
             latestComments: task.comments.map(c => ({
                 text: c.text,
@@ -2889,6 +2891,7 @@ export async function setTaskCrew(input: {
             await tx.taskAssignment.deleteMany({ where: { taskId: input.taskId, userId: { in: toRemove } } });
         }
         for (const userId of toAdd) {
+            // Lead assignment is intentionally not settable here yet; task crew changes remain assigned until the later lead-management PR.
             await tx.taskAssignment.create({ data: { taskId: input.taskId, userId, role: "assigned" } });
         }
 


### PR DESCRIPTION
First PR of the dispatch-cockpit arc (plan: dispatch board + publish loop + PM-bot digests). Fixes the stop-ship security findings from the GPT-5.6 plan review before anything is built on these paths.

## Fixes
- **Hardcoded service-role key removed** from `scripts/migrate-takeoffs.mjs` (env-required; the leaked key gets rotated at deploy — it was valid and committed since February)
- **Daily logs**: all CRUD actions were completely unauthenticated and `createDailyLog` trusted a client-supplied `createdById`. Now: session + `dailyLogs` permission + project access; author derived server-side
- **Portal schedule**: page loaded any project by ID with no client-ownership check, and `getScheduleTasks` (unauthenticated) served assignment emails, full subcontractor rows, and estimate totals to the portal. Now: ownership enforced (staff bypass preserved), and a new `getPortalScheduleTasks` authorizes inside the action (staff-or-owning-client + portal visibility) and serializes an allowlist only (crew first names, sub company names)
- **`toggleSchedulePublished`** (client-facing visibility) now requires ADMIN/MANAGER
- **Lead-role serialization bug**: dashboard emitted the user's account role where the assignment role belongs; now `userRole` + `assignmentRole` (unblocks lead badges in the dispatch views)
- **`verify-schedule-board.ts`** now requires `ALLOW_PROD_VERIFY=1` when DATABASE_URL targets Supabase — the prod-fixture practice stays, but opt-in

## Verification
- `verify-schedule-board-render-contract` PASS (assertion updated for the userRole rename — intent unchanged)
- `verify-schedule-board-layout` PASS
- `ALLOW_PROD_VERIFY=1 verify-schedule-board` (DB-backed, ~95 checks) ALL PASS with fixture cleanup
- `tsc --noEmit` clean, `npm run build` 0 errors
- Browser: session-less calls to all six hardened actions rejected; portal schedule 404s without an owning session; daily-log create via UI stores the session-derived author (checked in DB); company board renders with crew labels intact

Implemented by GPT-5.6-sol (xhigh) from a written spec; reviewed, gate-run, and browser-verified by Fable 5 (one review round: action-level portal auth + contract assertion update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)