### PR TITLE
Weather row, click-to-create, slim hover card, scoped motion (A3 part 2)

### DIFF
--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 
 // Owner-feedback round (2026-07-22) rewrote the company schedule board from
 // per-drag auto-save + project locking to local draft-mode + one explicit
@@ -26,9 +26,12 @@ const traySource = src("../src/app/company-dashboard/schedule-board/UnscheduledT
 const dialogSource = src("../src/app/company-dashboard/schedule-board/ShiftConfirmDialog.tsx");
 const layoutSource = src("../src/app/company-dashboard/schedule-board/useBarLayout.ts");
 const dragVisualSource = src("../src/app/company-dashboard/schedule-board/dragVisualLayer.ts");
+const cellActivationSource = src("../src/app/company-dashboard/schedule-board/emptyCellCreation.ts");
 const popoverSource = src("../src/app/company-dashboard/schedule-board/FloatingPopover.tsx");
 const actionsSource = src("../src/lib/actions.ts");
 const coreSource = src("../src/lib/schedule-core.ts");
+const weatherSource = src("../src/lib/weather.ts");
+const companyDashboardPageSource = src("../src/app/company-dashboard/page.tsx");
 const companyDashboardSource = src("../src/app/company-dashboard/CompanyDashboardClient.tsx");
 // CrewPicker/TaskCrewPicker moved out of CompanyDashboardClient.tsx into their
 // own module (item 1) so ProjectBar/TaskBlockSegment can reuse them from the
@@ -38,6 +41,11 @@ const crewPickersSource = src("../src/app/company-dashboard/schedule-board/CrewP
 const drawerSource = src("../src/app/company-dashboard/schedule-board/BoardTaskDrawer.tsx");
 const taskCreationDialogSource = src("../src/components/TaskCreationDialog.tsx");
 const detailPanelSource = src("../src/app/projects/[id]/schedule/TaskDetailPanel.tsx");
+const scheduleBoardDirectory = new URL("../src/app/company-dashboard/schedule-board/", import.meta.url);
+const scheduleBoardSourceTree = readdirSync(scheduleBoardDirectory, { recursive: true })
+    .filter(path => typeof path === "string" && /\.(?:ts|tsx)$/.test(path))
+    .map(path => readFileSync(new URL(path.replaceAll("\\", "/"), scheduleBoardDirectory), "utf8"))
+    .join("\n");
 
 // ── Item 2: draft mode replaces per-drag auto-save ──
 
@@ -186,6 +194,40 @@ assert.match(dragVisualSource, /observer\.disconnect\(\)/, "visual cleanup stops
 assert.match(dragVisualSource, /ghost\.remove\(\)/, "visual cleanup removes the detached ghost");
 assert.match(dragVisualSource, /ghost\.setAttribute\("aria-hidden", "true"\)/, "detached visual clones stay out of the accessibility tree");
 assert.match(dragVisualSource, /dispatchEvent\(new CustomEvent\(DRAG_VISUAL_ACTIVE_EVENT/, "pointer-drag activity is published below ScheduleBoard instead of root state");
+
+// PR-A3 step 5: the native Unscheduled tray drag must reuse the imperative
+// visual layer rather than writing React state in Month/Timeline. Empty-cell
+// creation shares one click/keyboard guard and reaches the existing dialog
+// seam with view-specific defaults.
+assert.match(dragVisualSource, /export function highlightScheduleTarget\(/, "native HTML drag targets must use the shared imperative highlighter");
+assert.match(dragVisualSource, /export function clearScheduleTargetHighlight\(/, "native drag target cleanup must be explicit");
+assert.match(dragVisualSource, /export function beginNativeScheduleDragActivity\(/, "native tray drags must publish the same below-root activity signal");
+assert.match(traySource, /beginNativeScheduleDragActivity\(\)/, "UnscheduledTray must publish native drag activity without React state");
+assert.match(traySource, /onDragEnd=\{handleDragEnd\}/, "UnscheduledTray must clean up activity/highlighting when a native drag ends");
+for (const [name, source] of [["Month", monthSource], ["Timeline", timelineSource]] as const) {
+    assert.match(source, /highlightScheduleTarget\(/, `${name} native drop targets must highlight imperatively`);
+    assert.match(source, /clearScheduleTargetHighlight\(\)/, `${name} native drop targets must clean up imperatively`);
+    assert.doesNotMatch(source, /dragOverDate|setDragOverDate/, `${name} must not render from native drag-over state`);
+    assert.match(source, /isDragVisualLayerActive\(\)/, `${name} empty-cell creation must ignore every active drag`);
+    assert.match(source, /isPrimaryUnmodifiedClick\(/, `${name} empty-cell creation must require an unmodified primary click`);
+    assert.match(source, /isScheduleCellBackgroundTarget\(/, `${name} empty-cell creation must ignore blocks and controls`);
+}
+assert.match(cellActivationSource, /event\.button === 0/, "the shared empty-cell guard must require the primary button");
+assert.match(cellActivationSource, /!event\.altKey && !event\.ctrlKey && !event\.metaKey && !event\.shiftKey/, "the shared empty-cell guard must reject modified clicks");
+assert.match(cellActivationSource, /data-task-edit-block/, "the shared empty-cell guard must reject task blocks");
+assert.match(cellActivationSource, /data-drag-visual-kind/, "the shared empty-cell guard must reject dragged schedule geometry");
+assert.match(monthSource, /role=\{data\.canEdit \? "button" : undefined\}[\s\S]{0,220}tabIndex=\{data\.canEdit \? 0 : undefined\}/, "editable Month day cells need a keyboard-equivalent activation path without exposing button semantics to read-only users");
+assert.match(monthSource, /onKeyDown=\{event => handleDayKeyDown\(dayKey, event\)\}/, "Month day cells must implement Enter/Space activation");
+assert.equal((timelineSource.match(/onKeyDown=\{event => handleEmptyCellKeyDown\(/g) ?? []).length, 2, "both Timeline cell modes must implement Enter/Space activation");
+assert.match(timelineSource, /const \[focusedCell, setFocusedCell\] = useState<TimelineCellFocus \| null>\(null\)/, "Timeline creation cells must use one roving focus owner");
+assert.match(timelineSource, /event\.key === "ArrowLeft"[\s\S]{0,500}event\.key === "ArrowRight"[\s\S]{0,500}event\.key === "ArrowUp"[\s\S]{0,500}event\.key === "ArrowDown"/, "Timeline roving focus must navigate dates and rows with arrow keys");
+assert.equal((timelineSource.match(/tabIndex=\{data\.canEdit \? \(isTimelineCellTabbable\(/g) ?? []).length, 2, "both Timeline modes must expose only the current roving cell in the tab order");
+assert.doesNotMatch(timelineSource, /tabIndex=\{data\.canEdit \? 0 : undefined\}/, "Timeline must not create one tab stop per day per row");
+assert.equal((timelineSource.match(/role=\{data\.canEdit \? "button" : undefined\}/g) ?? []).length, 2, "read-only Timeline cells must not expose button semantics");
+assert.match(monthSource, /onCreateTask\(\{ defaultStartDate: dayKey \}\)/, "Month creation must default only the date and leave project selection unlocked");
+assert.match(timelineSource, /defaultProjectId: project\.id,[\s\S]{0,100}lockProject: true,[\s\S]{0,100}defaultStartDate: dayKey/, "Timeline project cells must lock the row project and default the date");
+assert.match(timelineSource, /defaultStartDate: dayKey, defaultCrewIds: \[row\.userId\]/, "Timeline crew cells must default the date and row crew member");
+assert.equal((boardSource.match(/onCreateTask=\{openTaskCreation\}/g) ?? []).length, 3, "Dispatch, Month, and Timeline must share the one task-creation dialog seam");
 
 assert.match(taskBlockSource, /data-drag-visual-kind="task"/, "task roots expose a stable visual kind hook");
 assert.match(taskBlockSource, /data-drag-task-id=\{task\.id\}/, "task roots expose a stable task-id hook");
@@ -545,9 +587,13 @@ assert.match(addTaskCommentBody, /await assertScheduleTaskAccess\(taskId\);/, "a
 assert.match(taskBlockSource, /import \{ addTaskComment, deleteScheduleTask \} from "@\/lib\/actions"/);
 assert.match(taskBlockSource, /Add note…/, "the task context menu must offer Add note…");
 assert.match(taskBlockSource, /await addTaskComment\(task\.id, text\);/, "Add note must go through the existing (now hardened) addTaskComment action");
-assert.match(taskBlockSource, /task\.latestComments\.map\(\(comment, index\) => \(/, "the hover card must render latestComments");
-assert.match(taskBlockSource, /truncateNote\(comment\.text\)/, "note text in the hover card must be truncated");
-assert.match(taskBlockSource, /const NOTE_TRUNCATE_LENGTH = 140;/);
+const hoverCardStart = taskBlockSource.indexOf('<FloatingPopover open={hoverCardOpen}');
+const hoverCardBody = taskBlockSource.slice(hoverCardStart);
+assert.ok(hoverCardStart >= 0, "the task hover card must exist");
+assert.equal((hoverCardBody.match(/<p className=/g) ?? []).length, 3, "the hover card must have exactly three text lines");
+assert.match(hoverCardBody, /formatDate\(taskStart\)[\s\S]{0,120}formatDate\(isMilestone \? taskStart : taskEnd\)[\s\S]{0,120}\{task\.status\}[\s\S]{0,100}\{progress\}%/, "the second hover-card line must combine dates, status, and progress");
+assert.match(hoverCardBody, /\{crew\}/, "the third hover-card line must show crew or Unassigned");
+assert.doesNotMatch(hoverCardBody, /latestComments|comment\.|relativeDayLabel|truncateNote|estimatedHours|href=/, "comments, timestamps, hours, and links must stay out of the slim hover card");
 assert.match(taskBlockSource, /isAnyDragActive: boolean;/, "TaskBlockSegmentProps must accept the cross-board drag-active flag");
 assert.match(taskBlockSource, /if \(!isAnyDragActive && !menuOpen\) return;[\s\S]{0,300}setHoverCardOpen\(false\);/, "an active drag (or the click/context menu) must force-close an already-open hover card");
 assert.match(taskBlockSource, /if \(isAnyDragActive \|\| menuOpen(?: \|\| hoverOpenTimeoutRef\.current != null)?\) return;/, "opening the hover card must be gated on isAnyDragActive");
@@ -656,10 +702,74 @@ for (const [name, source] of [
     ["dispatchExceptions", dispatchExceptionsSource],
 ] as const) {
     assert.ok(source.length > 0, `${name} must exist`);
-    assert.doesNotMatch(source, /framer-motion/, `${name} must not add the deferred animation pass`);
+    if (name !== "DispatchExceptions") {
+        assert.doesNotMatch(source, /framer-motion/, `${name} must keep Motion out of schedule geometry and derivation`);
+    }
     assert.doesNotMatch(source, /FloatingPopover|openMenu|contextmenu/i, `${name} must use the shared drawer seam, not a new menu system`);
     if (/opacity-0/.test(source)) assert.match(source, /\[@media\(hover:none\)\]:opacity-100/, `${name} hover-reveal controls must stay visible on no-hover devices`);
 }
+
+// Motion is confined to status surfaces, drawer/dialog entrance, and the
+// Dispatch exceptions strip. Schedule geometry remains plain React/DOM.
+assert.match(boardSource, /<MotionConfig reducedMotion="user">/, "the schedule board must honor the user's reduced-motion preference");
+assert.match(boardSource, /data-motion-scope="status-change"/, "draft/refresh status changes must use the narrow status transition scope");
+assert.match(drawerSource, /<motion\.aside/, "the shared task drawer must animate its entrance");
+assert.match(dialogSource, /<motion\.div[\s\S]{0,220}data-motion-scope="dialog-enter"/, "the save-time confirmation dialog must animate its entrance");
+assert.match(taskCreationDialogSource, /<motion\.div[\s\S]{0,220}data-motion-scope="dialog-enter"/, "the shared creation dialog must animate its entrance");
+assert.match(dispatchStripSource, /<motion\.div[\s\S]{0,220}data-motion-scope="exceptions-strip"/, "the exceptions strip must use its narrow transition scope");
+assert.doesNotMatch(scheduleBoardSourceTree, /\s(?:layout|layoutId)=/, "layout and layoutId props are forbidden everywhere under schedule-board/");
+assert.doesNotMatch(scheduleBoardSourceTree, /<motion\.[^>]*\sdrag(?:=|\s)/, "Motion drag props are forbidden everywhere under schedule-board/");
+for (const [name, source] of [
+    ["TaskBlockSegment", taskBlockSource],
+    ["ProjectBar", projectBarSource],
+    ["MonthBarsView", monthSource],
+    ["TimelineView", timelineSource],
+    ["UnscheduledTray", traySource],
+] as const) {
+    assert.doesNotMatch(source, /from "framer-motion"|<motion\./, `${name} dragged schedule geometry must never be a Motion component`);
+}
+
+// PR-A3 step 7: Vancouver weather is a separate, failure-safe payload. It is
+// cached for one hour, fetched concurrently with core dashboard data, and
+// rendered by date in all three schedule views without widening schedule-core.
+assert.ok(weatherSource.length > 0, "src/lib/weather.ts must exist");
+for (const [name, source] of [["weather", weatherSource], ["Month", monthSource], ["Timeline", timelineSource], ["Dispatch", dispatchViewSource]] as const) {
+    assert.doesNotMatch(source, /Â|Ã|â€“|ðŸ/, `${name} weather copy and glyphs must not contain mojibake`);
+}
+assert.match(weatherSource, /import \{ unstable_cache \} from "next\/cache"/);
+assert.match(weatherSource, /latitude=45\.6617&longitude=-122\.5484/, "the forecast must stay pinned to Vancouver, WA");
+for (const dailyField of ["weather_code", "temperature_2m_max", "temperature_2m_min", "precipitation_probability_max"]) {
+    assert.match(weatherSource, new RegExp(dailyField), `Open-Meteo daily field ${dailyField} must be requested`);
+}
+assert.match(weatherSource, /forecast_days=10/);
+assert.match(weatherSource, /temperature_unit=fahrenheit/);
+assert.match(weatherSource, /const controller = new AbortController\(\);[\s\S]{0,180}controller\.abort\(\), 3_000\)/, "weather fetches must abort after about three seconds");
+const weatherFetchStart = weatherSource.indexOf("async function fetchVancouverWeather(");
+const weatherFetchEnd = weatherSource.indexOf("const getCachedVancouverWeather", weatherFetchStart);
+const weatherFetchBody = weatherSource.slice(weatherFetchStart, weatherFetchEnd);
+assert.ok(weatherFetchStart >= 0, "the uncached weather fetcher must exist");
+assert.match(weatherFetchBody, /try \{[\s\S]*await fetch\(/, "the provider fetch must be wrapped");
+assert.match(weatherFetchBody, /catch \{[\s\S]{0,80}return null;/, "provider failures must return null");
+assert.match(weatherFetchBody, /finally \{[\s\S]{0,100}clearTimeout\(timeoutId\)/, "the abort timer must always be cleared");
+assert.match(weatherSource, /unstable_cache\([\s\S]*\["vancouver-wa-weather"\][\s\S]*revalidate: 3_600/, "weather must use a stable one-hour cache");
+assert.match(weatherSource, /export async function getVancouverWeather\(\)[\s\S]*try \{[\s\S]*getCachedVancouverWeather\(\)[\s\S]*catch \{[\s\S]*return null;/, "cache-layer failures must also degrade to null");
+assert.match(weatherSource, /export function weatherCodeToGlyph\(/, "WMO weather codes must map through one glyph helper");
+assert.doesNotMatch(coreSource, /VancouverForecastDay|weatherForecast/, "weather must not widen the core scheduling contract");
+
+assert.match(companyDashboardPageSource, /Promise\.all\(\[[\s\S]*getCompanyDashboardData\([\s\S]*getVancouverWeather\(\)[\s\S]*\]\)/, "dashboard data and weather must fetch concurrently");
+assert.match(companyDashboardPageSource, /<CompanyDashboardClient data=\{data\} weather=\{weather \?\? \[\]\}/, "weather must be passed separately and failure must become an empty list");
+assert.match(companyDashboardSource, /weather: VancouverForecastDay\[\]/, "the client boundary must carry the small separate weather array");
+assert.match(companyDashboardSource, /<ScheduleBoard[\s\S]{0,180}weather=\{weather\}/, "the client must thread weather separately to ScheduleBoard");
+assert.match(boardSource, /weather: VancouverForecastDay\[\]/, "ScheduleBoard must accept weather outside CompanyDashboardData");
+assert.equal((boardSource.match(/weather=\{weather\}/g) ?? []).length, 3, "all three schedule views must receive the separate weather array");
+
+assert.match(monthSource, /weatherByDate\.get\(dayKey\)/);
+assert.match(monthSource, /absolute right-1\.5 top-1\.5/, "Month weather glyphs must stay quiet in the cell's top-right corner");
+assert.match(timelineSource, />Vancouver<\/div>/, "Timeline forecast row must identify Vancouver explicitly");
+assert.match(timelineSource, /aria-label="Vancouver 10-day forecast"/);
+assert.match(dispatchViewSource, /Vancouver forecast/, "Dispatch weather must identify Vancouver");
+assert.match(dispatchViewSource, /visibleWeekDays\s*\.map\(day => weatherByDate\.get\(formatDate\(day\)\)\)\s*\.find\(\(forecast\): forecast is VancouverForecastDay => Boolean\(forecast\)\)/, "Dispatch week summary must use the first visible forecast rather than an elapsed week-start day");
+assert.match(dispatchViewSource, /\{forecast\.glyph\} \{forecast\.precipitationProbability\}% \{forecast\.high\}\{"\\u00B0"\}/, "Dispatch day headers must show glyph, rain probability, and high");
 
 assert.match(boardSource, /import \{ DispatchView \} from "\.\/DispatchView"/, "ScheduleBoard must import the dispatch view");
 assert.match(boardSource, /export type BoardView = "month" \| "timeline" \| "dispatch"/, "the persisted board view union must include dispatch");

--- a/src/app/company-dashboard/CompanyDashboardClient.tsx
+++ b/src/app/company-dashboard/CompanyDashboardClient.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import type { CompanyDashboardData, DashboardProjectRow } from "@/lib/schedule-core";
+import type { VancouverForecastDay } from "@/lib/weather";
 import { PROJECT_STATUSES } from "@/lib/project-status";
 import { applyChangeOrderToScheduleAction, generateProjectScheduleAction, updateProjectStartDateAction } from "@/lib/actions";
 import { formatCurrency, parseUTCDate } from "@/app/projects/[id]/schedule/schedule-utils";
@@ -169,7 +170,7 @@ function StartDateRow({
     );
 }
 
-export default function CompanyDashboardClient({ data }: { data: CompanyDashboardData }) {
+export default function CompanyDashboardClient({ data, weather }: { data: CompanyDashboardData; weather: VancouverForecastDay[] }) {
     const router = useRouter();
     const { month, canEdit, isAdmin, canSeeFinancials, pipeline, cashflow, teamMembers, crewConflicts, strip } = data;
 
@@ -307,6 +308,7 @@ export default function CompanyDashboardClient({ data }: { data: CompanyDashboar
 
             <ScheduleBoard
                 data={data}
+                weather={weather}
                 externallyPendingProjectIds={legacyPendingProjectIds}
                 isProjectExternallyPending={isPageProjectPending}
                 onEffectivePendingProjectIdsChange={publishBoardPendingProjectIds}

--- a/src/app/company-dashboard/page.tsx
+++ b/src/app/company-dashboard/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { getSessionOrDev } from "@/lib/auth";
 import { getUserWithPermissionsByEmail, hasPermission } from "@/lib/permissions";
 import { getCompanyDashboardData } from "@/lib/schedule-core";
+import { getVancouverWeather } from "@/lib/weather";
 import CompanyDashboardClient from "./CompanyDashboardClient";
 
 // Company-wide pipeline dashboard (PB-pipeline-001 + PB-pipeline-002):
@@ -38,9 +39,12 @@ export default async function CompanyDashboardPage({
     const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
     const month = /^\d{4}-(0[1-9]|1[0-2])$/.test(rawMonth) ? rawMonth : currentMonth;
 
-    const data = await getCompanyDashboardData(
-        { role: effectiveUser.role, canSeeFinancials: hasPermission(effectiveUser, "financialReports") },
-        month,
-    );
-    return <CompanyDashboardClient data={data} />;
+    const [data, weather] = await Promise.all([
+        getCompanyDashboardData(
+            { role: effectiveUser.role, canSeeFinancials: hasPermission(effectiveUser, "financialReports") },
+            month,
+        ),
+        getVancouverWeather(),
+    ]);
+    return <CompanyDashboardClient data={data} weather={weather ?? []} />;
 }

--- a/src/app/company-dashboard/schedule-board/BoardTaskDrawer.tsx
+++ b/src/app/company-dashboard/schedule-board/BoardTaskDrawer.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
+import { motion } from "framer-motion";
 import { toast } from "sonner";
 import {
     addTaskComment,
@@ -149,9 +150,18 @@ export function BoardTaskDrawer({ taskId, hasDraft, teamMembers, onClose, onSele
     if (!taskId || typeof document === "undefined") return null;
 
     const content = (
-        <div className="pointer-events-none fixed inset-0 z-[180] bg-slate-950/15" aria-hidden={false}>
-            <aside
+        <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.16 }}
+            className="pointer-events-none fixed inset-0 z-[180] bg-slate-950/15"
+            aria-hidden={false}
+        >
+            <motion.aside
                 ref={drawerRef}
+                initial={{ x: 20, opacity: 0 }}
+                animate={{ x: 0, opacity: 1 }}
+                transition={{ duration: 0.18, ease: "easeOut" }}
                 role="dialog"
                 aria-modal="false"
                 aria-label="Task details"
@@ -229,8 +239,8 @@ export function BoardTaskDrawer({ taskId, hasDraft, teamMembers, onClose, onSele
                         </div>
                     </div>
                 )}
-            </aside>
-        </div>
+            </motion.aside>
+        </motion.div>
     );
 
     return createPortal(content, document.body);

--- a/src/app/company-dashboard/schedule-board/DispatchExceptions.tsx
+++ b/src/app/company-dashboard/schedule-board/DispatchExceptions.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { motion } from "framer-motion";
 import type { CrewConflict, DashboardProjectRow } from "@/lib/schedule-core";
 import { getDispatchExceptions } from "./dispatch-exceptions";
 
@@ -57,7 +58,14 @@ export function DispatchExceptions({ projects, crewConflicts, dayKey, onActivate
     ].filter(pill => pill.count > 0);
 
     return (
-        <div className="border-b border-hui-border bg-slate-50/80 px-4 py-2.5" aria-label="Dispatch exceptions">
+        <motion.div
+            data-motion-scope="exceptions-strip"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.16 }}
+            className="border-b border-hui-border bg-slate-50/80 px-4 py-2.5"
+            aria-label="Dispatch exceptions"
+        >
             {pills.length === 0 ? (
                 <p className="text-xs font-medium text-slate-500">{"Day clear \u2713"}</p>
             ) : (
@@ -77,6 +85,6 @@ export function DispatchExceptions({ projects, crewConflicts, dayKey, onActivate
                     ))}
                 </div>
             )}
-        </div>
+        </motion.div>
     );
 }

--- a/src/app/company-dashboard/schedule-board/DispatchView.tsx
+++ b/src/app/company-dashboard/schedule-board/DispatchView.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import type { CompanyDashboardData, DashboardProjectRow, DashboardTaskRow } from "@/lib/schedule-core";
+import type { VancouverForecastDay } from "@/lib/weather";
 import { addDays, formatDate, getFallbackProjectColor, getMonday, todayUTC } from "@/app/projects/[id]/schedule/schedule-utils";
 import { isConflictedDay } from "./availability";
 import { getCrewlessJobs, isTaskActiveOnDay } from "./dispatch-exceptions";
@@ -20,6 +21,7 @@ export interface DispatchTaskCreationDefaults {
 
 interface DispatchViewProps {
     data: CompanyDashboardData;
+    weather: VancouverForecastDay[];
     onActivate: (taskId: string) => void;
     onCreateTask: (defaults: DispatchTaskCreationDefaults) => void;
 }
@@ -59,7 +61,7 @@ function weekChipsForMember(projects: DashboardProjectRow[], memberId: string, d
     return chips;
 }
 
-export function DispatchView({ data, onActivate, onCreateTask }: DispatchViewProps) {
+export function DispatchView({ data, weather, onActivate, onCreateTask }: DispatchViewProps) {
     const [mode, setMode] = useState<DispatchMode>("today");
     const currentMonday = useMemo(() => getMonday(todayUTC()), []);
     const [weekStart, setWeekStart] = useState(currentMonday);
@@ -97,6 +99,7 @@ export function DispatchView({ data, onActivate, onCreateTask }: DispatchViewPro
     ], [data.pipeline]);
     const today = todayUTC();
     const todayKey = formatDate(today);
+    const weatherByDate = new Map(weather.map(forecast => [forecast.date, forecast]));
     const fieldCrew = (data.teamMembers ?? []).filter(member => member.role === "FIELD_CREW");
     const activeTodayByProject = new Map(projects.map(project => [
         project.id,
@@ -122,6 +125,11 @@ export function DispatchView({ data, onActivate, onCreateTask }: DispatchViewPro
     const showSunday = projects.some(project => project.tasks.some(task => isTaskActiveOnDay(task, formatDate(sunday))));
     const visibleWeekDays = [...mondayToFriday, ...(showSaturday ? [saturday] : []), ...(showSunday ? [sunday] : [])];
     const crewConflicts = data.crewConflicts;
+    const headerForecast = mode === "today"
+        ? weatherByDate.get(todayKey)
+        : visibleWeekDays
+            .map(day => weatherByDate.get(formatDate(day)))
+            .find((forecast): forecast is VancouverForecastDay => Boolean(forecast));
 
     useEffect(() => {
         if (!highlightedProjectId || mode !== "today") return;
@@ -154,6 +162,9 @@ export function DispatchView({ data, onActivate, onCreateTask }: DispatchViewPro
                 <div>
                     <h3 className="text-sm font-semibold text-hui-textMain">Dispatch</h3>
                     <p className="mt-0.5 text-xs text-hui-textMuted">Jobs first today. People first across the week.</p>
+                    <p className="mt-1 text-[10px] font-medium text-slate-500">
+                        Vancouver forecast{headerForecast ? ` \u00B7 ${headerForecast.glyph} ${headerForecast.precipitationProbability}% rain \u00B7 ${headerForecast.high}\u00B0/${headerForecast.low}\u00B0` : " unavailable"}
+                    </p>
                 </div>
                 <div className="inline-flex rounded-md border border-hui-border bg-white p-0.5" role="group" aria-label="Dispatch range">
                     {(["today", "week"] as const).map(nextMode => (
@@ -236,7 +247,16 @@ export function DispatchView({ data, onActivate, onCreateTask }: DispatchViewPro
                         >
                             <div className="grid bg-slate-50" role="row" style={{ gridTemplateColumns: `180px repeat(${visibleWeekDays.length}, minmax(140px, 1fr)) 110px` }}>
                                 <div role="columnheader" className="border-b border-r border-hui-border px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-slate-500">Crew</div>
-                                {visibleWeekDays.map(day => <div key={formatDate(day)} role="columnheader" className="border-b border-r border-hui-border px-2 py-2 text-center text-[10px] font-semibold uppercase tracking-wide text-slate-500">{dayLabel(day)}</div>)}
+                                {visibleWeekDays.map(day => {
+                                    const dayKey = formatDate(day);
+                                    const forecast = weatherByDate.get(dayKey);
+                                    return (
+                                        <div key={dayKey} role="columnheader" className="border-b border-r border-hui-border px-2 py-2 text-center text-[10px] font-semibold uppercase tracking-wide text-slate-500">
+                                            <div>{dayLabel(day)}</div>
+                                            {forecast && <div className="mt-0.5 normal-case tracking-normal text-slate-600">{forecast.glyph} {forecast.precipitationProbability}% {forecast.high}{"\u00B0"}</div>}
+                                        </div>
+                                    );
+                                })}
                                 <div role="columnheader" className="border-b border-hui-border px-2 py-2 text-center text-[10px] font-semibold uppercase tracking-wide text-slate-500">Assigned</div>
                             </div>
 

--- a/src/app/company-dashboard/schedule-board/MonthBarsView.tsx
+++ b/src/app/company-dashboard/schedule-board/MonthBarsView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type DragEvent, type MouseEvent as ReactMouseEvent } from "react";
+import { useEffect, useState, type DragEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent } from "react";
 import type {
     CalendarOverlays,
     CompanyDashboardData,
@@ -8,6 +8,7 @@ import type {
     OverlayChangeOrderItem,
     OverlayIncomeItem,
 } from "@/lib/schedule-core";
+import type { VancouverForecastDay } from "@/lib/weather";
 import {
     addDays,
     formatCurrency,
@@ -26,6 +27,9 @@ import { TaskBlockSegment, type ActiveTaskKeyboardEdit, type TaskEditCallbacks }
 import { MilestoneMarker } from "./MilestoneMarker";
 import { PROJECT_DRAG_MIME } from "./UnscheduledTray";
 import { assignMonthProjectLanes, getEffectiveProjectRange, segmentProjectRange } from "./useBarLayout";
+import type { DispatchTaskCreationDefaults } from "./DispatchView";
+import { clearScheduleTargetHighlight, highlightScheduleTarget, isDragVisualLayerActive } from "./dragVisualLayer";
+import { isPrimaryUnmodifiedClick, isScheduleCellBackgroundTarget } from "./emptyCellCreation";
 
 const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 const EMPTY_INCOME: OverlayIncomeItem[] = [];
@@ -33,6 +37,7 @@ const EMPTY_CHANGE_ORDERS: OverlayChangeOrderItem[] = [];
 
 interface MonthBarsViewProps extends TaskEditCallbacks, ProjectEditCallbacks {
     data: CompanyDashboardData;
+    weather: VancouverForecastDay[];
     showIncome: boolean;
     showProjectedCo: boolean;
     showExpenses: boolean;
@@ -47,6 +52,7 @@ interface MonthBarsViewProps extends TaskEditCallbacks, ProjectEditCallbacks {
     isSaving: boolean;
     activeTaskKeyboardEdit: ActiveTaskKeyboardEdit | null;
     onTrayProjectDrop: (_project: DashboardProjectRow, _targetStart: string) => void;
+    onCreateTask: (_defaults: DispatchTaskCreationDefaults) => void;
     // team/crew list for the context-menu "Project crew…"/"Task crew…"
     // pickers (item 1) — reuses the exact CrewPicker/TaskCrewPicker the
     // Schedule & crew table uses.
@@ -103,6 +109,7 @@ function buildDayTotals(overlays: CalendarOverlays | null) {
 
 export function MonthBarsView({
     data,
+    weather,
     showIncome,
     showProjectedCo,
     showExpenses,
@@ -114,6 +121,7 @@ export function MonthBarsView({
     isSaving,
     activeTaskKeyboardEdit,
     onTrayProjectDrop,
+    onCreateTask,
     teamMembers,
     isAnyDragActive,
     onProjectMoveCommit,
@@ -134,7 +142,6 @@ export function MonthBarsView({
     onActivate,
 }: MonthBarsViewProps) {
     const [expandedWeeks, setExpandedWeeks] = useState<Set<number>>(() => new Set());
-    const [dragOverDate, setDragOverDate] = useState<string | null>(null);
     // Empty-day-cell "Schedule here…" context menu (item 1) — one instance
     // for the whole view, point-anchored to the right-click location.
     const [dayContextMenu, setDayContextMenu] = useState<{ date: string; point: { x: number; y: number } } | null>(null);
@@ -226,26 +233,40 @@ export function MonthBarsView({
     }
     const layout = assignMonthProjectLanes(workSegmentsByProject, milestoneDaysByProject, gridStart, gridEnd);
     const dayTotals = buildDayTotals(adminOverlays);
+    const weatherByDate = new Map(weather.map(forecast => [forecast.date, forecast]));
 
     function handleDayDragOver(dayKey: string, event: DragEvent<HTMLDivElement>) {
         if (!data.canEdit || !hasProjectDragPayload(event)) return;
         event.preventDefault();
         event.dataTransfer.dropEffect = "move";
-        setDragOverDate(dayKey);
+        highlightScheduleTarget({ clientX: event.clientX, clientY: event.clientY, targetDate: dayKey });
     }
 
-    function handleDayDragLeave(dayKey: string, event: DragEvent<HTMLDivElement>) {
+    function handleDayDragLeave(event: DragEvent<HTMLDivElement>) {
         if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) return;
-        setDragOverDate(current => current === dayKey ? null : current);
+        clearScheduleTargetHighlight();
     }
 
     function handleDayDrop(dayKey: string, event: DragEvent<HTMLDivElement>) {
         if (!data.canEdit || !hasProjectDragPayload(event)) return;
         event.preventDefault();
-        setDragOverDate(null);
+        clearScheduleTargetHighlight();
         const projectId = event.dataTransfer.getData(PROJECT_DRAG_MIME);
         const project = data.pipeline.waitingToStart.find(candidate => candidate.id === projectId);
         if (project) onTrayProjectDrop(project, dayKey);
+    }
+
+    function handleDayClick(dayKey: string, event: ReactMouseEvent<HTMLDivElement>) {
+        if (!data.canEdit || isAnyDragActive || isDragVisualLayerActive()) return;
+        if (!isPrimaryUnmodifiedClick(event) || !isScheduleCellBackgroundTarget(event.target, event.currentTarget)) return;
+        onCreateTask({ defaultStartDate: dayKey });
+    }
+
+    function handleDayKeyDown(dayKey: string, event: KeyboardEvent<HTMLDivElement>) {
+        if (!data.canEdit || isAnyDragActive || isDragVisualLayerActive() || event.target !== event.currentTarget) return;
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        onCreateTask({ defaultStartDate: dayKey });
     }
 
     return (
@@ -279,17 +300,32 @@ export function MonthBarsView({
                                     const projectedCoTotal = showProjectedCo ? dayTotals?.projectedCo.get(dayKey) : undefined;
                                     const expenseTotal = showExpenses ? dayTotals?.expenses.get(dayKey) : undefined;
                                     const hoursTotal = showHours ? dayTotals?.hours.get(dayKey) : undefined;
+                                    const forecast = weatherByDate.get(dayKey);
                                     return (
                                         <div
                                             key={dayKey}
                                             data-schedule-date={dayKey}
                                             onDragOver={event => handleDayDragOver(dayKey, event)}
-                                            onDragLeave={event => handleDayDragLeave(dayKey, event)}
+                                            onDragLeave={handleDayDragLeave}
                                             onDrop={event => handleDayDrop(dayKey, event)}
+                                            onClick={event => handleDayClick(dayKey, event)}
+                                            onKeyDown={event => handleDayKeyDown(dayKey, event)}
                                             onContextMenu={event => handleDayContextMenu(dayKey, event)}
-                                            className={`min-w-0 border-r border-hui-border p-1.5 last:border-r-0 ${isCurrentMonth ? (isWeekend(day) ? "bg-slate-50/60" : "bg-white") : "bg-slate-50/40"} ${isToday ? "ring-1 ring-inset ring-indigo-300" : ""} ${dragOverDate === dayKey ? "bg-indigo-50 ring-2 ring-inset ring-indigo-500" : ""}`}
+                                            role={data.canEdit ? "button" : undefined}
+                                            tabIndex={data.canEdit ? 0 : undefined}
+                                            aria-label={data.canEdit ? `Create task on ${dayKey}` : undefined}
+                                            className={`relative min-w-0 border-r border-hui-border p-1.5 last:border-r-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 ${isCurrentMonth ? (isWeekend(day) ? "bg-slate-50/60" : "bg-white") : "bg-slate-50/40"} ${isToday ? "ring-1 ring-inset ring-indigo-300" : ""}`}
                                         >
                                             <span className={`text-xs font-semibold ${isToday ? "inline-flex h-6 w-6 items-center justify-center rounded-full bg-indigo-600 text-white" : isCurrentMonth ? "text-hui-textMain" : "text-slate-400"}`}>{day.getUTCDate()}</span>
+                                            {forecast && (
+                                                <span
+                                                    className="pointer-events-none absolute right-1.5 top-1.5 text-xs opacity-70"
+                                                    title={`Vancouver: ${forecast.low}\u00B0\u2013${forecast.high}\u00B0, ${forecast.precipitationProbability}% rain`}
+                                                    aria-hidden="true"
+                                                >
+                                                    {forecast.glyph}
+                                                </span>
+                                            )}
                                             <div className="space-y-0.5 pt-[332px]">
                                                 {incomeTotal != null && incomeTotal > 0 && <div className="truncate px-1 text-[10px] font-medium text-green-700" title="Income due this day (effective due date)">{formatCurrency(incomeTotal)} due</div>}
                                                 {projectedCoTotal != null && projectedCoTotal > 0 && <div className="truncate px-1 text-[10px] font-medium text-amber-700" title="Approved, unbilled change-order income projected this day">{formatCurrency(projectedCoTotal)} projected CO</div>}

--- a/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
+++ b/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
@@ -3,9 +3,11 @@
 import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { AnimatePresence, MotionConfig, motion } from "framer-motion";
 import { toast } from "sonner";
 import { saveCompanyScheduleTaskDatesAction, shiftNotStartedTasksAction, updateProjectEndDateAction, updateProjectStartDateAction } from "@/lib/actions";
 import type { CompanyDashboardData, DashboardProjectRow, DashboardTaskRow, OverlayIncomeItem } from "@/lib/schedule-core";
+import type { VancouverForecastDay } from "@/lib/weather";
 import { addDays, formatDate, getDaysBetween, parseUTCDate } from "@/app/projects/[id]/schedule/schedule-utils";
 import { MonthBarsView } from "./MonthBarsView";
 import { TimelineView, CREW_MODE_STORAGE_KEY } from "./TimelineView";
@@ -69,6 +71,7 @@ declare global {
 
 interface ScheduleBoardProps {
     data: CompanyDashboardData;
+    weather: VancouverForecastDay[];
     externallyPendingProjectIds: ReadonlySet<string>;
     isProjectExternallyPending: (projectId: string) => boolean;
     onEffectivePendingProjectIdsChange: (projectIds: ReadonlySet<string>) => void;
@@ -220,6 +223,7 @@ function shiftMonth(month: string, delta: number): string {
 
 export function ScheduleBoard({
     data,
+    weather,
     externallyPendingProjectIds,
     isProjectExternallyPending,
     onEffectivePendingProjectIdsChange,
@@ -1756,6 +1760,7 @@ export function ScheduleBoard({
     ].filter((kind): kind is string => Boolean(kind));
 
     return (
+        <MotionConfig reducedMotion="user">
         <div ref={boardContainerRef} className="hui-card mb-6 overflow-hidden">
             <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3 border-b border-hui-border">
                 <div className="flex items-baseline gap-3">
@@ -1809,8 +1814,18 @@ export function ScheduleBoard({
                     <button type="button" onClick={() => router.push('/company-dashboard?month=' + shiftMonth(month, 1))} className="hui-btn hui-btn-secondary text-sm">Next →</button>
                 </div>
             </div>
+            <AnimatePresence initial={false}>
             {draftCount > 0 && (
-                <div role="status" className="sticky top-0 z-40 flex flex-wrap items-center justify-between gap-3 border-b border-indigo-200 bg-indigo-50 px-4 py-2 text-sm text-indigo-900">
+                <motion.div
+                    key="draft-status"
+                    data-motion-scope="status-change"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.16 }}
+                    role="status"
+                    className="sticky top-0 z-40 flex flex-wrap items-center justify-between gap-3 border-b border-indigo-200 bg-indigo-50 px-4 py-2 text-sm text-indigo-900"
+                >
                     <span>{draftCount} unsaved change{draftCount === 1 ? "" : "s"}</span>
                     <div className="flex items-center gap-2">
                         <button type="button" onClick={discardAllDrafts} disabled={isSaving} className="hui-btn hui-btn-secondary text-xs disabled:cursor-wait disabled:opacity-60">
@@ -1820,20 +1835,32 @@ export function ScheduleBoard({
                             {isSaving ? "Saving..." : "Save"}
                         </button>
                     </div>
-                </div>
+                </motion.div>
             )}
+            </AnimatePresence>
             <UnscheduledTray
                 projects={data.pipeline.waitingToStart}
                 canEdit={data.canEdit}
                 pendingProjectIds={externallyPendingProjectIds}
                 onMoveProject={scheduleUnscheduledProject}
             />
+            <AnimatePresence initial={false}>
             {(Object.keys(projectRefreshExpectations).length > 0 || awaitingTaskRefreshIds.size > 0) && (
-                <div className="flex items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-900" role="status">
+                <motion.div
+                    key="refresh-status"
+                    data-motion-scope="status-change"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.16 }}
+                    className="flex items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-900"
+                    role="status"
+                >
                     <span>Refreshing saved {pendingRefreshKinds.join(" and ")} schedule changes...</span>
                     <button type="button" className="font-semibold underline" onClick={() => router.refresh()}>Retry now</button>
-                </div>
+                </motion.div>
             )}
+            </AnimatePresence>
             <span ref={projectKeyboardSentinelRef} tabIndex={-1} className="sr-only" aria-live="polite" data-project-keyboard-sentinel="true">
                 {projectKeyboardEdit ? `Moving project to ${projectKeyboardEdit.targetStart}. Use arrow keys, Enter to save, or Escape to cancel.` : ""}
             </span>
@@ -1843,12 +1870,14 @@ export function ScheduleBoard({
             {boardView === "dispatch" ? (
                 <DispatchView
                     data={boardData}
+                    weather={weather}
                     onActivate={handleBlockActivate}
                     onCreateTask={openTaskCreation}
                 />
             ) : boardView === "month" ? (
                 <MonthBarsView
                     data={boardData}
+                    weather={weather}
                     showIncome={showIncome}
                     showProjectedCo={showProjectedCo}
                     showExpenses={showExpenses}
@@ -1860,6 +1889,7 @@ export function ScheduleBoard({
                     isSaving={isSaving}
                     activeTaskKeyboardEdit={taskKeyboardEdit}
                     onTrayProjectDrop={scheduleUnscheduledProject}
+                    onCreateTask={openTaskCreation}
                     teamMembers={data.teamMembers ?? []}
                     isAnyDragActive={isAnyDragActive}
                     activeProjectKeyboardId={projectKeyboardEdit?.projectId ?? null}
@@ -1882,6 +1912,7 @@ export function ScheduleBoard({
             ) : (
                 <TimelineView
                     data={boardData}
+                    weather={weather}
                     showIncome={showIncome}
                     showProjectedCo={showProjectedCo}
                     showExpenses={showExpenses}
@@ -1893,6 +1924,7 @@ export function ScheduleBoard({
                     isSaving={isSaving}
                     activeTaskKeyboardEdit={taskKeyboardEdit}
                     onTrayProjectDrop={scheduleUnscheduledProject}
+                    onCreateTask={openTaskCreation}
                     groupByCrew={groupByCrew}
                     onToggleGroupByCrew={() => setGroupByCrewMode(!groupByCrew)}
                     scrollToTodayNonce={scrollToTodayNonce}
@@ -1941,5 +1973,6 @@ export function ScheduleBoard({
                 projects={activeProjectOptions}
             />
         </div>
+        </MotionConfig>
     );
 }

--- a/src/app/company-dashboard/schedule-board/ShiftConfirmDialog.tsx
+++ b/src/app/company-dashboard/schedule-board/ShiftConfirmDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as Dialog from "@radix-ui/react-dialog";
+import { motion } from "framer-motion";
 import type { ProjectDropIntent } from "./useBarLayout";
 
 export type ProjectMoveChoice = "marker-only" | "not-started-tasks";
@@ -19,8 +20,17 @@ export function ShiftConfirmDialog({ intent, isPending, onChoice, onCancel }: Sh
     return (
         <Dialog.Root open={Boolean(intent)} onOpenChange={open => { if (!open && !isPending) onCancel(); }}>
             <Dialog.Portal>
-                <Dialog.Overlay className="fixed inset-0 z-[70] bg-black/45" />
-                <Dialog.Content className="fixed left-1/2 top-1/2 z-[71] w-[min(92vw,32rem)] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-hui-border bg-white p-5 shadow-2xl focus:outline-none">
+                <Dialog.Overlay asChild>
+                    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.16 }} className="fixed inset-0 z-[70] bg-black/45" />
+                </Dialog.Overlay>
+                <Dialog.Content asChild>
+                <motion.div
+                    data-motion-scope="dialog-enter"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    transition={{ duration: 0.18 }}
+                    className="fixed left-1/2 top-1/2 z-[71] w-[min(92vw,32rem)] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-hui-border bg-white p-5 shadow-2xl focus:outline-none"
+                >
                     <Dialog.Title className="text-base font-semibold text-hui-textMain">Move In Progress project</Dialog.Title>
                     <Dialog.Description className="mt-2 text-sm text-hui-textMuted">
                         {intent ? `${intent.project.name} is previewed ${magnitude} day${magnitude === 1 ? "" : "s"} ${direction}. Choose one edit; these actions are intentionally not combined.` : "Choose how to move this project."}
@@ -50,6 +60,7 @@ export function ShiftConfirmDialog({ intent, isPending, onChoice, onCancel }: Sh
                             </button>
                         </Dialog.Close>
                     </div>
+                </motion.div>
                 </Dialog.Content>
             </Dialog.Portal>
         </Dialog.Root>

--- a/src/app/company-dashboard/schedule-board/TaskBlockSegment.tsx
+++ b/src/app/company-dashboard/schedule-board/TaskBlockSegment.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import type { DashboardTaskRow } from "@/lib/schedule-core";
 import { addTaskComment, deleteScheduleTask } from "@/lib/actions";
-import { addDays, formatDate, getDaysBetween, getDefaultColorForTaskName, parseUTCDate, todayUTC } from "@/app/projects/[id]/schedule/schedule-utils";
+import { addDays, formatDate, getDaysBetween, getDefaultColorForTaskName, parseUTCDate } from "@/app/projects/[id]/schedule/schedule-utils";
 import { clipRange, type DateRange, type TaskDateOverride, type TaskEditMode } from "./useBarLayout";
 import { FloatingPopover } from "./FloatingPopover";
 import { TaskCrewPicker } from "./CrewPickers";
@@ -81,20 +81,6 @@ function initials(name: string): string {
 
 // Hover-card notes (owner-feedback round, item 3).
 const HOVER_CARD_OPEN_DELAY_MS = 300;
-const NOTE_TRUNCATE_LENGTH = 140;
-
-function relativeDayLabel(iso: string): string {
-    const createdDay = parseUTCDate(iso.slice(0, 10));
-    const diffDays = getDaysBetween(createdDay, todayUTC());
-    if (diffDays <= 0) return "Today";
-    if (diffDays === 1) return "Yesterday";
-    if (diffDays < 7) return `${diffDays} days ago`;
-    return formatDate(createdDay);
-}
-
-function truncateNote(text: string): string {
-    return text.length > NOTE_TRUNCATE_LENGTH ? `${text.slice(0, NOTE_TRUNCATE_LENGTH)}…` : text;
-}
 
 // Readability pass (2026-07-22): a task chip only shows its text label once
 // it's wide enough for roughly 3 characters at the bumped 11px label font —
@@ -566,20 +552,8 @@ export function TaskBlockSegment({
             <FloatingPopover open={hoverCardOpen} anchorRef={rootRef} onClose={closeHoverCard} width={220} pointerEventsNone>
                 <div className="space-y-1">
                     <p className="text-xs font-semibold text-hui-textMain">{isMilestone ? `◆ ${task.name}` : task.name}</p>
-                    <p className="text-[10px] text-hui-textMuted">UTC {formatDate(taskStart)} → {formatDate(isMilestone ? taskStart : taskEnd)}</p>
+                    <p className="text-[10px] text-hui-textMuted">UTC {formatDate(taskStart)} → {formatDate(isMilestone ? taskStart : taskEnd)} · {task.status} · {progress}%</p>
                     <p className="text-[10px] text-hui-textMuted">Crew: {crew}</p>
-                    {task.latestComments.length > 0 && (
-                        <div className="space-y-1 border-t border-hui-border pt-1">
-                            {task.latestComments.map((comment, index) => (
-                                <p key={index} className="text-[10px] text-hui-textMain">
-                                    <span className="font-semibold">{comment.authorName}</span>{" "}
-                                    <span className="text-hui-textMuted">{relativeDayLabel(comment.createdAt)}</span>
-                                    {" — "}
-                                    {truncateNote(comment.text)}
-                                </p>
-                            ))}
-                        </div>
-                    )}
                 </div>
             </FloatingPopover>
         </div>

--- a/src/app/company-dashboard/schedule-board/TimelineView.tsx
+++ b/src/app/company-dashboard/schedule-board/TimelineView.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useRef, useState, type DragEvent, type MouseEvent as ReactMouseEvent } from "react";
+import { useEffect, useRef, useState, type DragEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent } from "react";
 import Link from "next/link";
 import type { CompanyDashboardData, DashboardProjectRow } from "@/lib/schedule-core";
+import type { VancouverForecastDay } from "@/lib/weather";
 import {
     addDays,
     formatCurrency,
@@ -22,6 +23,9 @@ import { ProjectBar, ProjectBarGridStartContext, computeTaskLaneLayout, type Pro
 import { TaskBlockSegment, type ActiveTaskKeyboardEdit, type TaskEditCallbacks } from "./TaskBlockSegment";
 import { PROJECT_DRAG_MIME } from "./UnscheduledTray";
 import { assignTaskLanes, clipRange, getEffectiveProjectRange, toTimelineRect, type WeekSegment } from "./useBarLayout";
+import type { DispatchTaskCreationDefaults } from "./DispatchView";
+import { clearScheduleTargetHighlight, highlightScheduleTarget, isDragVisualLayerActive } from "./dragVisualLayer";
+import { isPrimaryUnmodifiedClick, isScheduleCellBackgroundTarget } from "./emptyCellCreation";
 
 // Item 4 (2026-07-22 owner addendum): the canvas spans 28 days BEFORE the
 // anchor month's own grid start through 112 days after it — ~20 weeks total,
@@ -50,6 +54,7 @@ export const CREW_MODE_STORAGE_KEY = "gtr-company-schedule-board-crew-mode";
 
 interface TimelineViewProps extends TaskEditCallbacks, ProjectEditCallbacks {
     data: CompanyDashboardData;
+    weather: VancouverForecastDay[];
     showIncome: boolean;
     showProjectedCo: boolean;
     showExpenses: boolean;
@@ -61,6 +66,7 @@ interface TimelineViewProps extends TaskEditCallbacks, ProjectEditCallbacks {
     isSaving: boolean;
     activeTaskKeyboardEdit: ActiveTaskKeyboardEdit | null;
     onTrayProjectDrop: (_project: DashboardProjectRow, _targetStart: string) => void;
+    onCreateTask: (_defaults: DispatchTaskCreationDefaults) => void;
     // Lifted to ScheduleBoard (see CREW_MODE_STORAGE_KEY) so the availability
     // panel's drill-down can force crew mode on even when this view is
     // already mounted.
@@ -102,6 +108,11 @@ interface CrewTimelineRow {
     name: string;
     taskBlocks: CrewTaskBlock[];
     coverageBlocks: CrewCoverageBlock[];
+}
+
+interface TimelineCellFocus {
+    rowKey: string;
+    dayKey: string;
 }
 
 /**
@@ -160,6 +171,7 @@ function buildCrewTimelineRows(projects: DashboardProjectRow[], colorFor: (proje
 
 export function TimelineView({
     data,
+    weather,
     showIncome,
     showProjectedCo,
     showExpenses,
@@ -171,6 +183,7 @@ export function TimelineView({
     isSaving,
     activeTaskKeyboardEdit,
     onTrayProjectDrop,
+    onCreateTask,
     groupByCrew,
     onToggleGroupByCrew,
     scrollToTodayNonce,
@@ -194,7 +207,8 @@ export function TimelineView({
     onActivate,
 }: TimelineViewProps) {
     const scrollContainerRef = useRef<HTMLDivElement>(null);
-    const [dragOverDate, setDragOverDate] = useState<string | null>(null);
+    const timelineCellRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+    const [focusedCell, setFocusedCell] = useState<TimelineCellFocus | null>(null);
     // Empty-day-cell "Schedule here…" context menu (item 1) — one instance
     // for the whole view (only one day's menu can be open at a time), point-
     // anchored to the right-click location.
@@ -243,6 +257,7 @@ export function TimelineView({
     const days = Array.from({ length: TIMELINE_DAYS_TOTAL }, (_, index) => addDays(gridStart, index));
     const visibleRange = { start: gridStart, end: gridEnd };
     const today = todayUTC();
+    const weatherByDate = new Map(weather.map(forecast => [forecast.date, forecast]));
 
     // On mount and whenever the anchor month changes (Prev/Next/Today), bring
     // the anchor month's first day to the canvas's left edge. Re-anchors on
@@ -276,6 +291,13 @@ export function TimelineView({
     ];
     const colorForProject = (project: DashboardProjectRow) => project.color || getFallbackProjectColor(project.id);
     const crewRows = groupByCrew ? buildCrewTimelineRows(projects, colorForProject) : [];
+    const timelineRowKeys = groupByCrew
+        ? crewRows.map(row => `crew:${row.userId}`)
+        : projects.map(project => `project:${project.id}`);
+    const timelineDayKeys = days.map(formatDate);
+    const focusedCellIsVisible = focusedCell != null
+        && timelineRowKeys.includes(focusedCell.rowKey)
+        && timelineDayKeys.includes(focusedCell.dayKey);
     const adminOverlays = data.isAdmin ? data.overlays : null;
     const visibleIncomeMilestones = adminOverlays && showIncome ? adminOverlays.income : [];
     const visibleChangeOrderMilestones = adminOverlays && showProjectedCo ? adminOverlays.changeOrders : [];
@@ -310,16 +332,75 @@ export function TimelineView({
         if (!data.canEdit || !hasProjectDragPayload(event)) return;
         event.preventDefault();
         event.dataTransfer.dropEffect = "move";
-        setDragOverDate(dayKey);
+        highlightScheduleTarget({ clientX: event.clientX, clientY: event.clientY, targetDate: dayKey });
     }
 
     function handleDayDrop(dayKey: string, event: DragEvent<HTMLDivElement>) {
         if (!data.canEdit || !hasProjectDragPayload(event)) return;
         event.preventDefault();
-        setDragOverDate(null);
+        clearScheduleTargetHighlight();
         const projectId = event.dataTransfer.getData(PROJECT_DRAG_MIME);
         const project = data.pipeline.waitingToStart.find(candidate => candidate.id === projectId);
         if (project) onTrayProjectDrop(project, dayKey);
+    }
+
+    function handleDayDragLeave(event: DragEvent<HTMLDivElement>) {
+        if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) return;
+        clearScheduleTargetHighlight();
+    }
+
+    function handleEmptyCellClick(defaults: DispatchTaskCreationDefaults, event: ReactMouseEvent<HTMLDivElement>) {
+        if (!data.canEdit || isAnyDragActive || isDragVisualLayerActive()) return;
+        if (!isPrimaryUnmodifiedClick(event) || !isScheduleCellBackgroundTarget(event.target, event.currentTarget)) return;
+        onCreateTask(defaults);
+    }
+
+    function timelineCellKey(rowKey: string, dayKey: string): string {
+        return `${rowKey}|${dayKey}`;
+    }
+
+    function setTimelineCellRef(rowKey: string, dayKey: string, element: HTMLDivElement | null) {
+        const key = timelineCellKey(rowKey, dayKey);
+        if (element) timelineCellRefs.current.set(key, element);
+        else timelineCellRefs.current.delete(key);
+    }
+
+    function isTimelineCellTabbable(rowKey: string, dayKey: string): boolean {
+        const tabStop = focusedCellIsVisible
+            ? focusedCell
+            : timelineRowKeys.length > 0 && timelineDayKeys.length > 0
+                ? { rowKey: timelineRowKeys[0], dayKey: timelineDayKeys[0] }
+                : null;
+        return tabStop?.rowKey === rowKey && tabStop.dayKey === dayKey;
+    }
+
+    function handleEmptyCellKeyDown(
+        defaults: DispatchTaskCreationDefaults,
+        event: KeyboardEvent<HTMLDivElement>,
+        rowKey: string,
+        dayKey: string,
+    ) {
+        if (!data.canEdit || isAnyDragActive || isDragVisualLayerActive() || event.target !== event.currentTarget) return;
+        if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            onCreateTask(defaults);
+            return;
+        }
+
+        const dayDelta = event.key === "ArrowLeft" ? -1 : event.key === "ArrowRight" ? 1 : 0;
+        const rowDelta = event.key === "ArrowUp" ? -1 : event.key === "ArrowDown" ? 1 : 0;
+        if (dayDelta === 0 && rowDelta === 0) return;
+
+        event.preventDefault();
+        const rowIndex = timelineRowKeys.indexOf(rowKey);
+        const dayIndex = timelineDayKeys.indexOf(dayKey);
+        if (rowIndex < 0 || dayIndex < 0) return;
+        const nextRowKey = timelineRowKeys[Math.max(0, Math.min(timelineRowKeys.length - 1, rowIndex + rowDelta))];
+        const nextDayKey = timelineDayKeys[Math.max(0, Math.min(timelineDayKeys.length - 1, dayIndex + dayDelta))];
+        setFocusedCell({ rowKey: nextRowKey, dayKey: nextDayKey });
+        window.requestAnimationFrame(() => {
+            timelineCellRefs.current.get(timelineCellKey(nextRowKey, nextDayKey))?.focus();
+        });
     }
 
     return (
@@ -378,6 +459,27 @@ export function TimelineView({
                         </div>
                     </div>
 
+                    {weather.length > 0 && (
+                        <div className="flex border-b border-hui-border bg-sky-50/40" aria-label="Vancouver 10-day forecast">
+                            <div data-timeline-sticky-label="true" className="sticky left-0 z-40 shrink-0 border-r border-hui-border bg-sky-50 px-3 py-1.5 text-[10px] font-semibold text-slate-500" style={{ width: LABEL_WIDTH }}>Vancouver</div>
+                            <div className="grid h-7 shrink-0" style={{ width: CANVAS_WIDTH, gridTemplateColumns: `repeat(${TIMELINE_DAYS_TOTAL}, ${dayWidth}px)` }}>
+                                {days.map(day => {
+                                    const dayKey = formatDate(day);
+                                    const forecast = weatherByDate.get(dayKey);
+                                    return (
+                                        <div
+                                            key={`weather-${dayKey}`}
+                                            className="min-w-0 overflow-hidden border-r border-hui-border text-center text-[9px] leading-7"
+                                            title={forecast ? `Vancouver ${forecast.low}\u00B0\u2013${forecast.high}\u00B0, ${forecast.precipitationProbability}% rain` : undefined}
+                                        >
+                                            {forecast?.glyph ?? ""}
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        </div>
+                    )}
+
                     {adminOverlays && (showIncome || showProjectedCo || showExpenses || showHours) && (
                         <div className="flex border-b border-hui-border bg-slate-50/70" aria-label="Visible overlay totals by day">
                             <div data-timeline-sticky-label="true" className="sticky left-0 z-40 shrink-0 border-r border-hui-border bg-slate-50 px-3 py-2 text-[10px] font-semibold text-slate-500" style={{ width: LABEL_WIDTH }}>
@@ -418,6 +520,7 @@ export function TimelineView({
                         crewRows.length === 0 ? (
                             <div className="px-4 py-8 text-center text-sm text-hui-textMuted">No active crew coverage in this window.</div>
                         ) : crewRows.map(row => {
+                            const rowKey = `crew:${row.userId}`;
                             const { laneByTaskId, laneCount: rawLaneCount } = assignTaskLanes(row.taskBlocks.map(block => ({ id: block.taskId, start: block.start, end: block.end })));
                             const laneCount = Math.max(1, rawLaneCount);
                             const TASK_LANE_TOP = 20;
@@ -437,8 +540,19 @@ export function TimelineView({
                                                 return (
                                                     <div
                                                         key={dayKey}
+                                                        ref={element => setTimelineCellRef(rowKey, dayKey, element)}
+                                                        data-schedule-date={dayKey}
+                                                        onDragOver={event => handleDayDragOver(dayKey, event)}
+                                                        onDragLeave={handleDayDragLeave}
+                                                        onDrop={event => handleDayDrop(dayKey, event)}
+                                                        onClick={event => handleEmptyCellClick({ defaultStartDate: dayKey, defaultCrewIds: [row.userId] }, event)}
+                                                        onKeyDown={event => handleEmptyCellKeyDown({ defaultStartDate: dayKey, defaultCrewIds: [row.userId] }, event, rowKey, dayKey)}
+                                                        onFocus={() => setFocusedCell({ rowKey, dayKey })}
                                                         onContextMenu={event => handleDayContextMenu(dayKey, event)}
-                                                        className={`border-r border-hui-border ${isWeekend(day) ? "bg-slate-100/70" : "bg-white"}`}
+                                                        role={data.canEdit ? "button" : undefined}
+                                                        tabIndex={data.canEdit ? (isTimelineCellTabbable(rowKey, dayKey) ? 0 : -1) : undefined}
+                                                        aria-label={data.canEdit ? `Create task for ${row.name} on ${dayKey}` : undefined}
+                                                        className={`border-r border-hui-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 ${isWeekend(day) ? "bg-slate-100/70" : "bg-white"}`}
                                                     />
                                                 );
                                             })}
@@ -483,6 +597,7 @@ export function TimelineView({
                         })
                     ) : (<>
                     {projects.map((project, projectIndex) => {
+                        const rowKey = `project:${project.id}`;
                         const range = getEffectiveProjectRange(project);
                         const clipped = range ? clipRange(range, visibleRange) : null;
                         const rect = clipped ? toTimelineRect(clipped, gridStart, dayWidth) : null;
@@ -561,18 +676,33 @@ export function TimelineView({
                                     )}
                                 </div>
                                 <div data-timeline-schedule-grid="true" className="relative shrink-0" style={{ width: CANVAS_WIDTH, height: rowHeight }}>
-                                    <div className="absolute inset-0 grid" style={{ gridTemplateColumns: `repeat(${TIMELINE_DAYS_TOTAL}, ${dayWidth}px)` }} aria-hidden="true">
+                                    <div className="absolute inset-0 grid" style={{ gridTemplateColumns: `repeat(${TIMELINE_DAYS_TOTAL}, ${dayWidth}px)` }}>
                                         {days.map(day => {
                                             const dayKey = formatDate(day);
                                             return (
                                                 <div
                                                     key={dayKey}
+                                                    ref={element => setTimelineCellRef(rowKey, dayKey, element)}
                                                     data-schedule-date={dayKey}
                                                     onDragOver={event => handleDayDragOver(dayKey, event)}
-                                                    onDragLeave={() => setDragOverDate(current => current === dayKey ? null : current)}
+                                                    onDragLeave={handleDayDragLeave}
                                                     onDrop={event => handleDayDrop(dayKey, event)}
+                                                    onClick={event => handleEmptyCellClick({
+                                                        defaultProjectId: project.id,
+                                                        lockProject: true,
+                                                        defaultStartDate: dayKey,
+                                                    }, event)}
+                                                    onKeyDown={event => handleEmptyCellKeyDown({
+                                                        defaultProjectId: project.id,
+                                                        lockProject: true,
+                                                        defaultStartDate: dayKey,
+                                                    }, event, rowKey, dayKey)}
+                                                    onFocus={() => setFocusedCell({ rowKey, dayKey })}
                                                     onContextMenu={event => handleDayContextMenu(dayKey, event)}
-                                                    className={`border-r border-hui-border ${isWeekend(day) ? "bg-slate-100/70" : "bg-white"} ${dragOverDate === dayKey ? "bg-indigo-100 ring-1 ring-inset ring-indigo-500" : ""}`}
+                                                    role={data.canEdit ? "button" : undefined}
+                                                    tabIndex={data.canEdit ? (isTimelineCellTabbable(rowKey, dayKey) ? 0 : -1) : undefined}
+                                                    aria-label={data.canEdit ? `Create task for ${project.name} on ${dayKey}` : undefined}
+                                                    className={`border-r border-hui-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 ${isWeekend(day) ? "bg-slate-100/70" : "bg-white"}`}
                                                 />
                                             );
                                         })}

--- a/src/app/company-dashboard/schedule-board/UnscheduledTray.tsx
+++ b/src/app/company-dashboard/schedule-board/UnscheduledTray.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, type DragEvent, type FormEvent } from "react";
+import { useEffect, useRef, useState, type DragEvent, type FormEvent } from "react";
 import Link from "next/link";
 import type { DashboardProjectRow } from "@/lib/schedule-core";
+import { beginNativeScheduleDragActivity } from "./dragVisualLayer";
 
 export const PROJECT_DRAG_MIME = "application/x-gtr-project-id";
 
@@ -54,6 +55,9 @@ function ProjectActions({
 }
 
 export function UnscheduledTray({ projects, canEdit, pendingProjectIds, onMoveProject }: UnscheduledTrayProps) {
+    const dragActivityCleanupRef = useRef<(() => void) | null>(null);
+    useEffect(() => () => dragActivityCleanupRef.current?.(), []);
+
     function handleDragStart(project: DashboardProjectRow, event: DragEvent<HTMLElement>) {
         if (!canEdit || pendingProjectIds.has(project.id)) {
             event.preventDefault();
@@ -61,6 +65,13 @@ export function UnscheduledTray({ projects, canEdit, pendingProjectIds, onMovePr
         }
         event.dataTransfer.effectAllowed = "move";
         event.dataTransfer.setData(PROJECT_DRAG_MIME, project.id);
+        dragActivityCleanupRef.current?.();
+        dragActivityCleanupRef.current = beginNativeScheduleDragActivity();
+    }
+
+    function handleDragEnd() {
+        dragActivityCleanupRef.current?.();
+        dragActivityCleanupRef.current = null;
     }
 
     return (
@@ -82,6 +93,7 @@ export function UnscheduledTray({ projects, canEdit, pendingProjectIds, onMovePr
                                 key={project.id}
                                 draggable={canEdit && !pending ? true : undefined}
                                 onDragStart={event => handleDragStart(project, event)}
+                                onDragEnd={handleDragEnd}
                                 aria-busy={pending}
                                 className={`group flex min-w-52 items-center gap-2 rounded-md border border-indigo-200 bg-white px-3 py-2 shadow-sm ${canEdit && !pending ? "cursor-grab active:cursor-grabbing" : "opacity-60"}`}
                             >

--- a/src/app/company-dashboard/schedule-board/dragVisualLayer.ts
+++ b/src/app/company-dashboard/schedule-board/dragVisualLayer.ts
@@ -44,6 +44,7 @@ interface SavedTargetStyle {
 }
 
 let activeVisualLayerCount = 0;
+let savedScheduleTargetStyle: SavedTargetStyle | null = null;
 
 export function isDragVisualLayerActive(): boolean {
     return activeVisualLayerCount > 0;
@@ -54,6 +55,27 @@ function publishDragVisualActivity(active: boolean) {
     window.dispatchEvent(new CustomEvent(DRAG_VISUAL_ACTIVE_EVENT, {
         detail: { active: activeVisualLayerCount > 0 },
     }));
+}
+
+export function clearScheduleTargetHighlight() {
+    if (!savedScheduleTargetStyle) return;
+    const { element, backgroundColor, boxShadow, outline, outlineOffset } = savedScheduleTargetStyle;
+    element.style.backgroundColor = backgroundColor;
+    element.style.boxShadow = boxShadow;
+    element.style.outline = outline;
+    element.style.outlineOffset = outlineOffset;
+    savedScheduleTargetStyle = null;
+}
+
+export function beginNativeScheduleDragActivity(): () => void {
+    let active = true;
+    publishDragVisualActivity(true);
+    return () => {
+        if (!active) return;
+        active = false;
+        clearScheduleTargetHighlight();
+        publishDragVisualActivity(false);
+    };
 }
 
 function escapeAttributeValue(value: string): string {
@@ -110,6 +132,36 @@ function findScheduleTarget(clientX: number, clientY: number, targetDate: string
     return nearest;
 }
 
+export function highlightScheduleTarget({
+    clientX,
+    clientY,
+    targetDate,
+}: {
+    clientX: number;
+    clientY: number;
+    targetDate: string | null;
+}) {
+    if (!targetDate) {
+        clearScheduleTargetHighlight();
+        return;
+    }
+    const nextTarget = findScheduleTarget(clientX, clientY, targetDate);
+    if (savedScheduleTargetStyle?.element === nextTarget) return;
+    clearScheduleTargetHighlight();
+    if (!nextTarget) return;
+    savedScheduleTargetStyle = {
+        element: nextTarget,
+        backgroundColor: nextTarget.style.backgroundColor,
+        boxShadow: nextTarget.style.boxShadow,
+        outline: nextTarget.style.outline,
+        outlineOffset: nextTarget.style.outlineOffset,
+    };
+    nextTarget.style.backgroundColor = "rgba(224, 231, 255, 0.82)";
+    nextTarget.style.boxShadow = "inset 0 0 0 2px rgb(79, 70, 229)";
+    nextTarget.style.outline = "2px solid transparent";
+    nextTarget.style.outlineOffset = "-2px";
+}
+
 export function createDragVisualLayer({
     sourceElement,
     sourceSelector,
@@ -130,7 +182,6 @@ export function createDragVisualLayer({
     const ghost = document.createElement("div");
     const label = document.createElement("div");
     const savedSourceStyles = new Map<HTMLElement, SavedSourceStyle>();
-    let savedTargetStyle: SavedTargetStyle | null = null;
     let latestUpdate: DragVisualUpdate = { clientX: startClientX, clientY: startClientY };
     let cleaned = false;
 
@@ -206,37 +257,12 @@ export function createDragVisualLayer({
         });
     }
 
-    function restoreTarget() {
-        if (!savedTargetStyle) return;
-        const { element, backgroundColor, boxShadow, outline, outlineOffset } = savedTargetStyle;
-        element.style.backgroundColor = backgroundColor;
-        element.style.boxShadow = boxShadow;
-        element.style.outline = outline;
-        element.style.outlineOffset = outlineOffset;
-        savedTargetStyle = null;
-    }
-
     function refreshTarget() {
-        const targetDate = latestUpdate.targetDate;
-        if (!targetDate) {
-            restoreTarget();
-            return;
-        }
-        const nextTarget = findScheduleTarget(latestUpdate.clientX, latestUpdate.clientY, targetDate);
-        if (savedTargetStyle?.element === nextTarget) return;
-        restoreTarget();
-        if (!nextTarget) return;
-        savedTargetStyle = {
-            element: nextTarget,
-            backgroundColor: nextTarget.style.backgroundColor,
-            boxShadow: nextTarget.style.boxShadow,
-            outline: nextTarget.style.outline,
-            outlineOffset: nextTarget.style.outlineOffset,
-        };
-        nextTarget.style.backgroundColor = "rgba(224, 231, 255, 0.82)";
-        nextTarget.style.boxShadow = "inset 0 0 0 2px rgb(79, 70, 229)";
-        nextTarget.style.outline = "2px solid transparent";
-        nextTarget.style.outlineOffset = "-2px";
+        highlightScheduleTarget({
+            clientX: latestUpdate.clientX,
+            clientY: latestUpdate.clientY,
+            targetDate: latestUpdate.targetDate ?? null,
+        });
     }
 
     const observer = new MutationObserver(() => {
@@ -276,7 +302,7 @@ export function createDragVisualLayer({
             if (cleaned) return;
             cleaned = true;
             observer.disconnect();
-            restoreTarget();
+            clearScheduleTargetHighlight();
             for (const [element, style] of savedSourceStyles) element.style.opacity = style.opacity;
             savedSourceStyles.clear();
             ghost.remove();

--- a/src/app/company-dashboard/schedule-board/emptyCellCreation.ts
+++ b/src/app/company-dashboard/schedule-board/emptyCellCreation.ts
@@ -1,0 +1,35 @@
+const BLOCKED_CELL_TARGET_SELECTOR = [
+    "[data-task-edit-block]",
+    "[data-drag-visual-kind]",
+    "a",
+    "button",
+    "input",
+    "select",
+    "textarea",
+    "summary",
+    "form",
+    "details",
+    "[contenteditable=true]",
+    '[role="button"]',
+    '[role="menuitem"]',
+].join(",");
+
+export function isPrimaryUnmodifiedClick(event: {
+    button: number;
+    altKey: boolean;
+    ctrlKey: boolean;
+    metaKey: boolean;
+    shiftKey: boolean;
+}): boolean {
+    return event.button === 0
+        && !event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey;
+}
+
+export function isScheduleCellBackgroundTarget(
+    target: EventTarget | null,
+    currentTarget: HTMLElement,
+): boolean {
+    if (!(target instanceof Element)) return false;
+    const blockedTarget = target.closest(BLOCKED_CELL_TARGET_SELECTOR);
+    return blockedTarget === null || blockedTarget === currentTarget;
+}

--- a/src/components/TaskCreationDialog.tsx
+++ b/src/components/TaskCreationDialog.tsx
@@ -3,6 +3,7 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
+import { motion } from "framer-motion";
 import { toast } from "sonner";
 import { createScheduleTask, getScheduleCrewMembers } from "@/lib/actions";
 import { CrewChecklist, type CrewOption } from "@/app/company-dashboard/schedule-board/CrewPickers";
@@ -138,8 +139,17 @@ export default function TaskCreationDialog({
     return (
         <Dialog.Root open={open} onOpenChange={nextOpen => { if (!nextOpen && !isPending) onClose(); }}>
             <Dialog.Portal>
-                <Dialog.Overlay className="fixed inset-0 z-[190] bg-slate-950/45 backdrop-blur-[1px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in data-[state=closed]:fade-out" />
-                <Dialog.Content className="fixed left-1/2 top-1/2 z-[200] flex max-h-[calc(100dvh-2rem)] w-[calc(100vw-1.5rem)] max-w-2xl -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-xl border border-hui-border bg-white shadow-2xl outline-none data-[state=open]:animate-in data-[state=open]:fade-in data-[state=open]:zoom-in-95 sm:w-full">
+                <Dialog.Overlay asChild>
+                    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.16 }} className="fixed inset-0 z-[190] bg-slate-950/45 backdrop-blur-[1px]" />
+                </Dialog.Overlay>
+                <Dialog.Content asChild>
+                <motion.div
+                    data-motion-scope="dialog-enter"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    transition={{ duration: 0.18 }}
+                    className="fixed left-1/2 top-1/2 z-[200] flex max-h-[calc(100dvh-2rem)] w-[calc(100vw-1.5rem)] max-w-2xl -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-xl border border-hui-border bg-white shadow-2xl outline-none sm:w-full"
+                >
                     <div className="flex items-start justify-between border-b border-hui-border bg-slate-50 px-5 py-4">
                         <div>
                             <Dialog.Title className="text-base font-bold text-hui-textMain">Create schedule item</Dialog.Title>
@@ -216,6 +226,7 @@ export default function TaskCreationDialog({
                         <Dialog.Close asChild><button type="button" disabled={isPending} className="hui-btn hui-btn-secondary text-sm">Cancel</button></Dialog.Close>
                         <button type="button" onClick={submit} disabled={isPending || projects.length === 0} className="hui-btn hui-btn-green text-sm">{isPending ? "Creating…" : "Create item"}</button>
                     </div>
+                </motion.div>
                 </Dialog.Content>
             </Dialog.Portal>
         </Dialog.Root>

--- a/src/lib/weather.ts
+++ b/src/lib/weather.ts
@@ -1,0 +1,98 @@
+import { unstable_cache } from "next/cache";
+
+export interface VancouverForecastDay {
+    date: string;
+    high: number;
+    low: number;
+    precipitationProbability: number;
+    weatherCode: number;
+    glyph: string;
+}
+
+interface OpenMeteoDailyForecast {
+    time: string[];
+    weather_code: number[];
+    temperature_2m_max: number[];
+    temperature_2m_min: number[];
+    precipitation_probability_max: number[];
+}
+
+interface OpenMeteoForecastResponse {
+    daily: OpenMeteoDailyForecast;
+}
+
+const VANCOUVER_FORECAST_URL = "https://api.open-meteo.com/v1/forecast?latitude=45.6617&longitude=-122.5484&daily=weather_code%2Ctemperature_2m_max%2Ctemperature_2m_min%2Cprecipitation_probability_max&temperature_unit=fahrenheit&timezone=America%2FLos_Angeles&forecast_days=10";
+
+export function weatherCodeToGlyph(code: number): string {
+    if (code === 0) return "\u2600\uFE0F";
+    if (code === 1 || code === 2) return "\u{1F324}\uFE0F";
+    if (code === 3) return "\u2601\uFE0F";
+    if (code === 45 || code === 48) return "\u{1F32B}\uFE0F";
+    if ((code >= 51 && code <= 67) || (code >= 80 && code <= 82)) return "\u{1F327}\uFE0F";
+    if ((code >= 71 && code <= 77) || code === 85 || code === 86) return "\u{1F328}\uFE0F";
+    if (code >= 95 && code <= 99) return "\u26C8\uFE0F";
+    return "\u2601\uFE0F";
+}
+
+function isNumberArray(value: unknown): value is number[] {
+    return Array.isArray(value) && value.every(item => typeof item === "number" && Number.isFinite(item));
+}
+
+function parseForecast(value: unknown): VancouverForecastDay[] | null {
+    if (!value || typeof value !== "object" || !("daily" in value)) return null;
+    const daily = (value as OpenMeteoForecastResponse).daily;
+    if (!daily || !Array.isArray(daily.time) || !daily.time.every(item => typeof item === "string")) return null;
+    if (!isNumberArray(daily.weather_code)
+        || !isNumberArray(daily.temperature_2m_max)
+        || !isNumberArray(daily.temperature_2m_min)
+        || !isNumberArray(daily.precipitation_probability_max)) return null;
+
+    const dayCount = Math.min(
+        10,
+        daily.time.length,
+        daily.weather_code.length,
+        daily.temperature_2m_max.length,
+        daily.temperature_2m_min.length,
+        daily.precipitation_probability_max.length,
+    );
+    return Array.from({ length: dayCount }, (_, index) => ({
+        date: daily.time[index],
+        high: Math.round(daily.temperature_2m_max[index]),
+        low: Math.round(daily.temperature_2m_min[index]),
+        precipitationProbability: Math.round(daily.precipitation_probability_max[index]),
+        weatherCode: daily.weather_code[index],
+        glyph: weatherCodeToGlyph(daily.weather_code[index]),
+    }));
+}
+
+async function fetchVancouverWeather(): Promise<VancouverForecastDay[] | null> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 3_000);
+    try {
+        const response = await fetch(VANCOUVER_FORECAST_URL, {
+            cache: "no-store",
+            headers: { Accept: "application/json" },
+            signal: controller.signal,
+        });
+        if (!response.ok) return null;
+        return parseForecast(await response.json());
+    } catch {
+        return null;
+    } finally {
+        clearTimeout(timeoutId);
+    }
+}
+
+const getCachedVancouverWeather = unstable_cache(
+    fetchVancouverWeather,
+    ["vancouver-wa-weather"],
+    { revalidate: 3_600 },
+);
+
+export async function getVancouverWeather(): Promise<VancouverForecastDay[] | null> {
+    try {
+        return await getCachedVancouverWeather();
+    } catch {
+        return null;
+    }
+}


### PR DESCRIPTION
Completes PR-A3 of the dispatch arc (part 1 = the zero-re-render drag core, #236).

## What's new
- **Vancouver weather over the schedule**: 10-day forecast (rain %, high/low) in the Timeline header row, Dispatch day headers, and as quiet Month cell glyphs — cached hourly, fails to nothing (never breaks the dashboard), explicitly labeled Vancouver.
- **Click an empty day to create a task there** — prefilled with the date (and project/person when the row implies one). Keyboard-accessible (focusable cells / roving focus). Right-click keeps the "Schedule here…" menu.
- **Hover card = three lines**: task name / dates · status · % / crew. The full detail lives one click away in the drawer.
- **Motion polish, fenced**: transitions on status changes, the exceptions strip, drawer/dialog entrances — contract-enforced absence of any motion on drag geometry; reduced-motion honored.

## Verification
- All 5 gates green (contract ×2, tsc, build, DB-backed verify) — independent checker traced the weather null-path end-to-end, quoted the 3-line hover JSX, and audited motion boundaries by grep
- Browser: live Open-Meteo forecast rendering in Month + Timeline (10 glyphs each); empty-cell click opened the dialog prefilled 2026-07-11; hover card measured at exactly 3 lines

Implemented by GPT-5.6-sol (xhigh) per its own debated design; independently gate-checked; reviewed and browser-verified by Fable 5. (Note: codex's Windows sandbox wrapper is intermittently broken — this run used direct access with review-gate guardrails.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)