### PR TITLE
Fluidity core: drags never re-render the board (ghost overlay layer)

### DIFF
--- a/scripts/verify-schedule-board-layout.ts
+++ b/scripts/verify-schedule-board-layout.ts
@@ -444,6 +444,55 @@ assert.deepEqual(computeProjectEndResizeCandidate(resizeOriginalEnd, resizeStart
 assert.deepEqual(computeProjectEndResizeCandidate(resizeOriginalEnd, resizeStart, -10), addDays(resizeStart, 1), "dragging past the start clamps to start+1, never to or before the start");
 assert.deepEqual(computeProjectEndResizeCandidate(resizeOriginalEnd, resizeStart, -3), addDays(resizeStart, 1), "the clamp boundary itself (candidate === start) also clamps to start+1");
 
+// PR-A3 step 1: characterize the pure candidate semantics before replacing
+// React-rendered pointer previews with the detached visual layer. These are
+// release candidates (the values handed to the existing draft/immediate
+// writers), not transient ghost geometry.
+assert.deepEqual(
+    previewTaskPointerCandidate(task, "move", 0),
+    { startDate: "2037-01-03", endDate: "2037-01-06" },
+    "a threshold-crossing task drag that returns to its origin releases the canonical dates",
+);
+assert.deepEqual(
+    previewTaskPointerCandidate(task, "resize-right", 4),
+    { startDate: "2037-01-03", endDate: "2037-01-10" },
+    "task right-resize release candidates preserve the original start and move only the end",
+);
+assert.equal(
+    previewTaskPointerCandidate(task, "resize-left", 99),
+    null,
+    "an invalid task resize never produces a droppable candidate",
+);
+const backwardsProjectIntent = createProjectDropIntent(scheduledProject, "2036-12-30");
+assert.deepEqual(
+    backwardsProjectIntent && {
+        originalStart: backwardsProjectIntent.originalStart,
+        targetStart: backwardsProjectIntent.targetStart,
+        deltaDays: backwardsProjectIntent.deltaDays,
+    },
+    { originalStart: "2037-01-03", targetStart: "2036-12-30", deltaDays: -4 },
+    "project drop candidates retain signed day deltas for task-preview shifting and Save",
+);
+const backwardsProjectPreview = previewProjectMove(scheduledProject, "2036-12-30");
+assert.deepEqual(
+    backwardsProjectPreview.tasks.map(candidate => [candidate.startDate, candidate.endDate]),
+    [
+        ["2036-12-30", "2037-01-02"],
+        ["2037-01-16", "2037-01-16"],
+    ],
+    "Waiting-to-Start project previews shift every task by the exact project candidate delta",
+);
+assert.deepEqual(
+    previewProjectMove({ ...scheduledProject, status: "In Progress" }, "2036-12-30").tasks,
+    scheduledProject.tasks,
+    "In-Progress project previews remain marker-only until the Save-time choice",
+);
+assert.deepEqual(
+    computeProjectEndResizeCandidate(resizeOriginalEnd, resizeStart, 0),
+    resizeOriginalEnd,
+    "an end-resize released at its origin is a no-op candidate",
+);
+
 // Dispatch A2: pure exception derivation. Every category gets a positive and
 // negative fixture so the strip cannot silently broaden its meaning.
 const dispatchDay = "2037-01-05";

--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -25,6 +25,7 @@ const dispatchExceptionsSource = src("../src/app/company-dashboard/schedule-boar
 const traySource = src("../src/app/company-dashboard/schedule-board/UnscheduledTray.tsx");
 const dialogSource = src("../src/app/company-dashboard/schedule-board/ShiftConfirmDialog.tsx");
 const layoutSource = src("../src/app/company-dashboard/schedule-board/useBarLayout.ts");
+const dragVisualSource = src("../src/app/company-dashboard/schedule-board/dragVisualLayer.ts");
 const popoverSource = src("../src/app/company-dashboard/schedule-board/FloatingPopover.tsx");
 const actionsSource = src("../src/lib/actions.ts");
 const coreSource = src("../src/lib/schedule-core.ts");
@@ -114,6 +115,115 @@ assert.match(projectBarSource, /isDraft \? "border-dashed border-2 border-white\
 assert.doesNotMatch(projectBarSource, /canMoveProject && !isPending && !isDraft/, "a drafted project bar must stay as interactive as a saved one");
 assert.match(taskBlockSource, /isDraft\?: boolean/);
 assert.match(taskBlockSource, /isDraft \? "border-dashed border-2 border-white\/90 saturate-\[\.55\] brightness-95"/);
+
+// PR-A3 step 1: characterize pointer and draft behavior before replacing
+// React-rendered drag previews with the detached visual layer. These checks
+// pin the user-visible gates and final writer calls, not transient preview
+// implementation details.
+assert.match(boardSource, /const TASK_MOUSE_DRAG_THRESHOLD_PX = 5;/, "task mouse drag activation stays at 5px");
+assert.match(boardSource, /const TASK_TOUCH_DRAG_THRESHOLD_PX = 8;/, "task touch drag activation stays at 8px");
+assert.match(boardSource, /const PROJECT_MOUSE_DRAG_THRESHOLD_PX = 5;/, "project mouse and end-resize activation stays at 5px");
+assert.match(boardSource, /const PROJECT_TOUCH_DRAG_THRESHOLD_PX = 8;/, "project touch and end-resize activation stays at 8px");
+
+const characterizedTaskPointerStart = boardSource.indexOf("function handleTaskPointerEditStart(");
+const characterizedTaskPointerEnd = boardSource.indexOf("function handleTaskKeyboardStart(", characterizedTaskPointerStart);
+const characterizedTaskPointerBody = boardSource.slice(characterizedTaskPointerStart, characterizedTaskPointerEnd);
+assert.ok(characterizedTaskPointerStart >= 0, "task pointer edit machine must exist");
+assert.match(characterizedTaskPointerBody, /drag\.pointerType === "touch" \? TASK_TOUCH_DRAG_THRESHOLD_PX : TASK_MOUSE_DRAG_THRESHOLD_PX/, "task pointer threshold remains pointer-type specific");
+assert.match(characterizedTaskPointerBody, /Math\.hypot\(event\.clientX - drag\.startX, event\.clientY - drag\.startY\) < threshold/, "task threshold uses two-dimensional pointer distance");
+assert.match(characterizedTaskPointerBody, /return previewTaskPointerCandidate\(canonicalTask, mode, deltaDays\);/, "task drop candidates keep using the shared pure date helper");
+assert.match(characterizedTaskPointerBody, /drag\.latestClientX = releaseEvent\.clientX;\s*\n\s*drag\.latestClientY = releaseEvent\.clientY;[\s\S]*?const candidate = drag\.active && !cancelled \? calculatePointerCandidate\(\) : null;/, "task drop recomputes its final candidate from pointer-up coordinates");
+assert.match(characterizedTaskPointerBody, /if \(!drag\.active \|\| cancelled \|\| !candidate\) \{[\s\S]*?return;\s*\n\s*\}\s*\n\s*draftTaskChange\(task\.id, candidate\);/, "task cancel or outside-grid release never reaches the existing draft writer");
+assert.match(characterizedTaskPointerBody, /const onPointerCancel = \(event: PointerEvent\) => \{[\s\S]*?finish\(true\);/, "task pointercancel routes through cancellation");
+assert.match(characterizedTaskPointerBody, /const onWindowBlur = \(\) => finish\(true\);/, "task blur routes through cancellation");
+
+const characterizedProjectPointerStart = boardSource.indexOf("function handleProjectPointerEditStart(");
+const characterizedProjectPointerEnd = boardSource.indexOf("function commitProjectEndResize(", characterizedProjectPointerStart);
+const characterizedProjectPointerBody = boardSource.slice(characterizedProjectPointerStart, characterizedProjectPointerEnd);
+assert.ok(characterizedProjectPointerStart >= 0, "project pointer edit machine must exist");
+assert.match(characterizedProjectPointerBody, /drag\.pointerType === "touch" \? PROJECT_TOUCH_DRAG_THRESHOLD_PX : PROJECT_MOUSE_DRAG_THRESHOLD_PX/, "project pointer threshold remains pointer-type specific");
+assert.match(characterizedProjectPointerBody, /formatDate\(addDays\(parseUTCDate\(drag\.originalStart\), deltaDays\)\)/, "project drop candidates remain based on the original start plus the snapped signed delta");
+assert.match(characterizedProjectPointerBody, /drag\.latestClientX = releaseEvent\.clientX;\s*\n\s*drag\.latestClientY = releaseEvent\.clientY;[\s\S]*?const candidate = drag\.active && !cancelled \? calculateProjectPointerCandidate\(\) : null;/, "project drop recomputes its final candidate from pointer-up coordinates");
+assert.match(characterizedProjectPointerBody, /if \(cancelled \|\| !candidate\) \{[\s\S]*?return;\s*\n\s*\}\s*\n\s*draftProjectMove\(drag\.project, candidate\);/, "project cancel or outside-grid release never reaches the existing draft writer");
+assert.match(characterizedProjectPointerBody, /const onWindowBlur = \(\) => finish\(true\);/, "project blur routes through cancellation");
+
+const characterizedEndResizeStart = boardSource.indexOf("function handleProjectEndResizeStart(");
+const characterizedEndResizeEnd = boardSource.indexOf("function handleProjectKeyboardStart(", characterizedEndResizeStart);
+const characterizedEndResizeBody = boardSource.slice(characterizedEndResizeStart, characterizedEndResizeEnd);
+assert.ok(characterizedEndResizeStart >= 0, "project end-resize pointer machine must exist");
+assert.match(characterizedEndResizeBody, /drag\.pointerType === "touch" \? PROJECT_TOUCH_DRAG_THRESHOLD_PX : PROJECT_MOUSE_DRAG_THRESHOLD_PX/, "project end-resize shares the project pointer thresholds");
+assert.match(characterizedEndResizeBody, /computeProjectEndResizeCandidate\(/, "end-resize candidates keep using the shared clamp helper");
+assert.match(characterizedEndResizeBody, /!drag\.active \|\| cancelled \|\| !candidate \|\| candidate === drag\.originalEnd/, "cancelled, invalid, and origin end-resize releases stay no-ops");
+assert.match(characterizedEndResizeBody, /commitProjectEndResize\(drag\.project, candidate\);/, "a changed end-resize release keeps using the immediate end writer");
+assert.match(characterizedEndResizeBody, /const onWindowBlur = \(\) => finish\(true\);/, "project end-resize blur routes through cancellation");
+
+const characterizedDiscardStart = boardSource.indexOf("function discardAllDrafts()");
+const characterizedDiscardEnd = boardSource.indexOf("function waitForConfirmChoice(", characterizedDiscardStart);
+const characterizedDiscardBody = boardSource.slice(characterizedDiscardStart, characterizedDiscardEnd);
+assert.match(characterizedDiscardBody, /cancelActiveTaskEdit\(\);\s*\n\s*cancelActiveProjectEdit\(\);/, "Discard cancels every active edit before clearing unsaved state");
+assert.match(characterizedDiscardBody, /awaitingTaskRefreshIds\.has\(taskId\)/, "Discard preserves saved-awaiting task overrides");
+assert.match(saveAllDraftsBody, /if \(awaitingTaskRefreshIds\.has\(taskId\)\) return false;/, "Save never resubmits saved-awaiting task overrides");
+assert.match(boardSource, /rewriteAwaitingOverridesFromShift\(unseen\.flatMap\(event => event\.taskDates\)\)/, "all unseen external shifts keep rebasing saved-awaiting overrides");
+
+// PR-A3 steps 2-4: the new architecture must make active pointer frames an
+// imperative DOM-only path. These assertions intentionally start RED after
+// characterization passes and before production code changes.
+assert.ok(dragVisualSource.length > 0, "the isolated dragVisualLayer module must exist");
+assert.doesNotMatch(dragVisualSource, /@\/lib\/actions|schedule-core|router|toast|draftTaskChange|draftProjectMove|updateProjectEndDateAction/, "the visual layer must have no schedule persistence knowledge");
+assert.match(dragVisualSource, /export function createDragVisualLayer\(/, "the visual layer exposes one focused controller factory");
+assert.match(dragVisualSource, /cloneNode\(true\)/, "move ghosts clone the rendered task or project visual");
+assert.match(dragVisualSource, /document\.body\.appendChild\(/, "the detached ghost mounts outside React-owned schedule geometry");
+assert.match(dragVisualSource, /position = "fixed"/, "ghost positioning is viewport-fixed");
+assert.match(dragVisualSource, /pointerEvents = "none"/, "the ghost never interferes with hit testing");
+assert.match(dragVisualSource, /new MutationObserver\(/, "the controller re-applies source/target visuals across refresh remounts");
+assert.match(dragVisualSource, /querySelectorAll<HTMLElement>\(sourceSelector\)/, "stable data hooks reacquire every remounted source fragment");
+assert.match(dragVisualSource, /export function projectMarkerDragSourceSelector\(/, "marker-only project drags can target title strips without dimming task visuals");
+assert.match(dragVisualSource, /document\.elementsFromPoint\(/, "target highlighting is reacquired from the live DOM at the last pointer position");
+assert.match(dragVisualSource, /data-schedule-date/, "the visual layer owns schedule-date target highlighting");
+assert.match(dragVisualSource, /transform = `translate3d\(/, "active pointer frames update detached ghost geometry imperatively");
+assert.match(dragVisualSource, /sourceOffsetX\?: number;/, "resize ghosts can track source movement caused by timeline autoscroll");
+assert.match(dragVisualSource, /observer\.disconnect\(\)/, "visual cleanup stops refresh observation");
+assert.match(dragVisualSource, /ghost\.remove\(\)/, "visual cleanup removes the detached ghost");
+assert.match(dragVisualSource, /ghost\.setAttribute\("aria-hidden", "true"\)/, "detached visual clones stay out of the accessibility tree");
+assert.match(dragVisualSource, /dispatchEvent\(new CustomEvent\(DRAG_VISUAL_ACTIVE_EVENT/, "pointer-drag activity is published below ScheduleBoard instead of root state");
+
+assert.match(taskBlockSource, /data-drag-visual-kind="task"/, "task roots expose a stable visual kind hook");
+assert.match(taskBlockSource, /data-drag-task-id=\{task\.id\}/, "task roots expose a stable task-id hook");
+assert.match(projectBarSource, /data-drag-visual-kind="project"/, "project roots expose a stable visual kind hook");
+assert.match(projectBarSource, /data-drag-project-id=\{project\.id\}/, "project roots expose a stable project-id hook");
+assert.match(projectBarSource, /data-drag-project-title="true"/, "In-Progress marker-only ghosts have a stable title-strip hook");
+assert.match(taskBlockSource, /isDragVisualLayerActive\(\)/, "task hover opening reads pointer-drag activity without a board-root render");
+assert.match(taskBlockSource, /DRAG_VISUAL_ACTIVE_EVENT/, "active pointer drags close existing task hover cards below the board root");
+
+assert.match(boardSource, /let scheduleBoardRenderCount = 0;/, "a module-level development render counter must exist");
+assert.match(boardSource, /process\.env\.NODE_ENV !== "production"/, "the render counter must be development-only");
+assert.match(boardSource, /window\.__boardRenderCount = scheduleBoardRenderCount/, "the browser test can read the ScheduleBoard render count");
+assert.match(boardSource, /import \{\s*createDragVisualLayer[,\s\S]*?\} from "\.\/dragVisualLayer"/, "ScheduleBoard must consume the isolated visual controller");
+assert.doesNotMatch(boardSource, /setPointerDragActive/, "threshold crossing and pointer-up must not write board-root drag state");
+const taskRafBody = characterizedTaskPointerBody.slice(
+    characterizedTaskPointerBody.indexOf("const runTaskPointerFrame ="),
+    characterizedTaskPointerBody.indexOf("const onPointerMove ="),
+);
+const projectRafBody = characterizedProjectPointerBody.slice(
+    characterizedProjectPointerBody.indexOf("const runProjectPointerFrame ="),
+    characterizedProjectPointerBody.indexOf("const requestProjectPointerFrame ="),
+);
+const endResizeRafBody = characterizedEndResizeBody.slice(
+    characterizedEndResizeBody.indexOf("const runEndResizeFrame ="),
+    characterizedEndResizeBody.indexOf("const onPointerMove ="),
+);
+assert.doesNotMatch(taskRafBody, /setTaskPreview\(|clearTaskPreview\(|setTaskDateOverrides\(/, "task pointer RAFs must not write React preview state");
+assert.doesNotMatch(projectRafBody, /setProjectPreview\(|clearProjectPreview\(|setProjectPreviewOverrides\(|setProjectIncomeOverrides\(/, "project pointer RAFs must not write React preview state");
+assert.doesNotMatch(endResizeRafBody, /setProjectPreview\(|clearProjectPreview\(|setProjectPreviewOverrides\(/, "project end-resize RAFs must not write React preview state");
+assert.match(characterizedTaskPointerBody, /createDragVisualLayer\(/, "task move and resize paths use the detached controller");
+assert.match(characterizedEndResizeBody, /createDragVisualLayer\(/, "project end-resize uses the detached controller");
+assert.match(characterizedProjectPointerBody, /createDragVisualLayer\(/, "project move uses the detached controller");
+assert.match(characterizedProjectPointerBody, /sourceSelector: drag\.project\.status === "In Progress"\s*\n\s*\? projectMarkerDragSourceSelector\(project\.id\)\s*\n\s*: projectDragSourceSelector\(project\.id\)/, "In-Progress moves dim only marker/title fragments while Waiting-to-Start moves dim the full composite");
+assert.match(characterizedTaskPointerBody, /visualLayer\.update\(/, "task RAF updates only the visual controller");
+assert.match(characterizedEndResizeBody, /visualLayer\.update\(/, "end-resize RAF updates only the visual controller");
+assert.match(characterizedProjectPointerBody, /visualLayer\.update\(/, "project-move RAF updates only the visual controller");
+assert.match(characterizedTaskPointerBody, /sourceOffsetX: drag\.originX - drag\.startX/, "task resize ghosts stay anchored to their autoscrolled source");
+assert.match(characterizedEndResizeBody, /sourceOffsetX: drag\.originX - drag\.startX/, "project end-resize ghosts stay anchored to their autoscrolled source");
 
 // ── Item 1: crew ACTIVATED validation is added-only ──
 const setProjectCrewStart = coreSource.indexOf("export async function setProjectCrew");
@@ -394,9 +504,9 @@ assert.match(projectBarSource, /opacity-0 transition group-hover\/project:opacit
 // 16px grab zone with a 4px overhang past the bar edge (a 6px sliver was
 // unhittable in practice) — still confined to the title strip's 18px band.
 assert.match(projectBarSource, /className="absolute -right-1 top-0 z-20 h-\[18px\] w-4/, "the edge-resize handle must be a findable-width target confined to the title strip's 18px band, never the task strip");
-// ScheduleBoard: a SEPARATE drag machine from the whole-bar move, live local
-// preview via the SAME projectPreviewOverrides mechanism the move-drag/item-3
-// preview already uses, immediate commit (never draftProjectMove).
+// ScheduleBoard: a SEPARATE drag machine from the whole-bar move. Its active
+// visual stays detached; drop installs one final projectPreviewOverride before
+// the immediate commit (never draftProjectMove).
 assert.match(layoutSource, /export function computeProjectEndResizeCandidate\(originalEnd: Date, startDate: Date, deltaDays: number\): Date \{/, "the resize-preview clamp must be an exported PURE helper (testable, reused by both views)");
 assert.match(layoutSource, /candidate < minEnd \? minEnd : candidate/, "the clamp must floor the candidate at start+1, never at or before the start");
 assert.match(boardSource, /function measureMonthDayWidth\(clientX: number, clientY: number\): number \| null \{/, "Month's day width must be measured from the underlying week-grid day cell, not hardcoded");
@@ -605,3 +715,13 @@ assert.match(coreSource, /scheduledTime: string \| null;/, "dispatch appointment
 assert.match(coreSource, /confirmationStatus: string \| null;/, "dispatch appointments need confirmation status");
 assert.match(coreSource, /doneWhen: true, blockedReason: true, scheduledTime: true, confirmationStatus: true/, "the dashboard task query must select every dispatch field");
 console.log("schedule-board render contract verification: PASS");
+
+// A3 reviewer-approved deltas, pinned so they stay deliberate:
+// 1. Escape cancels an active POINTER drag (all three pointer machines wire a
+//    window keydown handler) — additive UX approved in the A3 review round.
+const escapeWirings = boardSource.match(/window\.addEventListener\("keydown", onWindowKeyDown\)/g) ?? [];
+assert.ok(escapeWirings.length >= 3, "all three pointer-drag machines must wire the Escape-cancel keydown handler");
+// 2. Drag sourceElement is the block/bar ROOT (not the resize handle) so the
+//    ghost gets block geometry and touch-action:none covers the whole block.
+assert.match(taskBlockSource, /sourceElement: rootRef\.current \?\? event\.currentTarget/, "task drags must source from the block root");
+assert.match(projectBarSource, /sourceElement: rootRef\.current \?\? event\.currentTarget/, "project drags must source from the bar root");

--- a/src/app/company-dashboard/schedule-board/ProjectBar.tsx
+++ b/src/app/company-dashboard/schedule-board/ProjectBar.tsx
@@ -277,7 +277,7 @@ export function ProjectBar({
             pointerType: event.pointerType,
             clientX: event.clientX,
             clientY: event.clientY,
-            sourceElement: event.currentTarget,
+            sourceElement: rootRef.current ?? event.currentTarget,
             originalStart: formatDate(projectRange!.start),
             originalEnd: formatDate(projectRange!.end),
             timelineDayWidth,
@@ -420,6 +420,8 @@ export function ProjectBar({
             ref={rootRef}
             className={`group/project relative touch-pan-y select-none overflow-visible rounded-md border text-white shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 ${canMoveProject && !isPending ? "cursor-move" : ""} ${isDraft ? "border-dashed border-2 border-white/90 saturate-[.55] brightness-95" : "border-black/10"}`}
             style={{ backgroundColor: projectColor, height: barHeight }}
+            data-drag-visual-kind="project"
+            data-drag-project-id={project.id}
             data-can-edit={canEdit ? "true" : "false"}
             role="group"
             aria-label={`${project.name} project bar${isDraft ? " (unsaved change)" : ""}`}
@@ -431,7 +433,7 @@ export function ProjectBar({
             onContextMenu={handleContextMenu}
             onKeyDown={handleKeyboard}
         >
-            <div className="absolute inset-x-0 top-0 z-10 flex h-[18px] min-w-0 items-center gap-1 px-1 text-[10px] leading-none">
+            <div data-drag-project-title="true" className="absolute inset-x-0 top-0 z-10 flex h-[18px] min-w-0 items-center gap-1 px-1 text-[10px] leading-none">
                 {segment.continuesBefore && <span aria-hidden="true">‹</span>}
                 <Link href={`/projects/${project.id}`} title={projectTitle} className="min-w-0 flex-1 truncate font-semibold text-white outline-none hover:underline focus-visible:ring-2 focus-visible:ring-white">
                     {project.name}

--- a/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
+++ b/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
@@ -37,6 +37,13 @@ import {
 } from "./useBarLayout";
 import type { TaskPointerEditStart } from "./TaskBlockSegment";
 import type { ProjectEndResizePointerStart, ProjectPointerEditStart } from "./ProjectBar";
+import {
+    createDragVisualLayer,
+    projectDragSourceSelector,
+    projectMarkerDragSourceSelector,
+    taskDragSourceSelector,
+    type DragVisualLayer,
+} from "./dragVisualLayer";
 
 export type { ProjectMoveChoice } from "./ShiftConfirmDialog";
 export type { ProjectDropIntent } from "./useBarLayout";
@@ -51,6 +58,14 @@ const PROJECT_TOUCH_DRAG_THRESHOLD_PX = 8;
 const EDGE_AUTOSCROLL_THRESHOLD_PX = 48;
 const MAX_AUTOSCROLL_PX_PER_FRAME = 16;
 const EMPTY_PROJECT_IDS: ReadonlySet<string> = new Set();
+
+let scheduleBoardRenderCount = 0;
+
+declare global {
+    interface Window {
+        __boardRenderCount?: number;
+    }
+}
 
 interface ScheduleBoardProps {
     data: CompanyDashboardData;
@@ -83,9 +98,11 @@ interface ActiveTaskPointerEdit {
     latestClientX: number;
     latestClientY: number;
     grabDate: string | null;
+    monthDayWidth: number | null;
     mode: TaskEditMode;
     active: boolean;
     currentCandidate: TaskDateOverride | null;
+    visualLayer: DragVisualLayer | null;
     animationFrameId: number | null;
     sourceElement: HTMLElement;
     previousTouchAction: string;
@@ -110,6 +127,7 @@ interface ActiveProjectPointerEdit {
     grabDate: string;
     originalStart: string;
     active: boolean;
+    visualLayer: DragVisualLayer | null;
     animationFrameId: number | null;
     sourceElement: HTMLElement;
     previousTouchAction: string;
@@ -118,10 +136,9 @@ interface ActiveProjectPointerEdit {
 }
 
 // Right-edge resize drag (item 2) — a SEPARATE pointer-drag from
-// ActiveProjectPointerEdit above: it previews via the SAME projectPreviewOverrides
-// slot (only one project edit can be active at a time — see cancelActiveProjectEdit)
-// but commits immediately (updateProjectEndDateAction), never joining the
-// draft/Save system.
+// ActiveProjectPointerEdit above. Its active preview lives in the detached
+// visual layer, but its final valid candidate still commits immediately through
+// updateProjectEndDateAction and never joins the draft/Save system.
 interface ActiveProjectEndResizeEdit {
     projectId: string;
     project: DashboardProjectRow;
@@ -140,6 +157,7 @@ interface ActiveProjectEndResizeEdit {
     monthDayWidth: number | null;
     active: boolean;
     currentCandidate: string | null;
+    visualLayer: DragVisualLayer | null;
     animationFrameId: number | null;
     sourceElement: HTMLElement;
     previousTouchAction: string;
@@ -207,6 +225,10 @@ export function ScheduleBoard({
     onEffectivePendingProjectIdsChange,
     externalShiftEvents,
 }: ScheduleBoardProps) {
+    if (process.env.NODE_ENV !== "production") {
+        scheduleBoardRenderCount += 1;
+        if (typeof window !== "undefined") window.__boardRenderCount = scheduleBoardRenderCount;
+    }
     const router = useRouter();
     const { month, isAdmin, overlays } = data;
     const [showIncome, setShowIncome] = useState(true);
@@ -255,11 +277,6 @@ export function ScheduleBoard({
     // it participates in the SAME isPending gating as every other lock).
     const activeProjectEndResizeRef = useRef<ActiveProjectEndResizeEdit | null>(null);
     const [endResizeSavingProjectIds, setEndResizeSavingProjectIds] = useState<ReadonlySet<string>>(EMPTY_PROJECT_IDS);
-    // True for the duration of ANY pointer drag whose threshold has been
-    // crossed (project move, project end-resize, task move/resize) —
-    // combined with the keyboard-edit states below to gate task hover cards
-    // off while an edit is in progress (item 3).
-    const [pointerDragActive, setPointerDragActive] = useState(false);
     const previousExternallyPendingProjectIdsRef = useRef<ReadonlySet<string>>(new Set(externallyPendingProjectIds));
     const [confirmIntent, setConfirmIntent] = useState<ProjectDropIntent | null>(null);
     // Bumped on every "Today" click so TimelineView re-scrolls to today even
@@ -353,9 +370,9 @@ export function ScheduleBoard({
         () => mergeProjectPendingIds(externallyPendingProjectIds, endResizeSavingProjectIds),
         [externallyPendingProjectIds, endResizeSavingProjectIds],
     );
-    // Hover cards go quiet the moment ANY drag — pointer or keyboard, project
-    // or task — is in progress (item 3).
-    const isAnyDragActive = pointerDragActive || projectKeyboardEdit !== null || taskKeyboardEdit !== null;
+    // Keyboard edits still gate hover cards through React. Active pointer edits
+    // publish below this root from dragVisualLayer, avoiding a board render.
+    const isAnyDragActive = projectKeyboardEdit !== null || taskKeyboardEdit !== null;
 
     useEffect(() => () => onEffectivePendingProjectIdsChange(EMPTY_PROJECT_IDS), [onEffectivePendingProjectIdsChange]);
     // ONE derived publisher for the page-wide lock: the live union of the
@@ -984,6 +1001,7 @@ export function ScheduleBoard({
             grabDate: hitTestScheduleDate(start.clientX, start.clientY) ?? start.fallbackGrabDate,
             originalStart: start.originalStart,
             active: false,
+            visualLayer: null,
             animationFrameId: null,
             sourceElement: start.sourceElement,
             previousTouchAction: start.sourceElement.style.touchAction,
@@ -1030,8 +1048,15 @@ export function ScheduleBoard({
                 drag.originX -= container.scrollLeft - before;
             }
             const candidate = calculateProjectPointerCandidate();
-            if (candidate) setProjectPreview(drag.project, candidate);
-            else clearProjectPreview(drag.projectId);
+            const visualLayer = drag.visualLayer;
+            if (visualLayer) {
+                visualLayer.update({
+                    clientX: drag.latestClientX,
+                    clientY: drag.latestClientY,
+                    label: candidate ? `UTC start ${candidate}` : null,
+                    targetDate: candidate ? hitTestScheduleDate(drag.latestClientX, drag.latestClientY) : null,
+                });
+            }
             if (getProjectAutoscrollStep() !== 0 && drag.animationFrameId == null) {
                 drag.animationFrameId = requestAnimationFrame(runProjectPointerFrame);
             }
@@ -1048,7 +1073,16 @@ export function ScheduleBoard({
                 if (Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY) < threshold) return;
                 drag.active = true;
                 drag.sourceElement.style.touchAction = "none";
-                setPointerDragActive(true);
+                drag.visualLayer = createDragVisualLayer({
+                    sourceElement: drag.sourceElement,
+                    sourceSelector: drag.project.status === "In Progress"
+                        ? projectMarkerDragSourceSelector(project.id)
+                        : projectDragSourceSelector(project.id),
+                    kind: drag.project.status === "In Progress" ? "project-marker-move" : "project-move",
+                    startClientX: drag.startX,
+                    startClientY: drag.startY,
+                    cloneSelector: drag.project.status === "In Progress" ? '[data-drag-project-title="true"]' : undefined,
+                });
             }
             event.preventDefault();
             requestProjectPointerFrame();
@@ -1076,20 +1110,27 @@ export function ScheduleBoard({
             if (event.pointerId === drag.pointerId) finish(true);
         };
         const onWindowBlur = () => finish(true);
+        const onWindowKeyDown = (event: globalThis.KeyboardEvent) => {
+            if (event.key !== "Escape" || !drag.active) return;
+            event.preventDefault();
+            finish(true);
+        };
         drag.cleanup = () => {
             if (activeProjectPointerRef.current === drag) activeProjectPointerRef.current = null;
-            setPointerDragActive(false);
             window.removeEventListener("pointermove", onPointerMove);
             window.removeEventListener("pointerup", onPointerUp);
             window.removeEventListener("pointercancel", onPointerCancel);
             window.removeEventListener("blur", onWindowBlur);
+            window.removeEventListener("keydown", onWindowKeyDown);
             if (drag.animationFrameId != null) cancelAnimationFrame(drag.animationFrameId);
             drag.animationFrameId = null;
+            drag.visualLayer?.cleanup();
+            drag.visualLayer = null;
             drag.sourceElement.style.touchAction = drag.previousTouchAction;
             try {
                 if (drag.sourceElement.hasPointerCapture(drag.pointerId)) drag.sourceElement.releasePointerCapture(drag.pointerId);
             } catch {
-                // The optimistic preview may re-key the originating segment.
+                // A refresh may replace the originating weekly segment.
             }
         };
         activeProjectPointerRef.current = drag;
@@ -1102,6 +1143,7 @@ export function ScheduleBoard({
         window.addEventListener("pointerup", onPointerUp);
         window.addEventListener("pointercancel", onPointerCancel);
         window.addEventListener("blur", onWindowBlur);
+        window.addEventListener("keydown", onWindowKeyDown);
     }
 
     // Immediate server write for a released end-resize drag (item 2) — NOT
@@ -1163,6 +1205,7 @@ export function ScheduleBoard({
             monthDayWidth: start.timelineDayWidth ? null : measureMonthDayWidth(start.clientX, start.clientY),
             active: false,
             currentCandidate: null,
+            visualLayer: null,
             animationFrameId: null,
             sourceElement: start.sourceElement,
             previousTouchAction: start.sourceElement.style.touchAction,
@@ -1203,17 +1246,24 @@ export function ScheduleBoard({
                 maxStep: MAX_AUTOSCROLL_PX_PER_FRAME,
             });
         };
-        const applyEndResizeCandidate = () => {
+        const updateEndResizeVisual = () => {
             const candidate = calculateEndResizeCandidate();
             drag.currentCandidate = candidate;
-            if (!candidate || candidate === drag.originalEnd) {
-                clearProjectPreview(drag.projectId);
-                return;
+            const dayWidth = drag.start.timelineDayWidth ?? drag.monthDayWidth;
+            const deltaX = candidate && dayWidth
+                ? getDaysBetween(parseUTCDate(drag.originalEnd), parseUTCDate(candidate)) * dayWidth
+                : undefined;
+            const visualLayer = drag.visualLayer;
+            if (visualLayer) {
+                visualLayer.update({
+                    clientX: drag.latestClientX,
+                    clientY: drag.latestClientY,
+                    deltaX,
+                    sourceOffsetX: drag.originX - drag.startX,
+                    label: candidate ? `UTC end ${candidate}` : null,
+                    targetDate: candidate ? hitTestScheduleDate(drag.latestClientX, drag.latestClientY) : null,
+                });
             }
-            setProjectPreviewOverrides(current => ({
-                ...current,
-                [drag.projectId]: { ...drag.project, endDate: `${candidate}T00:00:00.000Z` },
-            }));
         };
         const runEndResizeFrame = () => {
             drag.animationFrameId = null;
@@ -1225,7 +1275,7 @@ export function ScheduleBoard({
                 container.scrollLeft += scrollDelta;
                 drag.originX -= container.scrollLeft - before;
             }
-            applyEndResizeCandidate();
+            updateEndResizeVisual();
             if (getEndResizeAutoscrollStep() !== 0 && drag.animationFrameId == null) {
                 drag.animationFrameId = requestAnimationFrame(runEndResizeFrame);
             }
@@ -1239,7 +1289,13 @@ export function ScheduleBoard({
                 if (Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY) < threshold) return;
                 drag.active = true;
                 drag.sourceElement.style.touchAction = "none";
-                setPointerDragActive(true);
+                drag.visualLayer = createDragVisualLayer({
+                    sourceElement: drag.sourceElement,
+                    sourceSelector: projectDragSourceSelector(project.id),
+                    kind: "project-end-resize",
+                    startClientX: drag.startX,
+                    startClientY: drag.startY,
+                });
             }
             event.preventDefault();
             if (drag.animationFrameId == null) drag.animationFrameId = requestAnimationFrame(runEndResizeFrame);
@@ -1257,6 +1313,10 @@ export function ScheduleBoard({
                 clearProjectPreview(drag.projectId);
                 return;
             }
+            setProjectPreviewOverrides(current => ({
+                ...current,
+                [drag.projectId]: { ...drag.project, endDate: `${candidate}T00:00:00.000Z` },
+            }));
             commitProjectEndResize(drag.project, candidate);
         };
         const onPointerUp = (event: PointerEvent) => {
@@ -1266,20 +1326,27 @@ export function ScheduleBoard({
             if (event.pointerId === drag.pointerId) finish(true);
         };
         const onWindowBlur = () => finish(true);
+        const onWindowKeyDown = (event: globalThis.KeyboardEvent) => {
+            if (event.key !== "Escape" || !drag.active) return;
+            event.preventDefault();
+            finish(true);
+        };
         drag.cleanup = () => {
             if (activeProjectEndResizeRef.current === drag) activeProjectEndResizeRef.current = null;
-            setPointerDragActive(false);
             window.removeEventListener("pointermove", onPointerMove);
             window.removeEventListener("pointerup", onPointerUp);
             window.removeEventListener("pointercancel", onPointerCancel);
             window.removeEventListener("blur", onWindowBlur);
+            window.removeEventListener("keydown", onWindowKeyDown);
             if (drag.animationFrameId != null) cancelAnimationFrame(drag.animationFrameId);
             drag.animationFrameId = null;
+            drag.visualLayer?.cleanup();
+            drag.visualLayer = null;
             drag.sourceElement.style.touchAction = drag.previousTouchAction;
             try {
                 if (drag.sourceElement.hasPointerCapture(drag.pointerId)) drag.sourceElement.releasePointerCapture(drag.pointerId);
             } catch {
-                // The optimistic preview may re-key the originating segment.
+                // A refresh may replace the originating weekly segment.
             }
         };
         activeProjectEndResizeRef.current = drag;
@@ -1292,6 +1359,7 @@ export function ScheduleBoard({
         window.addEventListener("pointerup", onPointerUp);
         window.addEventListener("pointercancel", onPointerCancel);
         window.addEventListener("blur", onWindowBlur);
+        window.addEventListener("keydown", onWindowKeyDown);
     }
 
     function handleProjectKeyboardStart(project: DashboardProjectRow, sourceElement: HTMLElement) {
@@ -1387,9 +1455,11 @@ export function ScheduleBoard({
             latestClientX: start.clientX,
             latestClientY: start.clientY,
             grabDate: hitTestScheduleDate(start.clientX, start.clientY),
+            monthDayWidth: start.timelineDayWidth ? null : measureMonthDayWidth(start.clientX, start.clientY),
             mode,
             active: false,
             currentCandidate: originalDates,
+            visualLayer: null,
             animationFrameId: null,
             sourceElement: start.sourceElement,
             previousTouchAction: start.sourceElement.style.touchAction,
@@ -1410,18 +1480,27 @@ export function ScheduleBoard({
             }
             return previewTaskPointerCandidate(canonicalTask, mode, deltaDays);
         };
-        const applyPointerCandidate = (): TaskDateOverride | null => {
+        const updateTaskVisual = (): TaskDateOverride | null => {
             const candidate = calculatePointerCandidate();
-            const previousCandidate = drag.currentCandidate;
             drag.currentCandidate = candidate;
-            if (!candidate) {
-                drag.currentCandidate = null;
-                clearTaskPreview(task.id);
-                return null;
+            let deltaX: number | undefined;
+            const dayWidth = start.timelineDayWidth ?? drag.monthDayWidth;
+            if (candidate && dayWidth && mode !== "move") {
+                const originalBoundary = mode === "resize-left" ? originalDates.startDate : originalDates.endDate;
+                const candidateBoundary = mode === "resize-left" ? candidate.startDate : candidate.endDate;
+                deltaX = getDaysBetween(parseUTCDate(originalBoundary), parseUTCDate(candidateBoundary)) * dayWidth;
             }
-            if (previousCandidate?.startDate === candidate.startDate && previousCandidate.endDate === candidate.endDate) return candidate;
-            if (candidate.startDate === originalDates.startDate && candidate.endDate === originalDates.endDate) clearTaskPreview(task.id);
-            else setTaskPreview(task.id, candidate);
+            const visualLayer = drag.visualLayer;
+            if (visualLayer) {
+                visualLayer.update({
+                    clientX: drag.latestClientX,
+                    clientY: drag.latestClientY,
+                    deltaX,
+                    sourceOffsetX: drag.originX - drag.startX,
+                    label: candidate ? `UTC ${candidate.startDate} to ${candidate.endDate}` : null,
+                    targetDate: candidate ? hitTestScheduleDate(drag.latestClientX, drag.latestClientY) : null,
+                });
+            }
             return candidate;
         };
         const getTaskAutoscrollStep = () => {
@@ -1450,7 +1529,7 @@ export function ScheduleBoard({
                 container.scrollLeft += scrollDelta;
                 drag.originX -= container.scrollLeft - before;
             }
-            applyPointerCandidate();
+            updateTaskVisual();
             if (getTaskAutoscrollStep() !== 0 && drag.animationFrameId == null) {
                 drag.animationFrameId = requestAnimationFrame(runTaskPointerFrame);
             }
@@ -1464,7 +1543,13 @@ export function ScheduleBoard({
                 if (Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY) < threshold) return;
                 drag.active = true;
                 drag.sourceElement.style.touchAction = "none";
-                setPointerDragActive(true);
+                drag.visualLayer = createDragVisualLayer({
+                    sourceElement: drag.sourceElement,
+                    sourceSelector: taskDragSourceSelector(task.id),
+                    kind: mode === "move" ? "task-move" : mode === "resize-left" ? "task-resize-left" : "task-resize-right",
+                    startClientX: drag.startX,
+                    startClientY: drag.startY,
+                });
             }
             event.preventDefault();
             if (drag.animationFrameId == null) drag.animationFrameId = requestAnimationFrame(runTaskPointerFrame);
@@ -1494,21 +1579,28 @@ export function ScheduleBoard({
             if (event.pointerId === drag.pointerId) finish(true);
         };
         const onWindowBlur = () => finish(true);
+        const onWindowKeyDown = (event: globalThis.KeyboardEvent) => {
+            if (event.key !== "Escape" || !drag.active) return;
+            event.preventDefault();
+            finish(true);
+        };
 
         drag.cleanup = () => {
             if (activeTaskPointerRef.current === drag) activeTaskPointerRef.current = null;
-            setPointerDragActive(false);
             window.removeEventListener("pointermove", onPointerMove);
             window.removeEventListener("pointerup", onPointerUp);
             window.removeEventListener("pointercancel", onPointerCancel);
             window.removeEventListener("blur", onWindowBlur);
+            window.removeEventListener("keydown", onWindowKeyDown);
             if (drag.animationFrameId != null) cancelAnimationFrame(drag.animationFrameId);
             drag.animationFrameId = null;
+            drag.visualLayer?.cleanup();
+            drag.visualLayer = null;
             drag.sourceElement.style.touchAction = drag.previousTouchAction;
             try {
                 if (drag.sourceElement.hasPointerCapture(drag.pointerId)) drag.sourceElement.releasePointerCapture(drag.pointerId);
             } catch {
-                // A task preview can unmount its original weekly segment.
+                // A refresh may replace the originating weekly segment.
             }
         };
         activeTaskPointerRef.current = drag;
@@ -1521,6 +1613,7 @@ export function ScheduleBoard({
         window.addEventListener("pointerup", onPointerUp);
         window.addEventListener("pointercancel", onPointerCancel);
         window.addEventListener("blur", onWindowBlur);
+        window.addEventListener("keydown", onWindowKeyDown);
     }
 
     function handleTaskKeyboardStart(task: DashboardTaskRow, mode: TaskEditMode, sourceElement: HTMLElement) {

--- a/src/app/company-dashboard/schedule-board/TaskBlockSegment.tsx
+++ b/src/app/company-dashboard/schedule-board/TaskBlockSegment.tsx
@@ -10,6 +10,7 @@ import { clipRange, type DateRange, type TaskDateOverride, type TaskEditMode } f
 import { FloatingPopover } from "./FloatingPopover";
 import { TaskCrewPicker } from "./CrewPickers";
 import { activateExclusiveMenu, deactivateExclusiveMenu } from "./menuCoordinator";
+import { DRAG_VISUAL_ACTIVE_EVENT, isDragVisualLayerActive } from "./dragVisualLayer";
 
 export interface TaskPointerEditStart {
     pointerId: number;
@@ -208,12 +209,28 @@ export function TaskBlockSegment({
         }
         setHoverCardOpen(false);
     }, [isAnyDragActive, menuOpen]);
+    // Pointer drags no longer update ScheduleBoard state at threshold time.
+    // Listen below the board root so an already-open card still closes while
+    // the root render counter remains unchanged for the full active drag.
+    useEffect(() => {
+        const closeForPointerDrag = () => {
+            if (!isDragVisualLayerActive()) return;
+            if (hoverOpenTimeoutRef.current != null) {
+                window.clearTimeout(hoverOpenTimeoutRef.current);
+                hoverOpenTimeoutRef.current = null;
+            }
+            setHoverCardOpen(false);
+        };
+        window.addEventListener(DRAG_VISUAL_ACTIVE_EVENT, closeForPointerDrag);
+        return () => window.removeEventListener(DRAG_VISUAL_ACTIVE_EVENT, closeForPointerDrag);
+    }, []);
     useEffect(() => () => {
         if (hoverOpenTimeoutRef.current != null) window.clearTimeout(hoverOpenTimeoutRef.current);
     }, []);
 
     function handleHoverCardMouseEnter() {
         if (isAnyDragActive || menuOpen || hoverOpenTimeoutRef.current != null) return;
+        if (isDragVisualLayerActive()) return;
         hoverOpenTimeoutRef.current = window.setTimeout(() => {
             hoverOpenTimeoutRef.current = null;
             setHoverCardOpen(true);
@@ -221,6 +238,7 @@ export function TaskBlockSegment({
     }
     function handleHoverCardFocus() {
         if (isAnyDragActive || menuOpen) return;
+        if (isDragVisualLayerActive()) return;
         if (hoverOpenTimeoutRef.current != null) {
             window.clearTimeout(hoverOpenTimeoutRef.current);
             hoverOpenTimeoutRef.current = null;
@@ -256,7 +274,7 @@ export function TaskBlockSegment({
             pointerType: event.pointerType,
             clientX: event.clientX,
             clientY: event.clientY,
-            sourceElement: event.currentTarget,
+            sourceElement: rootRef.current ?? event.currentTarget,
             timelineDayWidth,
             timelineLeftInset,
             timelineScrollContainerRef,
@@ -405,6 +423,8 @@ export function TaskBlockSegment({
             aria-disabled={!canEdit || isPending}
             aria-busy={isPending}
             data-task-edit-block="true"
+            data-drag-visual-kind="task"
+            data-drag-task-id={task.id}
             data-project-start={formatDate(projectRange.start)}
             data-can-edit={canEdit ? "true" : "false"}
             onPointerDown={event => beginPointerEdit(event, "move")}

--- a/src/app/company-dashboard/schedule-board/dragVisualLayer.ts
+++ b/src/app/company-dashboard/schedule-board/dragVisualLayer.ts
@@ -1,0 +1,286 @@
+export const DRAG_VISUAL_ACTIVE_EVENT = "gtr:schedule-drag-visual-active";
+
+export type DragVisualKind =
+    | "task-move"
+    | "task-resize-left"
+    | "task-resize-right"
+    | "project-move"
+    | "project-marker-move"
+    | "project-end-resize";
+
+export interface DragVisualLayerOptions {
+    sourceElement: HTMLElement;
+    sourceSelector: string;
+    kind: DragVisualKind;
+    startClientX: number;
+    startClientY: number;
+    cloneSelector?: string;
+}
+
+export interface DragVisualUpdate {
+    clientX: number;
+    clientY: number;
+    deltaX?: number;
+    sourceOffsetX?: number;
+    label?: string | null;
+    targetDate?: string | null;
+}
+
+export interface DragVisualLayer {
+    update: (_update: DragVisualUpdate) => void;
+    cleanup: () => void;
+}
+
+interface SavedSourceStyle {
+    opacity: string;
+}
+
+interface SavedTargetStyle {
+    element: HTMLElement;
+    backgroundColor: string;
+    boxShadow: string;
+    outline: string;
+    outlineOffset: string;
+}
+
+let activeVisualLayerCount = 0;
+
+export function isDragVisualLayerActive(): boolean {
+    return activeVisualLayerCount > 0;
+}
+
+function publishDragVisualActivity(active: boolean) {
+    activeVisualLayerCount = Math.max(0, activeVisualLayerCount + (active ? 1 : -1));
+    window.dispatchEvent(new CustomEvent(DRAG_VISUAL_ACTIVE_EVENT, {
+        detail: { active: activeVisualLayerCount > 0 },
+    }));
+}
+
+function escapeAttributeValue(value: string): string {
+    return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+export function taskDragSourceSelector(taskId: string): string {
+    return `[data-drag-visual-kind="task"][data-drag-task-id="${escapeAttributeValue(taskId)}"]`;
+}
+
+export function projectDragSourceSelector(projectId: string): string {
+    return `[data-drag-visual-kind="project"][data-drag-project-id="${escapeAttributeValue(projectId)}"]`;
+}
+
+export function projectMarkerDragSourceSelector(projectId: string): string {
+    return `${projectDragSourceSelector(projectId)} [data-drag-project-title="true"]`;
+}
+
+function stripCloneInteractivity(root: HTMLElement) {
+    root.removeAttribute("id");
+    root.removeAttribute("tabindex");
+    root.removeAttribute("aria-describedby");
+    root.querySelectorAll<HTMLElement>("[id],[tabindex],[aria-describedby]").forEach(element => {
+        element.removeAttribute("id");
+        element.removeAttribute("tabindex");
+        element.removeAttribute("aria-describedby");
+    });
+}
+
+function findScheduleTarget(clientX: number, clientY: number, targetDate: string): HTMLElement | null {
+    for (const element of document.elementsFromPoint(clientX, clientY)) {
+        const cell = element instanceof HTMLElement
+            ? element.closest<HTMLElement>("[data-schedule-date]")
+            : null;
+        if (cell?.dataset.scheduleDate === targetDate) return cell;
+    }
+
+    // A refresh can briefly replace the element below the pointer before the
+    // next layout pass. Fall back to the matching cell whose rect is nearest
+    // the last pointer position; the following pointer/RAF update will refine
+    // this once the new tree has settled.
+    let nearest: HTMLElement | null = null;
+    let nearestDistance = Number.POSITIVE_INFINITY;
+    document.querySelectorAll<HTMLElement>(`[data-schedule-date="${escapeAttributeValue(targetDate)}"]`).forEach(cell => {
+        const rect = cell.getBoundingClientRect();
+        const dx = clientX < rect.left ? rect.left - clientX : clientX > rect.right ? clientX - rect.right : 0;
+        const dy = clientY < rect.top ? rect.top - clientY : clientY > rect.bottom ? clientY - rect.bottom : 0;
+        const distance = Math.hypot(dx, dy);
+        if (distance < nearestDistance) {
+            nearest = cell;
+            nearestDistance = distance;
+        }
+    });
+    return nearest;
+}
+
+export function createDragVisualLayer({
+    sourceElement,
+    sourceSelector,
+    kind,
+    startClientX,
+    startClientY,
+    cloneSelector,
+}: DragVisualLayerOptions): DragVisualLayer {
+    const resizeVisual = kind === "task-resize-left"
+        || kind === "task-resize-right"
+        || kind === "project-end-resize";
+    const sourceForClone = cloneSelector
+        ? sourceElement.querySelector<HTMLElement>(cloneSelector) ?? sourceElement
+        : sourceElement;
+    const sourceRect = sourceElement.getBoundingClientRect();
+    const cloneRect = sourceForClone.getBoundingClientRect();
+    const visualRect = kind === "project-marker-move" ? cloneRect : sourceRect;
+    const ghost = document.createElement("div");
+    const label = document.createElement("div");
+    const savedSourceStyles = new Map<HTMLElement, SavedSourceStyle>();
+    let savedTargetStyle: SavedTargetStyle | null = null;
+    let latestUpdate: DragVisualUpdate = { clientX: startClientX, clientY: startClientY };
+    let cleaned = false;
+
+    ghost.dataset.dragVisualLayer = "true";
+    ghost.dataset.dragVisualKind = kind;
+    ghost.setAttribute("aria-hidden", "true");
+    ghost.style.position = "fixed";
+    ghost.style.pointerEvents = "none";
+    ghost.style.left = `${visualRect.left}px`;
+    ghost.style.top = `${visualRect.top}px`;
+    ghost.style.width = `${Math.max(visualRect.width, 1)}px`;
+    ghost.style.height = `${Math.max(visualRect.height, 1)}px`;
+    ghost.style.zIndex = "90";
+    ghost.style.boxSizing = "border-box";
+    ghost.style.willChange = "transform,width";
+    ghost.style.transform = "translate3d(0px, 0px, 0px)";
+
+    if (resizeVisual) {
+        ghost.style.border = "2px solid rgba(79, 70, 229, 0.95)";
+        ghost.style.borderRadius = "4px";
+        ghost.style.background = "rgba(99, 102, 241, 0.10)";
+        ghost.style.boxShadow = "0 4px 14px rgba(15, 23, 42, 0.24)";
+
+        const edge = document.createElement("span");
+        edge.style.position = "absolute";
+        edge.style.insetBlock = "-2px";
+        edge.style.width = "3px";
+        edge.style.background = "rgb(79, 70, 229)";
+        edge.style.boxShadow = "0 0 0 1px rgba(255, 255, 255, 0.9)";
+        if (kind === "task-resize-left") edge.style.left = "-2px";
+        else edge.style.right = "-2px";
+        ghost.appendChild(edge);
+    } else {
+        const sourceClone = sourceForClone.cloneNode(true) as HTMLElement;
+        stripCloneInteractivity(sourceClone);
+        sourceClone.style.position = "relative";
+        sourceClone.style.inset = "auto";
+        sourceClone.style.left = "auto";
+        sourceClone.style.top = "auto";
+        sourceClone.style.width = "100%";
+        sourceClone.style.height = "100%";
+        sourceClone.style.margin = "0";
+        sourceClone.style.transform = "none";
+        sourceClone.style.pointerEvents = "none";
+        sourceClone.style.opacity = "0.92";
+        sourceClone.style.filter = "drop-shadow(0 8px 10px rgba(15, 23, 42, 0.28))";
+        ghost.appendChild(sourceClone);
+    }
+
+    label.dataset.dragVisualLabel = "true";
+    label.style.position = "absolute";
+    label.style.left = "50%";
+    label.style.bottom = "calc(100% + 6px)";
+    label.style.transform = "translateX(-50%)";
+    label.style.display = "none";
+    label.style.whiteSpace = "nowrap";
+    label.style.borderRadius = "6px";
+    label.style.background = "rgba(15, 23, 42, 0.94)";
+    label.style.color = "white";
+    label.style.padding = "3px 7px";
+    label.style.font = "600 11px/16px ui-sans-serif, system-ui, sans-serif";
+    label.style.boxShadow = "0 4px 10px rgba(15, 23, 42, 0.24)";
+    ghost.appendChild(label);
+    document.body.appendChild(ghost);
+
+    function refreshSources() {
+        document.querySelectorAll<HTMLElement>(sourceSelector).forEach(element => {
+            if (element.closest("[data-drag-visual-layer]")) return;
+            if (!savedSourceStyles.has(element)) {
+                savedSourceStyles.set(element, { opacity: element.style.opacity });
+            }
+            element.style.opacity = "0.28";
+        });
+    }
+
+    function restoreTarget() {
+        if (!savedTargetStyle) return;
+        const { element, backgroundColor, boxShadow, outline, outlineOffset } = savedTargetStyle;
+        element.style.backgroundColor = backgroundColor;
+        element.style.boxShadow = boxShadow;
+        element.style.outline = outline;
+        element.style.outlineOffset = outlineOffset;
+        savedTargetStyle = null;
+    }
+
+    function refreshTarget() {
+        const targetDate = latestUpdate.targetDate;
+        if (!targetDate) {
+            restoreTarget();
+            return;
+        }
+        const nextTarget = findScheduleTarget(latestUpdate.clientX, latestUpdate.clientY, targetDate);
+        if (savedTargetStyle?.element === nextTarget) return;
+        restoreTarget();
+        if (!nextTarget) return;
+        savedTargetStyle = {
+            element: nextTarget,
+            backgroundColor: nextTarget.style.backgroundColor,
+            boxShadow: nextTarget.style.boxShadow,
+            outline: nextTarget.style.outline,
+            outlineOffset: nextTarget.style.outlineOffset,
+        };
+        nextTarget.style.backgroundColor = "rgba(224, 231, 255, 0.82)";
+        nextTarget.style.boxShadow = "inset 0 0 0 2px rgb(79, 70, 229)";
+        nextTarget.style.outline = "2px solid transparent";
+        nextTarget.style.outlineOffset = "-2px";
+    }
+
+    const observer = new MutationObserver(() => {
+        if (cleaned) return;
+        refreshSources();
+        refreshTarget();
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    refreshSources();
+    publishDragVisualActivity(true);
+
+    return {
+        update(update) {
+            if (cleaned) return;
+            latestUpdate = update;
+            const rawDeltaX = update.deltaX ?? update.clientX - startClientX;
+            const sourceOffsetX = update.sourceOffsetX ?? 0;
+            const deltaY = update.clientY - startClientY;
+
+            if (kind === "task-resize-left") {
+                const clampedDelta = Math.min(rawDeltaX, sourceRect.width - 1);
+                ghost.style.width = `${Math.max(1, sourceRect.width - clampedDelta)}px`;
+                ghost.style.transform = `translate3d(${sourceOffsetX + clampedDelta}px, 0px, 0px)`;
+            } else if (kind === "task-resize-right" || kind === "project-end-resize") {
+                ghost.style.width = `${Math.max(1, sourceRect.width + rawDeltaX)}px`;
+                ghost.style.transform = `translate3d(${sourceOffsetX}px, 0px, 0px)`;
+            } else {
+                ghost.style.transform = `translate3d(${update.clientX - startClientX}px, ${deltaY}px, 0px)`;
+            }
+
+            label.textContent = update.label ?? "";
+            label.style.display = update.label ? "block" : "none";
+            refreshSources();
+            refreshTarget();
+        },
+        cleanup() {
+            if (cleaned) return;
+            cleaned = true;
+            observer.disconnect();
+            restoreTarget();
+            for (const [element, style] of savedSourceStyles) element.style.opacity = style.opacity;
+            savedSourceStyles.clear();
+            ghost.remove();
+            publishDragVisualActivity(false);
+        },
+    };
+}


### PR DESCRIPTION
PR-A3 (core) of the dispatch arc — the mechanics fix behind the owner's "does not feel or perform fluidly."

## The change
Dragging anything on the schedule board used to write React state every animation frame, re-rendering the ~1,800-line board tree per pointer move. Now a DOM-only ghost layer owns the visuals during a drag and React is untouched until drop.

**Measured on the live board:** a 30-move, 300px task drag = **0 board renders during the drag** (was ~1 per frame), 2 renders on drop. Save/Discard drafts, reconciliation, and every candidate calculation verified unchanged — characterization assertions were added *before* the refactor, and an independent checker traced the drag path against the previous commit function-by-function.

## Process notes
- Design was debated first: sol reviewed three approaches against the actual code and chose the ghost layer with per-drag-type risk ordering; implementation stopped at the risky core (weather/creation/motion polish follow in part 2).
- Checker flagged two uncharacterized behavior deltas; both reviewed and **kept deliberately** (now contract-pinned): Escape cancels an active drag, and resize drags capture from the block root (safer on touch, correct ghost geometry).
- Verified: contract + layout scripts (extended), tsc, build, DB-backed board verify, and the live drag → draft → Discard round-trip restoring original dates.

Implemented by GPT-5.6-sol (xhigh); independently gate-checked; reviewed and browser-verified by Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)