### PR TITLE
Schedule board: plain click opens menus, "…" buttons removed, × on popups

### DIFF
--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -122,6 +122,12 @@ assert.match(popoverSource, /event\.key !== "Escape"/);
 // anchorRef is now optional (item 1 — an anchorPoint-only context menu has
 // no trigger element to refocus), hence the extra `?.` before `.current`.
 assert.match(popoverSource, /anchorRef\?\.current\?\.focus\(\)/);
+// Interactive popovers expose an explicit close button, while non-interactive
+// hover cards do not. The button sits before/outside contentRef so it never
+// participates in the content ResizeObserver's measurements.
+assert.match(popoverSource, /\{!pointerEventsNone && \(\s*<button[\s\S]{0,500}type="button"[\s\S]{0,500}aria-label="Close"[\s\S]{0,500}onClick=\{onClose\}/, "interactive popovers must render an explicit Close button");
+assert.match(popoverSource, /aria-label="Close"[\s\S]{0,800}<\/button>\s*\)\}\s*\{\/\* Content wrapper:[\s\S]{0,300}<div ref=\{contentRef\}/, "the Close button must live outside and above the observed content wrapper");
+assert.match(popoverSource, /<div ref=\{contentRef\} className=\{pointerEventsNone \? undefined : "pr-6"\}>/, "interactive popover content must reserve minimal right-side room for the Close button");
 // Vertical placement must handle the neither-side-fits case (open on the
 // larger side, capped + scrollable) and the horizontal floor must be applied
 // last so narrow viewports pin to the margin instead of going negative.
@@ -241,11 +247,31 @@ assert.match(taskBlockSource, /import \{ TaskCrewPicker \} from "\.\/CrewPickers
 assert.match(taskBlockSource, /<TaskCrewPicker task=\{task\} teamMembers=\{teamMembers\} variant="inline" \/>/);
 
 // ── Item 6: a bar click toggles its menu, never navigates ──
+// PR-0 activation seam: block/bar chrome is replaced by root activation.
+assert.doesNotMatch(taskBlockSource, /aria-label=\{`Task actions for /, "TaskBlockSegment must not render the old ellipsis action button");
+assert.doesNotMatch(taskBlockSource, />\s*\u22ef\s*<\/button>/, "TaskBlockSegment must not render a vertical-ellipsis button");
+assert.doesNotMatch(taskBlockSource, /actionTriggerRef/, "the removed task action button must not leave a trigger ref behind");
+assert.match(taskBlockSource, /function handleBlockActivate\(event: ReactMouseEvent<HTMLDivElement> \| KeyboardEvent<HTMLElement>\) \{/);
+assert.match(taskBlockSource, /if \(!canEdit \|\| isPending\) return;\s*\n\s*if \(\(event\.target as HTMLElement\)\.closest\("a,button,input,summary,form,details"\)\) return;/, "task block activation must reuse the old action-button edit gates and ignore interactive descendants");
+assert.match(taskBlockSource, /onClick=\{handleBlockActivate\}/, "the task block root click must route through the named activation seam");
+assert.match(taskBlockSource, /handleBlockActivate[\s\S]{0,400}event\.stopPropagation\(\);/, "block activation must stop propagation — the parent bar's click opens the PROJECT menu and would instantly replace the task menu via the exclusive-menu coordinator");
+assert.match(taskBlockSource, /mode === "move" && activeMode === null && \(event\.key === " " \|\| event\.key === "Enter"\)[\s\S]{0,250}handleBlockActivate\(event\);/, "Enter/Space on a non-editing task block must route through the activation seam");
+assert.match(taskBlockSource, /<FloatingPopover open=\{menuOpen\} anchorRef=\{rootRef\} anchorPoint=\{menuAnchorPoint\}/, "keyboard-opened task menus must anchor to the block rect while pointer-opened menus may use a point");
+
+assert.doesNotMatch(projectBarSource, /aria-label=\{`Project actions for /, "ProjectBar must not render the redundant Actions chip");
+assert.doesNotMatch(projectBarSource, />\s*Actions\s*<\/button>/, "ProjectBar must not render the redundant Actions chip");
+assert.doesNotMatch(projectBarSource, /actionTriggerRef/, "the removed project Actions chip must not leave a trigger ref behind");
+assert.match(projectBarSource, /const rootRef = useRef<HTMLDivElement>\(null\)/);
+assert.match(projectBarSource, /ref=\{rootRef\}[\s\S]{0,1200}onClick=\{handleBarClick\}/, "ProjectBar's root ref and existing click activation must stay wired");
+assert.match(projectBarSource, /<FloatingPopover open=\{menuOpen\} anchorRef=\{rootRef\} anchorPoint=\{menuAnchorPoint\}/, "keyboard-opened project menus must anchor to the bar rect while pointer-opened menus may use a point");
+
+// A bar click still toggles its menu and never navigates; pointer activation
+// opens at the click point, while keyboard activation falls back to rootRef.
 assert.match(projectBarSource, /function handleBarClick\(/);
 // Item 1 (2026-07-22) replaced the bare `setMenuOpen(value => !value)` toggle
 // with explicit open/close (via `openMenu`, which also resets the menu's
 // view/anchor state) — still a toggle in effect, just no longer a one-liner.
-assert.match(projectBarSource, /if \(menuOpen\) \{\s*setMenuOpen\(false\);\s*\} else \{\s*openMenu\(null\);\s*\}/, "a bar click must still toggle the menu open/closed");
+assert.match(projectBarSource, /if \(menuOpen\) \{\s*setMenuOpen\(false\);\s*\} else \{\s*openMenu\(\{ x: event\.clientX, y: event\.clientY \}\);\s*\}/, "a bar click must still toggle the menu open/closed and pointer-open at the click point");
 assert.doesNotMatch(projectBarSource, /onClick=\{.*router\.push|onClick=\{.*navigate/, "the bar itself must never navigate on click");
 assert.match(projectBarSource, />\s*Open project\s*<\/Link>/, "Open project must be a menu item inside the Actions dropdown");
 

--- a/src/app/company-dashboard/schedule-board/FloatingPopover.tsx
+++ b/src/app/company-dashboard/schedule-board/FloatingPopover.tsx
@@ -163,13 +163,23 @@ export function FloatingPopover({ open, anchorRef, anchorPoint, onClose, childre
                 overscrollBehaviorY: "contain",
                 visibility: position ? "visible" : "hidden",
             }}
-            className={`z-[200] space-y-2 rounded-md border border-hui-border bg-white p-3 text-left text-hui-textMain shadow-xl ${pointerEventsNone ? "pointer-events-none" : ""}`}
+            className={`relative z-[200] rounded-md border border-hui-border bg-white p-3 text-left text-hui-textMain shadow-xl ${pointerEventsNone ? "pointer-events-none" : ""}`}
             onPointerDown={pointerEventsNone ? undefined : event => event.stopPropagation()}
         >
+            {!pointerEventsNone && (
+                <button
+                    type="button"
+                    aria-label="Close"
+                    onClick={onClose}
+                    className="absolute right-1 top-1 inline-flex h-6 w-6 items-center justify-center rounded text-base leading-none text-slate-400 transition hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary"
+                >
+                    ×
+                </button>
+            )}
             {/* Content wrapper: observed for size changes — the panel box
                 itself stops growing once maxHeight caps it, so observing the
                 panel alone misses menu→taller-view switches. */}
-            <div ref={contentRef}>{children}</div>
+            <div ref={contentRef} className={pointerEventsNone ? undefined : "pr-6"}>{children}</div>
         </div>,
         document.body,
     );

--- a/src/app/company-dashboard/schedule-board/ProjectBar.tsx
+++ b/src/app/company-dashboard/schedule-board/ProjectBar.tsx
@@ -171,7 +171,7 @@ export function ProjectBar({
     const gridStart = useContext(ProjectBarGridStartContext);
     const projectRange = getEffectiveProjectRange(project);
     const projectStart = projectRange ? formatDate(projectRange.start) : "";
-    const actionTriggerRef = useRef<HTMLButtonElement>(null);
+    const rootRef = useRef<HTMLDivElement>(null);
     const [menuOpen, setMenuOpen] = useState(false);
     const [menuAnchorPoint, setMenuAnchorPoint] = useState<{ x: number; y: number } | null>(null);
     const [menuView, setMenuView] = useState<BarMenuView>("main");
@@ -196,7 +196,7 @@ export function ProjectBar({
         setMenuOpen(false);
     }, [actionResetKey]);
     // Only one schedule-board menu open at a time (item 1) — including across
-    // a right-click/context menu vs the click-triggered Actions menu.
+    // right-click/context-menu and bar-activation paths.
     useEffect(() => {
         if (!menuOpen) {
             setMenuView("main");
@@ -408,7 +408,7 @@ export function ProjectBar({
         if (menuOpen) {
             setMenuOpen(false);
         } else {
-            openMenu(null);
+            openMenu({ x: event.clientX, y: event.clientY });
         }
     }
 
@@ -416,6 +416,7 @@ export function ProjectBar({
 
     return (
         <div
+            ref={rootRef}
             className={`group/project relative touch-pan-y select-none overflow-visible rounded-md border text-white shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 ${canMoveProject && !isPending ? "cursor-move" : ""} ${isDraft ? "border-dashed border-2 border-white/90 saturate-[.55] brightness-95" : "border-black/10"}`}
             style={{ backgroundColor: projectColor, height: barHeight }}
             data-can-edit={canEdit ? "true" : "false"}
@@ -445,18 +446,7 @@ export function ProjectBar({
                     </span>
                 )}
                 {canEdit && (
-                    <>
-                        <button
-                            ref={actionTriggerRef}
-                            type="button"
-                            onClick={event => { event.stopPropagation(); if (menuOpen) setMenuOpen(false); else openMenu(null); }}
-                            aria-expanded={menuOpen}
-                            className="shrink-0 cursor-pointer rounded bg-white/20 px-1 py-0.5 text-[9px] font-bold text-white opacity-0 transition hover:bg-white/30 group-hover/project:opacity-100 group-focus-within/project:opacity-100 [@media(hover:none)]:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
-                            aria-label={`Project actions for ${project.name}`}
-                        >
-                            Actions
-                        </button>
-                        <FloatingPopover open={menuOpen} anchorRef={actionTriggerRef} anchorPoint={menuAnchorPoint} onClose={() => setMenuOpen(false)} width={240}>
+                        <FloatingPopover open={menuOpen} anchorRef={rootRef} anchorPoint={menuAnchorPoint} onClose={() => setMenuOpen(false)} width={240}>
                             {menuView === "main" && (
                                 <div className="space-y-1">
                                     <Link
@@ -557,7 +547,6 @@ export function ProjectBar({
                                 </div>
                             )}
                         </FloatingPopover>
-                    </>
                 )}
                 {segment.continuesAfter && <span aria-hidden="true">›</span>}
             </div>

--- a/src/app/company-dashboard/schedule-board/TaskBlockSegment.tsx
+++ b/src/app/company-dashboard/schedule-board/TaskBlockSegment.tsx
@@ -134,7 +134,6 @@ export function TaskBlockSegment({
     const rootRef = useRef<HTMLDivElement | null>(null);
     const fragmentId = useId().replace(/:/g, "");
     const [allocatedWidth, setAllocatedWidth] = useState(0);
-    const actionTriggerRef = useRef<HTMLButtonElement>(null);
     const [menuOpen, setMenuOpen] = useState(false);
     const [menuAnchorPoint, setMenuAnchorPoint] = useState<{ x: number; y: number } | null>(null);
     const [menuView, setMenuView] = useState<TaskMenuView>("main");
@@ -185,7 +184,7 @@ export function TaskBlockSegment({
         if (!menuOpen) setNoteDraft("");
     }, [menuOpen]);
     // Only one schedule-board menu open at a time (item 1) — including across
-    // a right-click/context menu vs the click-triggered "⋯" menu.
+    // right-click/context-menu and block-activation paths.
     useEffect(() => {
         if (!menuOpen) {
             setMenuView("main");
@@ -268,6 +267,25 @@ export function TaskBlockSegment({
         setMenuOpen(true);
     }
 
+    // Activation seam: a future drawer can replace this one function while
+    // pointer, keyboard, and edit-gating behavior stays at the block boundary.
+    function handleBlockActivate(event: ReactMouseEvent<HTMLDivElement> | KeyboardEvent<HTMLElement>) {
+        if (!canEdit || isPending) return;
+        if ((event.target as HTMLElement).closest("a,button,input,summary,form,details")) return;
+        // A block sits inside its project bar, whose own click opens the
+        // PROJECT menu — without this, the bar menu instantly replaces the
+        // task menu via the exclusive-menu coordinator.
+        event.stopPropagation();
+        const anchorPoint = event.type === "click"
+            ? { x: (event as ReactMouseEvent<HTMLDivElement>).clientX, y: (event as ReactMouseEvent<HTMLDivElement>).clientY }
+            : null;
+        if (menuOpen) {
+            setMenuOpen(false);
+        } else {
+            openMenu(anchorPoint);
+        }
+    }
+
     function handleKeyboard(event: KeyboardEvent<HTMLElement>, mode: TaskEditMode) {
         if (event.target !== event.currentTarget) return;
         if (!canEdit || isPending) return;
@@ -278,6 +296,12 @@ export function TaskBlockSegment({
             event.preventDefault();
             event.stopPropagation();
             openMenu(null);
+            return;
+        }
+        if (mode === "move" && activeMode === null && (event.key === " " || event.key === "Enter")) {
+            event.preventDefault();
+            event.stopPropagation();
+            handleBlockActivate(event);
             return;
         }
         if (!editing && (event.key === " " || event.key === "Enter")) {
@@ -382,13 +406,14 @@ export function TaskBlockSegment({
             title={title}
             role="group"
             tabIndex={0}
-            aria-label={`${title}. ${canEdit ? "Press Space or Enter to move with the keyboard." : "Read only."}${isDraft ? " Unsaved change." : ""}`}
+            aria-label={`${title}. ${canEdit ? "Press Enter or Space to open task actions." : "Read only."}${isDraft ? " Unsaved change." : ""}`}
             aria-disabled={!canEdit || isPending}
             aria-busy={isPending}
             data-task-edit-block="true"
             data-project-start={formatDate(projectRange.start)}
             data-can-edit={canEdit ? "true" : "false"}
             onPointerDown={event => beginPointerEdit(event, "move")}
+            onClick={handleBlockActivate}
             onKeyDown={event => handleKeyboard(event, "move")}
             onContextMenu={handleContextMenu}
             onMouseEnter={handleHoverCardMouseEnter}
@@ -432,19 +457,7 @@ export function TaskBlockSegment({
             )}
 
             {!mutationDisabled && (
-            <>
-                <button
-                    ref={actionTriggerRef}
-                    type="button"
-                    onClick={event => { event.stopPropagation(); if (menuOpen) setMenuOpen(false); else openMenu(null); }}
-                    onPointerDown={event => event.stopPropagation()}
-                    aria-expanded={menuOpen}
-                    className="absolute right-0 top-0 z-30 cursor-pointer rounded bg-white/85 px-1 text-[8px] font-bold text-slate-800 opacity-0 shadow transition group-hover/task:opacity-100 group-focus-within/task:opacity-100 [@media(hover:none)]:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
-                    aria-label={`Task actions for ${task.name}`}
-                >
-                    ⋯
-                </button>
-                <FloatingPopover open={menuOpen} anchorRef={actionTriggerRef} anchorPoint={menuAnchorPoint} onClose={() => setMenuOpen(false)} width={240}>
+                <FloatingPopover open={menuOpen} anchorRef={rootRef} anchorPoint={menuAnchorPoint} onClose={() => setMenuOpen(false)} width={240}>
                     {menuView === "main" && (
                         <div className="space-y-1" onPointerDown={event => event.stopPropagation()}>
                             <button type="button" onClick={() => setMenuView("dates")} className="block w-full rounded px-2 py-1.5 text-left text-xs text-hui-textMain hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary">
@@ -534,7 +547,6 @@ export function TaskBlockSegment({
                         </div>
                     )}
                 </FloatingPopover>
-            </>
             )}
             <FloatingPopover open={hoverCardOpen} anchorRef={rootRef} onClose={closeHoverCard} width={220} pointerEventsNone>
                 <div className="space-y-1">


### PR DESCRIPTION
PR-0 of the dispatch arc — the owner's direct ask: "I really don't like the 3 buttons, I'd rather have them just click, and a little x to close the popup box."

## Changes
- **Task blocks**: "…" trigger removed. A plain click (below the existing 5px/8px drag threshold) opens the task menu at the click point. Drag-to-move, edge-resize, and the hover note card are unchanged. Enter/Space on a focused block open the menu too (keyboard date-editing stays available via the menu's Edit dates form and the resize handles — the old bare-Enter arrow-move entry is superseded).
- **Activation seam**: the click routes through one named `handleBlockActivate` function — the A1 task drawer will re-point exactly this seam, no state-machine rework.
- **Bug caught in browser verification**: without `stopPropagation`, the parent bar's click handler opened the PROJECT menu right after the task menu, and the single-menu coordinator closed the task menu — clicking a task showed the wrong menu. Fixed + pinned with a new render-contract assertion.
- **ProjectBar**: the "Actions" chip is removed as redundant chrome (bar click, right-click, and Shift+F10 all open the menu). *Owner veto welcome — easy to restore.*
- **FloatingPopover**: small × close button top-right (never in the pointer-events-none hover-card mode). Escape/outside-click unchanged.

## Verification
- Render-contract + layout scripts PASS (assertions extended: no ⋯, no Actions chip, × gated on popover mode, Enter/Space path, stopPropagation pin)
- `tsc --noEmit` clean, `npm run build` 0 errors (independent checker run)
- Browser: task click → task menu (Edit dates/Task crew/Add note/Delete) + × closes; bar click → project menu; both anchored at the click point

Implemented by GPT-5.6-sol (xhigh) from a written spec; independently gate-checked (Sonnet checker), reviewed and browser-verified by Fable 5 (one inline fix: the menu-coordinator propagation race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)