### PR TITLE
Atomic dispatch publication + delivery outbox (Publish, part 1)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,7 @@ model User {
   clippedImports   ClippedImport[]
   officeTasks        OfficeTask[]      @relation("OfficeTaskAssignee")
   createdOfficeTasks OfficeTask[]      @relation("OfficeTaskCreator")
+  dispatchPublications DispatchPublication[] @relation("DispatchPublisher")
 }
 
 model Client {
@@ -214,6 +215,7 @@ model Project {
   lead                Lead?                        @relation(fields: [leadId], references: [id], onDelete: Restrict)
   viewedAt            DateTime                     @default(now())
   createdAt           DateTime                     @default(now())
+  updatedAt           DateTime                     @default(now()) @updatedAt
   location            String?
   // Geofencing for mobile time-clock (added for gtr-probuild-mobile integration)
   locationLat            Float?
@@ -1696,6 +1698,66 @@ model ActivityLog {
   @@index([projectId, createdAt])
   @@index([entityType, entityId])
   @@index([leadId, createdAt])
+}
+
+model DispatchPublication {
+  id              String   @id @default(cuid())
+  clientRequestId String   @unique
+  requestHash     String
+
+  publishedById   String?
+  publishedBy     User?    @relation("DispatchPublisher", fields: [publishedById], references: [id], onDelete: SetNull)
+  publishedByName String
+  publishedAt     DateTime @default(now())
+
+  changes         DispatchPublicationChange[]
+  deliveries      ChatDelivery[]
+
+  @@index([publishedById])
+  @@index([publishedAt])
+}
+
+model DispatchPublicationChange {
+  id            String              @id @default(cuid())
+  publicationId String
+  publication   DispatchPublication @relation(fields: [publicationId], references: [id], onDelete: Cascade)
+
+  position      Int
+  projectId     String
+  targetType    String // PROJECT | TASK
+  targetId      String
+  kind          String // PROJECT_START | TASK_DATES | TASK_CREW
+  before        Json
+  after         Json
+  summary       String
+
+  @@unique([publicationId, position], map: "DispatchChange_pub_position_key")
+  @@unique([publicationId, kind, targetType, targetId], map: "DispatchChange_pub_target_kind_key")
+  @@index([projectId])
+  @@index([targetType, targetId])
+}
+
+model ChatDelivery {
+  id            String              @id @default(cuid())
+  publicationId String
+  publication   DispatchPublication @relation(fields: [publicationId], references: [id], onDelete: Cascade)
+
+  destination String
+  kind        String @default("dispatch_publication")
+  payload     Json
+
+  status              String   @default("PENDING") // PENDING | PROCESSING | PROCESSED | FAILED
+  attempts            Int      @default(0)
+  lastError           String?
+  claimToken          String?
+  processingStartedAt DateTime?
+  providerMessageId   String?
+  createdAt           DateTime @default(now())
+  processedAt         DateTime?
+
+  @@unique([publicationId, destination, kind], map: "ChatDelivery_pub_dest_kind_key")
+  @@index([status, createdAt])
+  @@index([status, processingStartedAt])
 }
 
 model Integration {

--- a/scripts/apply-dispatch-b1-schema.mjs
+++ b/scripts/apply-dispatch-b1-schema.mjs
@@ -1,0 +1,190 @@
+// One-off additive migration for PR-B1 atomic Dispatch publication.
+// Adds Project.updatedAt plus the publication audit and ChatDelivery outbox
+// tables. Safe to re-run while the old build is live.
+//
+// Run only through the release orchestrator:
+//   node scripts/apply-dispatch-b1-schema.mjs
+//
+// Do not run this during implementation handoff. The new Prisma client selects
+// Project.updatedAt immediately, so the schema must be applied before deploy.
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+function resolveDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const file of [".env", ".env.local"]) {
+    if (!fs.existsSync(file)) continue;
+    const match = fs.readFileSync(file, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+    if (match) return match[1];
+  }
+  throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const prisma = new PrismaClient({
+  datasources: { db: { url: resolveDatabaseUrl() } },
+});
+
+const statements = [
+  `ALTER TABLE "Project"
+     ADD COLUMN IF NOT EXISTS "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP`,
+
+  `CREATE TABLE IF NOT EXISTS "DispatchPublication" (
+     "id" TEXT NOT NULL,
+     "clientRequestId" TEXT NOT NULL,
+     "requestHash" TEXT NOT NULL,
+     "publishedById" TEXT,
+     "publishedByName" TEXT NOT NULL,
+     "publishedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+     CONSTRAINT "DispatchPublication_pkey" PRIMARY KEY ("id"),
+     CONSTRAINT "DispatchPublication_clientRequestId_key" UNIQUE ("clientRequestId")
+   )`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'DispatchPublication_clientRequestId_key'
+         AND conrelid = '"DispatchPublication"'::regclass
+     ) THEN
+       ALTER TABLE "DispatchPublication"
+         ADD CONSTRAINT "DispatchPublication_clientRequestId_key" UNIQUE ("clientRequestId");
+     END IF;
+   END $$`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'DispatchPublication_publishedById_fkey'
+         AND conrelid = '"DispatchPublication"'::regclass
+     ) THEN
+       ALTER TABLE "DispatchPublication"
+         ADD CONSTRAINT "DispatchPublication_publishedById_fkey"
+         FOREIGN KEY ("publishedById") REFERENCES "User"("id")
+         ON DELETE SET NULL ON UPDATE CASCADE;
+     END IF;
+   END $$`,
+  `CREATE INDEX IF NOT EXISTS "DispatchPublication_publishedById_idx"
+     ON "DispatchPublication" ("publishedById")`,
+  `CREATE INDEX IF NOT EXISTS "DispatchPublication_publishedAt_idx"
+     ON "DispatchPublication" ("publishedAt")`,
+
+  `CREATE TABLE IF NOT EXISTS "DispatchPublicationChange" (
+     "id" TEXT NOT NULL,
+     "publicationId" TEXT NOT NULL,
+     "position" INTEGER NOT NULL,
+     "projectId" TEXT NOT NULL,
+     "targetType" TEXT NOT NULL,
+     "targetId" TEXT NOT NULL,
+     "kind" TEXT NOT NULL,
+     "before" JSONB NOT NULL,
+     "after" JSONB NOT NULL,
+     "summary" TEXT NOT NULL,
+     CONSTRAINT "DispatchPublicationChange_pkey" PRIMARY KEY ("id"),
+     CONSTRAINT "DispatchChange_pub_position_key" UNIQUE ("publicationId", "position"),
+     CONSTRAINT "DispatchChange_pub_target_kind_key" UNIQUE ("publicationId", "kind", "targetType", "targetId")
+   )`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'DispatchChange_pub_position_key'
+         AND conrelid = '"DispatchPublicationChange"'::regclass
+     ) THEN
+       ALTER TABLE "DispatchPublicationChange"
+         ADD CONSTRAINT "DispatchChange_pub_position_key" UNIQUE ("publicationId", "position");
+     END IF;
+   END $$`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'DispatchChange_pub_target_kind_key'
+         AND conrelid = '"DispatchPublicationChange"'::regclass
+     ) THEN
+       ALTER TABLE "DispatchPublicationChange"
+         ADD CONSTRAINT "DispatchChange_pub_target_kind_key"
+         UNIQUE ("publicationId", "kind", "targetType", "targetId");
+     END IF;
+   END $$`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'DispatchPublicationChange_publicationId_fkey'
+         AND conrelid = '"DispatchPublicationChange"'::regclass
+     ) THEN
+       ALTER TABLE "DispatchPublicationChange"
+         ADD CONSTRAINT "DispatchPublicationChange_publicationId_fkey"
+         FOREIGN KEY ("publicationId") REFERENCES "DispatchPublication"("id")
+         ON DELETE CASCADE ON UPDATE CASCADE;
+     END IF;
+   END $$`,
+  `CREATE INDEX IF NOT EXISTS "DispatchPublicationChange_publicationId_idx"
+     ON "DispatchPublicationChange" ("publicationId")`,
+  `CREATE INDEX IF NOT EXISTS "DispatchPublicationChange_projectId_idx"
+     ON "DispatchPublicationChange" ("projectId")`,
+  `CREATE INDEX IF NOT EXISTS "DispatchPublicationChange_targetType_targetId_idx"
+     ON "DispatchPublicationChange" ("targetType", "targetId")`,
+
+  `CREATE TABLE IF NOT EXISTS "ChatDelivery" (
+     "id" TEXT NOT NULL,
+     "publicationId" TEXT NOT NULL,
+     "destination" TEXT NOT NULL,
+     "kind" TEXT NOT NULL DEFAULT 'dispatch_publication',
+     "payload" JSONB NOT NULL,
+     "status" TEXT NOT NULL DEFAULT 'PENDING',
+     "attempts" INTEGER NOT NULL DEFAULT 0,
+     "lastError" TEXT,
+     "claimToken" TEXT,
+     "processingStartedAt" TIMESTAMP(3),
+     "providerMessageId" TEXT,
+     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+     "processedAt" TIMESTAMP(3),
+     CONSTRAINT "ChatDelivery_pkey" PRIMARY KEY ("id"),
+     CONSTRAINT "ChatDelivery_pub_dest_kind_key" UNIQUE ("publicationId", "destination", "kind")
+   )`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'ChatDelivery_pub_dest_kind_key'
+         AND conrelid = '"ChatDelivery"'::regclass
+     ) THEN
+       ALTER TABLE "ChatDelivery"
+         ADD CONSTRAINT "ChatDelivery_pub_dest_kind_key"
+         UNIQUE ("publicationId", "destination", "kind");
+     END IF;
+   END $$`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'ChatDelivery_publicationId_fkey'
+         AND conrelid = '"ChatDelivery"'::regclass
+     ) THEN
+       ALTER TABLE "ChatDelivery"
+         ADD CONSTRAINT "ChatDelivery_publicationId_fkey"
+         FOREIGN KEY ("publicationId") REFERENCES "DispatchPublication"("id")
+         ON DELETE CASCADE ON UPDATE CASCADE;
+     END IF;
+   END $$`,
+  `CREATE INDEX IF NOT EXISTS "ChatDelivery_publicationId_idx"
+     ON "ChatDelivery" ("publicationId")`,
+  `CREATE INDEX IF NOT EXISTS "ChatDelivery_status_createdAt_idx"
+     ON "ChatDelivery" ("status", "createdAt")`,
+  `CREATE INDEX IF NOT EXISTS "ChatDelivery_status_processingStartedAt_idx"
+     ON "ChatDelivery" ("status", "processingStartedAt")`,
+
+  // These tables are server-only. RLS with no policies makes the exposed
+  // Supabase Data API deny anon/authenticated access. Prisma connects as the
+  // database owner through the server-only pooler and is not subject to RLS
+  // unless FORCE ROW LEVEL SECURITY is enabled (this script does not force it).
+  `ALTER TABLE "DispatchPublication" ENABLE ROW LEVEL SECURITY`,
+  `ALTER TABLE "DispatchPublicationChange" ENABLE ROW LEVEL SECURITY`,
+  `ALTER TABLE "ChatDelivery" ENABLE ROW LEVEL SECURITY`,
+];
+
+try {
+  for (const sql of statements) {
+    await prisma.$executeRawUnsafe(sql);
+    console.log("✔ applied:", sql.split("\n")[0]);
+  }
+  console.log("Done.");
+} catch (error) {
+  console.error("Migration failed:", error);
+  process.exitCode = 1;
+} finally {
+  await prisma.$disconnect();
+}

--- a/scripts/verify-dispatch-publication.ts
+++ b/scripts/verify-dispatch-publication.ts
@@ -1,0 +1,553 @@
+// Behavioral verification for PR-B1's atomic Dispatch publication core.
+//
+// This script intentionally exercises the session-free transaction core rather
+// than the authenticated Server Action wrapper. It creates isolated fixtures,
+// verifies all 15 design-review cases, and removes every row it creates.
+//
+// Run only after scripts/apply-dispatch-b1-schema.mjs has been applied by the
+// release orchestrator and the Prisma client has been regenerated:
+//   npx tsx scripts/verify-dispatch-publication.ts
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { prisma } from "../src/lib/prisma";
+import {
+    publishDispatch,
+    type PublishDispatchInput,
+    type PublishDispatchResult,
+} from "../src/lib/dispatch-publication";
+import type {
+    DispatchAssignment,
+    ProjectStartIntent,
+    TaskCrewIntent,
+    TaskDatesIntent,
+} from "../src/lib/dispatch-intent";
+import { setTaskCrew } from "../src/lib/schedule-core";
+
+const DAY = 86_400_000;
+const BASE = Date.UTC(2042, 0, 5);
+const RUN_ID = randomUUID().replaceAll("-", "").slice(0, 12);
+const REQUEST_PREFIX = `dispatch-b1-verify-${RUN_ID}`;
+
+type Fixture = Awaited<ReturnType<typeof createFixture>>;
+
+function day(offset: number): Date {
+    return new Date(BASE + offset * DAY);
+}
+
+function dayKey(offset: number): string {
+    return day(offset).toISOString().slice(0, 10);
+}
+
+function requestId(label: string): string {
+    return `${REQUEST_PREFIX}-${label}-${randomUUID()}`;
+}
+
+function actor(fixture: Fixture): PublishDispatchInput["actor"] {
+    return {
+        userId: fixture.publisher.id,
+        name: fixture.publisher.name ?? fixture.publisher.email,
+    };
+}
+
+function expectFailure(
+    result: PublishDispatchResult,
+    code: Extract<PublishDispatchResult, { ok: false }>["code"],
+): Extract<PublishDispatchResult, { ok: false }> {
+    assert.equal(result.ok, false, `expected ${code}, received ${JSON.stringify(result)}`);
+    assert.equal(result.code, code);
+    return result;
+}
+
+async function createFixture(label: string) {
+    const suffix = `${RUN_ID}-${label}-${randomUUID().slice(0, 8)}`;
+    const client = await prisma.client.create({
+        data: { name: `Dispatch B1 verify ${suffix}`, initials: "DV" },
+    });
+    const publisher = await prisma.user.create({
+        data: {
+            email: `dispatch-publisher-${suffix}@example.invalid`,
+            name: `Dispatch Publisher ${label}`,
+            role: "MANAGER",
+            status: "ACTIVATED",
+        },
+    });
+    const crewA = await prisma.user.create({
+        data: {
+            email: `dispatch-crew-a-${suffix}@example.invalid`,
+            name: `Crew A ${label}`,
+            role: "FIELD_CREW",
+            status: "ACTIVATED",
+        },
+    });
+    const crewB = await prisma.user.create({
+        data: {
+            email: `dispatch-crew-b-${suffix}@example.invalid`,
+            name: `Crew B ${label}`,
+            role: "FIELD_CREW",
+            status: "ACTIVATED",
+        },
+    });
+    const inactiveCrew = await prisma.user.create({
+        data: {
+            email: `dispatch-crew-inactive-${suffix}@example.invalid`,
+            name: `Inactive Crew ${label}`,
+            role: "FIELD_CREW",
+            status: "DISABLED",
+        },
+    });
+    const project = await prisma.project.create({
+        data: {
+            name: `Dispatch project ${label}`,
+            clientId: client.id,
+            status: "Waiting to Start",
+            startDate: day(0),
+            type: "Verify",
+        },
+    });
+    const taskA = await prisma.scheduleTask.create({
+        data: {
+            projectId: project.id,
+            name: `Framing ${label}`,
+            startDate: day(0),
+            endDate: day(3),
+            status: "Not Started",
+            order: 0,
+        },
+    });
+    const taskB = await prisma.scheduleTask.create({
+        data: {
+            projectId: project.id,
+            name: `Paint ${label}`,
+            startDate: day(4),
+            endDate: day(6),
+            status: "Not Started",
+            order: 1,
+        },
+    });
+    await prisma.taskAssignment.createMany({
+        data: [
+            { taskId: taskA.id, userId: crewA.id, role: "lead" },
+            { taskId: taskB.id, userId: crewA.id, role: "assigned" },
+        ],
+    });
+    return { client, publisher, crewA, crewB, inactiveCrew, project, taskA, taskB };
+}
+
+async function cleanupFixture(fixture: Fixture): Promise<void> {
+    await prisma.dispatchPublication.deleteMany({
+        where: { clientRequestId: { startsWith: REQUEST_PREFIX } },
+    });
+    await prisma.project.deleteMany({ where: { id: fixture.project.id } });
+    await prisma.client.deleteMany({ where: { id: fixture.client.id } });
+    await prisma.user.deleteMany({
+        where: {
+            id: {
+                in: [
+                    fixture.publisher.id,
+                    fixture.crewA.id,
+                    fixture.crewB.id,
+                    fixture.inactiveCrew.id,
+                ],
+            },
+        },
+    });
+}
+
+async function assignmentsForTask(taskId: string): Promise<DispatchAssignment[]> {
+    const rows = await prisma.taskAssignment.findMany({
+        where: { taskId },
+        orderBy: [{ userId: "asc" }, { role: "asc" }],
+        select: { userId: true, role: true },
+    });
+    return rows.map(row => ({
+        userId: row.userId,
+        role: row.role === "lead" ? "lead" : "assigned",
+    }));
+}
+
+async function taskDatesIntent(
+    taskId: string,
+    startDate: string,
+    endDate: string,
+): Promise<TaskDatesIntent> {
+    const task = await prisma.scheduleTask.findUniqueOrThrow({
+        where: { id: taskId },
+        select: { projectId: true, updatedAt: true },
+    });
+    assert.ok(task.projectId);
+    return {
+        kind: "TASK_DATES",
+        projectId: task.projectId,
+        taskId,
+        expectedUpdatedAt: task.updatedAt.toISOString(),
+        expectedAssignments: await assignmentsForTask(taskId),
+        startDate,
+        endDate,
+    };
+}
+
+async function taskCrewIntent(
+    taskId: string,
+    assignments: DispatchAssignment[],
+): Promise<TaskCrewIntent> {
+    const task = await prisma.scheduleTask.findUniqueOrThrow({
+        where: { id: taskId },
+        select: { projectId: true, updatedAt: true },
+    });
+    assert.ok(task.projectId);
+    return {
+        kind: "TASK_CREW",
+        projectId: task.projectId,
+        taskId,
+        expectedUpdatedAt: task.updatedAt.toISOString(),
+        expectedAssignments: await assignmentsForTask(taskId),
+        assignments,
+    };
+}
+
+async function projectStartIntent(
+    projectId: string,
+    startDate: string,
+    shiftMode: ProjectStartIntent["shiftMode"] = "ALL_TASKS",
+): Promise<ProjectStartIntent> {
+    const project = await prisma.project.findUniqueOrThrow({
+        where: { id: projectId },
+        select: {
+            updatedAt: true,
+            scheduleTasks: {
+                orderBy: { id: "asc" },
+                select: {
+                    id: true,
+                    updatedAt: true,
+                    assignments: {
+                        orderBy: [{ userId: "asc" }, { role: "asc" }],
+                        select: { userId: true, role: true },
+                    },
+                },
+            },
+        },
+    });
+    return {
+        kind: "PROJECT_START",
+        projectId,
+        expectedUpdatedAt: project.updatedAt.toISOString(),
+        expectedTasks: project.scheduleTasks.map(task => ({
+            taskId: task.id,
+            expectedUpdatedAt: task.updatedAt.toISOString(),
+            expectedAssignments: task.assignments.map(assignment => ({
+                userId: assignment.userId,
+                role: assignment.role === "lead" ? "lead" : "assigned",
+            })),
+        })),
+        startDate,
+        shiftMode,
+    };
+}
+
+async function publish(
+    fixture: Fixture,
+    label: string,
+    intents: PublishDispatchInput["intents"],
+    options?: { dryRun?: boolean; clientRequestId?: string },
+): Promise<PublishDispatchResult> {
+    return publishDispatch({
+        clientRequestId: options?.clientRequestId ?? requestId(label),
+        actor: actor(fixture),
+        intents,
+        dryRun: options?.dryRun,
+    });
+}
+
+async function withFixture(
+    label: string,
+    run: (fixture: Fixture) => Promise<void>,
+): Promise<void> {
+    const fixture = await createFixture(label);
+    try {
+        await run(fixture);
+        console.log(`PASS ${label}`);
+    } finally {
+        await cleanupFixture(fixture);
+    }
+}
+
+async function main() {
+    // 1. Atomic success: project shift + explicit task override + audit/outbox.
+    await withFixture("01-atomic-success", async fixture => {
+        const projectIntent = await projectStartIntent(fixture.project.id, dayKey(2));
+        const explicitTask = await taskDatesIntent(fixture.taskA.id, dayKey(5), dayKey(8));
+        const result = await publish(fixture, "atomic-success", [projectIntent, explicitTask]);
+        assert.equal(result.ok, true);
+        assert.ok(result.publicationId);
+
+        const [project, taskA, taskB, publication] = await Promise.all([
+            prisma.project.findUniqueOrThrow({ where: { id: fixture.project.id } }),
+            prisma.scheduleTask.findUniqueOrThrow({ where: { id: fixture.taskA.id } }),
+            prisma.scheduleTask.findUniqueOrThrow({ where: { id: fixture.taskB.id } }),
+            prisma.dispatchPublication.findUniqueOrThrow({
+                where: { id: result.publicationId! },
+                include: { changes: true, deliveries: true },
+            }),
+        ]);
+        assert.equal(project.startDate?.toISOString().slice(0, 10), dayKey(2));
+        assert.equal(taskA.startDate.toISOString().slice(0, 10), dayKey(5));
+        assert.equal(taskA.endDate.toISOString().slice(0, 10), dayKey(8));
+        assert.equal(taskB.startDate.toISOString().slice(0, 10), dayKey(6));
+        assert.equal(taskB.endDate.toISOString().slice(0, 10), dayKey(8));
+        assert.equal(publication.changes.length, 3);
+        assert.equal(publication.deliveries.length, 1);
+        assert.equal(publication.deliveries[0]?.destination, `user:${fixture.crewA.id}`);
+    });
+
+    // 2. One stale member rolls the entire requested batch back.
+    await withFixture("02-complete-rollback", async fixture => {
+        const request = requestId("complete-rollback");
+        const taskAIntent = await taskDatesIntent(fixture.taskA.id, dayKey(1), dayKey(4));
+        const taskBIntent = await taskDatesIntent(fixture.taskB.id, dayKey(7), dayKey(9));
+        await prisma.scheduleTask.update({
+            where: { id: fixture.taskB.id },
+            data: { updatedAt: new Date(Date.now() + 5_000) },
+        });
+        const beforeA = await prisma.scheduleTask.findUniqueOrThrow({ where: { id: fixture.taskA.id } });
+        const result = await publish(fixture, "complete-rollback", [taskAIntent, taskBIntent], { clientRequestId: request });
+        expectFailure(result, "STALE_DISPATCH");
+        const [afterA, publications] = await Promise.all([
+            prisma.scheduleTask.findUniqueOrThrow({ where: { id: fixture.taskA.id } }),
+            prisma.dispatchPublication.count({ where: { clientRequestId: request } }),
+        ]);
+        assert.equal(afterA.startDate.getTime(), beforeA.startDate.getTime());
+        assert.equal(afterA.endDate.getTime(), beforeA.endDate.getTime());
+        assert.equal(publications, 0);
+    });
+
+    // 3. A task updatedAt mismatch is a typed stale conflict.
+    await withFixture("03-task-stale", async fixture => {
+        const intent = await taskDatesIntent(fixture.taskA.id, dayKey(2), dayKey(5));
+        await prisma.scheduleTask.update({
+            where: { id: fixture.taskA.id },
+            data: { updatedAt: new Date(Date.now() + 5_000) },
+        });
+        const failure = expectFailure(await publish(fixture, "task-stale", [intent]), "STALE_DISPATCH");
+        assert.ok(failure.conflicts.some(conflict => conflict.targetType === "TASK" && conflict.targetId === fixture.taskA.id));
+    });
+
+    // 4. A Project.updatedAt mismatch is a typed stale conflict.
+    await withFixture("04-project-stale", async fixture => {
+        const intent = await projectStartIntent(fixture.project.id, dayKey(3));
+        await prisma.project.update({
+            where: { id: fixture.project.id },
+            data: { updatedAt: new Date(Date.now() + 5_000) },
+        });
+        const failure = expectFailure(await publish(fixture, "project-stale", [intent]), "STALE_DISPATCH");
+        assert.ok(failure.conflicts.some(conflict => conflict.targetType === "PROJECT" && conflict.targetId === fixture.project.id));
+    });
+
+    // 5. Whole-project shifts reject both newly-added and deleted tasks.
+    await withFixture("05a-added-task-stale", async fixture => {
+        const intent = await projectStartIntent(fixture.project.id, dayKey(2));
+        await prisma.scheduleTask.create({
+            data: {
+                projectId: fixture.project.id,
+                name: "Late-added task",
+                startDate: day(7),
+                endDate: day(8),
+            },
+        });
+        const failure = expectFailure(await publish(fixture, "added-task-stale", [intent]), "STALE_DISPATCH");
+        assert.ok(failure.conflicts.some(conflict => conflict.reason === "TASK_SET_CHANGED"));
+    });
+    await withFixture("05b-deleted-task-stale", async fixture => {
+        const intent = await projectStartIntent(fixture.project.id, dayKey(2));
+        await prisma.scheduleTask.delete({ where: { id: fixture.taskB.id } });
+        const failure = expectFailure(await publish(fixture, "deleted-task-stale", [intent]), "STALE_DISPATCH");
+        assert.ok(failure.conflicts.some(conflict => conflict.reason === "TASK_SET_CHANGED"));
+    });
+
+    // 6. Assignment writers bump the parent revision; stale snapshots reject.
+    await withFixture("06-assignment-stale-revision", async fixture => {
+        const intent = await taskDatesIntent(fixture.taskA.id, dayKey(1), dayKey(4));
+        const before = await prisma.scheduleTask.findUniqueOrThrow({ where: { id: fixture.taskA.id } });
+        await setTaskCrew({
+            taskId: fixture.taskA.id,
+            userIds: [fixture.crewA.id, fixture.crewB.id],
+            actor: { type: "TEAM", name: "Concurrent crew editor" },
+        });
+        const after = await prisma.scheduleTask.findUniqueOrThrow({ where: { id: fixture.taskA.id } });
+        assert.ok(after.updatedAt.getTime() > before.updatedAt.getTime());
+        const failure = expectFailure(await publish(fixture, "assignment-stale", [intent]), "STALE_DISPATCH");
+        assert.ok(failure.conflicts.some(conflict => conflict.reason === "ASSIGNMENTS_CHANGED"));
+    });
+
+    // 7. Concurrent publishers with distinct request IDs serialize: one wins.
+    await withFixture("07-concurrent-publishers", async fixture => {
+        const intent = await taskDatesIntent(fixture.taskA.id, dayKey(2), dayKey(5));
+        const [left, right] = await Promise.all([
+            publish(fixture, "concurrent-left", [intent]),
+            publish(fixture, "concurrent-right", [intent]),
+        ]);
+        const successes = [left, right].filter(result => result.ok);
+        const stale = [left, right].filter(result => !result.ok && result.code === "STALE_DISPATCH");
+        assert.equal(successes.length, 1);
+        assert.equal(stale.length, 1);
+    });
+
+    // 8. Exact clientRequestId replay returns the original publication.
+    await withFixture("08-idempotent-replay", async fixture => {
+        const id = requestId("idempotent-replay");
+        const intent = await taskDatesIntent(fixture.taskA.id, dayKey(2), dayKey(5));
+        const first = await publish(fixture, "idempotent-replay", [intent], { clientRequestId: id });
+        assert.equal(first.ok, true);
+        const beforeCounts = await prisma.dispatchPublication.findUniqueOrThrow({
+            where: { clientRequestId: id },
+            include: { changes: true, deliveries: true },
+        });
+        const replay = await publish(fixture, "idempotent-replay", [intent], { clientRequestId: id });
+        assert.equal(replay.ok, true);
+        assert.equal(replay.publicationId, first.publicationId);
+        assert.equal(replay.replayed, true);
+        const afterCounts = await prisma.dispatchPublication.findUniqueOrThrow({
+            where: { clientRequestId: id },
+            include: { changes: true, deliveries: true },
+        });
+        assert.equal(afterCounts.changes.length, beforeCounts.changes.length);
+        assert.equal(afterCounts.deliveries.length, beforeCounts.deliveries.length);
+    });
+
+    // 9. Reusing an idempotency key for a different request is rejected.
+    await withFixture("09-request-hash-conflict", async fixture => {
+        const id = requestId("request-hash-conflict");
+        const firstIntent = await taskDatesIntent(fixture.taskA.id, dayKey(2), dayKey(5));
+        const first = await publish(fixture, "request-hash-conflict", [firstIntent], { clientRequestId: id });
+        assert.equal(first.ok, true);
+        const changedIntent = { ...firstIntent, startDate: dayKey(3), endDate: dayKey(6) };
+        expectFailure(
+            await publish(fixture, "request-hash-conflict", [changedIntent], { clientRequestId: id }),
+            "REQUEST_ID_CONFLICT",
+        );
+    });
+
+    // 10. Multiple changed tasks for one user collapse into one delivery.
+    await withFixture("10-recipient-dedupe", async fixture => {
+        const intents = [
+            await taskDatesIntent(fixture.taskA.id, dayKey(1), dayKey(4)),
+            await taskDatesIntent(fixture.taskB.id, dayKey(5), dayKey(7)),
+        ];
+        const result = await publish(fixture, "recipient-dedupe", intents);
+        assert.equal(result.ok, true);
+        const deliveries = await prisma.chatDelivery.findMany({
+            where: { publicationId: result.publicationId! },
+        });
+        assert.deepEqual(deliveries.map(row => row.destination), [`user:${fixture.crewA.id}`]);
+    });
+
+    // 11. Removed assignees receive the cancellation digest.
+    await withFixture("11-removed-recipient", async fixture => {
+        const intent = await taskCrewIntent(fixture.taskA.id, []);
+        const result = await publish(fixture, "removed-recipient", [intent]);
+        assert.equal(result.ok, true);
+        const delivery = await prisma.chatDelivery.findUnique({
+            where: {
+                publicationId_destination_kind: {
+                    publicationId: result.publicationId!,
+                    destination: `user:${fixture.crewA.id}`,
+                    kind: "dispatch_publication",
+                },
+            },
+        });
+        assert.ok(delivery);
+    });
+
+    // 12. A project shift plus explicit override emits one net task change.
+    await withFixture("12-net-task-change", async fixture => {
+        const intents = [
+            await projectStartIntent(fixture.project.id, dayKey(2)),
+            await taskDatesIntent(fixture.taskA.id, dayKey(7), dayKey(9)),
+        ];
+        const result = await publish(fixture, "net-task-change", intents);
+        assert.equal(result.ok, true);
+        const taskChanges = await prisma.dispatchPublicationChange.findMany({
+            where: {
+                publicationId: result.publicationId!,
+                targetType: "TASK",
+                targetId: fixture.taskA.id,
+                kind: "TASK_DATES",
+            },
+        });
+        assert.equal(taskChanges.length, 1);
+        assert.deepEqual(taskChanges[0]?.before, { startDate: dayKey(0), endDate: dayKey(3) });
+        assert.deepEqual(taskChanges[0]?.after, { startDate: dayKey(7), endDate: dayKey(9) });
+    });
+
+    // 13. dryRun returns the authoritative diff and writes nothing.
+    await withFixture("13-dry-run", async fixture => {
+        const id = requestId("dry-run");
+        const intent = await taskDatesIntent(fixture.taskA.id, dayKey(2), dayKey(5));
+        const before = await prisma.scheduleTask.findUniqueOrThrow({ where: { id: fixture.taskA.id } });
+        const result = await publish(fixture, "dry-run", [intent], { dryRun: true, clientRequestId: id });
+        assert.equal(result.ok, true);
+        assert.equal(result.publicationId, null);
+        assert.equal(result.changes.length, 1);
+        const [after, publications] = await Promise.all([
+            prisma.scheduleTask.findUniqueOrThrow({ where: { id: fixture.taskA.id } }),
+            prisma.dispatchPublication.count({ where: { clientRequestId: id } }),
+        ]);
+        assert.equal(after.startDate.getTime(), before.startDate.getTime());
+        assert.equal(after.endDate.getTime(), before.endDate.getTime());
+        assert.equal(publications, 0);
+    });
+
+    // 14. No-op input creates no publication.
+    await withFixture("14-no-op", async fixture => {
+        const id = requestId("no-op");
+        const intent = await taskDatesIntent(fixture.taskA.id, dayKey(0), dayKey(3));
+        expectFailure(
+            await publish(fixture, "no-op", [intent], { clientRequestId: id }),
+            "NO_CHANGES",
+        );
+        assert.equal(await prisma.dispatchPublication.count({ where: { clientRequestId: id } }), 0);
+    });
+
+    // 15. Inactive and unknown crew additions each roll back completely.
+    await withFixture("15a-inactive-crew", async fixture => {
+        const id = requestId("inactive-crew");
+        const intent = await taskCrewIntent(fixture.taskA.id, [
+            { userId: fixture.crewA.id, role: "lead" },
+            { userId: fixture.inactiveCrew.id, role: "assigned" },
+        ]);
+        expectFailure(
+            await publish(fixture, "inactive-crew", [intent], { clientRequestId: id }),
+            "INVALID_DISPATCH",
+        );
+        assert.deepEqual(await assignmentsForTask(fixture.taskA.id), [{ userId: fixture.crewA.id, role: "lead" }]);
+        assert.equal(await prisma.dispatchPublication.count({ where: { clientRequestId: id } }), 0);
+    });
+    await withFixture("15b-unknown-crew", async fixture => {
+        const id = requestId("unknown-crew");
+        const intent = await taskCrewIntent(fixture.taskA.id, [
+            { userId: fixture.crewA.id, role: "lead" },
+            { userId: `missing-${randomUUID()}`, role: "assigned" },
+        ]);
+        expectFailure(
+            await publish(fixture, "unknown-crew", [intent], { clientRequestId: id }),
+            "INVALID_DISPATCH",
+        );
+        assert.deepEqual(await assignmentsForTask(fixture.taskA.id), [{ userId: fixture.crewA.id, role: "lead" }]);
+        assert.equal(await prisma.dispatchPublication.count({ where: { clientRequestId: id } }), 0);
+    });
+
+    console.log("dispatch publication verification: PASS");
+}
+
+main()
+    .catch(error => {
+        console.error("dispatch publication verification: FAIL");
+        console.error(error);
+        process.exitCode = 1;
+    })
+    .finally(async () => {
+        // Last-resort cleanup for an assertion/connection failure inside a case.
+        await prisma.dispatchPublication.deleteMany({
+            where: { clientRequestId: { startsWith: REQUEST_PREFIX } },
+        }).catch(() => undefined);
+        await prisma.$disconnect();
+    });

--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -19,6 +19,7 @@ const taskBlockSource = src("../src/app/company-dashboard/schedule-board/TaskBlo
 const availabilityPanelSource = src("../src/app/company-dashboard/schedule-board/AvailabilityPanel.tsx");
 const availabilityHelpersSource = src("../src/app/company-dashboard/schedule-board/availability.ts");
 const dispatchViewSource = src("../src/app/company-dashboard/schedule-board/DispatchView.tsx");
+const dispatchReviewDialogSource = src("../src/app/company-dashboard/schedule-board/DispatchReviewDialog.tsx");
 const dispatchJobCardSource = src("../src/app/company-dashboard/schedule-board/DispatchJobCard.tsx");
 const dispatchStripSource = src("../src/app/company-dashboard/schedule-board/DispatchExceptions.tsx");
 const dispatchExceptionsSource = src("../src/app/company-dashboard/schedule-board/dispatch-exceptions.ts");
@@ -30,6 +31,8 @@ const cellActivationSource = src("../src/app/company-dashboard/schedule-board/em
 const popoverSource = src("../src/app/company-dashboard/schedule-board/FloatingPopover.tsx");
 const actionsSource = src("../src/lib/actions.ts");
 const coreSource = src("../src/lib/schedule-core.ts");
+const dispatchIntentSource = src("../src/lib/dispatch-intent.ts");
+const dispatchPublicationSource = src("../src/lib/dispatch-publication.ts");
 const weatherSource = src("../src/lib/weather.ts");
 const companyDashboardPageSource = src("../src/app/company-dashboard/page.tsx");
 const companyDashboardSource = src("../src/app/company-dashboard/CompanyDashboardClient.tsx");
@@ -80,9 +83,10 @@ assert.doesNotMatch(boardSource, /updateCompanyScheduleTaskDatesAction/, "the bo
 // assertions further down.)
 assert.match(boardSource, /import \{ saveCompanyScheduleTaskDatesAction, shiftNotStartedTasksAction, updateProjectEndDateAction, updateProjectStartDateAction \} from "@\/lib\/actions"/);
 const saveAllDraftsStart = boardSource.indexOf("async function saveAllDrafts()");
-const saveAllDraftsEnd = boardSource.indexOf("function cancelProjectEditsForProjects", saveAllDraftsStart);
+const saveAllDraftsEnd = boardSource.indexOf("async function publishDispatchDrafts()", saveAllDraftsStart);
 const saveAllDraftsBody = boardSource.slice(saveAllDraftsStart, saveAllDraftsEnd);
 assert.ok(saveAllDraftsStart >= 0, "saveAllDrafts must exist");
+assert.ok(saveAllDraftsEnd > saveAllDraftsStart, "the legacy Save body must end before the atomic Dispatch gesture");
 assert.match(saveAllDraftsBody, /const chunk = changes\.slice\(offset, offset \+ 200\);\s*\n\s*try \{\s*\n\s*const batchResult = await saveCompanyScheduleTaskDatesAction\(chunk\)/, "Save batches task changes through the one canonical action, chunked to the server cap with per-chunk isolation");
 assert.match(saveAllDraftsBody, /updateProjectStartDateAction\(/);
 assert.match(saveAllDraftsBody, /shiftNotStartedTasksAction\(/);
@@ -824,6 +828,49 @@ assert.match(coreSource, /blockedReason: string \| null;/, "dispatch cards need 
 assert.match(coreSource, /scheduledTime: string \| null;/, "dispatch appointments need their scheduled time");
 assert.match(coreSource, /confirmationStatus: string \| null;/, "dispatch appointments need confirmation status");
 assert.match(coreSource, /doneWhen: true, blockedReason: true, scheduledTime: true, confirmationStatus: true/, "the dashboard task query must select every dispatch field");
+
+// PR-B1: Month/Timeline retain the intentionally-partial chunked Save path,
+// while Dispatch owns one atomic review-and-queue gesture.
+assert.ok(dispatchIntentSource.length > 0, "the pure dispatch intent/diff module must exist");
+assert.ok(dispatchPublicationSource.length > 0, "the atomic dispatch publication core must exist");
+assert.ok(dispatchReviewDialogSource.length > 0, "the Dispatch review dialog must exist");
+assert.match(actionsSource, /export async function publishDispatchAction\(/, "actions.ts must expose one authenticated Dispatch publication wrapper");
+assert.match(actionsSource, /return publishDispatch\(/, "the wrapper must delegate to the session-free atomic core");
+
+const publishDispatchStart = boardSource.indexOf("async function publishDispatchDrafts()");
+const publishDispatchEnd = boardSource.indexOf("function cancelProjectEditsForProjects", publishDispatchStart);
+const publishDispatchBody = boardSource.slice(publishDispatchStart, publishDispatchEnd);
+assert.ok(publishDispatchStart >= 0, "ScheduleBoard must own the atomic Dispatch publication gesture");
+assert.match(publishDispatchBody, /publishDispatchAction\(/, "Dispatch must call the atomic action");
+assert.doesNotMatch(
+    publishDispatchBody,
+    /saveCompanyScheduleTaskDatesAction|updateProjectStartDateAction|shiftNotStartedTasksAction/,
+    "Dispatch must never compose the existing partial Save actions",
+);
+assert.equal(
+    (publishDispatchBody.match(/publishDispatchAction\(/g) ?? []).length,
+    1,
+    "one Dispatch confirmation must issue exactly one atomic action call",
+);
+assert.match(boardSource, /interface DispatchReconciliationExpectation \{[\s\S]*publicationId: string;[\s\S]*projects: Record<[\s\S]*tasks: Record<[\s\S]*assignments: Record</, "publication-scoped reconciliation must cover projects, tasks, and assignments");
+assert.match(boardSource, /setDispatchReconciliationExpectation\(/, "successful publication must pin one publication expectation");
+assert.match(boardSource, /Dispatch changed while you were reviewing\. Nothing was queued\. Your drafts are still here\./, "stale UX must preserve and explain drafts");
+assert.match(boardSource, /boardView !== "dispatch"[\s\S]{0,400}saveAllDrafts/, "Month/Timeline must retain the existing Save gesture");
+assert.match(boardSource, /boardView === "dispatch"[\s\S]{0,500}<DispatchView/, "Dispatch must receive its own view-scoped publication control");
+assert.match(boardSource, /<DispatchReviewDialog/, "ScheduleBoard must own the review dialog beside its draft maps");
+
+assert.match(dispatchViewSource, /onReviewDispatch: \(\) => void;/, "DispatchView must accept the CTA callback without owning draft state");
+assert.match(dispatchViewSource, /Review dispatch/, "Dispatch CTA copy must not use Publish");
+assert.doesNotMatch(dispatchViewSource, /taskDateOverrides|projectDrafts|DispatchIntent/, "DispatchView must not own or construct drafts");
+assert.match(dispatchReviewDialogSource, /Confirm & queue dispatch/, "B1 confirmation copy must describe queueing");
+assert.match(dispatchReviewDialogSource, /Dispatch recorded [—-] delivery pending/, "the success state must be honest about deferred delivery");
+assert.doesNotMatch(dispatchReviewDialogSource, />\s*Publish\s*</, "Dispatch UI must not use the ambiguous Publish label");
+
+// Revisions are serialized so previews can carry complete optimistic snapshots.
+assert.match(coreSource, /updatedAt: string;/, "dashboard project/task contracts must expose revisions");
+assert.match(coreSource, /id: true, projectId: true, name: true, startDate: true, endDate: true,[^\n]*updatedAt: true/, "the dashboard task query must select updatedAt");
+assert.match(coreSource, /updatedAt: task\.updatedAt\.toISOString\(\)/, "task revisions must serialize as ISO strings");
+
 console.log("schedule-board render contract verification: PASS");
 
 // A3 reviewer-approved deltas, pinned so they stay deliberate:

--- a/scripts/verify-schedule-board.ts
+++ b/scripts/verify-schedule-board.ts
@@ -494,7 +494,11 @@ async function main() {
         check("withTxRetry retries one P2034 conflict and succeeds on attempt two", retryProbe === "retried" && retryAttempts === 2);
 
         const scheduleCoreSource = readFileSync(new URL("../src/lib/schedule-core.ts", import.meta.url), "utf8");
-        const shiftStart = scheduleCoreSource.indexOf("export async function shiftNotStartedTasks");
+        // B1 moved the shift core into the private runShiftNotStartedTasks
+        // (the export is now a thin delegator so Publish can run it inside
+        // its own transaction) — the invariant lives in the runner's body.
+        const shiftRunnerStart = scheduleCoreSource.indexOf("async function runShiftNotStartedTasks");
+        const shiftStart = shiftRunnerStart >= 0 ? shiftRunnerStart : scheduleCoreSource.indexOf("export async function shiftNotStartedTasks");
         const shiftEnd = scheduleCoreSource.indexOf("export interface CashflowBucket", shiftStart);
         const shiftBody = scheduleCoreSource.slice(shiftStart, shiftEnd);
         const projectLockIndex = shiftBody.indexOf('SELECT id FROM "Project"');

--- a/src/app/company-dashboard/schedule-board/DispatchReviewDialog.tsx
+++ b/src/app/company-dashboard/schedule-board/DispatchReviewDialog.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { motion } from "framer-motion";
+import type { PublishDispatchSuccess } from "@/lib/dispatch-publication";
+
+interface DispatchReviewDialogProps {
+    result: PublishDispatchSuccess | null;
+    published: boolean;
+    isPending: boolean;
+    conflictTargetIds: ReadonlySet<string>;
+    onConfirm: () => void;
+    onClose: () => void;
+}
+
+function changeLabel(kind: string): string {
+    if (kind === "PROJECT_START") return "Project";
+    if (kind === "TASK_CREW") return "Crew";
+    return "Dates";
+}
+
+export function DispatchReviewDialog({
+    result,
+    published,
+    isPending,
+    conflictTargetIds,
+    onConfirm,
+    onClose,
+}: DispatchReviewDialogProps) {
+    const changeCount = result?.changes.length ?? 0;
+    const deliveryCount = result?.deliveryCount ?? 0;
+
+    return (
+        <Dialog.Root open={Boolean(result)} onOpenChange={open => { if (!open && !isPending) onClose(); }}>
+            <Dialog.Portal>
+                <Dialog.Overlay asChild>
+                    <motion.div
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        transition={{ duration: 0.16 }}
+                        className="fixed inset-0 z-[80] bg-slate-950/50"
+                    />
+                </Dialog.Overlay>
+                <Dialog.Content asChild>
+                    <motion.div
+                        data-motion-scope="dialog-enter"
+                        initial={{ opacity: 0, y: 10 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ duration: 0.18 }}
+                        className="fixed left-1/2 top-1/2 z-[81] flex max-h-[min(88vh,46rem)] w-[min(94vw,42rem)] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-xl border border-hui-border bg-white shadow-2xl focus:outline-none"
+                    >
+                        {published ? (
+                            <div className="p-6">
+                                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-green-100 text-lg font-bold text-green-700" aria-hidden="true">✓</div>
+                                <Dialog.Title className="mt-4 text-lg font-semibold text-hui-textMain">
+                                    Dispatch recorded — delivery pending
+                                </Dialog.Title>
+                                <Dialog.Description className="mt-2 text-sm leading-6 text-hui-textMuted">
+                                    The schedule and audit record committed together. {deliveryCount} delivery {deliveryCount === 1 ? "row is" : "rows are"} queued for the later chat drainer.
+                                </Dialog.Description>
+                                <button
+                                    type="button"
+                                    onClick={onClose}
+                                    className="hui-btn hui-btn-primary mt-6 w-full justify-center"
+                                >
+                                    Close
+                                </button>
+                            </div>
+                        ) : (
+                            <>
+                                <div className="border-b border-hui-border bg-slate-50 px-5 py-4">
+                                    <div className="flex items-start justify-between gap-4">
+                                        <div>
+                                            <Dialog.Title className="text-lg font-semibold text-hui-textMain">Review dispatch</Dialog.Title>
+                                            <Dialog.Description className="mt-1 text-sm text-hui-textMuted">
+                                                One atomic schedule update. Nothing is queued unless every row is still current.
+                                            </Dialog.Description>
+                                        </div>
+                                        <div className="shrink-0 rounded-md border border-slate-200 bg-white px-3 py-2 text-right">
+                                            <div className="text-lg font-semibold tabular-nums text-hui-textMain">{changeCount}</div>
+                                            <div className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">changes</div>
+                                        </div>
+                                    </div>
+                                    <div className="mt-3 flex flex-wrap gap-2 text-xs">
+                                        <span className="rounded-full bg-indigo-100 px-2.5 py-1 font-semibold text-indigo-700">
+                                            {deliveryCount} pending {deliveryCount === 1 ? "delivery" : "deliveries"}
+                                        </span>
+                                        <span className="rounded-full bg-slate-200 px-2.5 py-1 font-semibold text-slate-700">
+                                            All-or-nothing
+                                        </span>
+                                    </div>
+                                </div>
+
+                                <div className="min-h-0 flex-1 overflow-y-auto p-4">
+                                    <div className="space-y-2" role="list" aria-label="Dispatch changes">
+                                        {result?.changes.map((change, index) => {
+                                            const conflicted = conflictTargetIds.has(change.targetId);
+                                            return (
+                                                <div
+                                                    key={`${change.kind}-${change.targetId}`}
+                                                    role="listitem"
+                                                    className={`grid grid-cols-[auto_1fr] gap-3 rounded-lg border px-3 py-3 ${conflicted ? "border-amber-300 bg-amber-50" : "border-hui-border bg-white"}`}
+                                                >
+                                                    <span className="mt-0.5 inline-flex h-6 min-w-14 items-center justify-center rounded bg-slate-100 px-2 text-[10px] font-bold uppercase tracking-wide text-slate-600">
+                                                        {changeLabel(change.kind)}
+                                                    </span>
+                                                    <div className="min-w-0">
+                                                        <p className="text-sm font-medium leading-5 text-hui-textMain">{change.summary}</p>
+                                                        {conflicted && (
+                                                            <p className="mt-1 text-xs font-medium text-amber-800">Changed since the previous review — check this line again.</p>
+                                                        )}
+                                                        <p className="mt-1 text-[10px] tabular-nums text-slate-400">Change {index + 1} of {changeCount}</p>
+                                                    </div>
+                                                </div>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
+
+                                <div className="flex flex-col-reverse gap-2 border-t border-hui-border bg-white px-5 py-4 sm:flex-row sm:justify-end">
+                                    <button
+                                        type="button"
+                                        disabled={isPending}
+                                        onClick={onClose}
+                                        className="hui-btn hui-btn-secondary justify-center disabled:cursor-wait disabled:opacity-60"
+                                    >
+                                        Keep editing
+                                    </button>
+                                    <button
+                                        type="button"
+                                        disabled={isPending}
+                                        onClick={onConfirm}
+                                        className="hui-btn hui-btn-green justify-center disabled:cursor-wait disabled:opacity-60"
+                                    >
+                                        {isPending ? "Queueing dispatch..." : "Confirm & queue dispatch"}
+                                    </button>
+                                </div>
+                            </>
+                        )}
+                    </motion.div>
+                </Dialog.Content>
+            </Dialog.Portal>
+        </Dialog.Root>
+    );
+}

--- a/src/app/company-dashboard/schedule-board/DispatchView.tsx
+++ b/src/app/company-dashboard/schedule-board/DispatchView.tsx
@@ -24,6 +24,9 @@ interface DispatchViewProps {
     weather: VancouverForecastDay[];
     onActivate: (taskId: string) => void;
     onCreateTask: (defaults: DispatchTaskCreationDefaults) => void;
+    onReviewDispatch: () => void;
+    draftCount: number;
+    isReviewingDispatch: boolean;
 }
 
 interface WeekChip {
@@ -61,7 +64,15 @@ function weekChipsForMember(projects: DashboardProjectRow[], memberId: string, d
     return chips;
 }
 
-export function DispatchView({ data, weather, onActivate, onCreateTask }: DispatchViewProps) {
+export function DispatchView({
+    data,
+    weather,
+    onActivate,
+    onCreateTask,
+    onReviewDispatch,
+    draftCount,
+    isReviewingDispatch,
+}: DispatchViewProps) {
     const [mode, setMode] = useState<DispatchMode>("today");
     const currentMonday = useMemo(() => getMonday(todayUTC()), []);
     const [weekStart, setWeekStart] = useState(currentMonday);
@@ -166,18 +177,34 @@ export function DispatchView({ data, weather, onActivate, onCreateTask }: Dispat
                         Vancouver forecast{headerForecast ? ` \u00B7 ${headerForecast.glyph} ${headerForecast.precipitationProbability}% rain \u00B7 ${headerForecast.high}\u00B0/${headerForecast.low}\u00B0` : " unavailable"}
                     </p>
                 </div>
-                <div className="inline-flex rounded-md border border-hui-border bg-white p-0.5" role="group" aria-label="Dispatch range">
-                    {(["today", "week"] as const).map(nextMode => (
+                <div className="flex flex-wrap items-center gap-2">
+                    {data.canEdit && (
                         <button
-                            key={nextMode}
                             type="button"
-                            onClick={() => selectMode(nextMode)}
-                            aria-pressed={mode === nextMode}
-                            className={`rounded px-3 py-1.5 text-xs font-semibold capitalize transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary ${mode === nextMode ? "bg-hui-primary text-white" : "text-hui-textMuted hover:bg-slate-50"}`}
+                            onClick={onReviewDispatch}
+                            disabled={draftCount === 0 || isReviewingDispatch}
+                            className="hui-btn hui-btn-green text-xs disabled:cursor-not-allowed disabled:opacity-50"
                         >
-                            {nextMode}
+                            {isReviewingDispatch
+                                ? "Reviewing..."
+                                : draftCount > 0
+                                    ? `Review dispatch (${draftCount})`
+                                    : "Review dispatch"}
                         </button>
-                    ))}
+                    )}
+                    <div className="inline-flex rounded-md border border-hui-border bg-white p-0.5" role="group" aria-label="Dispatch range">
+                        {(["today", "week"] as const).map(nextMode => (
+                            <button
+                                key={nextMode}
+                                type="button"
+                                onClick={() => selectMode(nextMode)}
+                                aria-pressed={mode === nextMode}
+                                className={`rounded px-3 py-1.5 text-xs font-semibold capitalize transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary ${mode === nextMode ? "bg-hui-primary text-white" : "text-hui-textMuted hover:bg-slate-50"}`}
+                            >
+                                {nextMode}
+                            </button>
+                        ))}
+                    </div>
                 </div>
             </div>
 

--- a/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
+++ b/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
@@ -5,14 +5,23 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { AnimatePresence, MotionConfig, motion } from "framer-motion";
 import { toast } from "sonner";
+import { publishDispatchAction } from "@/lib/actions";
 import { saveCompanyScheduleTaskDatesAction, shiftNotStartedTasksAction, updateProjectEndDateAction, updateProjectStartDateAction } from "@/lib/actions";
 import type { CompanyDashboardData, DashboardProjectRow, DashboardTaskRow, OverlayIncomeItem } from "@/lib/schedule-core";
+import type { PublishDispatchSuccess } from "@/lib/dispatch-publication";
+import type {
+    DispatchAssignment,
+    DispatchIntent,
+    PersistedDispatchProjectState,
+    PersistedDispatchTaskState,
+} from "@/lib/dispatch-intent";
 import type { VancouverForecastDay } from "@/lib/weather";
 import { addDays, formatDate, getDaysBetween, parseUTCDate } from "@/app/projects/[id]/schedule/schedule-utils";
 import { MonthBarsView } from "./MonthBarsView";
 import { TimelineView, CREW_MODE_STORAGE_KEY } from "./TimelineView";
 import { DispatchView } from "./DispatchView";
 import type { DispatchTaskCreationDefaults } from "./DispatchView";
+import { DispatchReviewDialog } from "./DispatchReviewDialog";
 import { AvailabilityPanel } from "./AvailabilityPanel";
 import { ShiftConfirmDialog, type ProjectMoveChoice } from "./ShiftConfirmDialog";
 import { UnscheduledTray } from "./UnscheduledTray";
@@ -175,6 +184,20 @@ interface ProjectDraftMove {
     deltaDays: number;
 }
 
+interface DispatchReconciliationExpectation {
+    publicationId: string;
+    projects: Record<string, PersistedDispatchProjectState>;
+    tasks: Record<string, PersistedDispatchTaskState>;
+    assignments: Record<string, DispatchAssignment[]>;
+}
+
+interface DispatchReviewState {
+    clientRequestId: string;
+    intents: DispatchIntent[];
+    preview: PublishDispatchSuccess;
+    published: boolean;
+}
+
 function hitTestScheduleDate(clientX: number, clientY: number): string | null {
     for (const element of document.elementsFromPoint(clientX, clientY)) {
         const cell = element instanceof HTMLElement ? element.closest<HTMLElement>("[data-schedule-date]") : null;
@@ -221,6 +244,27 @@ function shiftMonth(month: string, delta: number): string {
     return `${shifted.getUTCFullYear()}-${String(shifted.getUTCMonth() + 1).padStart(2, "0")}`;
 }
 
+function dashboardTaskAssignments(task: DashboardTaskRow): DispatchAssignment[] {
+    return task.assignments
+        .map(assignment => ({
+            userId: assignment.userId,
+            role: assignment.assignmentRole === "lead" ? "lead" as const : "assigned" as const,
+        }))
+        .sort((left, right) => left.userId.localeCompare(right.userId) || left.role.localeCompare(right.role));
+}
+
+function dashboardAssignmentsMatch(
+    task: DashboardTaskRow,
+    expected: DispatchAssignment[],
+): boolean {
+    const actual = dashboardTaskAssignments(task);
+    return actual.length === expected.length
+        && actual.every((assignment, index) =>
+            assignment.userId === expected[index]?.userId
+            && assignment.role === expected[index]?.role,
+        );
+}
+
 export function ScheduleBoard({
     data,
     weather,
@@ -252,6 +296,11 @@ export function ScheduleBoard({
     const [projectPreviewOverrides, setProjectPreviewOverrides] = useState<Record<string, DashboardProjectRow>>({});
     const [projectIncomeOverrides, setProjectIncomeOverrides] = useState<Record<string, OverlayIncomeItem[]>>({});
     const [projectRefreshExpectations, setProjectRefreshExpectations] = useState<Record<string, ProjectRefreshExpectation>>({});
+    const [dispatchReconciliationExpectation, setDispatchReconciliationExpectation] = useState<DispatchReconciliationExpectation | null>(null);
+    const [dispatchReview, setDispatchReview] = useState<DispatchReviewState | null>(null);
+    const [dispatchConflictTargetIds, setDispatchConflictTargetIds] = useState<Set<string>>(() => new Set());
+    const [isDispatchReviewing, setIsDispatchReviewing] = useState(false);
+    const [isDispatchPublishing, setIsDispatchPublishing] = useState(false);
     // Drafts accumulate here — the SAME map drives the live visual preview AND
     // the pending-to-save payload; nothing writes to the server until Save.
     const [taskDateOverrides, setTaskDateOverrides] = useState<Record<string, TaskDateOverride>>({});
@@ -342,9 +391,15 @@ export function ScheduleBoard({
     // A saved-but-not-yet-refreshed task keeps its override (pinned to the
     // persisted dates) purely for rendering/reconciliation — it is NOT an
     // unsaved draft and must not count toward or re-enter a Save.
+    const dispatchAwaitingTaskIds = useMemo(
+        () => new Set(Object.keys(dispatchReconciliationExpectation?.tasks ?? {})),
+        [dispatchReconciliationExpectation],
+    );
     const draftTaskIds = useMemo(
-        () => new Set(Object.keys(taskDateOverrides).filter(taskId => !awaitingTaskRefreshIds.has(taskId))),
-        [taskDateOverrides, awaitingTaskRefreshIds],
+        () => new Set(Object.keys(taskDateOverrides).filter(taskId =>
+            !awaitingTaskRefreshIds.has(taskId) && !dispatchAwaitingTaskIds.has(taskId),
+        )),
+        [taskDateOverrides, awaitingTaskRefreshIds, dispatchAwaitingTaskIds],
     );
     const draftProjectIds = useMemo(() => new Set(Object.keys(projectDrafts)), [projectDrafts]);
     const draftCount = draftTaskIds.size + draftProjectIds.size;
@@ -359,13 +414,13 @@ export function ScheduleBoard({
     // committing) or an externally-locked project (the legacy StartDateRow
     // mutating that same project directly) ever blocks an edit.
     const isProjectLocked = useCallback((projectId: string) => (
-        isSaving || isProjectExternallyPending(projectId)
-    ), [isSaving, isProjectExternallyPending]);
+        (isSaving || isProjectExternallyPending(projectId)) || isDispatchReviewing || isDispatchPublishing
+    ), [isDispatchPublishing, isDispatchReviewing, isSaving, isProjectExternallyPending]);
     const isTaskLocked = useCallback((taskId: string) => {
-        if (isSaving) return true;
+        if (isSaving || isDispatchReviewing || isDispatchPublishing) return true;
         const projectId = canonicalTaskProjectById.get(taskId);
         return Boolean(projectId && isProjectExternallyPending(projectId));
-    }, [isSaving, isProjectExternallyPending, canonicalTaskProjectById]);
+    }, [isDispatchPublishing, isDispatchReviewing, isSaving, isProjectExternallyPending, canonicalTaskProjectById]);
 
     // End-resize saves are a SECOND source of "externally" pending, alongside
     // the legacy StartDateRow (item 2) — merged so both views' isPending gate
@@ -380,12 +435,24 @@ export function ScheduleBoard({
 
     useEffect(() => () => onEffectivePendingProjectIdsChange(EMPTY_PROJECT_IDS), [onEffectivePendingProjectIdsChange]);
     // ONE derived publisher for the page-wide lock: the live union of the
-    // running batch save's locked projects and every in-flight end-resize
-    // save. Snapshot-based inline publications left windows where a resize
+    // running batch save's locked projects, every in-flight end-resize
+    // save, and — while a dispatch review/publish is in flight — every
+    // draft-affected project (the publish transaction will touch exactly
+    // those rows; sibling writers like StartDateRow must see them pending).
+    // Snapshot-based inline publications left windows where a resize
     // starting mid-batch went unpublished.
     useEffect(() => {
-        onEffectivePendingProjectIdsChange(mergeProjectPendingIds(saveLockedProjectIds, endResizeSavingProjectIds));
-    }, [saveLockedProjectIds, endResizeSavingProjectIds, onEffectivePendingProjectIdsChange]);
+        let pending = mergeProjectPendingIds(saveLockedProjectIds, endResizeSavingProjectIds);
+        if (isDispatchReviewing || isDispatchPublishing) {
+            const dispatchAffected = new Set(draftProjectIds);
+            for (const taskId of draftTaskIds) {
+                const projectId = canonicalTaskProjectById.get(taskId);
+                if (projectId) dispatchAffected.add(projectId);
+            }
+            pending = mergeProjectPendingIds(pending, dispatchAffected);
+        }
+        onEffectivePendingProjectIdsChange(pending);
+    }, [saveLockedProjectIds, endResizeSavingProjectIds, isDispatchReviewing, isDispatchPublishing, draftProjectIds, draftTaskIds, canonicalTaskProjectById, onEffectivePendingProjectIdsChange]);
 
     const applyPreview = (project: DashboardProjectRow) => {
         const projectPreview = projectPreviewOverrides[project.id] ?? project;
@@ -428,6 +495,36 @@ export function ScheduleBoard({
         setTaskDateOverrides(current => ({ ...current, [taskId]: dates }));
     }
 
+    function detachDispatchExpectationTargets(input: {
+        projectIds?: ReadonlySet<string>;
+        taskIds?: ReadonlySet<string>;
+    }) {
+        setDispatchConflictTargetIds(current => {
+            const next = new Set([...current].filter(targetId =>
+                !input.projectIds?.has(targetId) && !input.taskIds?.has(targetId),
+            ));
+            return next.size === current.size ? current : next;
+        });
+        setDispatchReconciliationExpectation(current => {
+            if (!current) return current;
+            const projects = Object.fromEntries(Object.entries(current.projects).filter(([projectId]) =>
+                !input.projectIds?.has(projectId),
+            ));
+            const tasks = Object.fromEntries(Object.entries(current.tasks).filter(([taskId]) =>
+                !input.taskIds?.has(taskId),
+            ));
+            const assignments = Object.fromEntries(Object.entries(current.assignments).filter(([taskId]) =>
+                !input.taskIds?.has(taskId),
+            ));
+            if (Object.keys(projects).length === 0
+                && Object.keys(tasks).length === 0
+                && Object.keys(assignments).length === 0) {
+                return null;
+            }
+            return { ...current, projects, tasks, assignments };
+        });
+    }
+
     // Shared by the board's own save loop AND external (legacy StartDateRow)
     // shifts: saved-awaiting overrides pinned to pre-shift dates can never
     // reconcile — rewrite them to the persisted shifted dates.
@@ -464,6 +561,7 @@ export function ScheduleBoard({
         // refresh — cancelling a speculative edit must restore it, never
         // delete it (deleting strands the awaiting id and the refresh poll).
         if (awaitingTaskRefreshIds.has(taskId)) return;
+        if (dispatchAwaitingTaskIds.has(taskId)) return;
         setTaskDateOverrides(current => {
             if (!(taskId in current)) return current;
             const next = { ...current };
@@ -540,10 +638,59 @@ export function ScheduleBoard({
     }, [canonicalProjectById, projectRefreshExpectations]);
 
     useEffect(() => {
-        if (Object.keys(projectRefreshExpectations).length === 0 && awaitingTaskRefreshIds.size === 0) return;
+        const expectation = dispatchReconciliationExpectation;
+        if (!expectation) return;
+        const projectsMatch = Object.entries(expectation.projects).every(([projectId, expected]) => {
+            const canonical = canonicalProjectById.get(projectId);
+            return Boolean(
+                canonical
+                && (canonical.startDate ? canonical.startDate.slice(0, 10) : null) === expected.startDate
+                && (canonical.endDate ? canonical.endDate.slice(0, 10) : null) === expected.endDate,
+            );
+        });
+        const tasksMatch = Object.entries(expectation.tasks).every(([taskId, expected]) => {
+            const canonical = canonicalTaskById.get(taskId);
+            return Boolean(
+                canonical
+                && canonical.startDate.slice(0, 10) === expected.startDate
+                && canonical.endDate.slice(0, 10) === expected.endDate,
+            );
+        });
+        const assignmentsMatch = Object.entries(expectation.assignments).every(([taskId, expected]) => {
+            const canonical = canonicalTaskById.get(taskId);
+            return Boolean(canonical && dashboardAssignmentsMatch(canonical, expected));
+        });
+        if (!projectsMatch || !tasksMatch || !assignmentsMatch) return;
+
+        const projectIds = new Set(Object.keys(expectation.projects));
+        const taskIds = new Set([
+            ...Object.keys(expectation.tasks),
+            ...Object.keys(expectation.assignments),
+        ]);
+        const timeoutId = window.setTimeout(() => {
+            setProjectPreviewOverrides(current => Object.fromEntries(
+                Object.entries(current).filter(([projectId]) => !projectIds.has(projectId)),
+            ));
+            setProjectIncomeOverrides(current => Object.fromEntries(
+                Object.entries(current).filter(([projectId]) => !projectIds.has(projectId)),
+            ));
+            setTaskDateOverrides(current => Object.fromEntries(
+                Object.entries(current).filter(([taskId]) => !taskIds.has(taskId)),
+            ));
+            setDispatchReconciliationExpectation(current =>
+                current?.publicationId === expectation.publicationId ? null : current,
+            );
+        }, 0);
+        return () => window.clearTimeout(timeoutId);
+    }, [canonicalProjectById, canonicalTaskById, dispatchReconciliationExpectation]);
+
+    useEffect(() => {
+        if (Object.keys(projectRefreshExpectations).length === 0
+            && awaitingTaskRefreshIds.size === 0
+            && !dispatchReconciliationExpectation) return;
         const intervalId = window.setInterval(() => router.refresh(), 2_000);
         return () => window.clearInterval(intervalId);
-    }, [awaitingTaskRefreshIds.size, projectRefreshExpectations, router]);
+    }, [awaitingTaskRefreshIds.size, dispatchReconciliationExpectation, projectRefreshExpectations, router]);
 
     useEffect(() => () => {
         activeProjectPointerRef.current?.cleanup();
@@ -663,7 +810,8 @@ export function ScheduleBoard({
         // would delete the pinned override and strand the awaiting id.
         if (!awaitingTaskRefreshIds.has(taskId)
             && normalizedDates.startDate === originalDates.startDate
-            && normalizedDates.endDate === originalDates.endDate) {
+            && normalizedDates.endDate === originalDates.endDate
+            && !dispatchAwaitingTaskIds.has(taskId)) {
             clearTaskPreview(taskId);
             return;
         }
@@ -672,6 +820,7 @@ export function ScheduleBoard({
             if (!current.has(taskId)) return current;
             return new Set([...current].filter(id => id !== taskId));
         });
+        detachDispatchExpectationTargets({ taskIds: new Set([taskId]) });
         setTaskPreview(taskId, normalizedDates);
     }
 
@@ -701,6 +850,10 @@ export function ScheduleBoard({
             clearProjectDraft(project.id);
             return;
         }
+        detachDispatchExpectationTargets({
+            projectIds: new Set([project.id]),
+            taskIds: new Set(canonicalProject.tasks.map(task => task.id)),
+        });
         setProjectPreview(canonicalProject, intent.targetStart);
         // Rebase this project's existing task drafts by the CHANGE in project
         // delta (full-shift projects only — the preview shifts their tasks, so
@@ -737,9 +890,11 @@ export function ScheduleBoard({
         // Discard clears UNSAVED drafts only. Saved-awaiting overrides are
         // committed state pending refresh — removing them here would strand
         // their awaiting ids and the refresh poll forever.
-        setTaskDateOverrides(current => Object.fromEntries(
-            Object.entries(current).filter(([taskId]) => awaitingTaskRefreshIds.has(taskId)),
-        ));
+        setTaskDateOverrides(current => {
+            const savedAwaitingEntries = Object.entries(current).filter(([taskId]) => awaitingTaskRefreshIds.has(taskId));
+            const dispatchAwaitingEntries = Object.entries(current).filter(([taskId]) => dispatchAwaitingTaskIds.has(taskId));
+            return Object.fromEntries([...savedAwaitingEntries, ...dispatchAwaitingEntries]);
+        });
     }
 
     function waitForConfirmChoice(): Promise<ProjectMoveChoice | "cancel"> {
@@ -756,6 +911,134 @@ export function ScheduleBoard({
     function cancelConfirmedMove() {
         confirmResolverRef.current?.("cancel");
         confirmResolverRef.current = null;
+    }
+
+    function handleDispatchFailure(result: Exclude<Awaited<ReturnType<typeof publishDispatchAction>>, { ok: true }>) {
+        if (result.code === "STALE_DISPATCH") {
+            setDispatchConflictTargetIds(new Set(result.conflicts.map(conflict => conflict.targetId)));
+            setDispatchReview(null);
+            toast.error("Dispatch changed while you were reviewing. Nothing was queued. Your drafts are still here.");
+            router.refresh();
+            return;
+        }
+        if (result.code === "NO_CHANGES") {
+            toast.info(result.message);
+            return;
+        }
+        toast.error(result.message);
+    }
+
+    async function collectDispatchIntents(): Promise<DispatchIntent[] | null> {
+        const projectEntries = Object.entries(projectDrafts);
+        const taskEntries = [...draftTaskIds].map(taskId => [taskId, taskDateOverrides[taskId]!] as const);
+        if (projectEntries.length === 0 && taskEntries.length === 0) return [];
+
+        const affectedProjectIds = new Set([
+            ...projectEntries.map(([projectId]) => projectId),
+            ...taskEntries
+                .map(([taskId]) => canonicalTaskProjectById.get(taskId))
+                .filter((projectId): projectId is string => Boolean(projectId)),
+        ]);
+        const lockedNames = [...affectedProjectIds]
+            .filter(projectId => combinedPendingProjectIds.has(projectId))
+            .map(projectId => canonicalProjectById.get(projectId)?.name ?? projectId);
+        if (lockedNames.length > 0) {
+            toast.info(`Review will be available after another edit finishes: ${lockedNames.join(", ")}`);
+            return null;
+        }
+
+        const inProgressChoices = new Map<string, ProjectMoveChoice>();
+        for (const [projectId, draft] of projectEntries) {
+            const project = canonicalProjectById.get(projectId);
+            if (!project) {
+                toast.error(`Project ${projectId} is no longer on this schedule. Refresh before reviewing.`);
+                router.refresh();
+                return null;
+            }
+            if (project.status !== "In Progress") continue;
+            const refreshedIntent = createProjectDropIntent(project, draft.targetStart);
+            if (!refreshedIntent) {
+                toast.error(`${project.name} no longer has a movable schedule range. Refresh before reviewing.`);
+                router.refresh();
+                return null;
+            }
+            setConfirmIntent(refreshedIntent);
+            const choice = await waitForConfirmChoice();
+            setConfirmIntent(null);
+            if (choice === "cancel") return null;
+            inProgressChoices.set(projectId, choice);
+        }
+
+        const intents: DispatchIntent[] = [];
+        for (const [projectId, draft] of projectEntries) {
+            const project = canonicalProjectById.get(projectId);
+            if (!project) return null;
+            intents.push({
+                kind: "PROJECT_START",
+                projectId,
+                expectedUpdatedAt: project.updatedAt,
+                expectedTasks: project.tasks.map(task => ({
+                    taskId: task.id,
+                    expectedUpdatedAt: task.updatedAt,
+                    expectedAssignments: dashboardTaskAssignments(task),
+                })),
+                startDate: draft.targetStart,
+                shiftMode: project.status === "In Progress"
+                    ? inProgressChoices.get(projectId) === "marker-only"
+                        ? "MARKER_ONLY"
+                        : "NOT_STARTED_TASKS"
+                    : "ALL_TASKS",
+            });
+        }
+        for (const [taskId, dates] of taskEntries) {
+            const task = canonicalTaskById.get(taskId);
+            const projectId = canonicalTaskProjectById.get(taskId);
+            if (!task || !projectId) {
+                toast.error(`Task ${taskId} is no longer on this schedule. Refresh before reviewing.`);
+                router.refresh();
+                return null;
+            }
+            intents.push({
+                kind: "TASK_DATES",
+                projectId,
+                taskId,
+                expectedUpdatedAt: task.updatedAt,
+                expectedAssignments: dashboardTaskAssignments(task),
+                startDate: dates.startDate,
+                endDate: dates.endDate,
+            });
+        }
+        return intents;
+    }
+
+    async function reviewDispatchDrafts() {
+        if (isDispatchReviewing || isDispatchPublishing || isSaving || draftCount === 0) return;
+        cancelActiveTaskEdit();
+        cancelActiveProjectEdit();
+        setIsDispatchReviewing(true);
+        try {
+            const intents = await collectDispatchIntents();
+            if (!intents || intents.length === 0) return;
+            const clientRequestId = crypto.randomUUID();
+            const result = await publishDispatchAction({
+                clientRequestId,
+                intents,
+                dryRun: true,
+            });
+            if (!result.ok) {
+                handleDispatchFailure(result);
+                return;
+            }
+            setDispatchReview({
+                clientRequestId,
+                intents,
+                preview: result,
+                published: false,
+            });
+        } finally {
+            setConfirmIntent(null);
+            setIsDispatchReviewing(false);
+        }
     }
 
     // Commits every drafted change in one Save gesture: project-start moves
@@ -940,6 +1223,75 @@ export function ScheduleBoard({
                 `${totalFailed} change${totalFailed === 1 ? "" : "s"} failed to save: ${failedNames.join(", ")}`,
                 totalSucceeded > 0 ? { description: `${totalSucceeded} other change${totalSucceeded === 1 ? "" : "s"} saved.` } : undefined,
             );
+        }
+    }
+
+    async function publishDispatchDrafts() {
+        if (!dispatchReview || dispatchReview.published || isDispatchPublishing) return;
+        setIsDispatchPublishing(true);
+        try {
+            const result = await publishDispatchAction({
+                clientRequestId: dispatchReview.clientRequestId,
+                intents: dispatchReview.intents,
+                dryRun: false,
+            });
+            if (!result.ok) {
+                handleDispatchFailure(result);
+                return;
+            }
+            if (!result.publicationId) {
+                toast.error("Dispatch committed without a publication ID. Refresh before trying again.");
+                return;
+            }
+
+            const publishedProjectIds = new Set(dispatchReview.intents
+                .filter(intent => intent.kind === "PROJECT_START")
+                .map(intent => intent.projectId));
+            const explicitlyDraftedTaskIds = new Set(dispatchReview.intents
+                .filter(intent => intent.kind === "TASK_DATES")
+                .map(intent => intent.taskId));
+
+            setProjectDrafts(current => Object.fromEntries(
+                Object.entries(current).filter(([projectId]) => !publishedProjectIds.has(projectId)),
+            ));
+            setProjectPreviewOverrides(current => {
+                const next = { ...current };
+                for (const [projectId, expected] of Object.entries(result.reconciliation.projects)) {
+                    const row = next[projectId] ?? canonicalProjectById.get(projectId);
+                    if (!row) continue;
+                    next[projectId] = {
+                        ...row,
+                        startDate: expected.startDate ? `${expected.startDate}T00:00:00.000Z` : null,
+                        endDate: expected.endDate ? `${expected.endDate}T00:00:00.000Z` : null,
+                    };
+                }
+                return next;
+            });
+            setTaskDateOverrides(current => {
+                const next = Object.fromEntries(
+                    Object.entries(current).filter(([taskId]) => !explicitlyDraftedTaskIds.has(taskId)),
+                );
+                for (const [taskId, dates] of Object.entries(result.reconciliation.tasks)) {
+                    next[taskId] = dates;
+                }
+                return next;
+            });
+            setDispatchReconciliationExpectation({
+                publicationId: result.publicationId,
+                projects: result.reconciliation.projects,
+                tasks: result.reconciliation.tasks,
+                assignments: result.reconciliation.assignments,
+            });
+            setDispatchConflictTargetIds(new Set());
+            setDispatchReview({
+                ...dispatchReview,
+                preview: result,
+                published: true,
+            });
+            toast.success("Dispatch recorded — delivery pending");
+            router.refresh();
+        } finally {
+            setIsDispatchPublishing(false);
         }
     }
 
@@ -1757,6 +2109,7 @@ export function ScheduleBoard({
     const pendingRefreshKinds = [
         Object.keys(projectRefreshExpectations).length > 0 ? "project" : null,
         awaitingTaskRefreshIds.size > 0 ? "task" : null,
+        dispatchReconciliationExpectation ? "dispatch" : null,
     ].filter((kind): kind is string => Boolean(kind));
 
     return (
@@ -1828,12 +2181,14 @@ export function ScheduleBoard({
                 >
                     <span>{draftCount} unsaved change{draftCount === 1 ? "" : "s"}</span>
                     <div className="flex items-center gap-2">
-                        <button type="button" onClick={discardAllDrafts} disabled={isSaving} className="hui-btn hui-btn-secondary text-xs disabled:cursor-wait disabled:opacity-60">
+                        <button type="button" onClick={discardAllDrafts} disabled={isSaving || isDispatchReviewing || isDispatchPublishing} className="hui-btn hui-btn-secondary text-xs disabled:cursor-wait disabled:opacity-60">
                             Discard
                         </button>
-                        <button type="button" onClick={() => void saveAllDrafts()} disabled={isSaving} className="hui-btn hui-btn-green text-xs disabled:cursor-wait disabled:opacity-60">
-                            {isSaving ? "Saving..." : "Save"}
-                        </button>
+                        {boardView !== "dispatch" && (
+                            <button type="button" onClick={() => void saveAllDrafts()} disabled={isSaving} className="hui-btn hui-btn-green text-xs disabled:cursor-wait disabled:opacity-60">
+                                {isSaving ? "Saving..." : "Save"}
+                            </button>
+                        )}
                     </div>
                 </motion.div>
             )}
@@ -1845,7 +2200,7 @@ export function ScheduleBoard({
                 onMoveProject={scheduleUnscheduledProject}
             />
             <AnimatePresence initial={false}>
-            {(Object.keys(projectRefreshExpectations).length > 0 || awaitingTaskRefreshIds.size > 0) && (
+            {(Object.keys(projectRefreshExpectations).length > 0 || awaitingTaskRefreshIds.size > 0 || dispatchReconciliationExpectation) && (
                 <motion.div
                     key="refresh-status"
                     data-motion-scope="status-change"
@@ -1873,6 +2228,9 @@ export function ScheduleBoard({
                     weather={weather}
                     onActivate={handleBlockActivate}
                     onCreateTask={openTaskCreation}
+                    onReviewDispatch={() => void reviewDispatchDrafts()}
+                    draftCount={draftCount}
+                    isReviewingDispatch={isDispatchReviewing || isDispatchPublishing}
                 />
             ) : boardView === "month" ? (
                 <MonthBarsView
@@ -1954,6 +2312,14 @@ export function ScheduleBoard({
                 isPending={false}
                 onChoice={handleMoveChoice}
                 onCancel={cancelConfirmedMove}
+            />
+            <DispatchReviewDialog
+                result={dispatchReview?.preview ?? null}
+                published={dispatchReview?.published ?? false}
+                isPending={isDispatchPublishing}
+                conflictTargetIds={dispatchConflictTargetIds}
+                onConfirm={() => void publishDispatchDrafts()}
+                onClose={() => setDispatchReview(null)}
             />
             <BoardTaskDrawer
                 taskId={openTaskId}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -17,7 +17,7 @@ import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { enqueueMilestonePaid, drainPaymentNotifications } from "./payment-outbox";
 import { deleteChangeOrderCore, updateChangeOrderCore } from "./change-order-core";
 import { approveChangeOrderWithSignature } from "./change-order-approval";
-import { applyChangeOrderToSchedule, autoGenerateScheduleForApprovedEstimate, setProjectStartDate, shiftNotStartedTasks, parseStartDateInput, generateScheduleFromEstimate, setProjectCrew, setTaskCrew, CONTRACT_ESTIMATE_STATUSES } from "./schedule-core";
+import { applyChangeOrderToSchedule, autoGenerateScheduleForApprovedEstimate, setProjectStartDate, shiftNotStartedTasks, parseStartDateInput, generateScheduleFromEstimate, setProjectCrew, setTaskCrew, CONTRACT_ESTIMATE_STATUSES, lockTaskAssignmentParent, touchTaskAssignmentRevision } from "./schedule-core";
 import { CLOSED_PROJECT_STATUSES } from "./gpt-estimate";
 import type { ShiftNotStartedTasksResult } from "./schedule-core";
 import type { ChangeOrderUpdateInput } from "./change-order-core";
@@ -32,6 +32,9 @@ import { appendContractCountersignaturePage } from "./pdf";
 import { defaultTaxForNewEstimate } from "./wa-tax";
 import { geocodeJobSiteAddress } from "./geocode";
 import { assertColumnExists, parseOfficeTaskDateOnly } from "./office-task-utils";
+import { publishDispatch } from "./dispatch-publication";
+import type { DispatchIntent } from "./dispatch-intent";
+import type { PublishDispatchResult } from "./dispatch-publication";
 
 type NotificationToggleKey = "newLead" | "estimateViewed" | "estimateSigned" | "contractSigned" | "invoiceViewed" | "paymentReceived" | "messageReceived";
 
@@ -7305,32 +7308,40 @@ export async function getTaskPunchItems(taskId: string) {
 // ========== TASK ASSIGNMENTS ==========
 
 export async function assignUserToTask(taskId: string, userId: string) {
-    await assertScheduleTaskAccess(taskId);
-    const user = await prisma.user.findUnique({ where: { id: userId }, select: { status: true } });
-    if (!user || user.status !== "ACTIVATED") throw new Error("Task crew members must be ACTIVATED users");
-    const assignment = await prisma.taskAssignment.create({
-        data: { taskId, userId },
-        include: { user: { select: { id: true, name: true, email: true } } },
-    });
-    const task = await prisma.scheduleTask.findUnique({ where: { id: taskId } });
-    if (task) revalidatePath(`/projects/${task.projectId}/schedule`);
+    const { projectId } = await assertScheduleTaskAccess(taskId);
+    const assignment = await withTxRetry(() => prisma.$transaction(async tx => {
+        await lockTaskAssignmentParent(tx, taskId, projectId);
+        const user = await tx.user.findUnique({ where: { id: userId }, select: { status: true } });
+        if (!user || user.status !== "ACTIVATED") throw new Error("Task crew members must be ACTIVATED users");
+        const created = await tx.taskAssignment.create({
+            data: { taskId, userId },
+            include: { user: { select: { id: true, name: true, email: true } } },
+        });
+        await touchTaskAssignmentRevision(tx, taskId);
+        return created;
+    }));
+    revalidatePath("/company-dashboard");
+    revalidatePath(`/projects/${projectId}/schedule`);
     return assignment;
 }
 
 export async function unassignUserFromTask(taskId: string, userId: string) {
-    await assertScheduleTaskAccess(taskId);
-    await prisma.taskAssignment.deleteMany({
-        where: { taskId, userId },
-    });
-    const task = await prisma.scheduleTask.findUnique({ where: { id: taskId } });
-    if (task) revalidatePath(`/projects/${task.projectId}/schedule`);
+    const { projectId } = await assertScheduleTaskAccess(taskId);
+    await withTxRetry(() => prisma.$transaction(async tx => {
+        await lockTaskAssignmentParent(tx, taskId, projectId);
+        const deleted = await tx.taskAssignment.deleteMany({
+            where: { taskId, userId },
+        });
+        if (deleted.count > 0) await touchTaskAssignmentRevision(tx, taskId);
+    }));
+    revalidatePath("/company-dashboard");
+    revalidatePath(`/projects/${projectId}/schedule`);
 }
 
 export async function setTaskLead(taskId: string, userId: string | null) {
     const { user, projectId } = await assertScheduleTaskAccess(taskId);
     const assignments = await withTxRetry(() => prisma.$transaction(async (tx) => {
-        await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${projectId} FOR UPDATE`;
-        await tx.$queryRaw`SELECT id FROM "ScheduleTask" WHERE id = ${taskId} FOR UPDATE`;
+        await lockTaskAssignmentParent(tx, taskId, projectId);
         const task = await tx.scheduleTask.findUnique({
             where: { id: taskId },
             select: {
@@ -7355,6 +7366,7 @@ export async function setTaskLead(taskId: string, userId: string | null) {
                 data: { role: "lead" },
             });
         }
+        await touchTaskAssignmentRevision(tx, taskId);
         await tx.activityLog.create({
             data: {
                 projectId,
@@ -7592,11 +7604,33 @@ export async function getScheduleCrewMembers() {
 }
 
 export async function clearAllTasks(projectId: string) {
-    // Delete all related data first (dependencies, comments, punch items, assignments)
-    const taskIds = (await prisma.scheduleTask.findMany({ where: { projectId }, select: { id: true } })).map(t => t.id);
-    if (taskIds.length === 0) return;
-    await prisma.taskAssignment.deleteMany({ where: { taskId: { in: taskIds } } });
-    await prisma.taskComment.deleteMany({ where: { taskId: { in: taskIds } } });
+    await assertScheduleProjectAccess(projectId);
+    await withTxRetry(() => prisma.$transaction(async tx => {
+        await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${projectId} FOR UPDATE`;
+        const taskRows = await tx.$queryRaw<{ id: string }[]>`
+            SELECT "id"
+            FROM "ScheduleTask"
+            WHERE "projectId" = ${projectId}
+            ORDER BY "id"
+            FOR UPDATE
+        `;
+        const taskIds = taskRows.map(task => task.id);
+        if (taskIds.length === 0) return;
+        const assignedTaskIds = (await tx.taskAssignment.findMany({
+            where: { taskId: { in: taskIds } },
+            distinct: ["taskId"],
+            select: { taskId: true },
+        })).map(row => row.taskId);
+        await tx.taskAssignment.deleteMany({ where: { taskId: { in: taskIds } } });
+        if (assignedTaskIds.length > 0) {
+            await tx.scheduleTask.updateMany({
+                where: { id: { in: assignedTaskIds } },
+                data: { updatedAt: new Date() },
+            });
+        }
+        await tx.taskComment.deleteMany({ where: { taskId: { in: taskIds } } });
+    }));
+    revalidatePath("/company-dashboard");
     revalidatePath(`/projects/${projectId}/schedule`);
 }
 
@@ -7805,6 +7839,57 @@ export interface SaveCompanyScheduleTaskDatesInput {
     taskId: string;
     startDate: string; // YYYY-MM-DD
     endDate: string;   // YYYY-MM-DD
+}
+
+export interface PublishDispatchActionInput {
+    clientRequestId: string;
+    intents: DispatchIntent[];
+    dryRun?: boolean;
+}
+
+export async function publishDispatchAction(
+    input: PublishDispatchActionInput,
+): Promise<PublishDispatchResult> {
+    // Same session helper as every other hardened schedule mutation — the
+    // dev fallback only exists under NODE_ENV=development.
+    const session = await getSessionOrDev();
+    const caller = session?.user?.email
+        ? await prisma.user.findUnique({
+            where: { email: session.user.email },
+            select: { id: true, role: true, status: true, name: true, email: true },
+        })
+        : null;
+    if (!caller || caller.status !== "ACTIVATED" || !["ADMIN", "MANAGER"].includes(caller.role)) {
+        return {
+            ok: false,
+            code: "FORBIDDEN",
+            message: "You do not have permission to queue a dispatch.",
+            conflicts: [],
+        };
+    }
+
+    return publishDispatch({
+        clientRequestId: input.clientRequestId,
+        intents: input.intents,
+        dryRun: input.dryRun,
+        actor: {
+            userId: caller.id,
+            name: caller.name || caller.email,
+        },
+    }).then(result => {
+        if (result.ok && result.publicationId) {
+            revalidatePath("/company-dashboard");
+        }
+        return result;
+    }).catch(error => {
+        console.error("Dispatch publication failed", error);
+        return {
+            ok: false as const,
+            code: "DISPATCH_FAILED" as const,
+            message: "Nothing was queued. Please try again with the same review.",
+            conflicts: [],
+        };
+    });
 }
 
 export interface SaveCompanyScheduleTaskDateResult {
@@ -10974,5 +11059,3 @@ export async function restoreOfficeTask(id: string) {
     revalidatePath("/tasks");
     return task;
 }
-
-

--- a/src/lib/dispatch-intent.ts
+++ b/src/lib/dispatch-intent.ts
@@ -1,0 +1,636 @@
+import { createHash } from "node:crypto";
+
+export type DispatchAssignmentRole = "assigned" | "lead";
+
+export interface DispatchAssignment {
+    userId: string;
+    role: DispatchAssignmentRole;
+}
+
+export interface ExpectedDispatchTask {
+    taskId: string;
+    expectedUpdatedAt: string;
+    expectedAssignments: DispatchAssignment[];
+}
+
+export interface ProjectStartIntent {
+    kind: "PROJECT_START";
+    projectId: string;
+    expectedUpdatedAt: string;
+    // Complete task snapshot. Whole-project moves use it to detect tasks added,
+    // deleted, revised, or re-crewed after the review was opened.
+    expectedTasks: ExpectedDispatchTask[];
+    startDate: string;
+    shiftMode: "ALL_TASKS" | "NOT_STARTED_TASKS" | "MARKER_ONLY";
+}
+
+export interface TaskDatesIntent {
+    kind: "TASK_DATES";
+    projectId: string;
+    taskId: string;
+    expectedUpdatedAt: string;
+    expectedAssignments: DispatchAssignment[];
+    startDate: string;
+    endDate: string;
+}
+
+export interface TaskCrewIntent {
+    kind: "TASK_CREW";
+    projectId: string;
+    taskId: string;
+    expectedUpdatedAt: string;
+    expectedAssignments: DispatchAssignment[];
+    assignments: DispatchAssignment[];
+}
+
+export type DispatchIntent =
+    | ProjectStartIntent
+    | TaskDatesIntent
+    | TaskCrewIntent;
+
+export type DispatchConflictReason =
+    | "MISSING"
+    | "REVISION_CHANGED"
+    | "ASSIGNMENTS_CHANGED"
+    | "TASK_SET_CHANGED";
+
+export interface DispatchConflict {
+    targetType: "PROJECT" | "TASK";
+    targetId: string;
+    reason: DispatchConflictReason;
+}
+
+export interface DispatchProjectSnapshot {
+    id: string;
+    name: string;
+    status: string;
+    startDate: string | null;
+    endDate: string | null;
+    updatedAt: string;
+}
+
+export interface DispatchTaskSnapshot {
+    id: string;
+    projectId: string;
+    name: string;
+    type: string;
+    status: string;
+    startDate: string;
+    endDate: string;
+    updatedAt: string;
+    assignments: DispatchAssignment[];
+}
+
+export interface DispatchUserSnapshot {
+    id: string;
+    name: string;
+    status: string;
+}
+
+export interface DispatchChange {
+    projectId: string;
+    targetType: "PROJECT" | "TASK";
+    targetId: string;
+    kind: DispatchIntent["kind"];
+    before: Record<string, unknown>;
+    after: Record<string, unknown>;
+    summary: string;
+}
+
+export interface PersistedDispatchProjectState {
+    startDate: string | null;
+    endDate: string | null;
+}
+
+export interface PersistedDispatchTaskState {
+    startDate: string;
+    endDate: string;
+}
+
+export interface DispatchReconciliationState {
+    projects: Record<string, PersistedDispatchProjectState>;
+    tasks: Record<string, PersistedDispatchTaskState>;
+    assignments: Record<string, DispatchAssignment[]>;
+}
+
+export interface DispatchProjectOperation {
+    projectId: string;
+    shiftMode: ProjectStartIntent["shiftMode"];
+    shiftDays: number;
+}
+
+export interface DispatchPlan {
+    changes: DispatchChange[];
+    reconciliation: DispatchReconciliationState;
+    recipientIds: string[];
+    projectOperations: DispatchProjectOperation[];
+    finalProjects: Record<string, PersistedDispatchProjectState>;
+    finalTasks: Record<string, PersistedDispatchTaskState>;
+    finalAssignments: Record<string, DispatchAssignment[]>;
+}
+
+export type DispatchPlanResult =
+    | { ok: true; plan: DispatchPlan }
+    | {
+        ok: false;
+        code: "STALE_DISPATCH" | "INVALID_DISPATCH" | "NO_CHANGES";
+        message: string;
+        conflicts: DispatchConflict[];
+    };
+
+const CLOSED_PROJECT_STATUSES = new Set([
+    "Closed Complete",
+    "Closed Lost",
+    "Cancelled",
+]);
+
+function parseDay(value: string, label: string): Date {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        throw new Error(`${label} must use YYYY-MM-DD`);
+    }
+    const parsed = new Date(`${value}T00:00:00.000Z`);
+    if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) {
+        throw new Error(`${label} is not a real calendar date`);
+    }
+    return parsed;
+}
+
+function dateOnly(value: string | null): string | null {
+    return value ? value.slice(0, 10) : null;
+}
+
+function addDays(value: string, amount: number): string {
+    const parsed = parseDay(value.slice(0, 10), "date");
+    parsed.setUTCDate(parsed.getUTCDate() + amount);
+    return parsed.toISOString().slice(0, 10);
+}
+
+function dayDelta(before: string, after: string): number {
+    return Math.round((parseDay(after, "after date").getTime() - parseDay(before, "before date").getTime()) / 86_400_000);
+}
+
+export function normalizeDispatchAssignments(
+    assignments: DispatchAssignment[],
+): DispatchAssignment[] {
+    const byUser = new Map<string, DispatchAssignment>();
+    for (const assignment of assignments) {
+        if (!assignment.userId?.trim()) throw new Error("Dispatch assignments require a userId");
+        if (assignment.role !== "assigned" && assignment.role !== "lead") {
+            throw new Error(`Unsupported task assignment role: ${String(assignment.role)}`);
+        }
+        if (byUser.has(assignment.userId)) {
+            throw new Error(`Duplicate task assignment for user ${assignment.userId}`);
+        }
+        byUser.set(assignment.userId, {
+            userId: assignment.userId,
+            role: assignment.role,
+        });
+    }
+    const normalized = [...byUser.values()].sort((left, right) =>
+        left.userId.localeCompare(right.userId) || left.role.localeCompare(right.role),
+    );
+    if (normalized.filter(assignment => assignment.role === "lead").length > 1) {
+        throw new Error("A task can have at most one lead");
+    }
+    return normalized;
+}
+
+export function dispatchAssignmentsEqual(
+    left: DispatchAssignment[],
+    right: DispatchAssignment[],
+): boolean {
+    const normalizedLeft = normalizeDispatchAssignments(left);
+    const normalizedRight = normalizeDispatchAssignments(right);
+    return normalizedLeft.length === normalizedRight.length
+        && normalizedLeft.every((assignment, index) =>
+            assignment.userId === normalizedRight[index]?.userId
+            && assignment.role === normalizedRight[index]?.role,
+        );
+}
+
+function normalizeRevision(value: string, label: string): string {
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) throw new Error(`${label} must be an ISO timestamp`);
+    return parsed.toISOString();
+}
+
+export function normalizeDispatchIntents(intents: DispatchIntent[]): DispatchIntent[] {
+    if (!Array.isArray(intents) || intents.length === 0) return [];
+    if (intents.length > 1_000) throw new Error("A dispatch cannot contain more than 1,000 intents");
+
+    const normalized = intents.map((intent): DispatchIntent => {
+        if (!intent.projectId?.trim()) throw new Error("Dispatch intents require a projectId");
+        if (intent.kind === "PROJECT_START") {
+            parseDay(intent.startDate, "Project start date");
+            if (!["ALL_TASKS", "NOT_STARTED_TASKS", "MARKER_ONLY"].includes(intent.shiftMode)) {
+                throw new Error(`Unsupported project shift mode: ${String(intent.shiftMode)}`);
+            }
+            const expectedTasks = intent.expectedTasks
+                .map(task => {
+                    if (!task.taskId?.trim()) throw new Error("Expected tasks require a taskId");
+                    return {
+                        taskId: task.taskId,
+                        expectedUpdatedAt: normalizeRevision(task.expectedUpdatedAt, "Task revision"),
+                        expectedAssignments: normalizeDispatchAssignments(task.expectedAssignments),
+                    };
+                })
+                .sort((left, right) => left.taskId.localeCompare(right.taskId));
+            if (new Set(expectedTasks.map(task => task.taskId)).size !== expectedTasks.length) {
+                throw new Error("Project dispatch snapshots cannot contain duplicate tasks");
+            }
+            return {
+                ...intent,
+                expectedUpdatedAt: normalizeRevision(intent.expectedUpdatedAt, "Project revision"),
+                expectedTasks,
+            };
+        }
+        if (!intent.taskId?.trim()) throw new Error("Task dispatch intents require a taskId");
+        if (intent.kind === "TASK_DATES") {
+            const startDate = parseDay(intent.startDate, "Task start date");
+            const endDate = parseDay(intent.endDate, "Task end date");
+            if (endDate < startDate) throw new Error("Task end date cannot be before its start date");
+            return {
+                ...intent,
+                expectedUpdatedAt: normalizeRevision(intent.expectedUpdatedAt, "Task revision"),
+                expectedAssignments: normalizeDispatchAssignments(intent.expectedAssignments),
+            };
+        }
+        return {
+            ...intent,
+            expectedUpdatedAt: normalizeRevision(intent.expectedUpdatedAt, "Task revision"),
+            expectedAssignments: normalizeDispatchAssignments(intent.expectedAssignments),
+            assignments: normalizeDispatchAssignments(intent.assignments),
+        };
+    });
+
+    const seen = new Set<string>();
+    for (const intent of normalized) {
+        const targetId = intent.kind === "PROJECT_START" ? intent.projectId : intent.taskId;
+        const key = `${intent.kind}:${targetId}`;
+        if (seen.has(key)) throw new Error(`Duplicate dispatch intent: ${key}`);
+        seen.add(key);
+    }
+    return normalized.sort((left, right) => {
+        const leftTarget = left.kind === "PROJECT_START" ? left.projectId : left.taskId;
+        const rightTarget = right.kind === "PROJECT_START" ? right.projectId : right.taskId;
+        return left.projectId.localeCompare(right.projectId)
+            || leftTarget.localeCompare(rightTarget)
+            || left.kind.localeCompare(right.kind);
+    });
+}
+
+export function hashDispatchIntents(intents: DispatchIntent[]): string {
+    return createHash("sha256")
+        .update(JSON.stringify(normalizeDispatchIntents(intents)))
+        .digest("hex");
+}
+
+function assignmentSummary(
+    assignments: DispatchAssignment[],
+    usersById: Map<string, DispatchUserSnapshot>,
+): string {
+    if (assignments.length === 0) return "Unassigned";
+    return assignments.map(assignment => {
+        const name = usersById.get(assignment.userId)?.name ?? assignment.userId;
+        return assignment.role === "lead" ? `${name} (lead)` : name;
+    }).join(", ");
+}
+
+function taskDateSummary(
+    task: DispatchTaskSnapshot,
+    before: PersistedDispatchTaskState,
+    after: PersistedDispatchTaskState,
+): string {
+    const startDelta = dayDelta(before.startDate, after.startDate);
+    const endDelta = dayDelta(before.endDate, after.endDate);
+    if (startDelta === endDelta && startDelta !== 0) {
+        return `${task.name}: ${startDelta > 0 ? "+" : ""}${startDelta} day${Math.abs(startDelta) === 1 ? "" : "s"} (${after.startDate})`;
+    }
+    return `${task.name}: ${before.startDate}–${before.endDate} → ${after.startDate}–${after.endDate}`;
+}
+
+function invalid(message: string): DispatchPlanResult {
+    return { ok: false, code: "INVALID_DISPATCH", message, conflicts: [] };
+}
+
+export function buildDispatchPlan(input: {
+    intents: DispatchIntent[];
+    projects: DispatchProjectSnapshot[];
+    tasks: DispatchTaskSnapshot[];
+    users: DispatchUserSnapshot[];
+}): DispatchPlanResult {
+    let intents: DispatchIntent[];
+    try {
+        intents = normalizeDispatchIntents(input.intents);
+    } catch (error) {
+        return invalid(error instanceof Error ? error.message : String(error));
+    }
+    if (intents.length === 0) {
+        return { ok: false, code: "NO_CHANGES", message: "There are no dispatch changes to queue.", conflicts: [] };
+    }
+
+    const projectsById = new Map(input.projects.map(project => [project.id, project]));
+    const tasksById = new Map(input.tasks.map(task => [
+        task.id,
+        { ...task, assignments: normalizeDispatchAssignments(task.assignments) },
+    ]));
+    const usersById = new Map(input.users.map(user => [user.id, user]));
+    const conflicts: DispatchConflict[] = [];
+
+    for (const intent of intents) {
+        const project = projectsById.get(intent.projectId);
+        if (!project) {
+            conflicts.push({ targetType: "PROJECT", targetId: intent.projectId, reason: "MISSING" });
+            continue;
+        }
+        if (intent.kind === "PROJECT_START") {
+            if (project.updatedAt !== intent.expectedUpdatedAt) {
+                conflicts.push({ targetType: "PROJECT", targetId: project.id, reason: "REVISION_CHANGED" });
+            }
+            const actualTasks = [...tasksById.values()]
+                .filter(task => task.projectId === project.id)
+                .sort((left, right) => left.id.localeCompare(right.id));
+            const expectedIds = intent.expectedTasks.map(task => task.taskId);
+            if (actualTasks.length !== expectedIds.length
+                || actualTasks.some((task, index) => task.id !== expectedIds[index])) {
+                conflicts.push({ targetType: "PROJECT", targetId: project.id, reason: "TASK_SET_CHANGED" });
+            }
+            for (const expectedTask of intent.expectedTasks) {
+                const task = tasksById.get(expectedTask.taskId);
+                if (!task || task.projectId !== project.id) {
+                    conflicts.push({ targetType: "TASK", targetId: expectedTask.taskId, reason: "MISSING" });
+                    continue;
+                }
+                if (task.updatedAt !== expectedTask.expectedUpdatedAt) {
+                    conflicts.push({ targetType: "TASK", targetId: task.id, reason: "REVISION_CHANGED" });
+                }
+                if (!dispatchAssignmentsEqual(task.assignments, expectedTask.expectedAssignments)) {
+                    conflicts.push({ targetType: "TASK", targetId: task.id, reason: "ASSIGNMENTS_CHANGED" });
+                }
+            }
+            continue;
+        }
+
+        const task = tasksById.get(intent.taskId);
+        if (!task || task.projectId !== intent.projectId) {
+            conflicts.push({ targetType: "TASK", targetId: intent.taskId, reason: "MISSING" });
+            continue;
+        }
+        if (task.updatedAt !== intent.expectedUpdatedAt) {
+            conflicts.push({ targetType: "TASK", targetId: task.id, reason: "REVISION_CHANGED" });
+        }
+        if (!dispatchAssignmentsEqual(task.assignments, intent.expectedAssignments)) {
+            conflicts.push({ targetType: "TASK", targetId: task.id, reason: "ASSIGNMENTS_CHANGED" });
+        }
+    }
+    if (conflicts.length > 0) {
+        return {
+            ok: false,
+            code: "STALE_DISPATCH",
+            message: "Dispatch changed while you were reviewing.",
+            conflicts: [...new Map(conflicts.map(conflict => [
+                `${conflict.targetType}:${conflict.targetId}:${conflict.reason}`,
+                conflict,
+            ])).values()],
+        };
+    }
+
+    const finalProjects: Record<string, PersistedDispatchProjectState> = {};
+    const finalTasks: Record<string, PersistedDispatchTaskState> = {};
+    const finalAssignments: Record<string, DispatchAssignment[]> = {};
+    for (const project of input.projects) {
+        finalProjects[project.id] = {
+            startDate: dateOnly(project.startDate),
+            endDate: dateOnly(project.endDate),
+        };
+    }
+    for (const task of tasksById.values()) {
+        finalTasks[task.id] = {
+            startDate: dateOnly(task.startDate)!,
+            endDate: dateOnly(task.endDate)!,
+        };
+        finalAssignments[task.id] = normalizeDispatchAssignments(task.assignments);
+    }
+
+    const projectOperations: DispatchProjectOperation[] = [];
+    for (const intent of intents) {
+        if (intent.kind !== "PROJECT_START") continue;
+        const project = projectsById.get(intent.projectId)!;
+        if (CLOSED_PROJECT_STATUSES.has(project.status)) {
+            return invalid(`Cannot dispatch a closed project (${project.status})`);
+        }
+        if (intent.shiftMode === "ALL_TASKS" && project.status !== "Waiting to Start") {
+            return invalid("ALL_TASKS is only valid for Waiting to Start projects");
+        }
+        if (intent.shiftMode === "NOT_STARTED_TASKS" && project.status !== "In Progress") {
+            return invalid("NOT_STARTED_TASKS is only valid for In Progress projects");
+        }
+        const beforeStart = dateOnly(project.startDate);
+        const shiftDays = beforeStart ? dayDelta(beforeStart, intent.startDate) : 0;
+        if (Math.abs(shiftDays) > 365) {
+            return invalid("Project moves cannot exceed 365 days in one dispatch");
+        }
+        const projectState = finalProjects[project.id]!;
+        projectState.startDate = intent.startDate;
+        if (projectState.endDate && projectState.endDate <= intent.startDate) {
+            projectState.endDate = null;
+        }
+        if (shiftDays !== 0 && intent.shiftMode !== "MARKER_ONLY") {
+            for (const task of tasksById.values()) {
+                if (task.projectId !== project.id) continue;
+                if (intent.shiftMode === "NOT_STARTED_TASKS" && task.status !== "Not Started") continue;
+                finalTasks[task.id] = {
+                    startDate: addDays(finalTasks[task.id]!.startDate, shiftDays),
+                    endDate: addDays(finalTasks[task.id]!.endDate, shiftDays),
+                };
+            }
+        }
+        projectOperations.push({
+            projectId: project.id,
+            shiftMode: intent.shiftMode,
+            shiftDays,
+        });
+    }
+
+    for (const intent of intents) {
+        if (intent.kind === "TASK_DATES") {
+            const task = tasksById.get(intent.taskId)!;
+            if (task.type === "milestone" && intent.endDate !== intent.startDate) {
+                return invalid(`Milestone "${task.name}" must start and end on the same day`);
+            }
+            if (task.type !== "milestone" && intent.endDate <= intent.startDate) {
+                return invalid(`Task "${task.name}" must end after it starts`);
+            }
+            finalTasks[task.id] = {
+                startDate: intent.startDate,
+                endDate: intent.endDate,
+            };
+        }
+        if (intent.kind === "TASK_CREW") {
+            finalAssignments[intent.taskId] = normalizeDispatchAssignments(intent.assignments);
+        }
+    }
+
+    const desiredUserIds = new Set(Object.values(finalAssignments).flatMap(assignments =>
+        assignments.map(assignment => assignment.userId),
+    ));
+    const unknownUserIds = [...desiredUserIds].filter(userId => !usersById.has(userId));
+    if (unknownUserIds.length > 0) {
+        return invalid(`Unknown user id(s): ${unknownUserIds.join(", ")}`);
+    }
+    for (const intent of intents) {
+        if (intent.kind !== "TASK_CREW") continue;
+        const beforeIds = new Set(intent.expectedAssignments.map(assignment => assignment.userId));
+        const inactiveAdditions = intent.assignments.filter(assignment =>
+            !beforeIds.has(assignment.userId)
+            && usersById.get(assignment.userId)?.status !== "ACTIVATED",
+        );
+        if (inactiveAdditions.length > 0) {
+            return invalid(`Task crew additions must be ACTIVATED users: ${inactiveAdditions.map(row =>
+                usersById.get(row.userId)?.name ?? row.userId,
+            ).join(", ")}`);
+        }
+    }
+
+    const changes: DispatchChange[] = [];
+    for (const project of [...input.projects].sort((left, right) => left.id.localeCompare(right.id))) {
+        const before = {
+            startDate: dateOnly(project.startDate),
+            endDate: dateOnly(project.endDate),
+        };
+        const after = finalProjects[project.id]!;
+        if (before.startDate !== after.startDate || before.endDate !== after.endDate) {
+            changes.push({
+                projectId: project.id,
+                targetType: "PROJECT",
+                targetId: project.id,
+                kind: "PROJECT_START",
+                before,
+                after: { ...after },
+                summary: `${project.name}: start ${before.startDate ?? "Unscheduled"} → ${after.startDate ?? "Unscheduled"}${before.endDate && !after.endDate ? "; saved end date cleared" : ""}`,
+            });
+        }
+    }
+
+    const changedTaskIds = new Set<string>();
+    for (const task of [...tasksById.values()].sort((left, right) =>
+        left.projectId.localeCompare(right.projectId) || left.id.localeCompare(right.id),
+    )) {
+        const beforeDates = {
+            startDate: dateOnly(task.startDate)!,
+            endDate: dateOnly(task.endDate)!,
+        };
+        const afterDates = finalTasks[task.id]!;
+        if (beforeDates.startDate !== afterDates.startDate || beforeDates.endDate !== afterDates.endDate) {
+            changes.push({
+                projectId: task.projectId,
+                targetType: "TASK",
+                targetId: task.id,
+                kind: "TASK_DATES",
+                before: beforeDates,
+                after: { ...afterDates },
+                summary: taskDateSummary(task, beforeDates, afterDates),
+            });
+            changedTaskIds.add(task.id);
+        }
+        const beforeCrew = normalizeDispatchAssignments(task.assignments);
+        const afterCrew = finalAssignments[task.id]!;
+        if (!dispatchAssignmentsEqual(beforeCrew, afterCrew)) {
+            changes.push({
+                projectId: task.projectId,
+                targetType: "TASK",
+                targetId: task.id,
+                kind: "TASK_CREW",
+                before: { assignments: beforeCrew },
+                after: { assignments: afterCrew },
+                summary: `${task.name}: ${assignmentSummary(beforeCrew, usersById)} → ${assignmentSummary(afterCrew, usersById)}`,
+            });
+            changedTaskIds.add(task.id);
+        }
+    }
+
+    if (changes.length === 0) {
+        return { ok: false, code: "NO_CHANGES", message: "There are no dispatch changes to queue.", conflicts: [] };
+    }
+
+    const recipientIds = new Set<string>();
+    for (const taskId of changedTaskIds) {
+        const task = tasksById.get(taskId)!;
+        for (const assignment of [
+            ...task.assignments,
+            ...finalAssignments[taskId]!,
+        ]) {
+            if (usersById.get(assignment.userId)?.status === "ACTIVATED") {
+                recipientIds.add(assignment.userId);
+            }
+        }
+    }
+
+    const reconciliation: DispatchReconciliationState = {
+        projects: {},
+        tasks: {},
+        assignments: {},
+    };
+    for (const change of changes) {
+        if (change.targetType === "PROJECT") {
+            reconciliation.projects[change.targetId] = { ...finalProjects[change.targetId]! };
+        } else {
+            reconciliation.tasks[change.targetId] = { ...finalTasks[change.targetId]! };
+            reconciliation.assignments[change.targetId] = [...finalAssignments[change.targetId]!];
+        }
+    }
+
+    return {
+        ok: true,
+        plan: {
+            changes,
+            reconciliation,
+            recipientIds: [...recipientIds].sort(),
+            projectOperations,
+            finalProjects,
+            finalTasks,
+            finalAssignments,
+        },
+    };
+}
+
+export function reconciliationFromChanges(
+    changes: DispatchChange[],
+): DispatchReconciliationState {
+    const reconciliation: DispatchReconciliationState = {
+        projects: {},
+        tasks: {},
+        assignments: {},
+    };
+    for (const change of changes) {
+        if (change.targetType === "PROJECT") {
+            reconciliation.projects[change.targetId] = {
+                startDate: typeof change.after.startDate === "string" ? change.after.startDate : null,
+                endDate: typeof change.after.endDate === "string" ? change.after.endDate : null,
+            };
+            continue;
+        }
+        if (change.kind === "TASK_DATES") {
+            if (typeof change.after.startDate === "string" && typeof change.after.endDate === "string") {
+                reconciliation.tasks[change.targetId] = {
+                    startDate: change.after.startDate,
+                    endDate: change.after.endDate,
+                };
+            }
+        }
+        if (change.kind === "TASK_CREW") {
+            const assignments = Array.isArray(change.after.assignments)
+                ? change.after.assignments.filter((row): row is DispatchAssignment =>
+                    Boolean(row)
+                    && typeof row === "object"
+                    && "userId" in row
+                    && "role" in row
+                    && typeof row.userId === "string"
+                    && (row.role === "assigned" || row.role === "lead"),
+                )
+                : [];
+            reconciliation.assignments[change.targetId] = normalizeDispatchAssignments(assignments);
+        }
+    }
+    return reconciliation;
+}

--- a/src/lib/dispatch-publication.ts
+++ b/src/lib/dispatch-publication.ts
@@ -1,0 +1,569 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "./prisma";
+import { withTxRetry } from "./tx-retry";
+import {
+    setProjectStartDateInTransaction,
+    shiftNotStartedTasksInTransaction,
+    touchTaskAssignmentRevision,
+} from "./schedule-core";
+import {
+    buildDispatchPlan,
+    hashDispatchIntents,
+    normalizeDispatchAssignments,
+    normalizeDispatchIntents,
+    reconciliationFromChanges,
+    type DispatchChange,
+    type DispatchConflict,
+    type DispatchIntent,
+    type DispatchProjectSnapshot,
+    type DispatchReconciliationState,
+    type DispatchTaskSnapshot,
+    type DispatchUserSnapshot,
+} from "./dispatch-intent";
+
+export interface PublishDispatchInput {
+    clientRequestId: string;
+    actor: {
+        userId: string | null;
+        name: string;
+    };
+    intents: DispatchIntent[];
+    dryRun?: boolean;
+}
+
+export interface PublishDispatchSuccess {
+    ok: true;
+    publicationId: string | null;
+    replayed: boolean;
+    dryRun: boolean;
+    changes: DispatchChange[];
+    reconciliation: DispatchReconciliationState;
+    deliveryCount: number;
+    notes: string[];
+}
+
+export interface PublishDispatchFailure {
+    ok: false;
+    code:
+        | "STALE_DISPATCH"
+        | "INVALID_DISPATCH"
+        | "NO_CHANGES"
+        | "REQUEST_ID_CONFLICT"
+        | "FORBIDDEN"
+        | "DISPATCH_FAILED";
+    message: string;
+    conflicts: DispatchConflict[];
+}
+
+export type PublishDispatchResult =
+    | PublishDispatchSuccess
+    | PublishDispatchFailure;
+
+type DbClient = Prisma.TransactionClient | typeof prisma;
+
+interface ExistingPublication {
+    id: string;
+    requestHash: string;
+    changes: {
+        projectId: string;
+        targetType: string;
+        targetId: string;
+        kind: string;
+        before: Prisma.JsonValue;
+        after: Prisma.JsonValue;
+        summary: string;
+    }[];
+    deliveries: { id: string }[];
+}
+
+function invalid(message: string): PublishDispatchFailure {
+    return {
+        ok: false,
+        code: "INVALID_DISPATCH",
+        message,
+        conflicts: [],
+    };
+}
+
+function asJsonRecord(value: Prisma.JsonValue): Record<string, unknown> {
+    return value && typeof value === "object" && !Array.isArray(value)
+        ? value as Record<string, unknown>
+        : {};
+}
+
+function changesFromPublication(publication: ExistingPublication): DispatchChange[] {
+    return publication.changes.map(change => ({
+        projectId: change.projectId,
+        targetType: change.targetType === "PROJECT" ? "PROJECT" : "TASK",
+        targetId: change.targetId,
+        kind: change.kind === "PROJECT_START"
+            ? "PROJECT_START"
+            : change.kind === "TASK_CREW"
+                ? "TASK_CREW"
+                : "TASK_DATES",
+        before: asJsonRecord(change.before),
+        after: asJsonRecord(change.after),
+        summary: change.summary,
+    }));
+}
+
+async function findExistingPublication(
+    client: DbClient,
+    clientRequestId: string,
+): Promise<ExistingPublication | null> {
+    return client.dispatchPublication.findUnique({
+        where: { clientRequestId },
+        select: {
+            id: true,
+            requestHash: true,
+            changes: {
+                orderBy: { position: "asc" },
+                select: {
+                    projectId: true,
+                    targetType: true,
+                    targetId: true,
+                    kind: true,
+                    before: true,
+                    after: true,
+                    summary: true,
+                },
+            },
+            deliveries: { select: { id: true } },
+        },
+    });
+}
+
+function replayResult(
+    publication: ExistingPublication,
+    requestHash: string,
+): PublishDispatchResult {
+    if (publication.requestHash !== requestHash) {
+        return {
+            ok: false,
+            code: "REQUEST_ID_CONFLICT",
+            message: "This dispatch request ID was already used for different changes.",
+            conflicts: [],
+        };
+    }
+    const changes = changesFromPublication(publication);
+    return {
+        ok: true,
+        publicationId: publication.id,
+        replayed: true,
+        dryRun: false,
+        changes,
+        reconciliation: reconciliationFromChanges(changes),
+        deliveryCount: publication.deliveries.length,
+        notes: [],
+    };
+}
+
+function isClientRequestUniqueError(error: unknown): boolean {
+    if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== "P2002") {
+        return false;
+    }
+    return /clientRequestId/i.test(JSON.stringify(error.meta ?? {}));
+}
+
+function changedCrewTaskIds(
+    changes: DispatchChange[],
+): Set<string> {
+    return new Set(changes
+        .filter(change => change.kind === "TASK_CREW")
+        .map(change => change.targetId));
+}
+
+function changedDateTaskIds(
+    changes: DispatchChange[],
+): Set<string> {
+    return new Set(changes
+        .filter(change => change.kind === "TASK_DATES")
+        .map(change => change.targetId));
+}
+
+async function applyPlan(
+    tx: Prisma.TransactionClient,
+    input: PublishDispatchInput,
+    requestHash: string,
+    plan: Extract<ReturnType<typeof buildDispatchPlan>, { ok: true }>["plan"],
+    projects: DispatchProjectSnapshot[],
+    tasks: DispatchTaskSnapshot[],
+    users: DispatchUserSnapshot[],
+): Promise<PublishDispatchSuccess> {
+    const projectsById = new Map(projects.map(project => [project.id, project]));
+    const tasksById = new Map(tasks.map(task => [task.id, task]));
+    const usersById = new Map(users.map(user => [user.id, user]));
+    const notes: string[] = [];
+    const changedProjectIds = new Set(plan.changes
+        .filter(change => change.targetType === "PROJECT")
+        .map(change => change.targetId));
+
+    for (const operation of plan.projectOperations.sort((left, right) =>
+        left.projectId.localeCompare(right.projectId),
+    )) {
+        if (!changedProjectIds.has(operation.projectId) && operation.shiftDays === 0) continue;
+        const projectState = plan.finalProjects[operation.projectId]!;
+        const markerResult = await setProjectStartDateInTransaction(tx, {
+            projectId: operation.projectId,
+            startDate: projectState.startDate
+                ? new Date(`${projectState.startDate}T00:00:00.000Z`)
+                : null,
+            shiftJobTasks: operation.shiftMode === "ALL_TASKS",
+            actor: { type: "TEAM", name: input.actor.name },
+            writeActivityLog: false,
+        });
+        notes.push(...markerResult.notes);
+        if (operation.shiftMode === "NOT_STARTED_TASKS" && operation.shiftDays !== 0) {
+            const shiftResult = await shiftNotStartedTasksInTransaction(tx, {
+                projectId: operation.projectId,
+                deltaDays: operation.shiftDays,
+                actor: { type: "TEAM", name: input.actor.name },
+                writeActivityLog: false,
+            });
+            notes.push(...shiftResult.notes);
+        }
+    }
+
+    const dateTaskIds = changedDateTaskIds(plan.changes);
+    const persistedDateRows = dateTaskIds.size > 0
+        ? await tx.scheduleTask.findMany({
+            where: { id: { in: [...dateTaskIds] } },
+            select: { id: true, startDate: true, endDate: true },
+        })
+        : [];
+    const persistedDatesById = new Map(persistedDateRows.map(task => [task.id, task]));
+    for (const taskId of [...dateTaskIds].sort((left, right) => {
+        const leftTask = tasksById.get(left)!;
+        const rightTask = tasksById.get(right)!;
+        return leftTask.projectId.localeCompare(rightTask.projectId) || left.localeCompare(right);
+    })) {
+        const state = plan.finalTasks[taskId]!;
+        const persisted = persistedDatesById.get(taskId);
+        if (persisted
+            && persisted.startDate.toISOString().slice(0, 10) === state.startDate
+            && persisted.endDate.toISOString().slice(0, 10) === state.endDate) {
+            continue;
+        }
+        await tx.scheduleTask.update({
+            where: { id: taskId },
+            data: {
+                startDate: new Date(`${state.startDate}T00:00:00.000Z`),
+                endDate: new Date(`${state.endDate}T00:00:00.000Z`),
+            },
+        });
+    }
+
+    const crewTaskIds = changedCrewTaskIds(plan.changes);
+    for (const taskId of [...crewTaskIds].sort((left, right) => {
+        const leftTask = tasksById.get(left)!;
+        const rightTask = tasksById.get(right)!;
+        return leftTask.projectId.localeCompare(rightTask.projectId) || left.localeCompare(right);
+    })) {
+        const current = new Map(tasksById.get(taskId)!.assignments.map(assignment => [assignment.userId, assignment]));
+        const desired = new Map(plan.finalAssignments[taskId]!.map(assignment => [assignment.userId, assignment]));
+        const removeIds = [...current.keys()].filter(userId => !desired.has(userId));
+        if (removeIds.length > 0) {
+            await tx.taskAssignment.deleteMany({
+                where: { taskId, userId: { in: removeIds } },
+            });
+        }
+        for (const assignment of desired.values()) {
+            const existing = current.get(assignment.userId);
+            if (!existing) {
+                await tx.taskAssignment.create({
+                    data: { taskId, userId: assignment.userId, role: assignment.role },
+                });
+            } else if (existing.role !== assignment.role) {
+                await tx.taskAssignment.update({
+                    where: { taskId_userId: { taskId, userId: assignment.userId } },
+                    data: { role: assignment.role },
+                });
+            }
+        }
+        // Assignment rows have no updatedAt of their own. Touch the parent task
+        // under the already-held lock so every assignment mutation advances the
+        // optimistic revision contract.
+        await touchTaskAssignmentRevision(tx, taskId);
+    }
+
+    const publication = await tx.dispatchPublication.create({
+        data: {
+            clientRequestId: input.clientRequestId,
+            requestHash,
+            publishedById: input.actor.userId,
+            publishedByName: input.actor.name,
+        },
+    });
+    await tx.dispatchPublicationChange.createMany({
+        data: plan.changes.map((change, position) => ({
+            publicationId: publication.id,
+            position,
+            projectId: change.projectId,
+            targetType: change.targetType,
+            targetId: change.targetId,
+            kind: change.kind,
+            before: change.before as Prisma.InputJsonValue,
+            after: change.after as Prisma.InputJsonValue,
+            summary: change.summary,
+        })),
+    });
+
+    const taskRecipientIds = new Map<string, Set<string>>();
+    for (const task of tasks) {
+        taskRecipientIds.set(task.id, new Set([
+            ...task.assignments.map(assignment => assignment.userId),
+            ...(plan.finalAssignments[task.id] ?? []).map(assignment => assignment.userId),
+        ]));
+    }
+    for (const userId of plan.recipientIds) {
+        const relevantTaskChanges = plan.changes.filter(change =>
+            change.targetType === "TASK"
+            && taskRecipientIds.get(change.targetId)?.has(userId),
+        );
+        const relevantProjectIds = new Set(relevantTaskChanges.map(change => change.projectId));
+        const payloadChanges = plan.changes.filter(change =>
+            change.targetType === "TASK"
+                ? relevantTaskChanges.includes(change)
+                : relevantProjectIds.has(change.projectId),
+        );
+        const destination = `user:${userId}`;
+        await tx.chatDelivery.create({
+            data: {
+                publicationId: publication.id,
+                destination,
+                kind: "dispatch_publication",
+                payload: {
+                    publicationId: publication.id,
+                    destination,
+                    recipient: {
+                        userId,
+                        name: usersById.get(userId)?.name ?? userId,
+                    },
+                    publishedBy: {
+                        userId: input.actor.userId,
+                        name: input.actor.name,
+                    },
+                    publishedAt: publication.publishedAt.toISOString(),
+                    changes: payloadChanges.map(change => ({
+                        projectId: change.projectId,
+                        targetType: change.targetType,
+                        targetId: change.targetId,
+                        kind: change.kind,
+                        before: change.before,
+                        after: change.after,
+                        summary: change.summary,
+                    })),
+                } as Prisma.InputJsonValue,
+                status: "PENDING",
+            },
+        });
+    }
+
+    const publicationProjectIds = [...new Set(plan.changes.map(change => change.projectId))].sort();
+    for (const projectId of publicationProjectIds) {
+        const projectChanges = plan.changes.filter(change => change.projectId === projectId);
+        await tx.activityLog.create({
+            data: {
+                projectId,
+                actorType: "TEAM",
+                actorName: input.actor.name,
+                action: "published_dispatch",
+                entityType: "dispatch_publication",
+                entityId: publication.id,
+                entityName: projectsById.get(projectId)?.name ?? "Dispatch",
+                metadata: JSON.stringify({
+                    publicationId: publication.id,
+                    clientRequestId: input.clientRequestId,
+                    changes: projectChanges.map(change => change.summary),
+                    deliveryPending: true,
+                }),
+            },
+        });
+    }
+
+    return {
+        ok: true,
+        publicationId: publication.id,
+        replayed: false,
+        dryRun: false,
+        changes: plan.changes,
+        reconciliation: plan.reconciliation,
+        deliveryCount: plan.recipientIds.length,
+        notes,
+    };
+}
+
+export async function publishDispatch(
+    rawInput: PublishDispatchInput,
+): Promise<PublishDispatchResult> {
+    const clientRequestId = rawInput.clientRequestId?.trim();
+    if (!clientRequestId || clientRequestId.length > 200) {
+        return invalid("clientRequestId is required and cannot exceed 200 characters");
+    }
+    const actorName = rawInput.actor?.name?.trim();
+    if (!actorName) return invalid("A publisher name is required");
+
+    let intents: DispatchIntent[];
+    let requestHash: string;
+    try {
+        intents = normalizeDispatchIntents(rawInput.intents);
+        requestHash = hashDispatchIntents(intents);
+    } catch (error) {
+        return invalid(error instanceof Error ? error.message : String(error));
+    }
+    const input: PublishDispatchInput = {
+        ...rawInput,
+        clientRequestId,
+        actor: { userId: rawInput.actor.userId ?? null, name: actorName },
+        intents,
+    };
+
+    const existing = await findExistingPublication(prisma, clientRequestId);
+    if (existing) return replayResult(existing, requestHash);
+
+    try {
+        return await withTxRetry(() => prisma.$transaction(async tx => {
+            const firstReplayCheck = await findExistingPublication(tx, clientRequestId);
+            if (firstReplayCheck) return replayResult(firstReplayCheck, requestHash);
+
+            const projectIds = [...new Set(intents.map(intent => intent.projectId))].sort();
+            if (projectIds.length > 0) {
+                await tx.$queryRaw`
+                    SELECT "id"
+                    FROM "Project"
+                    WHERE "id" IN (${Prisma.join(projectIds)})
+                    ORDER BY "id"
+                    FOR UPDATE
+                `;
+            }
+            const lockedTaskRows = projectIds.length > 0
+                ? await tx.$queryRaw<{ id: string; projectId: string }[]>`
+                    SELECT "id", "projectId"
+                    FROM "ScheduleTask"
+                    WHERE "projectId" IN (${Prisma.join(projectIds)})
+                    ORDER BY "projectId", "id"
+                    FOR UPDATE
+                `
+                : [];
+            const taskIds = lockedTaskRows.map(task => task.id);
+            if (taskIds.length > 0) {
+                await tx.$queryRaw`
+                    SELECT "id"
+                    FROM "TaskAssignment"
+                    WHERE "taskId" IN (${Prisma.join(taskIds)})
+                    ORDER BY "taskId", "userId"
+                    FOR UPDATE
+                `;
+            }
+
+            // The first transaction with this key may have committed while this
+            // one waited on a target lock. Recheck before any stale comparison.
+            const replayAfterLocks = await findExistingPublication(tx, clientRequestId);
+            if (replayAfterLocks) return replayResult(replayAfterLocks, requestHash);
+
+            const [projectRows, taskRows] = await Promise.all([
+                tx.project.findMany({
+                    where: { id: { in: projectIds } },
+                    orderBy: { id: "asc" },
+                    select: {
+                        id: true,
+                        name: true,
+                        status: true,
+                        startDate: true,
+                        endDate: true,
+                        updatedAt: true,
+                    },
+                }),
+                tx.scheduleTask.findMany({
+                    where: { id: { in: taskIds } },
+                    orderBy: [{ projectId: "asc" }, { id: "asc" }],
+                    select: {
+                        id: true,
+                        projectId: true,
+                        name: true,
+                        type: true,
+                        status: true,
+                        startDate: true,
+                        endDate: true,
+                        updatedAt: true,
+                        assignments: {
+                            orderBy: [{ userId: "asc" }, { role: "asc" }],
+                            select: { userId: true, role: true },
+                        },
+                    },
+                }),
+            ]);
+
+            const desiredUserIds = intents.flatMap(intent =>
+                intent.kind === "TASK_CREW"
+                    ? intent.assignments.map(assignment => assignment.userId)
+                    : [],
+            );
+            const userIds = [...new Set([
+                ...taskRows.flatMap(task => task.assignments.map(assignment => assignment.userId)),
+                ...desiredUserIds,
+            ])].sort();
+            const userRows = userIds.length > 0
+                ? await tx.user.findMany({
+                    where: { id: { in: userIds } },
+                    orderBy: { id: "asc" },
+                    select: { id: true, name: true, email: true, status: true },
+                })
+                : [];
+
+            const projects: DispatchProjectSnapshot[] = projectRows.map(project => ({
+                id: project.id,
+                name: project.name,
+                status: project.status,
+                startDate: project.startDate?.toISOString() ?? null,
+                endDate: project.endDate?.toISOString() ?? null,
+                updatedAt: project.updatedAt.toISOString(),
+            }));
+            const tasks: DispatchTaskSnapshot[] = taskRows
+                .filter((task): task is typeof task & { projectId: string } => Boolean(task.projectId))
+                .map(task => ({
+                    id: task.id,
+                    projectId: task.projectId,
+                    name: task.name,
+                    type: task.type,
+                    status: task.status,
+                    startDate: task.startDate.toISOString(),
+                    endDate: task.endDate.toISOString(),
+                    updatedAt: task.updatedAt.toISOString(),
+                    assignments: normalizeDispatchAssignments(task.assignments.map(assignment => ({
+                        userId: assignment.userId,
+                        role: assignment.role === "lead" ? "lead" : "assigned",
+                    }))),
+                }));
+            const users: DispatchUserSnapshot[] = userRows.map(user => ({
+                id: user.id,
+                name: user.name || user.email,
+                status: user.status,
+            }));
+
+            const planned = buildDispatchPlan({ intents, projects, tasks, users });
+            if (!planned.ok) return planned;
+            if (input.dryRun) {
+                return {
+                    ok: true,
+                    publicationId: null,
+                    replayed: false,
+                    dryRun: true,
+                    changes: planned.plan.changes,
+                    reconciliation: planned.plan.reconciliation,
+                    deliveryCount: planned.plan.recipientIds.length,
+                    notes: [],
+                } satisfies PublishDispatchSuccess;
+            }
+            return applyPlan(tx, input, requestHash, planned.plan, projects, tasks, users);
+        }, {
+            maxWait: 5_000,
+            timeout: 20_000,
+        }));
+    } catch (error) {
+        if (!isClientRequestUniqueError(error)) throw error;
+        const concurrent = await findExistingPublication(prisma, clientRequestId);
+        if (!concurrent) throw error;
+        return replayResult(concurrent, requestHash);
+    }
+}

--- a/src/lib/schedule-core.ts
+++ b/src/lib/schedule-core.ts
@@ -25,6 +25,55 @@ export const CONTRACT_ESTIMATE_STATUSES = ["Approved", "Invoiced", "Partially Pa
 
 export type ScheduleActor = { type: "TEAM" | "SYSTEM"; name: string };
 
+export interface LockedTaskAssignmentParent {
+    id: string;
+    projectId: string;
+    name: string;
+}
+
+/**
+ * Canonical lock order for every TaskAssignment writer: parent Project first,
+ * then the ScheduleTask row. The final read verifies the task did not move
+ * between the caller's access check and lock acquisition.
+ */
+export async function lockTaskAssignmentParent(
+    tx: Prisma.TransactionClient,
+    taskId: string,
+    expectedProjectId?: string,
+): Promise<LockedTaskAssignmentParent> {
+    const reference = expectedProjectId
+        ? { projectId: expectedProjectId }
+        : await tx.scheduleTask.findUnique({
+            where: { id: taskId },
+            select: { projectId: true },
+        });
+    if (!reference?.projectId) throw new Error("Task is not attached to a project");
+    await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${reference.projectId} FOR UPDATE`;
+    await tx.$queryRaw`SELECT id FROM "ScheduleTask" WHERE id = ${taskId} FOR UPDATE`;
+    const locked = await tx.scheduleTask.findUnique({
+        where: { id: taskId },
+        select: { id: true, projectId: true, name: true },
+    });
+    if (!locked || locked.projectId !== reference.projectId) {
+        throw new Error("Task moved to another project; refresh and retry");
+    }
+    return {
+        id: locked.id,
+        projectId: locked.projectId,
+        name: locked.name,
+    };
+}
+
+export async function touchTaskAssignmentRevision(
+    tx: Prisma.TransactionClient,
+    taskId: string,
+): Promise<void> {
+    await tx.scheduleTask.update({
+        where: { id: taskId },
+        data: { updatedAt: new Date() },
+    });
+}
+
 // The company shop — 5305 NE 121st Ave, Vancouver WA — anchor point for the
 // crew-availability panel's "how far is this job" distance (not money; safe
 // to serialize for every role).
@@ -72,6 +121,7 @@ export interface PipelineCrewMember {
 export interface PipelineProject {
     id: string;
     name: string;
+    updatedAt: string;
     client: string | null;
     location: string | null;
     status: string;
@@ -136,7 +186,7 @@ export async function getCompanyPipeline(): Promise<CompanyPipeline> {
             where: { status: { in: OPEN_PROJECT_STATUSES } },
             orderBy: { createdAt: "desc" },
             select: {
-                id: true, name: true, status: true, startDate: true, endDate: true, color: true,
+                id: true, name: true, status: true, startDate: true, endDate: true, updatedAt: true, color: true,
                 location: true,
                 locationLat: true, locationLng: true,
                 client: { select: { name: true } },
@@ -154,6 +204,7 @@ export async function getCompanyPipeline(): Promise<CompanyPipeline> {
     const bucket = (p: (typeof projects)[number]): PipelineProject => ({
         id: p.id,
         name: p.name,
+        updatedAt: p.updatedAt.toISOString(),
         client: p.client?.name ?? null,
         location: p.location,
         status: p.status,
@@ -345,18 +396,28 @@ export interface SetProjectStartDateResult {
  *
  * Every call writes an ActivityLog row (actorType TEAM for UI, SYSTEM for MCP).
  */
-export async function setProjectStartDate(input: {
+export interface SetProjectStartDateInput {
     projectId: string;
     startDate: Date | null;
     shiftJobTasks?: boolean;
     actor: ScheduleActor;
-}): Promise<SetProjectStartDateResult> {
+}
+
+interface InternalSetProjectStartDateInput extends SetProjectStartDateInput {
+    transaction?: Prisma.TransactionClient;
+    writeActivityLog?: boolean;
+    skipAutoGenerate?: boolean;
+}
+
+async function runSetProjectStartDate(
+    input: InternalSetProjectStartDateInput,
+): Promise<SetProjectStartDateResult> {
     const { projectId, startDate, actor } = input;
     const shiftJobTasks = input.shiftJobTasks !== false; // default true
 
     // Retry wrapper per the repo's money-path convention (see tx-retry.ts): a
     // rolled-back write-conflict on the shared pooler re-runs against fresh state.
-    const result = await withTxRetry(() => prisma.$transaction(async (tx) => {
+    const execute = async (tx: Prisma.TransactionClient) => {
         // Serialize concurrent start-date moves: lock the project row BEFORE
         // reading the current marker, so two moves can never compute their
         // deltas from the same stale startDate (lost-update / double-shift race).
@@ -579,25 +640,27 @@ export async function setProjectStartDate(input: {
             }
         }
 
-        await tx.activityLog.create({
-            data: {
-                projectId,
-                actorType: actor.type,
-                actorName: actor.name,
-                action: "moved_project_start",
-                entityType: "project",
-                entityId: projectId,
-                entityName: project.name,
-                metadata: JSON.stringify({
-                    previousStartDate: previousStartDate ? previousStartDate.toISOString() : null,
-                    startDate: startDate ? startDate.toISOString() : null,
-                    shiftedTasks,
-                    shiftedMilestones,
-                    skippedQbMilestones: skippedQbMilestones.length,
-                    notes,
-                }),
-            },
-        });
+        if (input.writeActivityLog !== false) {
+            await tx.activityLog.create({
+                data: {
+                    projectId,
+                    actorType: actor.type,
+                    actorName: actor.name,
+                    action: "moved_project_start",
+                    entityType: "project",
+                    entityId: projectId,
+                    entityName: project.name,
+                    metadata: JSON.stringify({
+                        previousStartDate: previousStartDate ? previousStartDate.toISOString() : null,
+                        startDate: startDate ? startDate.toISOString() : null,
+                        shiftedTasks,
+                        shiftedMilestones,
+                        skippedQbMilestones: skippedQbMilestones.length,
+                        notes,
+                    }),
+                },
+            });
+        }
 
         return {
             projectId,
@@ -609,13 +672,16 @@ export async function setProjectStartDate(input: {
             skippedQbMilestones,
             notes,
         };
-    }));
+    };
+    const result = input.transaction
+        ? await execute(input.transaction)
+        : await withTxRetry(() => prisma.$transaction(execute));
 
     // Post-commit best-effort generation hook (PB-pipeline-003): sign first,
     // date later ⇒ the schedule appears by itself. Fires when the project ends
     // up dated with zero tasks and a qualifying estimate; failures are caught
     // and surface in notes[], never fail the date move.
-    if (startDate !== null) {
+    if (!input.skipAutoGenerate && startDate !== null) {
         try {
             const [taskCount, qualifying] = await Promise.all([
                 prisma.scheduleTask.count({ where: { projectId } }),
@@ -642,6 +708,24 @@ export async function setProjectStartDate(input: {
     return result;
 }
 
+export async function setProjectStartDate(
+    input: SetProjectStartDateInput,
+): Promise<SetProjectStartDateResult> {
+    return runSetProjectStartDate(input);
+}
+
+export async function setProjectStartDateInTransaction(
+    tx: Prisma.TransactionClient,
+    input: SetProjectStartDateInput & { writeActivityLog?: boolean },
+): Promise<SetProjectStartDateResult> {
+    return runSetProjectStartDate({
+        ...input,
+        transaction: tx,
+        writeActivityLog: input.writeActivityLog,
+        skipAutoGenerate: true,
+    });
+}
+
 export interface ShiftNotStartedTasksInput {
     projectId: string;
     deltaDays: number;
@@ -662,8 +746,13 @@ export interface ShiftNotStartedTasksResult {
  * Pending payment milestones stay fixed and are returned as operator notes;
  * this path never changes the project marker or any payment/money row.
  */
-export async function shiftNotStartedTasks(
-    input: ShiftNotStartedTasksInput,
+interface InternalShiftNotStartedTasksInput extends ShiftNotStartedTasksInput {
+    transaction?: Prisma.TransactionClient;
+    writeActivityLog?: boolean;
+}
+
+async function runShiftNotStartedTasks(
+    input: InternalShiftNotStartedTasksInput,
 ): Promise<ShiftNotStartedTasksResult> {
     const { projectId, deltaDays, actor } = input;
     if (!Number.isSafeInteger(deltaDays) || deltaDays === 0) {
@@ -676,7 +765,7 @@ export async function shiftNotStartedTasks(
         throw new Error("deltaDays cannot exceed 365 days in a single shift");
     }
 
-    return withTxRetry(() => prisma.$transaction(async (tx) => {
+    const execute = async (tx: Prisma.TransactionClient) => {
         // Keep this lock first: all schedule moves serialize on Project before
         // selecting child tasks, matching setProjectStartDate's lock family.
         await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${projectId} FOR UPDATE`;
@@ -758,23 +847,25 @@ export async function shiftNotStartedTasks(
             }
         }
 
-        await tx.activityLog.create({
-            data: {
-                projectId,
-                actorType: actor.type,
-                actorName: actor.name,
-                action: "shift_not_started_tasks",
-                entityType: "project",
-                entityId: projectId,
-                entityName: project.name,
-                metadata: JSON.stringify({
-                    deltaDays,
-                    shiftedTasks: shiftedTaskIds.length,
-                    shiftedTaskIds,
-                    explicitDueDateMilestones: notes.length,
-                }),
-            },
-        });
+        if (input.writeActivityLog !== false) {
+            await tx.activityLog.create({
+                data: {
+                    projectId,
+                    actorType: actor.type,
+                    actorName: actor.name,
+                    action: "shift_not_started_tasks",
+                    entityType: "project",
+                    entityId: projectId,
+                    entityName: project.name,
+                    metadata: JSON.stringify({
+                        deltaDays,
+                        shiftedTasks: shiftedTaskIds.length,
+                        shiftedTaskIds,
+                        explicitDueDateMilestones: notes.length,
+                    }),
+                },
+            });
+        }
 
         return {
             projectId,
@@ -784,7 +875,27 @@ export async function shiftNotStartedTasks(
             shiftedTasks: shiftedTaskIds.length,
             notes,
         };
-    }));
+    };
+    return input.transaction
+        ? execute(input.transaction)
+        : withTxRetry(() => prisma.$transaction(execute));
+}
+
+export async function shiftNotStartedTasks(
+    input: ShiftNotStartedTasksInput,
+): Promise<ShiftNotStartedTasksResult> {
+    return runShiftNotStartedTasks(input);
+}
+
+export async function shiftNotStartedTasksInTransaction(
+    tx: Prisma.TransactionClient,
+    input: ShiftNotStartedTasksInput & { writeActivityLog?: boolean },
+): Promise<ShiftNotStartedTasksResult> {
+    return runShiftNotStartedTasks({
+        ...input,
+        transaction: tx,
+        writeActivityLog: input.writeActivityLog,
+    });
 }
 
 export interface CashflowBucket {
@@ -1902,6 +2013,7 @@ export interface DashboardTaskComment {
 export interface DashboardTaskRow {
     id: string;
     name: string;
+    updatedAt: string;
     startDate: string;
     endDate: string;
     color: string | null;
@@ -2177,7 +2289,7 @@ export async function getCompanyDashboardData(
             where: { projectId: { in: rowIds } },
             orderBy: [{ order: "asc" }, { startDate: "asc" }, { id: "asc" }],
             select: {
-                id: true, projectId: true, name: true, startDate: true, endDate: true, color: true, parentId: true, progress: true, status: true, type: true,
+                id: true, projectId: true, name: true, startDate: true, endDate: true, updatedAt: true, color: true, parentId: true, progress: true, status: true, type: true,
                 doneWhen: true, blockedReason: true, scheduledTime: true, confirmationStatus: true,
                 assignments: {
                     orderBy: { createdAt: "asc" },
@@ -2203,6 +2315,7 @@ export async function getCompanyDashboardData(
         rows.push({
             id: task.id,
             name: task.name,
+            updatedAt: task.updatedAt.toISOString(),
             startDate: task.startDate.toISOString(),
             endDate: task.endDate.toISOString(),
             color: task.color,
@@ -2860,14 +2973,7 @@ export async function setTaskCrew(input: {
     actor: ScheduleActor;
 }): Promise<{ taskId: string; projectId: string; assignments: { id: string; userId: string; name: string }[] }> {
     return withTxRetry(() => prisma.$transaction(async (tx) => {
-        const taskRef = await tx.scheduleTask.findUnique({
-            where: { id: input.taskId },
-            select: { projectId: true },
-        });
-        if (!taskRef) throw new Error("Task not found");
-        if (!taskRef.projectId) throw new Error("Task is not attached to a project");
-        await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${taskRef.projectId} FOR UPDATE`;
-        await tx.$queryRaw`SELECT id FROM "ScheduleTask" WHERE id = ${input.taskId} FOR UPDATE`;
+        const lockedParent = await lockTaskAssignmentParent(tx, input.taskId);
         const task = await tx.scheduleTask.findUnique({
             where: { id: input.taskId },
             select: {
@@ -2878,7 +2984,7 @@ export async function setTaskCrew(input: {
         });
         if (!task) throw new Error("Task not found");
         if (!task.projectId) throw new Error("Task is not attached to a project");
-        if (task.projectId !== taskRef.projectId) throw new Error("Task moved to another project; refresh and retry");
+        if (task.projectId !== lockedParent.projectId) throw new Error("Task moved to another project; refresh and retry");
 
         const wanted = [...new Set(input.userIds)];
         const users = wanted.length
@@ -2905,6 +3011,9 @@ export async function setTaskCrew(input: {
         for (const userId of toAdd) {
             // Lead assignment is intentionally not settable here yet; task crew changes remain assigned until the later lead-management PR.
             await tx.taskAssignment.create({ data: { taskId: input.taskId, userId, role: "assigned" } });
+        }
+        if (toAdd.length > 0 || toRemove.length > 0) {
+            await touchTaskAssignmentRevision(tx, input.taskId);
         }
 
         await tx.activityLog.create({


### PR DESCRIPTION
PR-B1 of the dispatch arc — the transaction at the heart of "Richard presses one button and the right people find out." This PR ships the atomic commit + audit + outbox; the Google Chat drainer that consumes the outbox is PR-D.

## What's new
- **Review dispatch → Confirm & queue dispatch** on the Dispatch view: a human-readable diff of every drafted change, then ONE transaction commits the dates, writes the publication + per-change audit rows, and queues delivery rows. All-or-nothing: any row changed since review aborts the whole publish with drafts intact ("Nothing was queued. Your drafts are still here.").
- **Deterministic locking + revisions**: Project → Task → Assignment lock order (sorted ids), per-row staleness via `updatedAt` + a new assignment revision; every TaskAssignment writer joined the contract.
- **Replay-safe**: `clientRequestId` unique at the DB; a retried publish returns the original publication, a tampered retry (hash mismatch) is rejected.
- **Schema** (applied to prod, RLS-enabled, no public policies): `DispatchPublication`, `DispatchPublicationChange`, `ChatDelivery`, `Project.updatedAt`.
- Month/Timeline keep their existing partial Save unchanged — Publish is Dispatch's gesture, and the CTA copy never says "Publish" (the schedule's portal-visibility toggle owns that word).

## Verification
- **17-case behavioral suite** (new `verify-dispatch-publication.ts`, runs against the DB): atomic rollback, 4 stale-rejection shapes, concurrent publishers, idempotent replay, hash conflict, recipient dedupe, dryRun purity, no-op, inactive-crew rollback — ALL PASS
- All 5 standing gates green; independent checker traced lock order, DB constraints, and wrapper equivalence against HEAD — its two findings fixed (verify-script assertion repointed after the primitive extraction; dispatch-in-flight projects folded into the page-wide pending union) plus one of mine (session helper aligned with every other hardened mutation)
- Browser, end-to-end on the Shop test job: drag → "Review dispatch (1)" → diff dialog → confirm → "Dispatch recorded — delivery pending" → DB shows the committed dates + one publication with the exact change summary → cleaned up

Design was debated before implementation (sol's 25KB design review is the blueprint); implemented by GPT-5.6-sol (xhigh); independently gate-checked; reviewed and browser-verified by Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)