### PR TITLE
Crew-chip drag drafts + Task Bank (Publish, part 2)

### DIFF
--- a/scripts/verify-dispatch-publication.ts
+++ b/scripts/verify-dispatch-publication.ts
@@ -2,7 +2,8 @@
 //
 // This script intentionally exercises the session-free transaction core rather
 // than the authenticated Server Action wrapper. It creates isolated fixtures,
-// verifies all 15 design-review cases, and removes every row it creates.
+// verifies all B1 design-review cases plus B2 crew-draft publication cases,
+// and removes every row it creates.
 //
 // Run only after scripts/apply-dispatch-b1-schema.mjs has been applied by the
 // release orchestrator and the Prisma client has been regenerated:
@@ -533,6 +534,121 @@ async function main() {
         );
         assert.deepEqual(await assignmentsForTask(fixture.taskA.id), [{ userId: fixture.crewA.id, role: "lead" }]);
         assert.equal(await prisma.dispatchPublication.count({ where: { clientRequestId: id } }), 0);
+    });
+
+    // 16. One crew draft can atomically add and remove people on one task.
+    await withFixture("16-crew-add-remove", async fixture => {
+        const intent = await taskCrewIntent(fixture.taskA.id, [
+            { userId: fixture.crewB.id, role: "assigned" },
+        ]);
+        const result = await publish(fixture, "crew-add-remove", [intent]);
+        assert.equal(result.ok, true);
+        assert.ok(result.publicationId);
+        assert.deepEqual(await assignmentsForTask(fixture.taskA.id), [
+            { userId: fixture.crewB.id, role: "assigned" },
+        ]);
+
+        const change = await prisma.dispatchPublicationChange.findFirstOrThrow({
+            where: {
+                publicationId: result.publicationId!,
+                targetId: fixture.taskA.id,
+                kind: "TASK_CREW",
+            },
+        });
+        assert.deepEqual(change.before, {
+            assignments: [{ userId: fixture.crewA.id, role: "lead" }],
+        });
+        assert.deepEqual(change.after, {
+            assignments: [{ userId: fixture.crewB.id, role: "assigned" }],
+        });
+        assert.match(change.summary, new RegExp(`${fixture.crewB.name} \u2192 ${fixture.taskA.name} \\(add\\)`));
+        assert.match(change.summary, new RegExp(`${fixture.crewA.name} removed from ${fixture.taskA.name}`));
+
+        const deliveries = await prisma.chatDelivery.findMany({
+            where: { publicationId: result.publicationId! },
+            orderBy: { destination: "asc" },
+            select: { destination: true },
+        });
+        assert.deepEqual(
+            new Set(deliveries.map(row => row.destination)),
+            new Set([`user:${fixture.crewA.id}`, `user:${fixture.crewB.id}`]),
+        );
+        assert.deepEqual(result.reconciliation.assignments[fixture.taskA.id], [
+            { userId: fixture.crewB.id, role: "assigned" },
+        ]);
+    });
+
+    // 17. A stale crew snapshot rolls back a separate valid date change too.
+    await withFixture("17-crew-stale-rolls-back-date", async fixture => {
+        const id = requestId("crew-stale-rolls-back-date");
+        const beforeTaskB = await prisma.scheduleTask.findUniqueOrThrow({
+            where: { id: fixture.taskB.id },
+        });
+        const dateIntent = await taskDatesIntent(fixture.taskB.id, dayKey(7), dayKey(9));
+        const crewIntent = await taskCrewIntent(fixture.taskA.id, [
+            { userId: fixture.crewB.id, role: "assigned" },
+        ]);
+        await setTaskCrew({
+            taskId: fixture.taskA.id,
+            userIds: [fixture.crewA.id, fixture.crewB.id],
+            actor: { type: "TEAM", name: "Concurrent crew editor" },
+        });
+
+        const failure = expectFailure(
+            await publish(fixture, "crew-stale-rolls-back-date", [dateIntent, crewIntent], { clientRequestId: id }),
+            "STALE_DISPATCH",
+        );
+        assert.ok(failure.conflicts.some(conflict =>
+            conflict.targetId === fixture.taskA.id && conflict.reason === "ASSIGNMENTS_CHANGED",
+        ));
+
+        const afterTaskB = await prisma.scheduleTask.findUniqueOrThrow({
+            where: { id: fixture.taskB.id },
+        });
+        assert.equal(afterTaskB.startDate.getTime(), beforeTaskB.startDate.getTime());
+        assert.equal(afterTaskB.endDate.getTime(), beforeTaskB.endDate.getTime());
+        const concurrentAssignments = await assignmentsForTask(fixture.taskA.id);
+        assert.deepEqual(
+            new Set(concurrentAssignments.map(assignment => assignment.userId)),
+            new Set([fixture.crewA.id, fixture.crewB.id]),
+        );
+        const concurrentRoles = new Map(concurrentAssignments.map(assignment => [
+            assignment.userId,
+            assignment.role,
+        ]));
+        assert.equal(concurrentRoles.get(fixture.crewA.id), "lead");
+        assert.equal(concurrentRoles.get(fixture.crewB.id), "assigned");
+        assert.equal(await prisma.dispatchPublication.count({ where: { clientRequestId: id } }), 0);
+    });
+
+    // 18. Replaying an old crew intent resolves by request ID before staleness.
+    await withFixture("18-crew-idempotent-replay", async fixture => {
+        const id = requestId("crew-idempotent-replay");
+        const intent = await taskCrewIntent(fixture.taskA.id, [
+            { userId: fixture.crewB.id, role: "assigned" },
+        ]);
+        const first = await publish(fixture, "crew-idempotent-replay", [intent], { clientRequestId: id });
+        assert.equal(first.ok, true);
+        assert.ok(first.publicationId);
+        const before = await prisma.dispatchPublication.findUniqueOrThrow({
+            where: { clientRequestId: id },
+            include: { changes: true, deliveries: true },
+        });
+
+        const replay = await publish(fixture, "crew-idempotent-replay", [intent], { clientRequestId: id });
+        assert.equal(replay.ok, true);
+        assert.equal(replay.publicationId, first.publicationId);
+        assert.equal(replay.replayed, true);
+        assert.equal(await prisma.dispatchPublication.count({ where: { clientRequestId: id } }), 1);
+        const after = await prisma.dispatchPublication.findUniqueOrThrow({
+            where: { clientRequestId: id },
+            include: { changes: true, deliveries: true },
+        });
+        assert.equal(after.changes.length, before.changes.length);
+        assert.equal(after.deliveries.length, before.deliveries.length);
+        assert.deepEqual(await assignmentsForTask(fixture.taskA.id), [
+            { userId: fixture.crewB.id, role: "assigned" },
+        ]);
     });
 
     console.log("dispatch publication verification: PASS");

--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -21,6 +21,8 @@ const availabilityHelpersSource = src("../src/app/company-dashboard/schedule-boa
 const dispatchViewSource = src("../src/app/company-dashboard/schedule-board/DispatchView.tsx");
 const dispatchReviewDialogSource = src("../src/app/company-dashboard/schedule-board/DispatchReviewDialog.tsx");
 const dispatchJobCardSource = src("../src/app/company-dashboard/schedule-board/DispatchJobCard.tsx");
+const dispatchCrewTaskChooserSource = src("../src/app/company-dashboard/schedule-board/DispatchCrewTaskChooser.tsx");
+const dispatchTaskBankSource = src("../src/app/company-dashboard/schedule-board/DispatchTaskBank.tsx");
 const dispatchStripSource = src("../src/app/company-dashboard/schedule-board/DispatchExceptions.tsx");
 const dispatchExceptionsSource = src("../src/app/company-dashboard/schedule-board/dispatch-exceptions.ts");
 const traySource = src("../src/app/company-dashboard/schedule-board/UnscheduledTray.tsx");
@@ -870,6 +872,96 @@ assert.doesNotMatch(dispatchReviewDialogSource, />\s*Publish\s*</, "Dispatch UI 
 assert.match(coreSource, /updatedAt: string;/, "dashboard project/task contracts must expose revisions");
 assert.match(coreSource, /id: true, projectId: true, name: true, startDate: true, endDate: true,[^\n]*updatedAt: true/, "the dashboard task query must select updatedAt");
 assert.match(coreSource, /updatedAt: task\.updatedAt\.toISOString\(\)/, "task revisions must serialize as ISO strings");
+
+// PR-B2: crew assignment drafts are Dispatch-only and ride the existing
+// atomic review/publication path. Month/Timeline retain immediate crew writes.
+assert.match(boardSource, /interface CrewDraft \{[\s\S]*addUserIds: string\[\];[\s\S]*removeUserIds: string\[\];[\s\S]*expectedAssignments: DispatchAssignment\[\];/, "ScheduleBoard must define the complete crew-draft snapshot");
+assert.match(boardSource, /const \[crewDrafts, setCrewDrafts\] = useState<Record<string, CrewDraft>>\(\{\}\)/, "ScheduleBoard must own crew drafts beside its existing draft maps");
+assert.match(boardSource, /function queueCrewAddition\(taskId: string, userId: string\)/, "crew additions must route through the board-owned draft writer");
+assert.match(boardSource, /function queueCrewRemoval\(taskId: string, userId: string\)/, "crew removals must route through the board-owned draft writer");
+assert.match(boardSource, /setCrewDrafts\(\{\}\)/, "Discard must clear unsaved crew drafts");
+assert.match(boardSource, /crewDraftTaskIds/, "crew-drafted task owners must join draft counting and project unions");
+assert.match(boardSource, /kind: "TASK_CREW"/, "dispatch intent collection must emit crew intents");
+assert.match(publishDispatchBody, /intent\.kind === "TASK_CREW"/, "successful publication must identify and clear published crew drafts");
+assert.match(boardSource, /onDraftCrewAdd=\{queueCrewAddition\}/, "DispatchView must receive the board-owned crew add callback");
+assert.match(boardSource, /onDraftCrewRemove=\{queueCrewRemoval\}/, "DispatchView must receive the board-owned crew remove callback");
+
+assert.match(dispatchViewSource, /function handleCrewPointerDragStart\(/, "Dispatch must use the board-style pointer drag machine for crew chips");
+assert.match(dispatchViewSource, /const CREW_MOUSE_DRAG_THRESHOLD_PX = 5;/);
+assert.match(dispatchViewSource, /const CREW_TOUCH_DRAG_THRESHOLD_PX = 8;/);
+assert.match(dispatchViewSource, /createDragVisualLayer\(/, "crew drag must use the detached visual layer");
+assert.match(dispatchViewSource, /window\.addEventListener\("keydown", onWindowKeyDown\)/, "Escape must cancel crew pointer drags");
+assert.match(dispatchViewSource, /data-dispatch-crew-chip/, "Dispatch crew sources need stable drag metadata");
+assert.match(dispatchJobCardSource, /data-dispatch-crew-chip/, "solid and outlined job-card crew chips must be drag sources");
+assert.match(dispatchJobCardSource, /data-dispatch-task-id=\{task\.id\}/, "Today task rows must be direct crew drop targets");
+assert.match(dispatchViewSource, /data-dispatch-week-cell/, "Week person/day cells must expose crew drop context");
+assert.match(dispatchJobCardSource, /border-dashed/, "drafted additions must preserve solid chips with a dashed ring");
+assert.match(dispatchJobCardSource, /\[@media\(hover:none\)\]:opacity-100/, "crew remove affordances must remain visible on no-hover devices");
+assert.ok(dispatchCrewTaskChooserSource.length > 0, "the shared crew task chooser must exist");
+assert.match(dispatchCrewTaskChooserSource, /import \{ FloatingPopover \} from "\.\/FloatingPopover"/, "pointer and keyboard crew choices must reuse FloatingPopover");
+assert.match(dispatchCrewTaskChooserSource, /anchorPoint=/, "drop ambiguity must anchor the chooser at the release point");
+assert.match(dispatchCrewTaskChooserSource, /anchorRef=/, "Enter must anchor the same chooser to the focused chip");
+for (const [name, source] of [["Month", monthSource], ["Timeline", timelineSource]] as const) {
+    assert.doesNotMatch(source, /crewDrafts|onDraftCrewAdd|onDraftCrewRemove|data-dispatch-crew-chip|handleCrewPointerDragStart/, `${name} must not gain Dispatch crew drafting`);
+}
+
+const projectCrewPickerStart = crewPickersSource.indexOf("export function CrewPicker(");
+const projectCrewPickerEnd = crewPickersSource.indexOf("export function TaskCrewPicker(", projectCrewPickerStart);
+const projectCrewPickerBody = crewPickersSource.slice(projectCrewPickerStart, projectCrewPickerEnd);
+const taskCrewPickerStart = projectCrewPickerEnd;
+const taskCrewPickerBody = crewPickersSource.slice(taskCrewPickerStart);
+assert.match(projectCrewPickerBody, /await updateProjectCrewAction\(projectId, ids\)/, "Month/Timeline project crew remains immediate");
+assert.match(taskCrewPickerBody, /await updateTaskCrewAction\(task\.id, ids\)/, "Month/Timeline task crew remains immediate");
+assert.match(projectCrewPickerBody, /router\.refresh\(\)/);
+assert.match(taskCrewPickerBody, /router\.refresh\(\)/);
+assert.doesNotMatch(crewPickersSource, /crewDrafts|TASK_CREW|queueCrewAddition|queueCrewRemoval/, "shared Month/Timeline pickers must not know about Dispatch drafts");
+
+// Task Bank must import, not re-derive, the canonical contract-estimate scope.
+assert.match(coreSource, /export function canonicalContractEstimateQuery\(projectId: string\)/, "schedule-core must export the canonical estimate selector");
+assert.match(coreSource, /export function deriveEstimateItemHours\(/, "Task Bank and generation must share the hours rule");
+assert.match(actionsSource, /canonicalContractEstimateQuery[\s\S]*from "\.\/schedule-core"/, "actions must import the canonical estimate selector");
+const getTaskBankStart = actionsSource.indexOf("export async function getTaskBank(");
+const getTaskBankEnd = actionsSource.indexOf("export async function", getTaskBankStart + 1);
+const getTaskBankBody = actionsSource.slice(getTaskBankStart, getTaskBankEnd);
+assert.ok(getTaskBankStart >= 0, "the authenticated Task Bank read action must exist");
+assert.match(getTaskBankBody, /canonicalContractEstimateQuery\(projectId\)/);
+assert.match(getTaskBankBody, /deriveEstimateItemHours\(/);
+assert.doesNotMatch(getTaskBankBody, /CONTRACT_ESTIMATE_STATUSES|orderBy:\s*\{\s*createdAt/, "Task Bank must not re-derive canonical estimate selection");
+const generateProjectScheduleStart = actionsSource.indexOf("export async function generateProjectScheduleAction(");
+const generateProjectScheduleEnd = actionsSource.indexOf("export async function", generateProjectScheduleStart + 1);
+const generateProjectScheduleBody = actionsSource.slice(generateProjectScheduleStart, generateProjectScheduleEnd);
+assert.match(generateProjectScheduleBody, /canonicalContractEstimateQuery\(projectId\)/, "manual generation must use the same canonical selector as Task Bank");
+assert.doesNotMatch(generateProjectScheduleBody, /CONTRACT_ESTIMATE_STATUSES|orderBy:\s*\{\s*createdAt/, "manual generation must not keep a second selector");
+assert.ok(dispatchTaskBankSource.length > 0, "the collapsible Dispatch Task Bank rail must exist");
+assert.match(dispatchTaskBankSource, /getTaskBank\(/);
+assert.match(dispatchTaskBankSource, /Task bank/);
+assert.match(dispatchTaskBankSource, /scheduledCount/);
+assert.match(dispatchTaskBankSource, /totalCount/);
+assert.match(dispatchTaskBankSource, /estimateItemId/);
+assert.match(dispatchViewSource, /data\.pipeline\.inProgress\[0\]\?\.id/, "Task Bank selection must default to the first In Progress project");
+assert.match(taskCreationDialogSource, /defaultName\?: string/);
+assert.match(taskCreationDialogSource, /defaultEstimatedHours\?: number \| null/);
+assert.match(taskCreationDialogSource, /estimateItemId\?: string/);
+const createScheduleTaskStart = actionsSource.indexOf("export async function createScheduleTask(");
+const createScheduleTaskEnd = actionsSource.indexOf("export async function updateScheduleTask(", createScheduleTaskStart);
+const createScheduleTaskBody = actionsSource.slice(createScheduleTaskStart, createScheduleTaskEnd);
+assert.match(createScheduleTaskBody, /estimateItemId\?: string \| null/);
+assert.match(createScheduleTaskBody, /estimateItemId,/, "Task Bank creation must persist its normalized estimate-item back-link");
+
+// A crew draft gates only immediate user-assignment controls in the drawer.
+assert.match(boardSource, /const openTaskHasCrewDraft = Boolean\(openTaskId && crewDrafts\[openTaskId\]\)/);
+assert.match(boardSource, /hasCrewDraft=\{openTaskHasCrewDraft\}/);
+assert.match(drawerSource, /hasCrewDraft: boolean;/);
+assert.match(drawerSource, /crewReadOnly=\{hasCrewDraft\}/);
+assert.match(drawerSource, /crewReadOnlyNote="Crew changes are drafted for dispatch/, "the drawer must explain why immediate crew controls are disabled");
+assert.match(detailPanelSource, /crewReadOnly\?: boolean;/);
+assert.match(detailPanelSource, /crewReadOnlyNote\?: string;/);
+assert.match(detailPanelSource, /\{crewReadOnly && crewReadOnlyNote && \(/, "the Team section must show the crew draft hint");
+assert.match(detailPanelSource, /disabled=\{crewReadOnly\}/, "immediate add/lead/remove controls must be disabled by the crew draft gate");
+
+assert.match(dispatchReviewDialogSource, /function crewChangeRows\(/, "crew audit changes must expand into person-level review rows");
+assert.match(dispatchReviewDialogSource, /\(add\)/);
+assert.match(dispatchReviewDialogSource, /removed from/);
 
 console.log("schedule-board render contract verification: PASS");
 

--- a/src/app/company-dashboard/schedule-board/BoardTaskDrawer.tsx
+++ b/src/app/company-dashboard/schedule-board/BoardTaskDrawer.tsx
@@ -33,6 +33,7 @@ import { activateExclusiveMenu, deactivateExclusiveMenu } from "./menuCoordinato
 type BoardTaskDrawerProps = {
     taskId: string | null;
     hasDraft: boolean;
+    hasCrewDraft: boolean;
     teamMembers: TeamMember[];
     onClose: () => void;
     onSelectTask: (taskId: string) => void;
@@ -43,7 +44,7 @@ function messageFromError(error: unknown, fallback: string) {
     return error instanceof Error && error.message ? error.message : fallback;
 }
 
-export function BoardTaskDrawer({ taskId, hasDraft, teamMembers, onClose, onSelectTask, onDeleted }: BoardTaskDrawerProps) {
+export function BoardTaskDrawer({ taskId, hasDraft, hasCrewDraft, teamMembers, onClose, onSelectTask, onDeleted }: BoardTaskDrawerProps) {
     const router = useRouter();
     const drawerRef = useRef<HTMLElement | null>(null);
     const requestRef = useRef(0);
@@ -226,6 +227,8 @@ export function BoardTaskDrawer({ taskId, hasDraft, teamMembers, onClose, onSele
                         onAppointmentChange={(id, data) => { void mutate(() => updateScheduleTask(id, data), "Could not update appointment"); }}
                         datesReadOnly={hasDraft}
                         dateReadOnlyNote="This task has unsaved changes on the board — Save or Discard them first."
+                        crewReadOnly={hasCrewDraft}
+                        crewReadOnlyNote="Crew changes are drafted for dispatch — Review or Discard them first."
                         embedded
                     />
                 ) : (

--- a/src/app/company-dashboard/schedule-board/DispatchCrewTaskChooser.tsx
+++ b/src/app/company-dashboard/schedule-board/DispatchCrewTaskChooser.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import type { RefObject } from "react";
+import { FloatingPopover } from "./FloatingPopover";
+import type { FloatingPopoverAnchorPoint } from "./FloatingPopover";
+
+export interface DispatchCrewTaskChoice {
+    projectId: string;
+    projectName: string;
+    taskId: string;
+    taskName: string;
+    dayLabel?: string;
+}
+
+interface DispatchCrewTaskChooserProps {
+    open: boolean;
+    crewName: string;
+    choices: DispatchCrewTaskChoice[];
+    anchorPoint: FloatingPopoverAnchorPoint | null;
+    anchorRef: RefObject<HTMLElement | null>;
+    onChoose: (taskId: string) => void;
+    onClose: () => void;
+}
+
+export function DispatchCrewTaskChooser({
+    open,
+    crewName,
+    choices,
+    anchorPoint,
+    anchorRef,
+    onChoose,
+    onClose,
+}: DispatchCrewTaskChooserProps) {
+    return (
+        <FloatingPopover
+            open={open}
+            anchorPoint={anchorPoint}
+            anchorRef={anchorRef}
+            onClose={onClose}
+            width={300}
+        >
+            <div>
+                <p className="text-xs font-semibold text-hui-textMain">Assign {crewName}</p>
+                <p className="mt-0.5 text-[11px] text-hui-textMuted">Choose a task for this crew draft.</p>
+                <div className="mt-3 space-y-1">
+                    {choices.length === 0 ? (
+                        <p className="rounded border border-dashed border-hui-border px-3 py-4 text-center text-xs text-hui-textMuted">
+                            No active tasks are available.
+                        </p>
+                    ) : choices.map(choice => (
+                        <button
+                            key={`${choice.taskId}-${choice.dayLabel ?? ""}`}
+                            type="button"
+                            onClick={() => onChoose(choice.taskId)}
+                            className="block w-full rounded-md px-2.5 py-2 text-left transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary"
+                        >
+                            <span className="block text-xs font-semibold text-hui-textMain">{choice.taskName}</span>
+                            <span className="mt-0.5 block text-[10px] text-hui-textMuted">
+                                {choice.projectName}{choice.dayLabel ? ` · ${choice.dayLabel}` : ""}
+                            </span>
+                        </button>
+                    ))}
+                </div>
+            </div>
+        </FloatingPopover>
+    );
+}

--- a/src/app/company-dashboard/schedule-board/DispatchJobCard.tsx
+++ b/src/app/company-dashboard/schedule-board/DispatchJobCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
 import type { DashboardProjectRow, DashboardTaskRow } from "@/lib/schedule-core";
 import { getFallbackProjectColor } from "@/app/projects/[id]/schedule/schedule-utils";
 
@@ -20,11 +21,26 @@ interface DispatchJobCardProps {
     tasks: DashboardTaskRow[];
     highlighted: boolean;
     canCreate: boolean;
+    crewDrafts: Readonly<Record<string, { addUserIds: string[]; removeUserIds: string[] }>>;
     onActivate: (taskId: string) => void;
     onAddTask: () => void;
+    onCrewPointerDown: (event: ReactPointerEvent<HTMLElement>, member: { id: string; name: string }) => void;
+    onCrewKeyboardActivate: (event: ReactKeyboardEvent<HTMLElement>, member: { id: string; name: string }) => void;
+    onDraftCrewRemove: (taskId: string, userId: string) => void;
 }
 
-export function DispatchJobCard({ project, tasks, highlighted, canCreate, onActivate, onAddTask }: DispatchJobCardProps) {
+export function DispatchJobCard({
+    project,
+    tasks,
+    highlighted,
+    canCreate,
+    crewDrafts,
+    onActivate,
+    onAddTask,
+    onCrewPointerDown,
+    onCrewKeyboardActivate,
+    onDraftCrewRemove,
+}: DispatchJobCardProps) {
     const projectColor = project.color || getFallbackProjectColor(project.id);
 
     return (
@@ -61,7 +77,7 @@ export function DispatchJobCard({ project, tasks, highlighted, canCreate, onActi
                         const statusTitle = task.status === "Blocked" && task.blockedReason ? `Blocked \u2014 ${task.blockedReason}` : task.status;
                         const progress = Math.max(0, Math.min(100, task.progress));
                         return (
-                            <section key={task.id} className="px-4 py-3">
+                            <section key={task.id} data-dispatch-task-id={task.id} className="px-4 py-3">
                                 <div className="flex flex-wrap items-start justify-between gap-2">
                                     <div className="min-w-0 flex-1">
                                         <div className="flex flex-wrap items-center gap-2">
@@ -81,25 +97,52 @@ export function DispatchJobCard({ project, tasks, highlighted, canCreate, onActi
                                         </div>
                                         {task.doneWhen && <p className="mt-2 text-xs text-hui-textMuted"><span className="font-semibold text-slate-600">Done when:</span> {task.doneWhen}</p>}
                                         <div className="mt-2 flex flex-wrap items-center gap-1.5" aria-label={`${task.name} crew`}>
-                                            {solidAssignments.map(assignment => (
-                                                <span
-                                                    key={assignment.id}
-                                                    className="inline-flex h-7 min-w-7 items-center justify-center rounded-full px-1.5 text-[10px] font-bold text-white shadow-sm"
-                                                    style={{ backgroundColor: projectColor }}
-                                                    title={`${assignment.name}${assignment.assignmentRole === "lead" ? " \u2014 lead" : " \u2014 task assigned"}`}
-                                                >
-                                                    {assignment.assignmentRole === "lead" && <span aria-hidden="true">{"\u2605"}</span>}{initials(assignment.name)}
-                                                </span>
-                                            ))}
+                                            {solidAssignments.map(assignment => {
+                                                const draftedAddition = crewDrafts[task.id]?.addUserIds.includes(assignment.userId) ?? false;
+                                                return (
+                                                    <span key={assignment.id} className="group relative inline-flex">
+                                                        <button
+                                                            type="button"
+                                                            data-dispatch-crew-chip="true"
+                                                            data-dispatch-user-id={assignment.userId}
+                                                            onPointerDown={event => onCrewPointerDown(event, { id: assignment.userId, name: assignment.name })}
+                                                            onKeyDown={event => onCrewKeyboardActivate(event, { id: assignment.userId, name: assignment.name })}
+                                                            className={`inline-flex h-7 min-w-7 touch-none items-center justify-center rounded-full px-1.5 text-[10px] font-bold text-white shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary focus-visible:ring-offset-2 ${draftedAddition ? "border-2 border-dashed border-white ring-2 ring-indigo-400 ring-offset-1" : ""}`}
+                                                            style={{ backgroundColor: projectColor }}
+                                                            title={`${assignment.name}${assignment.assignmentRole === "lead" ? " \u2014 lead" : draftedAddition ? " \u2014 drafted assignment" : " \u2014 task assigned"}`}
+                                                            aria-label={`${assignment.name}. Press Enter to choose another task, or drag onto a task.`}
+                                                        >
+                                                            {assignment.assignmentRole === "lead" && <span aria-hidden="true">{"\u2605"}</span>}{initials(assignment.name)}
+                                                        </button>
+                                                        {canCreate && (
+                                                            <button
+                                                                type="button"
+                                                                onPointerDown={event => event.stopPropagation()}
+                                                                onClick={() => onDraftCrewRemove(task.id, assignment.userId)}
+                                                                className="absolute -right-1.5 -top-1.5 inline-flex h-4 w-4 items-center justify-center rounded-full bg-slate-700 text-[10px] font-bold leading-none text-white opacity-0 shadow transition hover:bg-red-600 focus:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 group-hover:opacity-100 [@media(hover:none)]:opacity-100"
+                                                                aria-label={`Remove ${assignment.name} from ${task.name}`}
+                                                            >
+                                                                {"\u00D7"}
+                                                            </button>
+                                                        )}
+                                                    </span>
+                                                );
+                                            })}
                                             {outlinedCrew.map(member => (
-                                                <span
+                                                <button
                                                     key={member.id}
-                                                    className="inline-flex h-7 min-w-7 items-center justify-center rounded-full border-2 bg-white px-1.5 text-[10px] font-bold"
+                                                    type="button"
+                                                    data-dispatch-crew-chip="true"
+                                                    data-dispatch-user-id={member.id}
+                                                    onPointerDown={event => onCrewPointerDown(event, member)}
+                                                    onKeyDown={event => onCrewKeyboardActivate(event, member)}
+                                                    className="inline-flex h-7 min-w-7 touch-none items-center justify-center rounded-full border-2 bg-white px-1.5 text-[10px] font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary focus-visible:ring-offset-2"
                                                     style={{ borderColor: projectColor, color: projectColor }}
                                                     title={`${member.name} \u2014 project crew only`}
+                                                    aria-label={`${member.name}. Press Enter to choose a task, or drag onto a task.`}
                                                 >
                                                     {initials(member.name)}
-                                                </span>
+                                                </button>
                                             ))}
                                             {solidAssignments.length === 0 && outlinedCrew.length === 0 && <span className="text-[10px] text-slate-400">No crew</span>}
                                         </div>

--- a/src/app/company-dashboard/schedule-board/DispatchReviewDialog.tsx
+++ b/src/app/company-dashboard/schedule-board/DispatchReviewDialog.tsx
@@ -3,12 +3,15 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import { motion } from "framer-motion";
 import type { PublishDispatchSuccess } from "@/lib/dispatch-publication";
+import type { DispatchAssignment, DispatchChange } from "@/lib/dispatch-intent";
 
 interface DispatchReviewDialogProps {
     result: PublishDispatchSuccess | null;
     published: boolean;
     isPending: boolean;
     conflictTargetIds: ReadonlySet<string>;
+    taskNamesById: ReadonlyMap<string, string>;
+    memberNamesById: ReadonlyMap<string, string>;
     onConfirm: () => void;
     onClose: () => void;
 }
@@ -19,15 +22,71 @@ function changeLabel(kind: string): string {
     return "Dates";
 }
 
+function assignmentsFromChange(value: unknown): DispatchAssignment[] {
+    if (!Array.isArray(value)) return [];
+    return value.filter((row): row is DispatchAssignment =>
+        Boolean(row)
+        && typeof row === "object"
+        && "userId" in row
+        && "role" in row
+        && typeof row.userId === "string"
+        && (row.role === "assigned" || row.role === "lead"),
+    );
+}
+
+function crewChangeRows(
+    change: DispatchChange,
+    taskNamesById: ReadonlyMap<string, string>,
+    memberNamesById: ReadonlyMap<string, string>,
+): { key: string; summary: string }[] {
+    const before = assignmentsFromChange(change.before.assignments);
+    const after = assignmentsFromChange(change.after.assignments);
+    const beforeByUser = new Map(before.map(assignment => [assignment.userId, assignment]));
+    const afterByUser = new Map(after.map(assignment => [assignment.userId, assignment]));
+    const taskName = taskNamesById.get(change.targetId) ?? "task";
+    const rows: { key: string; summary: string }[] = [];
+    for (const assignment of after) {
+        const previous = beforeByUser.get(assignment.userId);
+        const memberName = memberNamesById.get(assignment.userId) ?? assignment.userId;
+        if (!previous) {
+            rows.push({
+                key: `add-${assignment.userId}`,
+                summary: `${memberName} \u2192 ${taskName} (add)`,
+            });
+        } else if (previous.role !== assignment.role) {
+            rows.push({
+                key: `role-${assignment.userId}`,
+                summary: `${memberName} on ${taskName}: ${previous.role} \u2192 ${assignment.role}`,
+            });
+        }
+    }
+    for (const assignment of before) {
+        if (afterByUser.has(assignment.userId)) continue;
+        const memberName = memberNamesById.get(assignment.userId) ?? assignment.userId;
+        rows.push({
+            key: `remove-${assignment.userId}`,
+            summary: `${memberName} removed from ${taskName}`,
+        });
+    }
+    return rows.length > 0 ? rows : [{ key: "crew", summary: change.summary }];
+}
+
 export function DispatchReviewDialog({
     result,
     published,
     isPending,
     conflictTargetIds,
+    taskNamesById,
+    memberNamesById,
     onConfirm,
     onClose,
 }: DispatchReviewDialogProps) {
-    const changeCount = result?.changes.length ?? 0;
+    const reviewRows = result?.changes.flatMap(change =>
+        change.kind === "TASK_CREW"
+            ? crewChangeRows(change, taskNamesById, memberNamesById).map(row => ({ ...row, change }))
+            : [{ key: "change", summary: change.summary, change }],
+    ) ?? [];
+    const changeCount = reviewRows.length;
     const deliveryCount = result?.deliveryCount ?? 0;
 
     return (
@@ -93,11 +152,11 @@ export function DispatchReviewDialog({
 
                                 <div className="min-h-0 flex-1 overflow-y-auto p-4">
                                     <div className="space-y-2" role="list" aria-label="Dispatch changes">
-                                        {result?.changes.map((change, index) => {
+                                        {reviewRows.map(({ change, key, summary }, index) => {
                                             const conflicted = conflictTargetIds.has(change.targetId);
                                             return (
                                                 <div
-                                                    key={`${change.kind}-${change.targetId}`}
+                                                    key={`${change.kind}-${change.targetId}-${key}`}
                                                     role="listitem"
                                                     className={`grid grid-cols-[auto_1fr] gap-3 rounded-lg border px-3 py-3 ${conflicted ? "border-amber-300 bg-amber-50" : "border-hui-border bg-white"}`}
                                                 >
@@ -105,7 +164,7 @@ export function DispatchReviewDialog({
                                                         {changeLabel(change.kind)}
                                                     </span>
                                                     <div className="min-w-0">
-                                                        <p className="text-sm font-medium leading-5 text-hui-textMain">{change.summary}</p>
+                                                        <p className="text-sm font-medium leading-5 text-hui-textMain">{summary}</p>
                                                         {conflicted && (
                                                             <p className="mt-1 text-xs font-medium text-amber-800">Changed since the previous review — check this line again.</p>
                                                         )}

--- a/src/app/company-dashboard/schedule-board/DispatchTaskBank.tsx
+++ b/src/app/company-dashboard/schedule-board/DispatchTaskBank.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getTaskBank, type TaskBankResult } from "@/lib/actions";
+
+export interface DispatchTaskBankItem {
+    estimateItemId: string;
+    name: string;
+    estimatedHours: number | null;
+}
+
+interface DispatchTaskBankProps {
+    projects: { id: string; name: string; taskCount: number }[];
+    selectedProjectId: string;
+    refreshKey: number;
+    canSchedule: boolean;
+    onProjectChange: (projectId: string) => void;
+    onSchedule: (item: DispatchTaskBankItem) => void;
+}
+
+export function DispatchTaskBank({
+    projects,
+    selectedProjectId,
+    refreshKey,
+    canSchedule,
+    onProjectChange,
+    onSchedule,
+}: DispatchTaskBankProps) {
+    const [expanded, setExpanded] = useState(true);
+    const [result, setResult] = useState<TaskBankResult | null>(null);
+    const [resultProjectId, setResultProjectId] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<{ projectId: string; message: string } | null>(null);
+
+    useEffect(() => {
+        if (!selectedProjectId) return;
+        let cancelled = false;
+        Promise.resolve().then(async () => {
+            if (cancelled) return;
+            setLoading(true);
+            setError(null);
+            try {
+                const next = await getTaskBank(selectedProjectId);
+                if (!cancelled) {
+                    setResult(next);
+                    setResultProjectId(selectedProjectId);
+                }
+            } catch (cause) {
+                if (!cancelled) {
+                    setResult(null);
+                    setResultProjectId(selectedProjectId);
+                    setError({
+                        projectId: selectedProjectId,
+                        message: cause instanceof Error ? cause.message : "Could not load the task bank",
+                    });
+                }
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        });
+        return () => { cancelled = true; };
+    }, [selectedProjectId, refreshKey]);
+
+    if (!expanded) {
+        return (
+            <aside className="shrink-0 border-t border-hui-border bg-slate-50 p-2 xl:w-14 xl:border-l xl:border-t-0">
+                <button
+                    type="button"
+                    onClick={() => setExpanded(true)}
+                    className="hui-btn hui-btn-secondary w-full justify-center px-2 text-xs xl:min-h-28 xl:[writing-mode:vertical-rl]"
+                    aria-expanded={false}
+                >
+                    Task bank
+                </button>
+            </aside>
+        );
+    }
+
+    const visibleResult = selectedProjectId && resultProjectId === selectedProjectId ? result : null;
+    const visibleError = error?.projectId === selectedProjectId ? error.message : null;
+    const waitingForSelection = Boolean(selectedProjectId) && resultProjectId !== selectedProjectId;
+    const scheduledCount = visibleResult?.scheduledCount ?? 0;
+    const totalCount = visibleResult?.totalCount ?? 0;
+    const coverage = totalCount > 0 ? Math.round((scheduledCount / totalCount) * 100) : 0;
+
+    return (
+        <aside className="shrink-0 border-t border-hui-border bg-slate-50/80 xl:w-80 xl:border-l xl:border-t-0" aria-label="Task bank">
+            <div className="flex items-start justify-between gap-3 border-b border-hui-border px-4 py-3">
+                <div>
+                    <h3 className="text-sm font-semibold text-hui-textMain">Task bank</h3>
+                    <p className="mt-0.5 text-xs text-hui-textMuted">Unscheduled contract scope</p>
+                </div>
+                <button
+                    type="button"
+                    onClick={() => setExpanded(false)}
+                    className="inline-flex h-7 w-7 items-center justify-center rounded text-slate-400 transition hover:bg-slate-200 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary"
+                    aria-label="Collapse Task bank"
+                    aria-expanded={true}
+                >
+                    {"\u2192"}
+                </button>
+            </div>
+
+            <div className="space-y-4 p-4">
+                <div>
+                    <label htmlFor="dispatch-task-bank-project" className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Project</label>
+                    <select
+                        id="dispatch-task-bank-project"
+                        value={selectedProjectId}
+                        onChange={event => onProjectChange(event.target.value)}
+                        className="hui-input mt-1.5 w-full text-sm"
+                        disabled={projects.length === 0}
+                    >
+                        {projects.length === 0
+                            ? <option value="">No active projects</option>
+                            : projects.map(project => <option key={project.id} value={project.id}>{project.name}</option>)}
+                    </select>
+                </div>
+
+                <div className="rounded-lg border border-hui-border bg-white p-3">
+                    <div className="flex items-baseline justify-between gap-3">
+                        <span className="text-xs font-semibold text-hui-textMain">Coverage</span>
+                        <span className="text-xs font-semibold tabular-nums text-hui-textMuted">{scheduledCount} of {totalCount} items scheduled</span>
+                    </div>
+                    <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-slate-100" role="progressbar" aria-label="Contract items scheduled" aria-valuemin={0} aria-valuemax={100} aria-valuenow={coverage}>
+                        <div className="h-full rounded-full bg-hui-primary transition-[width]" style={{ width: `${coverage}%` }} />
+                    </div>
+                    {visibleResult?.estimate && <p className="mt-2 text-[10px] text-slate-400">Contract estimate {visibleResult.estimate.code}</p>}
+                </div>
+
+                <div className="space-y-2">
+                    {loading || waitingForSelection ? (
+                        <p className="rounded-lg border border-dashed border-hui-border bg-white px-3 py-6 text-center text-xs text-hui-textMuted">Loading contract scope...</p>
+                    ) : visibleError ? (
+                        <p className="rounded-lg border border-red-200 bg-red-50 px-3 py-3 text-xs text-red-700">{visibleError}</p>
+                    ) : !visibleResult?.estimate ? (
+                        <p className="rounded-lg border border-dashed border-hui-border bg-white px-3 py-6 text-center text-xs text-hui-textMuted">No contract estimate for this project.</p>
+                    ) : visibleResult.items.length === 0 ? (
+                        <p className="rounded-lg border border-green-200 bg-green-50 px-3 py-4 text-center text-xs font-medium text-green-700">All contract items are scheduled.</p>
+                    ) : visibleResult.items.map(item => (
+                        <div key={item.estimateItemId} className="rounded-lg border border-hui-border bg-white px-3 py-2.5">
+                            <div className="flex items-start justify-between gap-3">
+                                <div className="min-w-0">
+                                    <p className="text-xs font-semibold leading-5 text-hui-textMain">{item.name}</p>
+                                    {item.estimatedHours != null && <p className="mt-0.5 text-[10px] text-hui-textMuted">{item.estimatedHours} estimated hours</p>}
+                                </div>
+                                {canSchedule && (
+                                    <button
+                                        type="button"
+                                        onClick={() => onSchedule(item)}
+                                        className="hui-btn hui-btn-secondary shrink-0 px-2 py-1 text-xs"
+                                    >
+                                        Schedule
+                                    </button>
+                                )}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </aside>
+    );
+}

--- a/src/app/company-dashboard/schedule-board/DispatchView.tsx
+++ b/src/app/company-dashboard/schedule-board/DispatchView.tsx
@@ -1,13 +1,17 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type PointerEvent as ReactPointerEvent } from "react";
+import { toast } from "sonner";
 import type { CompanyDashboardData, DashboardProjectRow, DashboardTaskRow } from "@/lib/schedule-core";
 import type { VancouverForecastDay } from "@/lib/weather";
 import { addDays, formatDate, getFallbackProjectColor, getMonday, todayUTC } from "@/app/projects/[id]/schedule/schedule-utils";
 import { isConflictedDay } from "./availability";
 import { getCrewlessJobs, isTaskActiveOnDay } from "./dispatch-exceptions";
 import { DispatchExceptions } from "./DispatchExceptions";
+import { DispatchCrewTaskChooser, type DispatchCrewTaskChoice } from "./DispatchCrewTaskChooser";
 import { DispatchJobCard } from "./DispatchJobCard";
+import { DispatchTaskBank, type DispatchTaskBankItem } from "./DispatchTaskBank";
+import { createDragVisualLayer, crewChipDragSourceSelector, type DragVisualLayer } from "./dragVisualLayer";
 
 export type DispatchMode = "today" | "week";
 export const DISPATCH_MODE_STORAGE_KEY = "gtr-company-schedule-dispatch-mode";
@@ -17,6 +21,9 @@ export interface DispatchTaskCreationDefaults {
     lockProject?: boolean;
     defaultStartDate: string;
     defaultCrewIds?: string[];
+    defaultName?: string;
+    defaultEstimatedHours?: number | null;
+    estimateItemId?: string;
 }
 
 interface DispatchViewProps {
@@ -27,6 +34,9 @@ interface DispatchViewProps {
     onReviewDispatch: () => void;
     draftCount: number;
     isReviewingDispatch: boolean;
+    crewDrafts: Readonly<Record<string, { addUserIds: string[]; removeUserIds: string[] }>>;
+    onDraftCrewAdd: (taskId: string, userId: string) => boolean;
+    onDraftCrewRemove: (taskId: string, userId: string) => void;
 }
 
 interface WeekChip {
@@ -35,6 +45,20 @@ interface WeekChip {
     solid: boolean;
     lead: boolean;
 }
+
+interface CrewIdentity {
+    id: string;
+    name: string;
+}
+
+interface CrewChooserState {
+    crew: CrewIdentity;
+    choices: DispatchCrewTaskChoice[];
+    anchorPoint: { x: number; y: number } | null;
+}
+
+const CREW_MOUSE_DRAG_THRESHOLD_PX = 5;
+const CREW_TOUCH_DRAG_THRESHOLD_PX = 8;
 
 function initials(name: string): string {
     return name.split(/\s+/).filter(Boolean).map(part => part[0]).join("").toUpperCase().slice(0, 2) || "?";
@@ -64,6 +88,18 @@ function weekChipsForMember(projects: DashboardProjectRow[], memberId: string, d
     return chips;
 }
 
+function taskChoicesForDay(projects: DashboardProjectRow[], dayKey: string): DispatchCrewTaskChoice[] {
+    return projects.flatMap(project => project.tasks
+        .filter(task => isTaskActiveOnDay(task, dayKey))
+        .map(task => ({
+            projectId: project.id,
+            projectName: project.name,
+            taskId: task.id,
+            taskName: task.name,
+            dayLabel: dayKey,
+        })));
+}
+
 export function DispatchView({
     data,
     weather,
@@ -72,11 +108,24 @@ export function DispatchView({
     onReviewDispatch,
     draftCount,
     isReviewingDispatch,
+    crewDrafts,
+    onDraftCrewAdd,
+    onDraftCrewRemove,
 }: DispatchViewProps) {
     const [mode, setMode] = useState<DispatchMode>("today");
     const currentMonday = useMemo(() => getMonday(todayUTC()), []);
     const [weekStart, setWeekStart] = useState(currentMonday);
     const [highlightedProjectId, setHighlightedProjectId] = useState<string | null>(null);
+    const [taskBankProjectId, setTaskBankProjectId] = useState(
+        () => data.pipeline.inProgress[0]?.id
+            ?? data.pipeline.scheduled[0]?.id
+            ?? data.pipeline.waitingToStart[0]?.id
+            ?? data.pipeline.substantialCompletion[0]?.id
+            ?? "",
+    );
+    const [crewChooser, setCrewChooser] = useState<CrewChooserState | null>(null);
+    const crewChooserAnchorRef = useRef<HTMLElement | null>(null);
+    const activeCrewDragCleanupRef = useRef<(() => void) | null>(null);
 
     useEffect(() => {
         let restoreFrame: number | null = null;
@@ -108,6 +157,9 @@ export function DispatchView({
         ...data.pipeline.inProgress,
         ...data.pipeline.substantialCompletion,
     ], [data.pipeline]);
+
+    useEffect(() => () => activeCrewDragCleanupRef.current?.(), []);
+
     const today = todayUTC();
     const todayKey = formatDate(today);
     const weatherByDate = new Map(weather.map(forecast => [forecast.date, forecast]));
@@ -135,6 +187,10 @@ export function DispatchView({
     const showSaturday = projects.some(project => project.tasks.some(task => isTaskActiveOnDay(task, formatDate(saturday))));
     const showSunday = projects.some(project => project.tasks.some(task => isTaskActiveOnDay(task, formatDate(sunday))));
     const visibleWeekDays = [...mondayToFriday, ...(showSaturday ? [saturday] : []), ...(showSunday ? [sunday] : [])];
+    const selectedTaskBankProjectId = projects.some(project => project.id === taskBankProjectId)
+        ? taskBankProjectId
+        : data.pipeline.inProgress[0]?.id ?? projects[0]?.id ?? "";
+    const taskBankRefreshKey = projects.reduce((sum, project) => sum + project.tasks.length, 0);
     const crewConflicts = data.crewConflicts;
     const headerForecast = mode === "today"
         ? weatherByDate.get(todayKey)
@@ -157,6 +213,151 @@ export function DispatchView({
     function focusProject(projectId: string) {
         selectMode("today");
         setHighlightedProjectId(projectId);
+    }
+
+    function openCrewChooser(
+        crew: CrewIdentity,
+        choices: DispatchCrewTaskChoice[],
+        anchorElement: HTMLElement | null,
+        anchorPoint: { x: number; y: number } | null,
+    ) {
+        crewChooserAnchorRef.current = anchorElement;
+        setCrewChooser({ crew, choices, anchorPoint });
+    }
+
+    function closeCrewChooser() {
+        setCrewChooser(null);
+        crewChooserAnchorRef.current = null;
+    }
+
+    function applyCrewChoice(taskId: string) {
+        if (!crewChooser) return;
+        const added = onDraftCrewAdd(taskId, crewChooser.crew.id);
+        if (added) closeCrewChooser();
+    }
+
+    function resolveCrewDrop(crew: CrewIdentity, clientX: number, clientY: number) {
+        const elements = document.elementsFromPoint(clientX, clientY);
+        const taskTarget = elements
+            .map(element => element instanceof HTMLElement ? element.closest<HTMLElement>("[data-dispatch-task-id]") : null)
+            .find((element): element is HTMLElement => Boolean(element));
+        const directTaskId = taskTarget?.dataset.dispatchTaskId;
+        if (directTaskId) {
+            onDraftCrewAdd(directTaskId, crew.id);
+            return;
+        }
+
+        const weekCell = elements
+            .map(element => element instanceof HTMLElement ? element.closest<HTMLElement>("[data-dispatch-week-cell]") : null)
+            .find((element): element is HTMLElement => Boolean(element));
+        if (!weekCell) {
+            toast.info("Drop crew onto a task or a Week day cell.");
+            return;
+        }
+        if (weekCell.dataset.dispatchMemberId !== crew.id) {
+            toast.info(`Drop ${crew.name} on ${crew.name}'s own Week row.`);
+            return;
+        }
+        const dayKey = weekCell.dataset.dispatchDay;
+        if (!dayKey) return;
+        const choices = taskChoicesForDay(projects, dayKey);
+        if (choices.length === 1) {
+            onDraftCrewAdd(choices[0].taskId, crew.id);
+        } else {
+            openCrewChooser(crew, choices, null, { x: clientX, y: clientY });
+        }
+    }
+
+    function handleCrewPointerDragStart(event: ReactPointerEvent<HTMLElement>, crew: CrewIdentity) {
+        if (!data.canEdit || event.button !== 0) return;
+        activeCrewDragCleanupRef.current?.();
+        const sourceElement = event.currentTarget;
+        const pointerId = event.pointerId;
+        const startClientX = event.clientX;
+        const startClientY = event.clientY;
+        const threshold = event.pointerType === "touch" ? CREW_TOUCH_DRAG_THRESHOLD_PX : CREW_MOUSE_DRAG_THRESHOLD_PX;
+        let dragVisual: DragVisualLayer | null = null;
+        let lastClientX = startClientX;
+        let lastClientY = startClientY;
+        let cleaned = false;
+
+        sourceElement.setPointerCapture?.(pointerId);
+
+        function cleanup() {
+            if (cleaned) return;
+            cleaned = true;
+            dragVisual?.cleanup();
+            if (sourceElement.hasPointerCapture?.(pointerId)) sourceElement.releasePointerCapture(pointerId);
+            window.removeEventListener("pointermove", onWindowPointerMove);
+            window.removeEventListener("pointerup", onWindowPointerUp);
+            window.removeEventListener("pointercancel", onWindowPointerCancel);
+            window.removeEventListener("keydown", onWindowKeyDown);
+            if (activeCrewDragCleanupRef.current === cleanup) activeCrewDragCleanupRef.current = null;
+        }
+
+        function onWindowPointerMove(moveEvent: PointerEvent) {
+            if (moveEvent.pointerId !== pointerId) return;
+            lastClientX = moveEvent.clientX;
+            lastClientY = moveEvent.clientY;
+            if (!dragVisual && Math.hypot(lastClientX - startClientX, lastClientY - startClientY) >= threshold) {
+                dragVisual = createDragVisualLayer({
+                    sourceElement,
+                    sourceSelector: crewChipDragSourceSelector(crew.id),
+                    kind: "crew-chip",
+                    startClientX,
+                    startClientY,
+                });
+            }
+            if (!dragVisual) return;
+            moveEvent.preventDefault();
+            dragVisual.update({ clientX: lastClientX, clientY: lastClientY, label: crew.name });
+        }
+
+        function onWindowPointerUp(upEvent: PointerEvent) {
+            if (upEvent.pointerId !== pointerId) return;
+            const didDrag = Boolean(dragVisual);
+            lastClientX = upEvent.clientX;
+            lastClientY = upEvent.clientY;
+            if (didDrag) upEvent.preventDefault();
+            cleanup();
+            if (didDrag) resolveCrewDrop(crew, lastClientX, lastClientY);
+        }
+
+        function onWindowPointerCancel(cancelEvent: PointerEvent) {
+            if (cancelEvent.pointerId === pointerId) cleanup();
+        }
+
+        function onWindowKeyDown(keyEvent: KeyboardEvent) {
+            if (keyEvent.key !== "Escape") return;
+            keyEvent.preventDefault();
+            cleanup();
+        }
+
+        window.addEventListener("pointermove", onWindowPointerMove, { passive: false });
+        window.addEventListener("pointerup", onWindowPointerUp);
+        window.addEventListener("pointercancel", onWindowPointerCancel);
+        window.addEventListener("keydown", onWindowKeyDown);
+        activeCrewDragCleanupRef.current = cleanup;
+    }
+
+    function handleCrewKeyboardActivate(event: ReactKeyboardEvent<HTMLElement>, crew: CrewIdentity) {
+        if (!data.canEdit || (event.key !== "Enter" && event.key !== " ")) return;
+        event.preventDefault();
+        const choices = mode === "today"
+            ? taskChoicesForDay(projects, todayKey)
+            : visibleWeekDays.flatMap(day => taskChoicesForDay(projects, formatDate(day)));
+        openCrewChooser(crew, choices, event.currentTarget, null);
+    }
+
+    function scheduleTaskBankItem(item: DispatchTaskBankItem) {
+        onCreateTask({
+            defaultProjectId: selectedTaskBankProjectId,
+            lockProject: true,
+            defaultStartDate: todayKey,
+            defaultName: item.name,
+            defaultEstimatedHours: item.estimatedHours,
+            estimateItemId: item.estimateItemId,
+        });
     }
 
     return (
@@ -208,16 +409,27 @@ export function DispatchView({
                 </div>
             </div>
 
+            <div className="min-w-0 xl:flex">
+            <div className="min-w-0 flex-1">
             {mode === "today" ? (
                 <div className="space-y-4 p-4">
                     <div className="rounded-lg border border-hui-border bg-slate-50 px-3 py-2.5">
                         <div className="flex flex-wrap items-center gap-2">
                             <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Available</span>
                             {available.length === 0 ? <span className="text-xs text-slate-400">No unassigned field crew</span> : available.map(member => (
-                                <span key={member.id} className="inline-flex items-center gap-1.5 rounded-full border border-green-200 bg-white px-2 py-1 text-xs font-semibold text-green-700" title={`${member.name} has no task assignment today`}>
+                                <button
+                                    key={member.id}
+                                    type="button"
+                                    data-dispatch-crew-chip="true"
+                                    data-dispatch-user-id={member.id}
+                                    onPointerDown={event => handleCrewPointerDragStart(event, member)}
+                                    onKeyDown={event => handleCrewKeyboardActivate(event, member)}
+                                    className="inline-flex touch-none items-center gap-1.5 rounded-full border border-green-200 bg-white px-2 py-1 text-xs font-semibold text-green-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary"
+                                    title={`${member.name} has no task assignment today. Drag onto a task or press Enter.`}
+                                >
                                     <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-green-100 text-[9px] font-bold">{initials(member.name)}</span>
                                     {member.name}
-                                </span>
+                                </button>
                             ))}
                         </div>
                         {managerSupport.length > 0 && (
@@ -242,7 +454,11 @@ export function DispatchView({
                                     tasks={activeTodayByProject.get(project.id) ?? []}
                                     highlighted={highlightedProjectId === project.id}
                                     canCreate={data.canEdit}
+                                    crewDrafts={crewDrafts}
                                     onActivate={onActivate}
+                                    onCrewPointerDown={handleCrewPointerDragStart}
+                                    onCrewKeyboardActivate={handleCrewKeyboardActivate}
+                                    onDraftCrewRemove={onDraftCrewRemove}
                                     onAddTask={() => onCreateTask({
                                         defaultProjectId: project.id,
                                         lockProject: true,
@@ -293,13 +509,32 @@ export function DispatchView({
                                 const weekdayAssignedCount = mondayToFriday.filter(day => weekChipsForMember(projects, member.id, formatDate(day)).some(chip => chip.solid)).length;
                                 return (
                                     <div key={member.id} className="grid" role="row" style={{ gridTemplateColumns: `180px repeat(${visibleWeekDays.length}, minmax(140px, 1fr)) 110px` }}>
-                                        <div role="rowheader" className="border-b border-r border-hui-border bg-white px-3 py-3 text-xs font-semibold text-hui-textMain">{member.name}</div>
+                                        <div role="rowheader" className="border-b border-r border-hui-border bg-white px-3 py-3 text-xs font-semibold text-hui-textMain">
+                                            <button
+                                                type="button"
+                                                data-dispatch-crew-chip="true"
+                                                data-dispatch-user-id={member.id}
+                                                onPointerDown={event => handleCrewPointerDragStart(event, member)}
+                                                onKeyDown={event => handleCrewKeyboardActivate(event, member)}
+                                                className="touch-none rounded text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary"
+                                                title={`Drag ${member.name} to a Week day, or press Enter to choose a task`}
+                                            >
+                                                {member.name}
+                                            </button>
+                                        </div>
                                         {visibleWeekDays.map(day => {
                                             const dayKey = formatDate(day);
                                             const chips = weekChipsForMember(projects, member.id, dayKey);
                                             const conflicted = isConflictedDay(crewConflicts, member.id, dayKey, true);
                                             return (
-                                                <div key={`${member.id}-${dayKey}`} role="cell" className="min-h-16 border-b border-r border-hui-border bg-white p-1.5">
+                                                <div
+                                                    key={`${member.id}-${dayKey}`}
+                                                    role="cell"
+                                                    data-dispatch-week-cell="true"
+                                                    data-dispatch-member-id={member.id}
+                                                    data-dispatch-day={dayKey}
+                                                    className="min-h-16 border-b border-r border-hui-border bg-white p-1.5"
+                                                >
                                                     <div className={`flex min-h-12 flex-col gap-1 rounded ${conflicted ? "ring-2 ring-red-500 ring-inset" : ""}`}>
                                                         {chips.map(chip => {
                                                             const color = chip.project.color || getFallbackProjectColor(chip.project.id);
@@ -307,6 +542,7 @@ export function DispatchView({
                                                                 <button
                                                                     key={`${chip.task.id}-${chip.solid ? "solid" : "soft"}`}
                                                                     type="button"
+                                                                    data-dispatch-task-id={chip.task.id}
                                                                     onClick={() => onActivate(chip.task.id)}
                                                                     title={`${chip.project.name} \u2014 ${taskLabel(chip.task)}`}
                                                                     className={`block truncate rounded px-1.5 py-1 text-left text-[11px] font-semibold leading-tight focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary ${chip.solid ? "text-white" : "border-2 bg-white"}`}
@@ -338,6 +574,25 @@ export function DispatchView({
                     </div>
                 </div>
             )}
+            </div>
+            <DispatchTaskBank
+                projects={projects.map(project => ({ id: project.id, name: project.name, taskCount: project.taskCount }))}
+                selectedProjectId={selectedTaskBankProjectId}
+                refreshKey={taskBankRefreshKey}
+                canSchedule={data.canEdit}
+                onProjectChange={setTaskBankProjectId}
+                onSchedule={scheduleTaskBankItem}
+            />
+            </div>
+            <DispatchCrewTaskChooser
+                open={Boolean(crewChooser)}
+                crewName={crewChooser?.crew.name ?? ""}
+                choices={crewChooser?.choices ?? []}
+                anchorPoint={crewChooser?.anchorPoint ?? null}
+                anchorRef={crewChooserAnchorRef}
+                onChoose={applyCrewChoice}
+                onClose={closeCrewChooser}
+            />
         </div>
     );
 }

--- a/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
+++ b/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
@@ -184,6 +184,12 @@ interface ProjectDraftMove {
     deltaDays: number;
 }
 
+interface CrewDraft {
+    addUserIds: string[];
+    removeUserIds: string[];
+    expectedAssignments: DispatchAssignment[];
+}
+
 interface DispatchReconciliationExpectation {
     publicationId: string;
     projects: Record<string, PersistedDispatchProjectState>;
@@ -305,6 +311,7 @@ export function ScheduleBoard({
     // the pending-to-save payload; nothing writes to the server until Save.
     const [taskDateOverrides, setTaskDateOverrides] = useState<Record<string, TaskDateOverride>>({});
     const [projectDrafts, setProjectDrafts] = useState<Record<string, ProjectDraftMove>>({});
+    const [crewDrafts, setCrewDrafts] = useState<Record<string, CrewDraft>>({});
     // Read at reconciliation-timeout FIRE time (an effect-render snapshot can
     // miss a just-added draft or resurrect a just-discarded one).
     const projectDraftsRef = useRef(projectDrafts);
@@ -383,11 +390,25 @@ export function ScheduleBoard({
     const canonicalTaskProjectById = useMemo(() => new Map(canonicalProjects.flatMap(project => (
         project.tasks.map(task => [task.id, project.id] as const)
     ))), [canonicalProjects]);
+    const dispatchTaskNamesById = useMemo(
+        () => new Map(canonicalProjects.flatMap(project => project.tasks.map(task => [task.id, task.name] as const))),
+        [canonicalProjects],
+    );
+    const dispatchMemberNamesById = useMemo(() => new Map([
+        ...(data.teamMembers ?? []).map(member => [member.id, member.name || member.email] as const),
+        ...canonicalProjects.flatMap(project => project.tasks.flatMap(task =>
+            task.assignments.map(assignment => [assignment.userId, assignment.name] as const),
+        )),
+    ]), [canonicalProjects, data.teamMembers]);
     const activeProjectOptions = useMemo(() => canonicalProjects.map(project => ({
         id: project.id,
         name: project.name,
         color: project.color || "#4c9a2a",
     })), [canonicalProjects]);
+    const teamMemberById = useMemo(
+        () => new Map((data.teamMembers ?? []).map(member => [member.id, member])),
+        [data.teamMembers],
+    );
     // A saved-but-not-yet-refreshed task keeps its override (pinned to the
     // persisted dates) purely for rendering/reconciliation — it is NOT an
     // unsaved draft and must not count toward or re-enter a Save.
@@ -401,13 +422,15 @@ export function ScheduleBoard({
         )),
         [taskDateOverrides, awaitingTaskRefreshIds, dispatchAwaitingTaskIds],
     );
+    const crewDraftTaskIds = useMemo(() => new Set(Object.keys(crewDrafts)), [crewDrafts]);
     const draftProjectIds = useMemo(() => new Set(Object.keys(projectDrafts)), [projectDrafts]);
-    const draftCount = draftTaskIds.size + draftProjectIds.size;
+    const draftCount = draftTaskIds.size + draftProjectIds.size + crewDraftTaskIds.size;
     const openTaskProjectId = openTaskId ? canonicalTaskProjectById.get(openTaskId) : null;
     const openTaskHasDraft = Boolean(openTaskId && (
         draftTaskIds.has(openTaskId)
         || (openTaskProjectId && draftProjectIds.has(openTaskProjectId))
     ));
+    const openTaskHasCrewDraft = Boolean(openTaskId && crewDrafts[openTaskId]);
 
     // Locking during draft mode: a drafted item stays fully interactive.
     // Only an in-flight Save (global — the whole board pauses while
@@ -445,14 +468,14 @@ export function ScheduleBoard({
         let pending = mergeProjectPendingIds(saveLockedProjectIds, endResizeSavingProjectIds);
         if (isDispatchReviewing || isDispatchPublishing) {
             const dispatchAffected = new Set(draftProjectIds);
-            for (const taskId of draftTaskIds) {
+            for (const taskId of [...draftTaskIds, ...crewDraftTaskIds]) {
                 const projectId = canonicalTaskProjectById.get(taskId);
                 if (projectId) dispatchAffected.add(projectId);
             }
             pending = mergeProjectPendingIds(pending, dispatchAffected);
         }
         onEffectivePendingProjectIdsChange(pending);
-    }, [saveLockedProjectIds, endResizeSavingProjectIds, isDispatchReviewing, isDispatchPublishing, draftProjectIds, draftTaskIds, canonicalTaskProjectById, onEffectivePendingProjectIdsChange]);
+    }, [saveLockedProjectIds, endResizeSavingProjectIds, isDispatchReviewing, isDispatchPublishing, draftProjectIds, draftTaskIds, crewDraftTaskIds, canonicalTaskProjectById, onEffectivePendingProjectIdsChange]);
 
     const applyPreview = (project: DashboardProjectRow) => {
         const projectPreview = projectPreviewOverrides[project.id] ?? project;
@@ -460,7 +483,29 @@ export function ScheduleBoard({
             ...projectPreview,
             tasks: projectPreview.tasks.map(task => {
                 const dates = taskDateOverrides[task.id];
-                return dates ? { ...task, ...dates } : task;
+                const draft = crewDrafts[task.id];
+                const reconciledAssignments = dispatchReconciliationExpectation?.assignments[task.id];
+                const expectedAssignments = draft
+                    ? draft.expectedAssignments
+                        .filter(assignment => !draft.removeUserIds.includes(assignment.userId))
+                        .concat(draft.addUserIds.map(userId => ({ userId, role: "assigned" as const })))
+                        .sort((left, right) => left.userId.localeCompare(right.userId) || left.role.localeCompare(right.role))
+                    : reconciledAssignments;
+                const assignments = expectedAssignments
+                    ? expectedAssignments.map(assignment => {
+                        const existing = task.assignments.find(row => row.userId === assignment.userId);
+                        const member = teamMemberById.get(assignment.userId);
+                        return {
+                            id: existing?.id ?? `crew-draft:${task.id}:${assignment.userId}`,
+                            userId: assignment.userId,
+                            name: existing?.name ?? member?.name ?? member?.email ?? "Crew member",
+                            status: existing?.status ?? "ACTIVATED",
+                            userRole: existing?.userRole ?? member?.role ?? "FIELD_CREW",
+                            assignmentRole: assignment.role,
+                        };
+                    })
+                    : task.assignments;
+                return { ...task, ...(dates ?? {}), assignments };
             }),
         };
     };
@@ -739,6 +784,12 @@ export function ScheduleBoard({
             next.delete(taskId);
             return next;
         });
+        setCrewDrafts(current => {
+            if (!(taskId in current)) return current;
+            const next = { ...current };
+            delete next[taskId];
+            return next;
+        });
         setOpenTaskId(null);
     }, []);
 
@@ -781,6 +832,76 @@ export function ScheduleBoard({
     }
 
     // ── Draft-mode writers: accumulate locally, never touch the server. ──
+
+    function queueCrewAddition(taskId: string, userId: string): boolean {
+        const task = canonicalTaskById.get(taskId);
+        if (!data.canEdit || isTaskLocked(taskId) || !task) return false;
+        const existingDraft = crewDrafts[taskId];
+        const expectedAssignments = existingDraft?.expectedAssignments ?? dashboardTaskAssignments(task);
+        const addUserIds = new Set(existingDraft?.addUserIds ?? []);
+        const removeUserIds = new Set(existingDraft?.removeUserIds ?? []);
+        const isExpected = expectedAssignments.some(assignment => assignment.userId === userId);
+        const isEffectivelyAssigned = (isExpected && !removeUserIds.has(userId)) || addUserIds.has(userId);
+        if (isEffectivelyAssigned) {
+            toast.info(`${teamMemberById.get(userId)?.name ?? "Crew member"} is already on ${task.name}.`);
+            return false;
+        }
+
+        if (isExpected) removeUserIds.delete(userId);
+        else addUserIds.add(userId);
+        detachDispatchExpectationTargets({ taskIds: new Set([taskId]) });
+        if (addUserIds.size === 0 && removeUserIds.size === 0) {
+            setCrewDrafts(current => {
+                if (!(taskId in current)) return current;
+                const next = { ...current };
+                delete next[taskId];
+                return next;
+            });
+            return true;
+        }
+        setCrewDrafts(current => ({
+            ...current,
+            [taskId]: {
+                expectedAssignments,
+                addUserIds: [...addUserIds].sort(),
+                removeUserIds: [...removeUserIds].sort(),
+            },
+        }));
+        return true;
+    }
+
+    function queueCrewRemoval(taskId: string, userId: string) {
+        const task = canonicalTaskById.get(taskId);
+        if (!data.canEdit || isTaskLocked(taskId) || !task) return;
+        const existingDraft = crewDrafts[taskId];
+        const expectedAssignments = existingDraft?.expectedAssignments ?? dashboardTaskAssignments(task);
+        const addUserIds = new Set(existingDraft?.addUserIds ?? []);
+        const removeUserIds = new Set(existingDraft?.removeUserIds ?? []);
+        const isExpected = expectedAssignments.some(assignment => assignment.userId === userId);
+        const isEffectivelyAssigned = (isExpected && !removeUserIds.has(userId)) || addUserIds.has(userId);
+        if (!isEffectivelyAssigned) return;
+
+        if (addUserIds.has(userId)) addUserIds.delete(userId);
+        else if (isExpected) removeUserIds.add(userId);
+        detachDispatchExpectationTargets({ taskIds: new Set([taskId]) });
+        if (addUserIds.size === 0 && removeUserIds.size === 0) {
+            setCrewDrafts(current => {
+                if (!(taskId in current)) return current;
+                const next = { ...current };
+                delete next[taskId];
+                return next;
+            });
+            return;
+        }
+        setCrewDrafts(current => ({
+            ...current,
+            [taskId]: {
+                expectedAssignments,
+                addUserIds: [...addUserIds].sort(),
+                removeUserIds: [...removeUserIds].sort(),
+            },
+        }));
+    }
 
     function draftTaskChange(taskId: string, dates: TaskDateOverride) {
         const canonicalTask = canonicalTaskById.get(taskId);
@@ -887,6 +1008,7 @@ export function ScheduleBoard({
         cancelActiveProjectEdit();
         for (const projectId of Object.keys(projectDrafts)) clearProjectPreview(projectId);
         setProjectDrafts({});
+        setCrewDrafts({});
         // Discard clears UNSAVED drafts only. Saved-awaiting overrides are
         // committed state pending refresh — removing them here would strand
         // their awaiting ids and the refresh poll forever.
@@ -931,11 +1053,15 @@ export function ScheduleBoard({
     async function collectDispatchIntents(): Promise<DispatchIntent[] | null> {
         const projectEntries = Object.entries(projectDrafts);
         const taskEntries = [...draftTaskIds].map(taskId => [taskId, taskDateOverrides[taskId]!] as const);
-        if (projectEntries.length === 0 && taskEntries.length === 0) return [];
+        const crewEntries = Object.entries(crewDrafts);
+        if (projectEntries.length === 0 && taskEntries.length === 0 && crewEntries.length === 0) return [];
 
         const affectedProjectIds = new Set([
             ...projectEntries.map(([projectId]) => projectId),
             ...taskEntries
+                .map(([taskId]) => canonicalTaskProjectById.get(taskId))
+                .filter((projectId): projectId is string => Boolean(projectId)),
+            ...crewEntries
                 .map(([taskId]) => canonicalTaskProjectById.get(taskId))
                 .filter((projectId): projectId is string => Boolean(projectId)),
         ]);
@@ -1006,6 +1132,28 @@ export function ScheduleBoard({
                 expectedAssignments: dashboardTaskAssignments(task),
                 startDate: dates.startDate,
                 endDate: dates.endDate,
+            });
+        }
+        for (const [taskId, draft] of crewEntries) {
+            const task = canonicalTaskById.get(taskId);
+            const projectId = canonicalTaskProjectById.get(taskId);
+            if (!task || !projectId) {
+                toast.error(`Task ${taskId} is no longer on this schedule. Refresh before reviewing.`);
+                router.refresh();
+                return null;
+            }
+            const removeIds = new Set(draft.removeUserIds);
+            const assignments = draft.expectedAssignments
+                .filter(assignment => !removeIds.has(assignment.userId))
+                .concat(draft.addUserIds.map(userId => ({ userId, role: "assigned" as const })))
+                .sort((left, right) => left.userId.localeCompare(right.userId) || left.role.localeCompare(right.role));
+            intents.push({
+                kind: "TASK_CREW",
+                projectId,
+                taskId,
+                expectedUpdatedAt: task.updatedAt,
+                expectedAssignments: draft.expectedAssignments,
+                assignments,
             });
         }
         return intents;
@@ -1250,6 +1398,9 @@ export function ScheduleBoard({
             const explicitlyDraftedTaskIds = new Set(dispatchReview.intents
                 .filter(intent => intent.kind === "TASK_DATES")
                 .map(intent => intent.taskId));
+            const publishedCrewTaskIds = new Set(dispatchReview.intents
+                .filter(intent => intent.kind === "TASK_CREW")
+                .map(intent => intent.taskId));
 
             setProjectDrafts(current => Object.fromEntries(
                 Object.entries(current).filter(([projectId]) => !publishedProjectIds.has(projectId)),
@@ -1276,6 +1427,9 @@ export function ScheduleBoard({
                 }
                 return next;
             });
+            setCrewDrafts(current => Object.fromEntries(
+                Object.entries(current).filter(([taskId]) => !publishedCrewTaskIds.has(taskId)),
+            ));
             setDispatchReconciliationExpectation({
                 publicationId: result.publicationId,
                 projects: result.reconciliation.projects,
@@ -2231,6 +2385,9 @@ export function ScheduleBoard({
                     onReviewDispatch={() => void reviewDispatchDrafts()}
                     draftCount={draftCount}
                     isReviewingDispatch={isDispatchReviewing || isDispatchPublishing}
+                    crewDrafts={crewDrafts}
+                    onDraftCrewAdd={queueCrewAddition}
+                    onDraftCrewRemove={queueCrewRemoval}
                 />
             ) : boardView === "month" ? (
                 <MonthBarsView
@@ -2318,12 +2475,15 @@ export function ScheduleBoard({
                 published={dispatchReview?.published ?? false}
                 isPending={isDispatchPublishing}
                 conflictTargetIds={dispatchConflictTargetIds}
+                taskNamesById={dispatchTaskNamesById}
+                memberNamesById={dispatchMemberNamesById}
                 onConfirm={() => void publishDispatchDrafts()}
                 onClose={() => setDispatchReview(null)}
             />
             <BoardTaskDrawer
                 taskId={openTaskId}
                 hasDraft={openTaskHasDraft}
+                hasCrewDraft={openTaskHasCrewDraft}
                 teamMembers={data.teamMembers ?? []}
                 onClose={closeTaskDrawer}
                 onSelectTask={selectDrawerTask}
@@ -2336,6 +2496,9 @@ export function ScheduleBoard({
                 lockProject={taskCreationDefaults.lockProject}
                 defaultStartDate={taskCreationDefaults.defaultStartDate}
                 defaultCrewIds={taskCreationDefaults.defaultCrewIds}
+                defaultName={taskCreationDefaults.defaultName}
+                defaultEstimatedHours={taskCreationDefaults.defaultEstimatedHours}
+                estimateItemId={taskCreationDefaults.estimateItemId}
                 projects={activeProjectOptions}
             />
         </div>

--- a/src/app/company-dashboard/schedule-board/dragVisualLayer.ts
+++ b/src/app/company-dashboard/schedule-board/dragVisualLayer.ts
@@ -6,7 +6,8 @@ export type DragVisualKind =
     | "task-resize-right"
     | "project-move"
     | "project-marker-move"
-    | "project-end-resize";
+    | "project-end-resize"
+    | "crew-chip";
 
 export interface DragVisualLayerOptions {
     sourceElement: HTMLElement;
@@ -92,6 +93,10 @@ export function projectDragSourceSelector(projectId: string): string {
 
 export function projectMarkerDragSourceSelector(projectId: string): string {
     return `${projectDragSourceSelector(projectId)} [data-drag-project-title="true"]`;
+}
+
+export function crewChipDragSourceSelector(userId: string): string {
+    return `[data-dispatch-crew-chip][data-dispatch-user-id="${escapeAttributeValue(userId)}"]`;
 }
 
 function stripCloneInteractivity(root: HTMLElement) {

--- a/src/app/projects/[id]/schedule/TaskDetailPanel.tsx
+++ b/src/app/projects/[id]/schedule/TaskDetailPanel.tsx
@@ -53,6 +53,8 @@ export type TaskDetailPanelProps = {
     onAppointmentChange: (taskId: string, data: { scheduledTime?: string | null; confirmationStatus?: "planned" | "requested" | "confirmed" | null }) => void;
     datesReadOnly?: boolean;
     dateReadOnlyNote?: string;
+    crewReadOnly?: boolean;
+    crewReadOnlyNote?: string;
     embedded?: boolean;
 };
 
@@ -65,7 +67,9 @@ export default function TaskDetailPanel({
     comments, onAddComment,
     showCriticalPath, criticalPathIds,
     allTasks, onLinkPredecessor, onUnlinkPredecessor, onSelectTask, onAppointmentChange,
-    datesReadOnly = false, dateReadOnlyNote, embedded = false,
+    datesReadOnly = false, dateReadOnlyNote,
+    crewReadOnly = false, crewReadOnlyNote,
+    embedded = false,
 }: TaskDetailPanelProps) {
     const [showAssignMenu, setShowAssignMenu] = useState(false);
     const [showEstimateLinkMenu, setShowEstimateLinkMenu] = useState(false);
@@ -552,11 +556,16 @@ export default function TaskDetailPanel({
                                 {hasTeam && <span className="text-xs text-slate-400 ml-1">({(task.assignments || []).length + (task.subAssignments || []).length})</span>}
                             </summary>
                             <div className="pb-4 pl-5.5">
+                                {crewReadOnly && crewReadOnlyNote && (
+                                    <p className="mb-3 rounded-md border border-indigo-200 bg-indigo-50 px-3 py-2 text-xs font-medium text-indigo-800">
+                                        {crewReadOnlyNote}
+                                    </p>
+                                )}
                                 <div className="flex items-center justify-between mb-2">
                                     <label className={SECTION_LABEL}>Assigned</label>
                                     <div className="relative">
-                                        <button onClick={() => setShowAssignMenu(!showAssignMenu)} className="text-xs text-indigo-600 font-semibold hover:text-indigo-800 transition">+ Add</button>
-                                        {showAssignMenu && (
+                                        <button disabled={crewReadOnly} onClick={() => setShowAssignMenu(!showAssignMenu)} className="text-xs text-indigo-600 font-semibold hover:text-indigo-800 transition disabled:cursor-not-allowed disabled:text-slate-300">+ Add</button>
+                                        {showAssignMenu && !crewReadOnly && (
                                             <div className="absolute right-0 top-full mt-1 bg-white border border-hui-border rounded-lg shadow-xl z-50 min-w-[240px] py-1 animate-in fade-in max-h-60 overflow-y-auto">
                                                 <div className="px-3 py-2 text-xs font-semibold text-slate-400 uppercase tracking-wider bg-slate-50">Team Members</div>
                                                 {teamMembers.filter(m => !(task.assignments || []).some(a => a.userId === m.id)).map(m => (
@@ -584,15 +593,16 @@ export default function TaskDetailPanel({
                                             <span className="text-xs font-medium text-hui-textMain flex-1 truncate">{a.user.name || a.user.email}</span>
                                             <button
                                                 type="button"
+                                                disabled={crewReadOnly}
                                                 onClick={() => onSetLead(a.role === "lead" ? null : a.userId)}
                                                 aria-label={a.role === "lead" ? `Remove ${a.user.name || a.user.email} as lead` : `Set ${a.user.name || a.user.email} as lead`}
                                                 aria-pressed={a.role === "lead"}
                                                 title={a.role === "lead" ? "Task lead — click to remove" : "Make task lead"}
-                                                className={`shrink-0 rounded p-1 transition ${a.role === "lead" ? "text-amber-500 bg-amber-50" : "text-slate-300 hover:text-amber-500 hover:bg-amber-50"}`}
+                                                className={`shrink-0 rounded p-1 transition disabled:cursor-not-allowed disabled:opacity-40 ${a.role === "lead" ? "text-amber-500 bg-amber-50" : "text-slate-300 hover:text-amber-500 hover:bg-amber-50"}`}
                                             >
                                                 <svg width="14" height="14" viewBox="0 0 24 24" fill={a.role === "lead" ? "currentColor" : "none"} stroke="currentColor" strokeWidth="1.8"><path d="m12 2.75 2.84 5.75 6.35.92-4.6 4.48 1.09 6.32L12 17.24l-5.68 2.98 1.09-6.32-4.6-4.48 6.35-.92L12 2.75Z" /></svg>
                                             </button>
-                                            <button onClick={() => onUnassign(a.userId)} className="text-slate-300 hover:text-red-500 transition shrink-0">
+                                            <button disabled={crewReadOnly} onClick={() => onUnassign(a.userId)} className="text-slate-300 hover:text-red-500 transition shrink-0 disabled:cursor-not-allowed disabled:opacity-40" aria-label={`Remove ${a.user.name || a.user.email} from task`}>
                                                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6 6 18M6 6l12 12" /></svg>
                                             </button>
                                         </div>

--- a/src/components/TaskCreationDialog.tsx
+++ b/src/components/TaskCreationDialog.tsx
@@ -16,6 +16,9 @@ type TaskCreationDialogProps = {
     lockProject?: boolean;
     defaultStartDate?: string;
     defaultCrewIds?: string[];
+    defaultName?: string;
+    defaultEstimatedHours?: number | null;
+    estimateItemId?: string;
     projects: { id: string; name: string; color: string }[];
 };
 
@@ -28,6 +31,9 @@ export default function TaskCreationDialog({
     lockProject = false,
     defaultStartDate,
     defaultCrewIds,
+    defaultName,
+    defaultEstimatedHours,
+    estimateItemId,
     projects,
 }: TaskCreationDialogProps) {
     const router = useRouter();
@@ -58,7 +64,7 @@ export default function TaskCreationDialog({
         if (initializedOpenRef.current) return;
         initializedOpenRef.current = true;
         const initialStart = defaultStartDate ?? formatDate(todayUTC());
-        setName("");
+        setName(defaultName ?? "");
         setProjectId(defaultProjectId && projects.some(project => project.id === defaultProjectId) ? defaultProjectId : (projects[0]?.id ?? ""));
         setType("task");
         setStartDate(initialStart);
@@ -68,9 +74,9 @@ export default function TaskCreationDialog({
         setCrewIds([...new Set(defaultCrewValues)]);
         setLeadUserId(null);
         setDoneWhen("");
-        setEstimatedHours("");
+        setEstimatedHours(defaultEstimatedHours == null ? "" : String(defaultEstimatedHours));
         setNote("");
-    }, [open, defaultProjectId, defaultStartDate, defaultCrewValues, projects]);
+    }, [open, defaultProjectId, defaultStartDate, defaultCrewValues, defaultName, defaultEstimatedHours, projects]);
 
     useEffect(() => {
         if (!open || projectId || !projects[0]) return;
@@ -119,6 +125,7 @@ export default function TaskCreationDialog({
                     endDate: type === "milestone" ? startDate : endDate,
                     color: selectedProject?.color,
                     type,
+                    estimateItemId: estimateItemId ?? null,
                     crewIds,
                     leadUserId,
                     estimatedHours: hours,
@@ -166,6 +173,7 @@ export default function TaskCreationDialog({
                         <div>
                             <label className="text-xs font-semibold uppercase tracking-wider text-hui-textMuted" htmlFor="create-task-name">Name</label>
                             <input id="create-task-name" value={name} onChange={event => setName(event.target.value)} className="hui-input mt-1.5 w-full text-sm" placeholder="e.g. Electrical rough-in walkthrough" autoFocus />
+                            {estimateItemId && <p className="mt-1.5 text-xs text-hui-textMuted">Linked to this contract estimate item.</p>}
                         </div>
 
                         <div className="grid gap-4 sm:grid-cols-2">

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -17,7 +17,7 @@ import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { enqueueMilestonePaid, drainPaymentNotifications } from "./payment-outbox";
 import { deleteChangeOrderCore, updateChangeOrderCore } from "./change-order-core";
 import { approveChangeOrderWithSignature } from "./change-order-approval";
-import { applyChangeOrderToSchedule, autoGenerateScheduleForApprovedEstimate, setProjectStartDate, shiftNotStartedTasks, parseStartDateInput, generateScheduleFromEstimate, setProjectCrew, setTaskCrew, CONTRACT_ESTIMATE_STATUSES, lockTaskAssignmentParent, touchTaskAssignmentRevision } from "./schedule-core";
+import { applyChangeOrderToSchedule, autoGenerateScheduleForApprovedEstimate, canonicalContractEstimateQuery, deriveEstimateItemHours, setProjectStartDate, shiftNotStartedTasks, parseStartDateInput, generateScheduleFromEstimate, setProjectCrew, setTaskCrew, lockTaskAssignmentParent, touchTaskAssignmentRevision } from "./schedule-core";
 import { CLOSED_PROJECT_STATUSES } from "./gpt-estimate";
 import type { ShiftNotStartedTasksResult } from "./schedule-core";
 import type { ChangeOrderUpdateInput } from "./change-order-core";
@@ -6531,6 +6531,68 @@ export async function getScheduleTasks(projectId: string) {
     });
 }
 
+export interface TaskBankResult {
+    estimate: { id: string; code: string } | null;
+    items: {
+        estimateItemId: string;
+        name: string;
+        estimatedHours: number | null;
+    }[];
+    scheduledCount: number;
+    totalCount: number;
+}
+
+export async function getTaskBank(projectId: string): Promise<TaskBankResult> {
+    const session = await getSessionOrDev();
+    if (!session?.user) throw new Error("Unauthorized");
+
+    const estimate = await prisma.estimate.findFirst({
+        ...canonicalContractEstimateQuery(projectId),
+        select: {
+            id: true,
+            code: true,
+            items: {
+                where: { type: { not: "Section" } },
+                orderBy: [{ order: "asc" }, { id: "asc" }],
+                select: {
+                    id: true,
+                    name: true,
+                    quantity: true,
+                    budgetUnit: true,
+                    _count: { select: { subItems: true } },
+                    scheduleTask: { select: { id: true } },
+                },
+            },
+        },
+    });
+    if (!estimate) {
+        return {
+            estimate: null,
+            items: [],
+            scheduledCount: 0,
+            totalCount: 0,
+        };
+    }
+
+    const scheduledCount = estimate.items.filter(item => Boolean(item.scheduleTask)).length;
+    return {
+        estimate: { id: estimate.id, code: estimate.code },
+        items: estimate.items
+            .filter(item => !item.scheduleTask)
+            .map(item => ({
+                estimateItemId: item.id,
+                name: item.name,
+                estimatedHours: deriveEstimateItemHours({
+                    quantity: item.quantity,
+                    budgetUnit: item.budgetUnit,
+                    childCount: item._count.subItems,
+                }),
+            })),
+        scheduledCount,
+        totalCount: estimate.items.length,
+    };
+}
+
 function serializeScheduleTaskForDetail(task: any) {
     return {
         id: task.id,
@@ -6784,6 +6846,7 @@ export async function createScheduleTask(projectId: string, data: {
     assignee?: string;
     parentId?: string;
     type?: ScheduleTaskType;
+    estimateItemId?: string | null;
     crewIds?: string[];
     leadUserId?: string | null;
     estimatedHours?: number | null;
@@ -6812,6 +6875,7 @@ export async function createScheduleTask(projectId: string, data: {
         throw new Error("Scheduled time and confirmation status are appointment-only fields");
     }
     const confirmationStatus = type === "appointment" ? (data.confirmationStatus ?? "planned") : null;
+    const estimateItemId = data.estimateItemId?.trim() || null;
     const crewIds = [...new Set((data.crewIds ?? []).filter(Boolean))];
     const leadUserId = data.leadUserId ?? null;
     if (leadUserId && !crewIds.includes(leadUserId)) throw new Error("Task lead must be assigned to the crew");
@@ -6819,6 +6883,31 @@ export async function createScheduleTask(projectId: string, data: {
     const commentAuthor = note ? await resolveTaskCommentAuthor() : null;
     const task = await withTxRetry(() => prisma.$transaction(async (tx) => {
         await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${projectId} FOR UPDATE`;
+        const estimateItem = estimateItemId
+            ? await tx.estimateItem.findUnique({
+                where: { id: estimateItemId },
+                select: {
+                    id: true,
+                    type: true,
+                    quantity: true,
+                    budgetUnit: true,
+                    estimate: { select: { projectId: true } },
+                    scheduleTask: { select: { id: true, name: true } },
+                    _count: { select: { subItems: true } },
+                },
+            })
+            : null;
+        if (estimateItemId) {
+            if (!estimateItem || estimateItem.estimate.projectId !== projectId) {
+                throw new Error("Estimate item does not belong to this project");
+            }
+            if (estimateItem.type === "Section") {
+                throw new Error("Estimate sections cannot be scheduled as tasks");
+            }
+            if (estimateItem.scheduleTask) {
+                throw new Error(`Already linked to "${estimateItem.scheduleTask.name}"`);
+            }
+        }
         const maxOrder = await tx.scheduleTask.aggregate({
             where: { projectId },
             _max: { order: true },
@@ -6841,7 +6930,14 @@ export async function createScheduleTask(projectId: string, data: {
             parentId: data.parentId || null,
             order: (maxOrder._max.order ?? -1) + 1,
             type,
-            estimatedHours: data.estimatedHours ?? null,
+            estimateItemId,
+            estimatedHours: data.estimatedHours ?? (estimateItem
+                ? deriveEstimateItemHours({
+                    quantity: estimateItem.quantity,
+                    budgetUnit: estimateItem.budgetUnit,
+                    childCount: estimateItem._count.subItems,
+                })
+                : null),
             doneWhen: data.doneWhen?.trim() || null,
             scheduledTime,
             confirmationStatus,
@@ -6871,6 +6967,7 @@ export async function createScheduleTask(projectId: string, data: {
                     color: createData.color,
                     status: createData.status,
                     type,
+                    estimateItemId,
                     crewIds,
                     leadUserId,
                     estimatedHours: createData.estimatedHours,
@@ -7769,8 +7866,7 @@ export async function generateProjectScheduleAction(projectId: string) {
     if (!caller || !["ADMIN", "MANAGER"].includes(caller.role)) throw new Error("Forbidden");
 
     const estimate = await prisma.estimate.findFirst({
-        where: { projectId, status: { in: CONTRACT_ESTIMATE_STATUSES } },
-        orderBy: { createdAt: "desc" },
+        ...canonicalContractEstimateQuery(projectId),
         select: { id: true },
     });
     if (!estimate) throw new Error("No Approved, Invoiced, Partially Paid, or Paid estimate on this project yet — approve an estimate first.");

--- a/src/lib/dispatch-intent.ts
+++ b/src/lib/dispatch-intent.ts
@@ -296,6 +296,34 @@ function assignmentSummary(
     }).join(", ");
 }
 
+function taskCrewSummary(
+    task: DispatchTaskSnapshot,
+    before: DispatchAssignment[],
+    after: DispatchAssignment[],
+    usersById: Map<string, DispatchUserSnapshot>,
+): string {
+    const beforeByUser = new Map(before.map(assignment => [assignment.userId, assignment]));
+    const afterByUser = new Map(after.map(assignment => [assignment.userId, assignment]));
+    const rows: string[] = [];
+    for (const assignment of after) {
+        const previous = beforeByUser.get(assignment.userId);
+        const name = usersById.get(assignment.userId)?.name ?? assignment.userId;
+        if (!previous) {
+            rows.push(`${name} \u2192 ${task.name} (add)`);
+        } else if (previous.role !== assignment.role) {
+            rows.push(`${name} on ${task.name}: ${previous.role} \u2192 ${assignment.role}`);
+        }
+    }
+    for (const assignment of before) {
+        if (afterByUser.has(assignment.userId)) continue;
+        const name = usersById.get(assignment.userId)?.name ?? assignment.userId;
+        rows.push(`${name} removed from ${task.name}`);
+    }
+    return rows.length > 0
+        ? rows.join("; ")
+        : `${task.name}: ${assignmentSummary(before, usersById)} \u2192 ${assignmentSummary(after, usersById)}`;
+}
+
 function taskDateSummary(
     task: DispatchTaskSnapshot,
     before: PersistedDispatchTaskState,
@@ -543,7 +571,7 @@ export function buildDispatchPlan(input: {
                 kind: "TASK_CREW",
                 before: { assignments: beforeCrew },
                 after: { assignments: afterCrew },
-                summary: `${task.name}: ${assignmentSummary(beforeCrew, usersById)} → ${assignmentSummary(afterCrew, usersById)}`,
+                summary: taskCrewSummary(task, beforeCrew, afterCrew, usersById),
             });
             changedTaskIds.add(task.id);
         }

--- a/src/lib/schedule-core.ts
+++ b/src/lib/schedule-core.ts
@@ -23,6 +23,16 @@ import { formatDate, parseUTCDate, addDays, getMonthGrid, getDefaultColorForTask
 // for schedule generation (same selection rule, PB-pipeline-002 R1 fix 6).
 export const CONTRACT_ESTIMATE_STATUSES = ["Approved", "Invoiced", "Partially Paid", "Paid"];
 
+export function canonicalContractEstimateQuery(projectId: string) {
+    return {
+        where: {
+            projectId,
+            status: { in: CONTRACT_ESTIMATE_STATUSES },
+        },
+        orderBy: { createdAt: "desc" as const },
+    };
+}
+
 export type ScheduleActor = { type: "TEAM" | "SYSTEM"; name: string };
 
 export interface LockedTaskAssignmentParent {
@@ -686,8 +696,7 @@ async function runSetProjectStartDate(
             const [taskCount, qualifying] = await Promise.all([
                 prisma.scheduleTask.count({ where: { projectId } }),
                 prisma.estimate.findFirst({
-                    where: { projectId, status: { in: CONTRACT_ESTIMATE_STATUSES } },
-                    orderBy: { createdAt: "desc" },
+                    ...canonicalContractEstimateQuery(projectId),
                     select: { id: true, code: true },
                 }),
             ]);
@@ -977,6 +986,15 @@ function isLaborLine(line: { type: string; costTypeName: string | null }): boole
 const HOUR_LIKE_BUDGET_UNITS = new Set(["hr", "hrs", "hour", "hours"]);
 function isHourLikeBudgetUnit(budgetUnit: string | null): boolean {
     return !!budgetUnit && HOUR_LIKE_BUDGET_UNITS.has(budgetUnit.toLowerCase());
+}
+
+export function deriveEstimateItemHours(item: {
+    quantity: number;
+    budgetUnit: string | null;
+    childCount?: number;
+}): number | null {
+    if ((item.childCount ?? 0) > 0) return null;
+    return isHourLikeBudgetUnit(item.budgetUnit) ? item.quantity : null;
 }
 
 interface EstimateLine {
@@ -1318,7 +1336,7 @@ export async function generateScheduleFromEstimate(input: {
                     color: colorFor(line),
                     order: nextOrder++,
                     type: "task",
-                    estimatedHours: isHourLikeBudgetUnit(line.budgetUnit) ? line.quantity : null,
+                    estimatedHours: deriveEstimateItemHours(line),
                     estimateItemId: line.id,
                     parentId: parentTaskId,
                 });


### PR DESCRIPTION
PR-B2 of the dispatch arc — the owner's original ask verbatim: "the ability to drag and drop and move resources like crew."

## What's new
- **Drag a crew chip onto a task** (or a Week-grid day cell) and it queues as a draft — dashed ring, removable, Escape cancels, full keyboard path. Crew drafts commit through the same atomic "Review dispatch → Confirm & queue dispatch" transaction as date drafts, with per-person diff rows. A stale crew snapshot aborts the entire publish, dates included (proven: verifier case 17).
- **Task Bank**: a dispatch rail showing contract-estimate items that have no scheduled task yet, with a "N of M scheduled" coverage meter and one-click prefilled creation — everything sold gets planned.
- Month/Timeline crew pickers keep their immediate-commit behavior; the drawer's crew section locks while a draft exists on that task.

## Verification
- All 6 gates green, including the publish behavioral suite grown to **18 cases**
- Independent checker traced: dispatch-only drafting, the whole-publish rollback quote, the pending-union fold, the canonical-estimate IMPORT (same function generation uses), and createScheduleTask's new estimateItemId validation chain
- Browser, end-to-end on Shop: chip → chooser → draft → "Review dispatch (1)" showing "Pierce Gange → B2-VERIFY chip drag task (add)" + **1 pending delivery** → confirmed → DB shows the assignment AND the PENDING ChatDelivery row PR-D will drain → cleaned up
- Sol correction of my spec: `createScheduleTask` did NOT already accept `estimateItemId` — added with ownership/Section/duplicate-link validation

Implemented by GPT-5.6-sol (xhigh); independently gate-checked; reviewed and browser-verified by Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)