### PR TITLE
Task materials + staging queue for Chris

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,8 @@ model User {
   officeTasks        OfficeTask[]      @relation("OfficeTaskAssignee")
   createdOfficeTasks OfficeTask[]      @relation("OfficeTaskCreator")
   dispatchPublications DispatchPublication[] @relation("DispatchPublisher")
+  createdTaskMaterials TaskMaterial[] @relation("TaskMaterialCreator")
+  taskMaterialStatusChanges TaskMaterial[] @relation("TaskMaterialStatusChanger")
 }
 
 model Client {
@@ -874,6 +876,7 @@ model ScheduleTask {
 
   // Task details
   comments       TaskComment[]
+  materials      TaskMaterial[]
   punchItems     TaskPunchItem[]
   assignments    TaskAssignment[]
   subAssignments SubTaskAssignment[]
@@ -887,6 +890,33 @@ model ScheduleTask {
   @@index([leadId])
   @@index([generatedFromEstimateId])
   @@index([generatedFromChangeOrderId])
+}
+
+model TaskMaterial {
+  id                   String       @id @default(cuid())
+  taskId               String
+  task                 ScheduleTask @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  text                 String
+  quantity             Decimal?
+  unit                 String?
+  location             String?
+  status               String       @default("pending") // pending | staged | missing | resolved
+  sourceKind           String       @default("manual") // manual | estimate | ai
+  sourceEstimateItemId String?
+  resolutionNote       String?
+  order                Int          @default(0)
+  createdById          String?
+  createdBy            User?        @relation("TaskMaterialCreator", fields: [createdById], references: [id], onDelete: SetNull)
+  createdAt            DateTime     @default(now())
+  updatedAt            DateTime     @updatedAt
+  statusChangedById    String?
+  statusChangedBy      User?        @relation("TaskMaterialStatusChanger", fields: [statusChangedById], references: [id], onDelete: SetNull)
+  statusChangedAt      DateTime?
+
+  @@index([taskId, status])
+  @@index([taskId, sourceEstimateItemId])
+  @@index([createdById])
+  @@index([statusChangedById])
 }
 
 model TaskDependency {

--- a/scripts/apply-task-materials-schema.mjs
+++ b/scripts/apply-task-materials-schema.mjs
@@ -1,0 +1,106 @@
+// One-off additive migration for SPEC-c task materials and staging.
+// Safe to re-run while the previous build is live.
+//
+// Run only through the release orchestrator:
+//   node scripts/apply-task-materials-schema.mjs
+//
+// Do not run this during implementation handoff. The new Prisma client uses
+// TaskMaterial immediately, so this schema must be applied before deploy.
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+function resolveDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const file of [".env", ".env.local"]) {
+    if (!fs.existsSync(file)) continue;
+    const match = fs.readFileSync(file, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+    if (match) return match[1];
+  }
+  throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const prisma = new PrismaClient({
+  datasources: { db: { url: resolveDatabaseUrl() } },
+});
+
+const statements = [
+  `CREATE TABLE IF NOT EXISTS "TaskMaterial" (
+     "id" TEXT NOT NULL,
+     "taskId" TEXT NOT NULL,
+     "text" TEXT NOT NULL,
+     "quantity" DECIMAL(65,30),
+     "unit" TEXT,
+     "location" TEXT,
+     "status" TEXT NOT NULL DEFAULT 'pending',
+     "sourceKind" TEXT NOT NULL DEFAULT 'manual',
+     "sourceEstimateItemId" TEXT,
+     "resolutionNote" TEXT,
+     "order" INTEGER NOT NULL DEFAULT 0,
+     "createdById" TEXT,
+     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+     "updatedAt" TIMESTAMP(3) NOT NULL,
+     "statusChangedById" TEXT,
+     "statusChangedAt" TIMESTAMP(3),
+     CONSTRAINT "TaskMaterial_pkey" PRIMARY KEY ("id")
+   )`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'TaskMaterial_taskId_fkey'
+         AND conrelid = '"TaskMaterial"'::regclass
+     ) THEN
+       ALTER TABLE "TaskMaterial"
+         ADD CONSTRAINT "TaskMaterial_taskId_fkey"
+         FOREIGN KEY ("taskId") REFERENCES "ScheduleTask"("id")
+         ON DELETE CASCADE ON UPDATE CASCADE;
+     END IF;
+   END $$`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'TaskMaterial_createdById_fkey'
+         AND conrelid = '"TaskMaterial"'::regclass
+     ) THEN
+       ALTER TABLE "TaskMaterial"
+         ADD CONSTRAINT "TaskMaterial_createdById_fkey"
+         FOREIGN KEY ("createdById") REFERENCES "User"("id")
+         ON DELETE SET NULL ON UPDATE CASCADE;
+     END IF;
+   END $$`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'TaskMaterial_statusChangedById_fkey'
+         AND conrelid = '"TaskMaterial"'::regclass
+     ) THEN
+       ALTER TABLE "TaskMaterial"
+         ADD CONSTRAINT "TaskMaterial_statusChangedById_fkey"
+         FOREIGN KEY ("statusChangedById") REFERENCES "User"("id")
+         ON DELETE SET NULL ON UPDATE CASCADE;
+     END IF;
+   END $$`,
+  `CREATE INDEX IF NOT EXISTS "TaskMaterial_taskId_status_idx"
+     ON "TaskMaterial" ("taskId", "status")`,
+  `CREATE INDEX IF NOT EXISTS "TaskMaterial_taskId_sourceEstimateItemId_idx"
+     ON "TaskMaterial" ("taskId", "sourceEstimateItemId")`,
+  `CREATE INDEX IF NOT EXISTS "TaskMaterial_createdById_idx"
+     ON "TaskMaterial" ("createdById")`,
+  `CREATE INDEX IF NOT EXISTS "TaskMaterial_statusChangedById_idx"
+     ON "TaskMaterial" ("statusChangedById")`,
+
+  // This table is server-only. RLS with no policies makes the exposed
+  // Supabase Data API deny anon/authenticated access. Prisma connects as the
+  // database owner through the server-only pooler and is not subject to RLS
+  // unless FORCE ROW LEVEL SECURITY is enabled (this script does not force it).
+  `ALTER TABLE "TaskMaterial" ENABLE ROW LEVEL SECURITY`,
+];
+
+try {
+  for (const sql of statements) {
+    await prisma.$executeRawUnsafe(sql);
+    console.log("applied:", sql.split("\n")[0]);
+  }
+  console.log("TaskMaterial schema applied successfully.");
+} finally {
+  await prisma.$disconnect();
+}

--- a/scripts/verify-task-materials.ts
+++ b/scripts/verify-task-materials.ts
@@ -1,0 +1,588 @@
+// Behavioral verification for SPEC-c task materials and staging.
+//
+// This script exercises the session-free mutation/query core with isolated
+// database fixtures, and statically verifies that authenticated Server Action
+// wrappers and UI boundaries use that core safely.
+//
+// The release orchestrator must apply scripts/apply-task-materials-schema.mjs
+// before the DB cases can pass. This verifier never applies schema itself.
+//
+// Usage against Supabase:
+//   ALLOW_PROD_VERIFY=1 npx tsx scripts/verify-task-materials.ts
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+import { prisma } from "../src/lib/prisma";
+import {
+    addTaskMaterialCore,
+    deleteTaskMaterialCore,
+    getStagingQueueCore,
+    getTaskMaterialsCore,
+    importEstimateMaterialsCore,
+    setTaskMaterialStatusCore,
+    updateTaskMaterialCore,
+    type TaskMaterialActor,
+} from "../src/lib/task-materials-core";
+
+const DAY = 86_400_000;
+const BASE = Date.UTC(2045, 2, 10);
+const RUN_ID = randomUUID().replaceAll("-", "").slice(0, 12);
+const FIXTURE_PREFIX = `TASK MATERIAL VERIFY ${RUN_ID}`;
+
+function day(offset: number): Date {
+    return new Date(BASE + offset * DAY);
+}
+
+function dayKey(offset: number): string {
+    return day(offset).toISOString().slice(0, 10);
+}
+
+function source(path: string): string {
+    return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
+async function rejectsWith(run: () => Promise<unknown>, pattern: RegExp): Promise<void> {
+    let message = "";
+    try {
+        await run();
+    } catch (error) {
+        message = String((error as Error)?.message ?? error);
+    }
+    assert.match(message, pattern);
+}
+
+async function main() {
+    const databaseUrl = process.env.DATABASE_URL ?? "";
+    if (databaseUrl.includes("supabase.c") && process.env.ALLOW_PROD_VERIFY !== "1") {
+        console.error(
+            "[verify-task-materials] REFUSING TO RUN: DATABASE_URL points at Supabase.\n" +
+            "This script creates and deletes verification fixtures.\n" +
+            "Set ALLOW_PROD_VERIFY=1 to opt in.",
+        );
+        process.exit(1);
+    }
+
+    const actionsSource = source("../src/lib/actions.ts");
+    const coreSource = source("../src/lib/task-materials-core.ts");
+    const scheduleCoreSource = source("../src/lib/schedule-core.ts");
+    const schemaSource = source("../prisma/schema.prisma");
+    const applySource = source("./apply-task-materials-schema.mjs");
+    const detailSource = source("../src/app/projects/[id]/schedule/TaskDetailPanel.tsx");
+    const materialSectionSource = source("../src/app/projects/[id]/schedule/TaskMaterialsSection.tsx");
+    const dispatchCardSource = source("../src/app/company-dashboard/schedule-board/DispatchJobCard.tsx");
+    const dispatchViewSource = source("../src/app/company-dashboard/schedule-board/DispatchView.tsx");
+    const stagingPageSource = source("../src/app/company-dashboard/staging/page.tsx");
+    const stagingClientSource = source("../src/app/company-dashboard/staging/StagingQueueClient.tsx");
+
+    // Schema and migration contract.
+    assert.match(schemaSource, /model TaskMaterial \{/);
+    for (const field of [
+        "taskId",
+        "text",
+        "quantity",
+        "unit",
+        "location",
+        "status",
+        "sourceKind",
+        "sourceEstimateItemId",
+        "resolutionNote",
+        "order",
+        "createdById",
+        "statusChangedById",
+        "statusChangedAt",
+    ]) {
+        assert.match(schemaSource, new RegExp(`\\b${field}\\b`), `TaskMaterial must include ${field}`);
+    }
+    assert.match(schemaSource, /@@index\(\[taskId, status\]\)/);
+    assert.match(applySource, /CREATE TABLE IF NOT EXISTS "TaskMaterial"/);
+    assert.match(applySource, /ENABLE ROW LEVEL SECURITY/);
+    assert.doesNotMatch(applySource, /CREATE POLICY/i, "server-only TaskMaterial must not gain anon/authenticated policies");
+
+    // Authenticated Server Action wrappers must keep the canonical schedule
+    // task gate. The core is deliberately session-free for deterministic DB
+    // verification, but it is not a Server Action surface.
+    for (const functionName of [
+        "getTaskMaterials",
+        "addTaskMaterial",
+        "updateTaskMaterial",
+        "setTaskMaterialStatus",
+        "deleteTaskMaterial",
+        "importEstimateMaterials",
+    ]) {
+        const start = actionsSource.indexOf(`export async function ${functionName}(`);
+        const end = actionsSource.indexOf("export async function", start + 1);
+        const body = actionsSource.slice(start, end < 0 ? undefined : end);
+        assert.ok(start >= 0, `${functionName} must exist in actions.ts`);
+        assert.match(body, /assertScheduleTaskAccess\(/, `${functionName} must use the canonical task access gate`);
+    }
+    const stagingActionStart = actionsSource.indexOf("export async function getStagingQueue(");
+    const stagingActionEnd = actionsSource.indexOf("export async function", stagingActionStart + 1);
+    const stagingActionBody = actionsSource.slice(stagingActionStart, stagingActionEnd < 0 ? undefined : stagingActionEnd);
+    assert.ok(stagingActionStart >= 0, "getStagingQueue must exist");
+    assert.match(stagingActionBody, /assertStagingQueueAccess\(/);
+    assert.match(actionsSource, /\["ADMIN", "MANAGER", "FIELD_CREW"\]/);
+
+    // Domain and provenance rules live in the session-free core and are
+    // enforced again by the DB behavioral cases below.
+    assert.match(coreSource, /Resolved materials require a resolution note/);
+    assert.match(coreSource, /canonicalContractEstimateQuery\(task\.projectId\)/);
+    assert.match(coreSource, /isTaskActiveOnDay\(/);
+    assert.match(coreSource, /createdById: (?:input\.)?actor\.userId/);
+    assert.match(coreSource, /statusChangedById: (?:input\.)?actor\.userId/);
+    assert.match(coreSource, /statusChangedAt:/);
+
+    // Dashboard serialization is counts-only. The task contract and card may
+    // know integers, but no material text or rows may cross this boundary.
+    const dashboardTaskStart = scheduleCoreSource.indexOf("export interface DashboardTaskRow");
+    const dashboardTaskEnd = scheduleCoreSource.indexOf("export interface", dashboardTaskStart + 1);
+    const dashboardTaskContract = scheduleCoreSource.slice(dashboardTaskStart, dashboardTaskEnd);
+    for (const field of ["pendingMaterials", "stagedMaterials", "missingMaterials"]) {
+        assert.match(dashboardTaskContract, new RegExp(`${field}: number;`));
+    }
+    assert.doesNotMatch(dashboardTaskContract, /TaskMaterial|materials:|materialText|\btext:/);
+    assert.match(scheduleCoreSource, /taskMaterial\.groupBy\(/);
+    assert.doesNotMatch(scheduleCoreSource, /materials:\s*\{\s*(?:select|include)[\s\S]*?text:/);
+    assert.match(dispatchCardSource, /pendingMaterials/);
+    assert.match(dispatchCardSource, /stagedMaterials/);
+    assert.match(dispatchCardSource, /missingMaterials/);
+    assert.match(dispatchCardSource, /\\u\{1F4E6\}|📦/u);
+
+    // Task drawer and staging-page render/action wiring.
+    assert.match(detailSource, /TaskMaterialsSection/);
+    assert.match(detailSource, /estimateItemId=\{task\.estimateItemId(?: \?\? null)?\}/);
+    for (const action of [
+        "getTaskMaterials",
+        "addTaskMaterial",
+        "updateTaskMaterial",
+        "setTaskMaterialStatus",
+        "deleteTaskMaterial",
+        "importEstimateMaterials",
+    ]) {
+        assert.match(materialSectionSource, new RegExp(`\\b${action}\\b`));
+    }
+    assert.match(materialSectionSource, /Materials/);
+    assert.match(materialSectionSource, /\[@media\(hover:none\)\]:opacity-100/);
+    assert.match(stagingPageSource, /\["ADMIN", "MANAGER", "FIELD_CREW"\]/);
+    assert.match(stagingPageSource, /hasPermission\(effectiveUser, "schedules"\)/);
+    assert.doesNotMatch(stagingPageSource, /financialReports|contractValue|totalAmount|budget/i);
+    assert.match(stagingClientSource, /getStagingQueue/);
+    assert.match(stagingClientSource, /setTaskMaterialStatus/);
+    assert.match(stagingClientSource, /Missing/);
+    assert.match(stagingClientSource, /Today/);
+    assert.match(dispatchViewSource, /href="\/company-dashboard\/staging"/);
+    assert.match(dispatchViewSource, /Staging queue/);
+
+    console.log("PASS static schema, auth, serializer, and render contracts");
+
+    const collected = {
+        clientIds: [] as string[],
+        projectIds: [] as string[],
+        estimateIds: [] as string[],
+        userIds: [] as string[],
+    };
+
+    let cleanupPassed = false;
+    try {
+        const client = await prisma.client.create({
+            data: {
+                name: `${FIXTURE_PREFIX} CLIENT DELETE ME`,
+                initials: "TM",
+                email: `task-material-client-${RUN_ID}@example.invalid`,
+            },
+        });
+        collected.clientIds.push(client.id);
+
+        const creator = await prisma.user.create({
+            data: {
+                email: `task-material-creator-${RUN_ID}@example.invalid`,
+                name: `${FIXTURE_PREFIX} Creator`,
+                role: "FIELD_CREW",
+                status: "ACTIVATED",
+            },
+        });
+        const otherCrew = await prisma.user.create({
+            data: {
+                email: `task-material-other-${RUN_ID}@example.invalid`,
+                name: `${FIXTURE_PREFIX} Other`,
+                role: "FIELD_CREW",
+                status: "ACTIVATED",
+            },
+        });
+        const manager = await prisma.user.create({
+            data: {
+                email: `task-material-manager-${RUN_ID}@example.invalid`,
+                name: `${FIXTURE_PREFIX} Manager`,
+                role: "MANAGER",
+                status: "ACTIVATED",
+            },
+        });
+        collected.userIds.push(creator.id, otherCrew.id, manager.id);
+
+        const creatorActor: TaskMaterialActor = {
+            userId: creator.id,
+            role: creator.role,
+            name: creator.name ?? creator.email,
+        };
+        const otherActor: TaskMaterialActor = {
+            userId: otherCrew.id,
+            role: otherCrew.role,
+            name: otherCrew.name ?? otherCrew.email,
+        };
+        const managerActor: TaskMaterialActor = {
+            userId: manager.id,
+            role: manager.role,
+            name: manager.name ?? manager.email,
+        };
+
+        const project = await prisma.project.create({
+            data: {
+                name: `${FIXTURE_PREFIX} PROJECT DELETE ME`,
+                clientId: client.id,
+                status: "In Progress",
+                startDate: day(0),
+                color: "#4f46e5",
+                location: "123 Verify Way",
+                userAccess: {
+                    create: [
+                        { userId: creator.id },
+                        { userId: otherCrew.id },
+                    ],
+                },
+            },
+        });
+        collected.projectIds.push(project.id);
+
+        const estimate = await prisma.estimate.create({
+            data: {
+                title: `${FIXTURE_PREFIX} CONTRACT`,
+                projectId: project.id,
+                code: `TM-${RUN_ID}`,
+                status: "Approved",
+                totalAmount: 100,
+                balanceDue: 100,
+            },
+        });
+        collected.estimateIds.push(estimate.id);
+
+        const rootItem = await prisma.estimateItem.create({
+            data: {
+                estimateId: estimate.id,
+                name: "Cabinet installation",
+                type: "Labor",
+                order: 0,
+            },
+        });
+        const plywoodItem = await prisma.estimateItem.create({
+            data: {
+                estimateId: estimate.id,
+                parentId: rootItem.id,
+                name: "Cabinet-grade plywood",
+                type: "Material",
+                quantity: 4,
+                budgetUnit: "sheet",
+                order: 1,
+            },
+        });
+        const screwsItem = await prisma.estimateItem.create({
+            data: {
+                estimateId: estimate.id,
+                parentId: rootItem.id,
+                name: "Cabinet screws",
+                type: "Material",
+                quantity: 2,
+                budgetUnit: "box",
+                order: 2,
+            },
+        });
+        await prisma.estimateItem.create({
+            data: {
+                estimateId: estimate.id,
+                parentId: rootItem.id,
+                name: "Install cabinets",
+                type: "Labor",
+                quantity: 8,
+                budgetUnit: "hour",
+                order: 3,
+            },
+        });
+
+        const task = await prisma.scheduleTask.create({
+            data: {
+                projectId: project.id,
+                estimateItemId: rootItem.id,
+                name: "Install cabinets",
+                startDate: day(0),
+                endDate: day(2),
+                status: "Not Started",
+                order: 0,
+            },
+        });
+        const milestone = await prisma.scheduleTask.create({
+            data: {
+                projectId: project.id,
+                name: "Cabinet delivery",
+                startDate: day(2),
+                endDate: day(2),
+                type: "milestone",
+                status: "Not Started",
+                order: 1,
+            },
+        });
+
+        const waitingProject = await prisma.project.create({
+            data: {
+                name: `${FIXTURE_PREFIX} WAITING DELETE ME`,
+                clientId: client.id,
+                status: "Waiting to Start",
+                startDate: day(0),
+            },
+        });
+        collected.projectIds.push(waitingProject.id);
+        const waitingTask = await prisma.scheduleTask.create({
+            data: {
+                projectId: waitingProject.id,
+                name: "Waiting task",
+                startDate: day(0),
+                endDate: day(3),
+            },
+        });
+
+        // Add/update/status provenance and domain rules.
+        const disposable = await addTaskMaterialCore({
+            taskId: task.id,
+            input: { text: "Disposable shim", quantity: 1, unit: "pack", location: "Truck" },
+            actor: creatorActor,
+        });
+        assert.equal(disposable.createdById, creator.id);
+        await rejectsWith(
+            () => deleteTaskMaterialCore({ materialId: disposable.id, actor: otherActor }),
+            /Only the creator, an admin, or a manager can delete/i,
+        );
+        assert.ok(await prisma.taskMaterial.findUnique({ where: { id: disposable.id } }));
+        await deleteTaskMaterialCore({ materialId: disposable.id, actor: creatorActor });
+        assert.equal(await prisma.taskMaterial.count({ where: { id: disposable.id } }), 0);
+
+        const manual = await addTaskMaterialCore({
+            taskId: task.id,
+            input: {
+                text: "Jobsite primer",
+                quantity: 2.5,
+                unit: "gal",
+                location: "Garage",
+            },
+            actor: creatorActor,
+        });
+        assert.equal(manual.sourceKind, "manual");
+        assert.equal(manual.createdById, creator.id);
+        assert.equal(manual.quantity, 2.5);
+
+        const updated = await updateTaskMaterialCore({
+            materialId: manual.id,
+            input: {
+                text: "Low-VOC jobsite primer",
+                quantity: 3,
+                unit: "gal",
+                location: "North garage",
+            },
+            actor: creatorActor,
+        });
+        assert.equal(updated.text, "Low-VOC jobsite primer");
+        assert.equal(updated.location, "North garage");
+
+        await rejectsWith(
+            () => setTaskMaterialStatusCore({
+                materialId: manual.id,
+                status: "resolved",
+                actor: otherActor,
+            }),
+            /Resolved materials require a resolution note/i,
+        );
+        assert.equal((await prisma.taskMaterial.findUniqueOrThrow({ where: { id: manual.id } })).status, "pending");
+
+        const staged = await setTaskMaterialStatusCore({
+            materialId: manual.id,
+            status: "staged",
+            actor: otherActor,
+        });
+        assert.equal(staged.status, "staged");
+        assert.equal(staged.statusChangedById, otherCrew.id);
+        assert.ok(staged.statusChangedAt);
+
+        const resolved = await setTaskMaterialStatusCore({
+            materialId: manual.id,
+            status: "resolved",
+            resolutionNote: "Substituted the approved low-VOC product.",
+            actor: managerActor,
+        });
+        assert.equal(resolved.resolutionNote, "Substituted the approved low-VOC product.");
+        assert.equal(resolved.statusChangedById, manager.id);
+
+        const provenanceLogs = await prisma.activityLog.findMany({
+            where: {
+                projectId: project.id,
+                entityType: "task_material",
+                entityId: manual.id,
+            },
+            orderBy: { createdAt: "asc" },
+        });
+        assert.ok(provenanceLogs.some(log => log.action === "add_task_material" && log.actorName === creatorActor.name));
+        assert.ok(provenanceLogs.some(log => log.action === "set_task_material_status" && log.actorName === otherActor.name));
+        assert.ok(provenanceLogs.some(log => log.action === "set_task_material_status" && log.actorName === managerActor.name));
+        console.log("PASS add/update/status/delete rules and actor provenance");
+
+        // Canonical estimate import is additive and deduplicated.
+        const manualPending = await addTaskMaterialCore({
+            taskId: task.id,
+            input: { text: "Manual protection paper", quantity: 1, unit: "roll", location: "Shop" },
+            actor: creatorActor,
+        });
+        const firstImport = await importEstimateMaterialsCore({ taskId: task.id, actor: managerActor });
+        assert.equal(firstImport.created, 2);
+        const importedAfterFirst = await prisma.taskMaterial.findMany({
+            where: { taskId: task.id, sourceKind: "estimate" },
+            orderBy: { sourceEstimateItemId: "asc" },
+        });
+        assert.deepEqual(
+            new Set(importedAfterFirst.map(row => row.sourceEstimateItemId)),
+            new Set([plywoodItem.id, screwsItem.id]),
+        );
+        assert.ok(importedAfterFirst.every(row => row.createdById === manager.id));
+
+        const stagedEstimate = importedAfterFirst.find(row => row.sourceEstimateItemId === plywoodItem.id)!;
+        await setTaskMaterialStatusCore({
+            materialId: stagedEstimate.id,
+            status: "staged",
+            actor: creatorActor,
+        });
+        await prisma.estimateItem.update({
+            where: { id: plywoodItem.id },
+            data: { name: "Renamed plywood must not overwrite", quantity: 99 },
+        });
+        const hingesItem = await prisma.estimateItem.create({
+            data: {
+                estimateId: estimate.id,
+                parentId: rootItem.id,
+                name: "Soft-close hinges",
+                type: "Material",
+                quantity: 12,
+                budgetUnit: "ea",
+                order: 4,
+            },
+        });
+
+        const secondImport = await importEstimateMaterialsCore({ taskId: task.id, actor: managerActor });
+        assert.equal(secondImport.created, 1);
+        assert.equal((await prisma.taskMaterial.findUniqueOrThrow({ where: { id: stagedEstimate.id } })).text, "Cabinet-grade plywood");
+        assert.equal((await prisma.taskMaterial.findUniqueOrThrow({ where: { id: stagedEstimate.id } })).status, "staged");
+        assert.equal((await prisma.taskMaterial.findUniqueOrThrow({ where: { id: manualPending.id } })).text, "Manual protection paper");
+        assert.equal((await prisma.taskMaterial.findUniqueOrThrow({ where: { id: manualPending.id } })).status, "pending");
+        assert.equal(
+            await prisma.taskMaterial.count({
+                where: { taskId: task.id, sourceEstimateItemId: hingesItem.id },
+            }),
+            1,
+        );
+        assert.equal((await importEstimateMaterialsCore({ taskId: task.id, actor: managerActor })).created, 0);
+        console.log("PASS canonical estimate import, deduplication, and sacred-row preservation");
+
+        // Queue grouping/counts and half-open date semantics.
+        const missing = await addTaskMaterialCore({
+            taskId: task.id,
+            input: { text: "Missing queue probe", quantity: 1, unit: "ea", location: "Shop" },
+            actor: creatorActor,
+        });
+        await setTaskMaterialStatusCore({
+            materialId: missing.id,
+            status: "missing",
+            resolutionNote: "Vendor shorted the order.",
+            actor: creatorActor,
+        });
+        await addTaskMaterialCore({
+            taskId: milestone.id,
+            input: { text: "Milestone delivery packet", quantity: 1, unit: "packet" },
+            actor: creatorActor,
+        });
+        await addTaskMaterialCore({
+            taskId: waitingTask.id,
+            input: { text: "Must stay outside In Progress queue", quantity: 1, unit: "ea" },
+            actor: managerActor,
+        });
+
+        const activeQueue = await getStagingQueueCore(dayKey(1));
+        const activeGroup = activeQueue.projects.find(group => group.projectId === project.id);
+        assert.ok(activeGroup);
+        assert.ok(activeGroup.materials.some(row => row.taskId === task.id));
+        assert.ok(activeGroup.materials.every(row => row.taskId !== milestone.id));
+        assert.ok(activeQueue.projects.every(group => group.projectId !== waitingProject.id));
+        assert.equal(activeGroup.counts.pending, activeGroup.materials.filter(row => row.status === "pending").length);
+        assert.equal(activeGroup.counts.staged, activeGroup.materials.filter(row => row.status === "staged").length);
+        assert.equal(activeGroup.counts.missing, activeGroup.materials.filter(row => row.status === "missing").length);
+        assert.equal(activeQueue.counts.pending, activeQueue.projects.reduce((sum, group) => sum + group.counts.pending, 0));
+        assert.equal(activeQueue.counts.staged, activeQueue.projects.reduce((sum, group) => sum + group.counts.staged, 0));
+        assert.equal(activeQueue.counts.missing, activeQueue.projects.reduce((sum, group) => sum + group.counts.missing, 0));
+
+        const boundaryQueue = await getStagingQueueCore(dayKey(2));
+        const boundaryGroup = boundaryQueue.projects.find(group => group.projectId === project.id);
+        assert.ok(boundaryGroup);
+        assert.ok(boundaryGroup.materials.some(row => row.taskId === milestone.id), "milestone is active on its start day");
+        assert.ok(boundaryGroup.materials.every(row => row.taskId !== task.id), "normal task end is half-open");
+        console.log("PASS staging grouping/counts and half-open active-day boundaries");
+
+        const rows = await getTaskMaterialsCore(task.id);
+        assert.ok(rows.length >= 5);
+        assert.ok(rows.every(row => typeof row.quantity === "number" || row.quantity === null));
+
+        const managerDisposable = await addTaskMaterialCore({
+            taskId: task.id,
+            input: { text: "Manager delete probe" },
+            actor: creatorActor,
+        });
+        await deleteTaskMaterialCore({ materialId: managerDisposable.id, actor: managerActor });
+        assert.equal(await prisma.taskMaterial.count({ where: { id: managerDisposable.id } }), 0);
+        console.log("PASS task-material read serialization and manager deletion");
+    } finally {
+        try {
+            if (collected.estimateIds.length > 0) {
+                await prisma.estimate.deleteMany({ where: { id: { in: collected.estimateIds } } });
+            }
+            if (collected.projectIds.length > 0) {
+                await prisma.project.deleteMany({ where: { id: { in: collected.projectIds } } });
+            }
+            if (collected.userIds.length > 0) {
+                await prisma.user.deleteMany({ where: { id: { in: collected.userIds } } });
+            }
+            if (collected.clientIds.length > 0) {
+                await prisma.client.deleteMany({ where: { id: { in: collected.clientIds } } });
+            }
+
+            const [clientsLeft, projectsLeft, estimatesLeft, usersLeft] = await Promise.all([
+                prisma.client.count({ where: { id: { in: collected.clientIds } } }),
+                prisma.project.count({ where: { id: { in: collected.projectIds } } }),
+                prisma.estimate.count({ where: { id: { in: collected.estimateIds } } }),
+                prisma.user.count({ where: { id: { in: collected.userIds } } }),
+            ]);
+            cleanupPassed = clientsLeft === 0 && projectsLeft === 0 && estimatesLeft === 0 && usersLeft === 0;
+        } catch (error) {
+            console.error("Fixture cleanup error:", error);
+        }
+        console.log(`${cleanupPassed ? "PASS" : "FAIL"} fixture cleanup`);
+    }
+
+    assert.equal(cleanupPassed, true);
+    console.log("task-materials verification: PASS");
+}
+
+main()
+    .catch(error => {
+        console.error("task-materials verification: FAIL");
+        console.error(error);
+        process.exitCode = 1;
+    })
+    .finally(async () => {
+        try {
+            await prisma.$disconnect();
+        } catch {
+            // Static-contract failures can happen before DATABASE_URL is loaded.
+        }
+    });

--- a/src/app/company-dashboard/schedule-board/DispatchJobCard.tsx
+++ b/src/app/company-dashboard/schedule-board/DispatchJobCard.tsx
@@ -76,6 +76,12 @@ export function DispatchJobCard({
                         const outlinedCrew = project.crew.filter(member => member.status === "ACTIVATED" && member.role === "FIELD_CREW" && !assignedIds.has(member.id));
                         const statusTitle = task.status === "Blocked" && task.blockedReason ? `Blocked \u2014 ${task.blockedReason}` : task.status;
                         const progress = Math.max(0, Math.min(100, task.progress));
+                        const materialCount = task.pendingMaterials + task.stagedMaterials + task.missingMaterials;
+                        const materialBadgeStyle = task.missingMaterials > 0
+                            ? "bg-red-100 text-red-700"
+                            : task.pendingMaterials > 0
+                                ? "bg-amber-100 text-amber-800"
+                                : "bg-green-100 text-green-700";
                         return (
                             <section key={task.id} data-dispatch-task-id={task.id} className="px-4 py-3">
                                 <div className="flex flex-wrap items-start justify-between gap-2">
@@ -88,6 +94,14 @@ export function DispatchJobCard({
                                             <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${STATUS_STYLES[task.status] ?? STATUS_STYLES["Not Started"]}`} title={statusTitle}>
                                                 {task.status}
                                             </span>
+                                            {materialCount > 0 && (
+                                                <span
+                                                    className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${materialBadgeStyle}`}
+                                                    title={`${task.stagedMaterials} staged, ${task.pendingMaterials} pending, ${task.missingMaterials} missing`}
+                                                >
+                                                    {"\u{1F4E6}"} {materialCount} {"\u00B7"} {task.missingMaterials} missing
+                                                </span>
+                                            )}
                                         </div>
                                         <div className="mt-2 flex items-center gap-2">
                                             <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-slate-100" role="progressbar" aria-label={`${task.name} progress`} aria-valuemin={0} aria-valuemax={100} aria-valuenow={progress}>

--- a/src/app/company-dashboard/schedule-board/DispatchView.tsx
+++ b/src/app/company-dashboard/schedule-board/DispatchView.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type PointerEvent as ReactPointerEvent } from "react";
 import { toast } from "sonner";
 import type { CompanyDashboardData, DashboardProjectRow, DashboardTaskRow } from "@/lib/schedule-core";
@@ -379,6 +380,9 @@ export function DispatchView({
                     </p>
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
+                    <Link href="/company-dashboard/staging" className="hui-btn hui-btn-secondary text-xs">
+                        {"\u{1F4E6}"} Staging queue
+                    </Link>
                     {data.canEdit && (
                         <button
                             type="button"

--- a/src/app/company-dashboard/staging/StagingQueueClient.tsx
+++ b/src/app/company-dashboard/staging/StagingQueueClient.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState, type FormEvent } from "react";
+import { toast } from "sonner";
+
+import { getStagingQueue, setTaskMaterialStatus } from "@/lib/actions";
+import type { StagingQueue, TaskMaterialStatus } from "@/lib/task-materials-core";
+
+const STATUS_STYLES: Record<TaskMaterialStatus, string> = {
+    pending: "bg-amber-100 text-amber-800",
+    staged: "bg-green-100 text-green-700",
+    missing: "bg-red-100 text-red-700",
+    resolved: "bg-slate-100 text-slate-600",
+};
+
+function localDayISO(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+}
+
+function todayISO(): string {
+    return localDayISO(new Date());
+}
+
+function tomorrowISO(): string {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    return localDayISO(tomorrow);
+}
+
+function readableDay(dayISO: string): string {
+    return new Intl.DateTimeFormat("en-US", {
+        weekday: "long",
+        month: "short",
+        day: "numeric",
+        timeZone: "UTC",
+    }).format(new Date(`${dayISO}T00:00:00.000Z`));
+}
+
+function materialQuantity(quantity: number | null, unit: string | null): string | null {
+    if (quantity === null && !unit) return null;
+    return [quantity, unit].filter(value => value !== null && value !== "").join(" ");
+}
+
+export function StagingQueueClient() {
+    const [dayISO, setDayISO] = useState(tomorrowISO);
+    const [queue, setQueue] = useState<StagingQueue | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+    const [busyId, setBusyId] = useState<string | null>(null);
+    const [missingId, setMissingId] = useState<string | null>(null);
+    const [missingNote, setMissingNote] = useState("");
+
+    async function load(day: string) {
+        const next = await getStagingQueue(day);
+        setQueue(next);
+    }
+
+    useEffect(() => {
+        let cancelled = false;
+        setLoading(true);
+        setError("");
+        getStagingQueue(dayISO)
+            .then(next => {
+                if (!cancelled) setQueue(next);
+            })
+            .catch(reason => {
+                if (!cancelled) setError(reason?.message || "The staging queue could not be loaded.");
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [dayISO]);
+
+    async function changeStatus(
+        materialId: string,
+        status: TaskMaterialStatus,
+        note?: string | null,
+    ) {
+        setBusyId(materialId);
+        setError("");
+        try {
+            await setTaskMaterialStatus(materialId, status, note);
+            await load(dayISO);
+            toast.success(status === "staged" ? "Material staged" : status === "missing" ? "Material marked missing" : "Material returned to pending");
+        } catch (reason: any) {
+            const message = reason?.message || "Material status could not be updated.";
+            setError(message);
+            toast.error(message);
+        } finally {
+            setBusyId(null);
+        }
+    }
+
+    async function submitMissing(event: FormEvent) {
+        event.preventDefault();
+        if (!missingId || !missingNote.trim()) {
+            setError("Add a short note so the office knows what is missing.");
+            return;
+        }
+        await changeStatus(missingId, "missing", missingNote);
+        setMissingId(null);
+        setMissingNote("");
+    }
+
+    const today = todayISO();
+    const total = queue
+        ? queue.counts.pending + queue.counts.staged + queue.counts.missing
+        : 0;
+
+    return (
+        <main className="min-h-screen bg-slate-50">
+            <div className="mx-auto max-w-3xl px-3 py-4 sm:px-5 sm:py-6">
+                <header className="rounded-xl border border-hui-border bg-white p-4 shadow-sm">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                            <Link href="/company-dashboard" className="text-xs font-semibold text-hui-primary hover:underline">
+                                {"\u2190"} Dispatch
+                            </Link>
+                            <h1 className="mt-2 text-xl font-bold tracking-tight text-hui-textMain">Staging queue</h1>
+                            <p className="mt-1 text-sm text-hui-textMuted">Load the truck and jobsite before the crew arrives.</p>
+                        </div>
+                        <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-right">
+                            <p className="text-lg font-bold tabular-nums text-hui-textMain">
+                                {queue?.counts.staged ?? 0} of {total} staged
+                            </p>
+                            <p className={`text-xs font-semibold ${(queue?.counts.missing ?? 0) > 0 ? "text-red-600" : "text-slate-500"}`}>
+                                {queue?.counts.missing ?? 0} missing
+                            </p>
+                        </div>
+                    </div>
+
+                    <div className="mt-4 flex flex-wrap items-end gap-2 border-t border-slate-100 pt-4">
+                        <label className="min-w-44 flex-1 text-xs font-semibold uppercase tracking-wider text-hui-textMuted">
+                            Staging day
+                            <input
+                                type="date"
+                                value={dayISO}
+                                onChange={event => setDayISO(event.target.value)}
+                                className="hui-input mt-1.5 w-full text-sm"
+                            />
+                        </label>
+                        <button type="button" onClick={() => setDayISO(today)} className="hui-btn hui-btn-secondary min-h-10 text-sm">
+                            Today
+                        </button>
+                    </div>
+                    <p className="mt-2 text-xs text-slate-400">{readableDay(dayISO)}{dayISO === tomorrowISO() ? " \u00B7 tomorrow's default run" : ""}</p>
+                </header>
+
+                {error && (
+                    <p className="mt-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2.5 text-sm text-red-700" role="alert">
+                        {error}
+                    </p>
+                )}
+
+                {loading ? (
+                    <div className="mt-4 rounded-xl border border-hui-border bg-white px-4 py-12 text-center text-sm text-hui-textMuted">
+                        Loading the staging run...
+                    </div>
+                ) : !queue || queue.projects.length === 0 ? (
+                    <div className="mt-4 rounded-xl border border-dashed border-hui-border bg-white px-4 py-12 text-center">
+                        <p className="text-sm font-semibold text-hui-textMain">Nothing to stage for this day</p>
+                        <p className="mt-1 text-sm text-hui-textMuted">Choose another day or add materials from a task’s Details panel.</p>
+                    </div>
+                ) : (
+                    <div className="mt-4 space-y-4">
+                        {queue.projects.map(project => (
+                            <section key={project.projectId} className="overflow-hidden rounded-xl border border-hui-border bg-white shadow-sm">
+                                <div className="flex items-start gap-3 border-b border-hui-border px-4 py-3">
+                                    <span
+                                        className="mt-1 h-4 w-1.5 shrink-0 rounded-full"
+                                        style={{ backgroundColor: project.projectColor || "#64748b" }}
+                                        aria-hidden="true"
+                                    />
+                                    <div className="min-w-0 flex-1">
+                                        <Link href={`/projects/${project.projectId}`} className="font-bold text-hui-textMain hover:text-hui-primary hover:underline">
+                                            {project.projectName}
+                                        </Link>
+                                        {project.projectLocation && <p className="mt-0.5 text-xs text-hui-textMuted">{project.projectLocation}</p>}
+                                    </div>
+                                    <div className="shrink-0 text-right text-[11px] font-semibold tabular-nums text-slate-500">
+                                        <p>{project.counts.staged} staged</p>
+                                        {project.counts.missing > 0 && <p className="text-red-600">{project.counts.missing} missing</p>}
+                                    </div>
+                                </div>
+
+                                <div className="divide-y divide-slate-100">
+                                    {project.materials.map(material => {
+                                        const quantity = materialQuantity(material.quantity, material.unit);
+                                        return (
+                                            <article key={material.id} className={`px-4 py-3 ${material.status === "missing" ? "bg-red-50/40" : ""}`}>
+                                                <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">{material.taskName}</p>
+                                                <div className="mt-1 flex items-start gap-3">
+                                                    <label className="flex min-h-12 min-w-12 shrink-0 cursor-pointer items-center justify-center rounded-xl border-2 border-green-200 bg-green-50 focus-within:ring-2 focus-within:ring-green-500">
+                                                        <input
+                                                            type="checkbox"
+                                                            checked={material.status === "staged"}
+                                                            disabled={busyId !== null}
+                                                            onChange={event => void changeStatus(material.id, event.target.checked ? "staged" : "pending")}
+                                                            className="h-6 w-6 accent-green-600"
+                                                            aria-label={`Mark ${material.text} staged`}
+                                                        />
+                                                    </label>
+                                                    <div className="min-w-0 flex-1">
+                                                        <p className="text-sm font-semibold leading-snug text-hui-textMain">
+                                                            {material.text}
+                                                            {quantity && <span className="font-normal text-slate-500"> {"\u00B7"} {quantity}</span>}
+                                                        </p>
+                                                        <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                                                            {material.location && <span className="rounded-full bg-indigo-50 px-2 py-0.5 text-[10px] font-semibold text-indigo-700">{material.location}</span>}
+                                                            <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold capitalize ${STATUS_STYLES[material.status]}`}>{material.status}</span>
+                                                        </div>
+                                                        {material.resolutionNote && <p className="mt-1.5 text-xs leading-relaxed text-slate-500">{material.resolutionNote}</p>}
+                                                    </div>
+                                                    <button
+                                                        type="button"
+                                                        disabled={busyId !== null}
+                                                        onClick={() => {
+                                                            setMissingId(material.id);
+                                                            setMissingNote(material.status === "missing" ? material.resolutionNote ?? "" : "");
+                                                        }}
+                                                        className="min-h-11 shrink-0 rounded-lg border border-red-200 px-3 text-xs font-bold text-red-600 transition hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 disabled:opacity-50"
+                                                    >
+                                                        Missing
+                                                    </button>
+                                                </div>
+
+                                                {missingId === material.id && (
+                                                    <form onSubmit={submitMissing} className="mt-3 flex flex-col gap-2 rounded-lg border border-red-100 bg-red-50 p-2.5 sm:flex-row">
+                                                        <input
+                                                            value={missingNote}
+                                                            onChange={event => setMissingNote(event.target.value)}
+                                                            className="hui-input min-h-11 min-w-0 flex-1 text-sm"
+                                                            placeholder="What is missing or delayed?"
+                                                            aria-label="Missing material note"
+                                                            autoFocus
+                                                        />
+                                                        <button type="submit" disabled={busyId !== null} className="hui-btn min-h-11 bg-red-600 text-sm text-white hover:bg-red-700 disabled:opacity-50">Mark missing</button>
+                                                        <button type="button" onClick={() => setMissingId(null)} className="hui-btn hui-btn-secondary min-h-11 text-sm">Cancel</button>
+                                                    </form>
+                                                )}
+                                            </article>
+                                        );
+                                    })}
+                                </div>
+                            </section>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </main>
+    );
+}

--- a/src/app/company-dashboard/staging/page.tsx
+++ b/src/app/company-dashboard/staging/page.tsx
@@ -1,0 +1,28 @@
+export const dynamic = "force-dynamic";
+
+import { redirect } from "next/navigation";
+
+import { getSessionOrDev } from "@/lib/auth";
+import { getUserWithPermissionsByEmail, hasPermission } from "@/lib/permissions";
+
+import { StagingQueueClient } from "./StagingQueueClient";
+
+export default async function StagingQueuePage() {
+    const session = await getSessionOrDev();
+    if (!session?.user?.email) return redirect("/login");
+
+    const user = await getUserWithPermissionsByEmail(session.user.email);
+    const effectiveUser = user ?? (process.env.NODE_ENV === "development"
+        ? { role: "ADMIN", permissions: null }
+        : null);
+    const allowedRoles = ["ADMIN", "MANAGER", "FIELD_CREW"];
+    if (
+        !effectiveUser
+        || !allowedRoles.includes(effectiveUser.role)
+        || !hasPermission(effectiveUser, "schedules")
+    ) {
+        return <div className="p-8 text-red-500">Access Denied.</div>;
+    }
+
+    return <StagingQueueClient />;
+}

--- a/src/app/projects/[id]/schedule/TaskDetailPanel.tsx
+++ b/src/app/projects/[id]/schedule/TaskDetailPanel.tsx
@@ -5,6 +5,7 @@ import type { Task, PunchItem, Comment, TeamMember, Subcontractor, EstimateItemS
 import { STATUS_OPTIONS, getInitials, formatCurrency } from "./schedule-utils";
 import DependencyPicker from "./DependencyPicker";
 import ColorPicker from "./ColorPicker";
+import { TaskMaterialsSection } from "./TaskMaterialsSection";
 
 const ESTIMATE_LINK_STOPWORDS = new Set(["and", "or", "the", "a", "to", "of", "with", "for", "in", "on", "at", "&"]);
 function tokenizeForMatch(s: string): string[] {
@@ -338,6 +339,10 @@ export default function TaskDetailPanel({
                                 )}
                             </div>
                         </details>
+
+                        <div className="border-t border-slate-100" />
+
+                        <TaskMaterialsSection taskId={task.id} estimateItemId={task.estimateItemId ?? null} />
 
                         <div className="border-t border-slate-100" />
 

--- a/src/app/projects/[id]/schedule/TaskMaterialsSection.tsx
+++ b/src/app/projects/[id]/schedule/TaskMaterialsSection.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import { toast } from "sonner";
+
+import {
+    addTaskMaterial,
+    deleteTaskMaterial,
+    getTaskMaterials,
+    importEstimateMaterials,
+    setTaskMaterialStatus,
+    updateTaskMaterial,
+} from "@/lib/actions";
+import type { TaskMaterialRow, TaskMaterialStatus } from "@/lib/task-materials-core";
+
+type MaterialRow = TaskMaterialRow & { canDelete: boolean };
+
+const STATUS_STYLES: Record<TaskMaterialStatus, string> = {
+    pending: "bg-amber-100 text-amber-800",
+    staged: "bg-green-100 text-green-700",
+    missing: "bg-red-100 text-red-700",
+    resolved: "bg-slate-100 text-slate-600",
+};
+
+const EMPTY_DRAFT = { text: "", quantity: "", unit: "", location: "" };
+
+function quantityLabel(row: Pick<MaterialRow, "quantity" | "unit">): string | null {
+    if (row.quantity === null && !row.unit) return null;
+    return [row.quantity, row.unit].filter(value => value !== null && value !== "").join(" ");
+}
+
+function quantityValue(value: string): number | null {
+    if (!value.trim()) return null;
+    return Number(value);
+}
+
+export function TaskMaterialsSection({
+    taskId,
+    estimateItemId,
+}: {
+    taskId: string;
+    estimateItemId: string | null;
+}) {
+    const [materials, setMaterials] = useState<MaterialRow[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+    const [busyKey, setBusyKey] = useState<string | null>(null);
+    const [addDraft, setAddDraft] = useState(EMPTY_DRAFT);
+    const [editId, setEditId] = useState<string | null>(null);
+    const [editDraft, setEditDraft] = useState(EMPTY_DRAFT);
+    const [noteTarget, setNoteTarget] = useState<{ id: string; status: "missing" | "resolved" } | null>(null);
+    const [noteDraft, setNoteDraft] = useState("");
+
+    async function refresh() {
+        const rows = await getTaskMaterials(taskId);
+        setMaterials(rows);
+    }
+
+    useEffect(() => {
+        let cancelled = false;
+        setLoading(true);
+        setError("");
+        getTaskMaterials(taskId)
+            .then(rows => {
+                if (!cancelled) setMaterials(rows);
+            })
+            .catch(reason => {
+                if (!cancelled) setError(reason?.message || "Materials could not be loaded.");
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [taskId]);
+
+    async function run(key: string, action: () => Promise<unknown>, success: string) {
+        setBusyKey(key);
+        setError("");
+        try {
+            await action();
+            await refresh();
+            toast.success(success);
+            return true;
+        } catch (reason: any) {
+            const message = reason?.message || "Material update failed.";
+            setError(message);
+            toast.error(message);
+            return false;
+        } finally {
+            setBusyKey(null);
+        }
+    }
+
+    async function handleAdd(event: FormEvent) {
+        event.preventDefault();
+        const saved = await run("add", () => addTaskMaterial(taskId, {
+            text: addDraft.text,
+            quantity: quantityValue(addDraft.quantity),
+            unit: addDraft.unit || null,
+            location: addDraft.location || null,
+        }), "Material added");
+        if (saved) setAddDraft(EMPTY_DRAFT);
+    }
+
+    function beginEdit(row: MaterialRow) {
+        setEditId(row.id);
+        setEditDraft({
+            text: row.text,
+            quantity: row.quantity?.toString() ?? "",
+            unit: row.unit ?? "",
+            location: row.location ?? "",
+        });
+    }
+
+    async function saveEdit(event: FormEvent) {
+        event.preventDefault();
+        if (!editId) return;
+        const saved = await run(`edit:${editId}`, () => updateTaskMaterial(editId, {
+            text: editDraft.text,
+            quantity: quantityValue(editDraft.quantity),
+            unit: editDraft.unit || null,
+            location: editDraft.location || null,
+        }), "Material updated");
+        if (saved) setEditId(null);
+    }
+
+    function requestNotedStatus(id: string, status: "missing" | "resolved", existingNote?: string | null) {
+        setNoteTarget({ id, status });
+        setNoteDraft(existingNote ?? "");
+    }
+
+    async function saveNotedStatus(event: FormEvent) {
+        event.preventDefault();
+        if (!noteTarget) return;
+        if (noteTarget.status === "resolved" && !noteDraft.trim()) {
+            setError("Resolved materials require a resolution note.");
+            return;
+        }
+        const saved = await run(
+            `status:${noteTarget.id}`,
+            () => setTaskMaterialStatus(noteTarget.id, noteTarget.status, noteDraft || null),
+            noteTarget.status === "missing" ? "Material marked missing" : "Material resolved",
+        );
+        if (saved) {
+            setNoteTarget(null);
+            setNoteDraft("");
+        }
+    }
+
+    async function handleImport() {
+        setBusyKey("import");
+        setError("");
+        try {
+            const result = await importEstimateMaterials(taskId);
+            await refresh();
+            if (result.created === 0) {
+                toast.info("Estimate materials are already on this task.");
+            } else {
+                toast.success(`${result.created} estimate material${result.created === 1 ? "" : "s"} imported`);
+            }
+        } catch (reason: any) {
+            const message = reason?.message || "Estimate materials could not be imported.";
+            setError(message);
+            toast.error(message);
+        } finally {
+            setBusyKey(null);
+        }
+    }
+
+    return (
+        <details open className="group">
+            <summary className="flex cursor-pointer list-none items-center gap-2 py-2 select-none [&::-webkit-details-marker]:hidden">
+                <svg className="h-3.5 w-3.5 text-slate-400 transition-transform group-open:rotate-90" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2"><path d="m9 18 6-6-6-6" /></svg>
+                <span className="text-xs font-semibold uppercase tracking-wider text-hui-textMuted">Materials</span>
+                {!loading && (
+                    <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-semibold text-slate-500">
+                        {materials.length}
+                    </span>
+                )}
+            </summary>
+
+            <div className="space-y-3 pb-4 pl-5.5">
+                {error && (
+                    <p className="rounded-md border border-red-200 bg-red-50 px-2.5 py-2 text-xs text-red-700" role="alert">
+                        {error}
+                    </p>
+                )}
+
+                {loading ? (
+                    <p className="py-3 text-xs text-slate-400">Loading materials...</p>
+                ) : materials.length === 0 ? (
+                    <div className="rounded-lg border border-dashed border-slate-200 px-3 py-4">
+                        <p className="text-xs font-semibold text-slate-600">No staging list yet</p>
+                        <p className="mt-1 text-xs leading-relaxed text-slate-400">
+                            Add the first jobsite item{estimateItemId ? " or pull material lines from the linked estimate" : ""}.
+                        </p>
+                    </div>
+                ) : (
+                    <div className="space-y-2">
+                        {materials.map(row => (
+                            <div key={row.id} className="group/material rounded-lg border border-slate-200 bg-white p-2.5">
+                                {editId === row.id ? (
+                                    <form onSubmit={saveEdit} className="space-y-2">
+                                        <input
+                                            value={editDraft.text}
+                                            onChange={event => setEditDraft(current => ({ ...current, text: event.target.value }))}
+                                            className="hui-input w-full text-xs"
+                                            aria-label="Material text"
+                                            autoFocus
+                                        />
+                                        <div className="grid grid-cols-2 gap-2">
+                                            <input type="number" min="0" step="any" value={editDraft.quantity} onChange={event => setEditDraft(current => ({ ...current, quantity: event.target.value }))} className="hui-input text-xs" placeholder="Qty" aria-label="Quantity" />
+                                            <input value={editDraft.unit} onChange={event => setEditDraft(current => ({ ...current, unit: event.target.value }))} className="hui-input text-xs" placeholder="Unit" aria-label="Unit" />
+                                        </div>
+                                        <input value={editDraft.location} onChange={event => setEditDraft(current => ({ ...current, location: event.target.value }))} className="hui-input w-full text-xs" placeholder="Location" aria-label="Location" />
+                                        <div className="flex gap-2">
+                                            <button type="submit" disabled={busyKey !== null} className="hui-btn hui-btn-green text-xs">Save changes</button>
+                                            <button type="button" onClick={() => setEditId(null)} className="hui-btn hui-btn-secondary text-xs">Cancel</button>
+                                        </div>
+                                    </form>
+                                ) : (
+                                    <>
+                                        <div className="flex items-start justify-between gap-2">
+                                            <div className="min-w-0">
+                                                <p className="text-xs font-semibold leading-relaxed text-hui-textMain">
+                                                    {row.text}
+                                                    {quantityLabel(row) && <span className="font-normal text-slate-500"> {"\u00B7"} {quantityLabel(row)}</span>}
+                                                </p>
+                                                <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                                                    {row.location && <span className="rounded-full bg-indigo-50 px-2 py-0.5 text-[10px] font-semibold text-indigo-700">{row.location}</span>}
+                                                    <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold capitalize ${STATUS_STYLES[row.status]}`}>{row.status}</span>
+                                                    {row.sourceKind !== "manual" && <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] text-slate-500">{row.sourceKind}</span>}
+                                                </div>
+                                                {row.resolutionNote && <p className="mt-1.5 text-[11px] leading-relaxed text-slate-500">{row.resolutionNote}</p>}
+                                            </div>
+                                            <div className="flex shrink-0 gap-1 opacity-0 pointer-events-none transition group-hover/material:opacity-100 group-hover/material:pointer-events-auto group-focus-within/material:opacity-100 group-focus-within/material:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto">
+                                                <button type="button" onClick={() => beginEdit(row)} className="rounded px-1.5 py-1 text-[10px] font-semibold text-indigo-600 hover:bg-indigo-50">Edit</button>
+                                                {row.canDelete && (
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => {
+                                                            if (window.confirm(`Delete "${row.text}"?`)) {
+                                                                void run(`delete:${row.id}`, () => deleteTaskMaterial(row.id), "Material deleted");
+                                                            }
+                                                        }}
+                                                        className="rounded px-1.5 py-1 text-[10px] font-semibold text-red-600 hover:bg-red-50"
+                                                    >
+                                                        Delete
+                                                    </button>
+                                                )}
+                                            </div>
+                                        </div>
+                                        <div className="mt-2 flex flex-wrap gap-1.5">
+                                            {(["pending", "staged"] as const).map(status => (
+                                                <button
+                                                    key={status}
+                                                    type="button"
+                                                    disabled={busyKey !== null || row.status === status}
+                                                    onClick={() => void run(`status:${row.id}`, () => setTaskMaterialStatus(row.id, status), `Material marked ${status}`)}
+                                                    className="rounded border border-slate-200 px-2 py-1 text-[10px] font-semibold capitalize text-slate-600 transition hover:bg-slate-50 disabled:opacity-40"
+                                                >
+                                                    {status}
+                                                </button>
+                                            ))}
+                                            <button type="button" disabled={busyKey !== null || row.status === "missing"} onClick={() => requestNotedStatus(row.id, "missing", row.resolutionNote)} className="rounded border border-red-200 px-2 py-1 text-[10px] font-semibold text-red-600 transition hover:bg-red-50 disabled:opacity-40">Missing</button>
+                                            <button type="button" disabled={busyKey !== null || row.status === "resolved"} onClick={() => requestNotedStatus(row.id, "resolved", row.resolutionNote)} className="rounded border border-slate-200 px-2 py-1 text-[10px] font-semibold text-slate-600 transition hover:bg-slate-50 disabled:opacity-40">Resolved</button>
+                                        </div>
+                                        {noteTarget?.id === row.id && (
+                                            <form onSubmit={saveNotedStatus} className="mt-2 flex gap-2">
+                                                <input
+                                                    value={noteDraft}
+                                                    onChange={event => setNoteDraft(event.target.value)}
+                                                    className="hui-input min-w-0 flex-1 text-xs"
+                                                    placeholder={noteTarget.status === "missing" ? "What is missing?" : "How was it resolved?"}
+                                                    aria-label="Material status note"
+                                                    autoFocus
+                                                />
+                                                <button type="submit" className="hui-btn hui-btn-green text-xs">Set {noteTarget.status}</button>
+                                                <button type="button" onClick={() => setNoteTarget(null)} className="hui-btn hui-btn-secondary px-2 text-xs" aria-label="Cancel status note">{"\u00D7"}</button>
+                                            </form>
+                                        )}
+                                    </>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                )}
+
+                <form onSubmit={handleAdd} className="space-y-2 rounded-lg bg-slate-50 p-2.5">
+                    <input value={addDraft.text} onChange={event => setAddDraft(current => ({ ...current, text: event.target.value }))} className="hui-input w-full text-xs" placeholder="Add material or supply" aria-label="New material text" />
+                    <div className="grid grid-cols-3 gap-2">
+                        <input type="number" min="0" step="any" value={addDraft.quantity} onChange={event => setAddDraft(current => ({ ...current, quantity: event.target.value }))} className="hui-input text-xs" placeholder="Qty" aria-label="New material quantity" />
+                        <input value={addDraft.unit} onChange={event => setAddDraft(current => ({ ...current, unit: event.target.value }))} className="hui-input text-xs" placeholder="Unit" aria-label="New material unit" />
+                        <input value={addDraft.location} onChange={event => setAddDraft(current => ({ ...current, location: event.target.value }))} className="hui-input text-xs" placeholder="Location" aria-label="New material location" />
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                        <button type="submit" disabled={busyKey !== null || !addDraft.text.trim()} className="hui-btn hui-btn-green text-xs disabled:opacity-50">Add material</button>
+                        {estimateItemId && (
+                            <button
+                                type="button"
+                                disabled={busyKey !== null}
+                                onClick={() => void handleImport()}
+                                className="hui-btn hui-btn-secondary text-xs disabled:opacity-50"
+                            >
+                                Import estimate
+                            </button>
+                        )}
+                    </div>
+                </form>
+            </div>
+        </details>
+    );
+}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -35,6 +35,19 @@ import { assertColumnExists, parseOfficeTaskDateOnly } from "./office-task-utils
 import { publishDispatch } from "./dispatch-publication";
 import type { DispatchIntent } from "./dispatch-intent";
 import type { PublishDispatchResult } from "./dispatch-publication";
+import {
+    addTaskMaterialCore,
+    deleteTaskMaterialCore,
+    getStagingQueueCore,
+    getTaskMaterialsCore,
+    importEstimateMaterialsCore,
+    setTaskMaterialStatusCore,
+    updateTaskMaterialCore,
+    type TaskMaterialActor,
+    type TaskMaterialInput,
+    type TaskMaterialUpdateInput,
+    type TaskMaterialStatus,
+} from "./task-materials-core";
 
 type NotificationToggleKey = "newLead" | "estimateViewed" | "estimateSigned" | "contractSigned" | "invoiceViewed" | "paymentReceived" | "messageReceived";
 
@@ -4023,6 +4036,29 @@ async function assertScheduleTaskAccess(taskId: string) {
     return { user, projectId: task.projectId };
 }
 
+async function assertStagingQueueAccess() {
+    const user = await assertActiveStaff();
+    if (!["ADMIN", "MANAGER", "FIELD_CREW"].includes(user.role) || !hasPermission(user, "schedules")) {
+        throw new Error("Forbidden");
+    }
+    return user;
+}
+
+function taskMaterialActor(user: any): TaskMaterialActor {
+    if (!user?.id) throw new Error("Authenticated staff user is required");
+    return {
+        userId: user.id,
+        role: user.role,
+        name: user.name || user.email,
+    };
+}
+
+function revalidateTaskMaterialPaths(projectId: string) {
+    revalidatePath(`/projects/${projectId}/schedule`);
+    revalidatePath("/company-dashboard");
+    revalidatePath("/company-dashboard/staging");
+}
+
 async function assertFinancialPermission() {
     return assertStaffPermission("financialReports");
 }
@@ -6643,6 +6679,102 @@ export async function getScheduleTaskDetail(taskId: string) {
         ...serializeScheduleTaskForDetail(task),
         allTasks: tasks.map(serializeScheduleTaskForDetail),
     };
+}
+
+export async function getTaskMaterials(taskId: string) {
+    const { user } = await assertScheduleTaskAccess(taskId);
+    const rows = await getTaskMaterialsCore(taskId);
+    return rows.map(row => ({
+        ...row,
+        canDelete: ["ADMIN", "MANAGER"].includes(user.role) || row.createdById === user.id,
+    }));
+}
+
+export async function addTaskMaterial(taskId: string, input: TaskMaterialInput) {
+    const { user, projectId } = await assertScheduleTaskAccess(taskId);
+    const row = await addTaskMaterialCore({
+        taskId,
+        input,
+        actor: taskMaterialActor(user),
+    });
+    revalidateTaskMaterialPaths(projectId);
+    return {
+        ...row,
+        canDelete: ["ADMIN", "MANAGER"].includes(user.role) || row.createdById === user.id,
+    };
+}
+
+export async function updateTaskMaterial(materialId: string, input: TaskMaterialUpdateInput) {
+    const material = await prisma.taskMaterial.findUnique({
+        where: { id: materialId },
+        select: { taskId: true },
+    });
+    if (!material) throw new Error("Material not found");
+    const { user, projectId } = await assertScheduleTaskAccess(material.taskId);
+    const row = await updateTaskMaterialCore({
+        materialId,
+        input,
+        actor: taskMaterialActor(user),
+    });
+    revalidateTaskMaterialPaths(projectId);
+    return {
+        ...row,
+        canDelete: ["ADMIN", "MANAGER"].includes(user.role) || row.createdById === user.id,
+    };
+}
+
+export async function setTaskMaterialStatus(
+    materialId: string,
+    status: TaskMaterialStatus,
+    resolutionNote?: string | null,
+) {
+    const material = await prisma.taskMaterial.findUnique({
+        where: { id: materialId },
+        select: { taskId: true },
+    });
+    if (!material) throw new Error("Material not found");
+    const { user, projectId } = await assertScheduleTaskAccess(material.taskId);
+    const row = await setTaskMaterialStatusCore({
+        materialId,
+        status,
+        resolutionNote,
+        actor: taskMaterialActor(user),
+    });
+    revalidateTaskMaterialPaths(projectId);
+    return {
+        ...row,
+        canDelete: ["ADMIN", "MANAGER"].includes(user.role) || row.createdById === user.id,
+    };
+}
+
+export async function deleteTaskMaterial(materialId: string) {
+    const material = await prisma.taskMaterial.findUnique({
+        where: { id: materialId },
+        select: { taskId: true },
+    });
+    if (!material) throw new Error("Material not found");
+    const { user, projectId } = await assertScheduleTaskAccess(material.taskId);
+    const result = await deleteTaskMaterialCore({
+        materialId,
+        actor: taskMaterialActor(user),
+    });
+    revalidateTaskMaterialPaths(projectId);
+    return result;
+}
+
+export async function importEstimateMaterials(taskId: string) {
+    const { user, projectId } = await assertScheduleTaskAccess(taskId);
+    const result = await importEstimateMaterialsCore({
+        taskId,
+        actor: taskMaterialActor(user),
+    });
+    revalidateTaskMaterialPaths(projectId);
+    return result;
+}
+
+export async function getStagingQueue(dayISO: string) {
+    await assertStagingQueueAccess();
+    return getStagingQueueCore(dayISO);
 }
 
 export async function getPortalScheduleTasks(projectId: string) {

--- a/src/lib/schedule-core.ts
+++ b/src/lib/schedule-core.ts
@@ -2043,6 +2043,9 @@ export interface DashboardTaskRow {
     blockedReason: string | null;
     scheduledTime: string | null;
     confirmationStatus: string | null;
+    pendingMaterials: number;
+    stagedMaterials: number;
+    missingMaterials: number;
     assignments: DashboardTaskAssignment[];
     // Hover-card notes (owner-feedback round, item 3): most recent 2 task
     // comments, newest first — same TaskComment source the project schedule
@@ -2302,7 +2305,7 @@ export async function getCompanyDashboardData(
         ...pipeline.inProgress.map(p => p.id),
         ...pipeline.substantialCompletion.map(p => p.id),
     ];
-    const [taskRows, qualifying, unappliedByProject] = await Promise.all([
+    const [taskRows, qualifying, unappliedByProject, materialCounts] = await Promise.all([
         prisma.scheduleTask.findMany({
             where: { projectId: { in: rowIds } },
             orderBy: [{ order: "asc" }, { startDate: "asc" }, { id: "asc" }],
@@ -2325,11 +2328,28 @@ export async function getCompanyDashboardData(
         }),
         prisma.estimate.groupBy({ by: ["projectId"], where: { projectId: { in: rowIds }, status: { in: CONTRACT_ESTIMATE_STATUSES } }, _count: { id: true } }),
         getUnappliedChangeOrders(rowIds),
+        prisma.taskMaterial.groupBy({
+            by: ["taskId", "status"],
+            where: {
+                task: { projectId: { in: rowIds } },
+                status: { in: ["pending", "staged", "missing"] },
+            },
+            _count: { id: true },
+        }),
     ]);
+    const materialCountsByTask = new Map<string, { pending: number; staged: number; missing: number }>();
+    for (const count of materialCounts) {
+        const current = materialCountsByTask.get(count.taskId) ?? { pending: 0, staged: 0, missing: 0 };
+        if (count.status === "pending" || count.status === "staged" || count.status === "missing") {
+            current[count.status] = count._count.id;
+        }
+        materialCountsByTask.set(count.taskId, current);
+    }
     const tasksByProject = new Map<string, DashboardTaskRow[]>();
     for (const task of taskRows) {
         if (!task.projectId) continue;
         const rows = tasksByProject.get(task.projectId) ?? [];
+        const taskMaterialCounts = materialCountsByTask.get(task.id) ?? { pending: 0, staged: 0, missing: 0 };
         rows.push({
             id: task.id,
             name: task.name,
@@ -2345,6 +2365,9 @@ export async function getCompanyDashboardData(
             blockedReason: task.blockedReason,
             scheduledTime: task.scheduledTime,
             confirmationStatus: task.confirmationStatus,
+            pendingMaterials: taskMaterialCounts.pending,
+            stagedMaterials: taskMaterialCounts.staged,
+            missingMaterials: taskMaterialCounts.missing,
             assignments: task.assignments.map(a => ({
                 id: a.id,
                 userId: a.userId,

--- a/src/lib/task-materials-core.ts
+++ b/src/lib/task-materials-core.ts
@@ -1,0 +1,580 @@
+import { Prisma } from "@prisma/client";
+
+import { isTaskActiveOnDay } from "@/app/company-dashboard/schedule-board/dispatch-exceptions";
+import { prisma } from "@/lib/prisma";
+import { canonicalContractEstimateQuery } from "@/lib/schedule-core";
+
+export const TASK_MATERIAL_STATUSES = ["pending", "staged", "missing", "resolved"] as const;
+export type TaskMaterialStatus = (typeof TASK_MATERIAL_STATUSES)[number];
+
+export const TASK_MATERIAL_SOURCE_KINDS = ["manual", "estimate", "ai"] as const;
+export type TaskMaterialSourceKind = (typeof TASK_MATERIAL_SOURCE_KINDS)[number];
+
+export interface TaskMaterialActor {
+    userId: string;
+    role: string;
+    name: string;
+}
+
+export interface TaskMaterialInput {
+    text: string;
+    quantity?: number | null;
+    unit?: string | null;
+    location?: string | null;
+}
+
+export interface TaskMaterialUpdateInput {
+    text?: string;
+    quantity?: number | null;
+    unit?: string | null;
+    location?: string | null;
+}
+
+export interface TaskMaterialRow {
+    id: string;
+    taskId: string;
+    text: string;
+    quantity: number | null;
+    unit: string | null;
+    location: string | null;
+    status: TaskMaterialStatus;
+    sourceKind: TaskMaterialSourceKind;
+    sourceEstimateItemId: string | null;
+    resolutionNote: string | null;
+    order: number;
+    createdById: string | null;
+    createdByName: string | null;
+    createdAt: string;
+    updatedAt: string;
+    statusChangedById: string | null;
+    statusChangedAt: string | null;
+}
+
+export interface StagingCounts {
+    pending: number;
+    staged: number;
+    missing: number;
+}
+
+export interface StagingMaterialRow {
+    id: string;
+    taskId: string;
+    taskName: string;
+    text: string;
+    quantity: number | null;
+    unit: string | null;
+    location: string | null;
+    status: TaskMaterialStatus;
+    resolutionNote: string | null;
+    order: number;
+}
+
+export interface StagingProjectGroup {
+    projectId: string;
+    projectName: string;
+    projectLocation: string | null;
+    projectColor: string | null;
+    materials: StagingMaterialRow[];
+    counts: StagingCounts;
+}
+
+export interface StagingQueue {
+    dayISO: string;
+    projects: StagingProjectGroup[];
+    counts: StagingCounts;
+}
+
+const MATERIAL_SELECT = {
+    id: true,
+    taskId: true,
+    text: true,
+    quantity: true,
+    unit: true,
+    location: true,
+    status: true,
+    sourceKind: true,
+    sourceEstimateItemId: true,
+    resolutionNote: true,
+    order: true,
+    createdById: true,
+    createdBy: { select: { name: true, email: true } },
+    createdAt: true,
+    updatedAt: true,
+    statusChangedById: true,
+    statusChangedAt: true,
+} satisfies Prisma.TaskMaterialSelect;
+
+type SelectedTaskMaterial = Prisma.TaskMaterialGetPayload<{ select: typeof MATERIAL_SELECT }>;
+
+function cleanRequiredText(value: string, label: string, maxLength: number): string {
+    const cleaned = value.trim();
+    if (!cleaned) throw new Error(`${label} is required`);
+    if (cleaned.length > maxLength) throw new Error(`${label} cannot exceed ${maxLength} characters`);
+    return cleaned;
+}
+
+function cleanOptionalText(
+    value: string | null | undefined,
+    label: string,
+    maxLength: number,
+): string | null | undefined {
+    if (value === undefined) return undefined;
+    if (value === null) return null;
+    const cleaned = value.trim();
+    if (!cleaned) return null;
+    if (cleaned.length > maxLength) throw new Error(`${label} cannot exceed ${maxLength} characters`);
+    return cleaned;
+}
+
+function cleanQuantity(value: number | null | undefined): number | null | undefined {
+    if (value === undefined || value === null) return value;
+    if (!Number.isFinite(value) || value < 0) {
+        throw new Error("Quantity must be a non-negative number");
+    }
+    return value;
+}
+
+function assertMaterialStatus(value: string): asserts value is TaskMaterialStatus {
+    if (!(TASK_MATERIAL_STATUSES as readonly string[]).includes(value)) {
+        throw new Error("Invalid material status");
+    }
+}
+
+function serializeMaterial(row: SelectedTaskMaterial): TaskMaterialRow {
+    assertMaterialStatus(row.status);
+    if (!(TASK_MATERIAL_SOURCE_KINDS as readonly string[]).includes(row.sourceKind)) {
+        throw new Error("Invalid material source");
+    }
+    return {
+        id: row.id,
+        taskId: row.taskId,
+        text: row.text,
+        quantity: row.quantity === null ? null : Number(row.quantity),
+        unit: row.unit,
+        location: row.location,
+        status: row.status,
+        sourceKind: row.sourceKind as TaskMaterialSourceKind,
+        sourceEstimateItemId: row.sourceEstimateItemId,
+        resolutionNote: row.resolutionNote,
+        order: row.order,
+        createdById: row.createdById,
+        createdByName: row.createdBy?.name ?? row.createdBy?.email ?? null,
+        createdAt: row.createdAt.toISOString(),
+        updatedAt: row.updatedAt.toISOString(),
+        statusChangedById: row.statusChangedById,
+        statusChangedAt: row.statusChangedAt?.toISOString() ?? null,
+    };
+}
+
+function activityData(input: {
+    projectId: string;
+    actor: TaskMaterialActor;
+    action: string;
+    entityId: string;
+    entityName: string;
+    metadata?: Record<string, unknown>;
+}): Prisma.ActivityLogUncheckedCreateInput {
+    return {
+        projectId: input.projectId,
+        actorType: "TEAM",
+        actorName: input.actor.name,
+        action: input.action,
+        entityType: "task_material",
+        entityId: input.entityId,
+        entityName: input.entityName,
+        metadata: input.metadata ? JSON.stringify(input.metadata) : undefined,
+    };
+}
+
+async function materialContext(
+    materialId: string,
+): Promise<{ material: SelectedTaskMaterial; projectId: string }> {
+    const material = await prisma.taskMaterial.findUnique({
+        where: { id: materialId },
+        select: {
+            ...MATERIAL_SELECT,
+            task: { select: { projectId: true } },
+        },
+    });
+    if (!material) throw new Error("Material not found");
+    if (!material.task.projectId) throw new Error("Task is not attached to a project");
+    return { material, projectId: material.task.projectId };
+}
+
+export async function getTaskMaterialsCore(taskId: string): Promise<TaskMaterialRow[]> {
+    const rows = await prisma.taskMaterial.findMany({
+        where: { taskId },
+        select: MATERIAL_SELECT,
+        orderBy: [{ order: "asc" }, { createdAt: "asc" }, { id: "asc" }],
+    });
+    return rows.map(serializeMaterial);
+}
+
+export async function addTaskMaterialCore(input: {
+    taskId: string;
+    input: TaskMaterialInput;
+    actor: TaskMaterialActor;
+}): Promise<TaskMaterialRow> {
+    const text = cleanRequiredText(input.input.text, "Material text", 500);
+    const quantity = cleanQuantity(input.input.quantity);
+    const unit = cleanOptionalText(input.input.unit, "Unit", 40);
+    const location = cleanOptionalText(input.input.location, "Location", 120);
+
+    const created = await prisma.$transaction(async tx => {
+        const task = await tx.scheduleTask.findUnique({
+            where: { id: input.taskId },
+            select: { projectId: true },
+        });
+        if (!task) throw new Error("Task not found");
+        if (!task.projectId) throw new Error("Task is not attached to a project");
+        const maxOrder = await tx.taskMaterial.aggregate({
+            where: { taskId: input.taskId },
+            _max: { order: true },
+        });
+        const row = await tx.taskMaterial.create({
+            data: {
+                taskId: input.taskId,
+                text,
+                quantity,
+                unit,
+                location,
+                sourceKind: "manual",
+                createdById: input.actor.userId,
+                order: (maxOrder._max.order ?? -1) + 1,
+            },
+            select: MATERIAL_SELECT,
+        });
+        await tx.activityLog.create({
+            data: activityData({
+                projectId: task.projectId,
+                actor: input.actor,
+                action: "add_task_material",
+                entityId: row.id,
+                entityName: row.text,
+                metadata: { taskId: input.taskId, sourceKind: "manual" },
+            }),
+        });
+        return row;
+    });
+    return serializeMaterial(created);
+}
+
+export async function updateTaskMaterialCore(input: {
+    materialId: string;
+    input: TaskMaterialUpdateInput;
+    actor: TaskMaterialActor;
+}): Promise<TaskMaterialRow> {
+    const existing = await materialContext(input.materialId);
+    const data: Prisma.TaskMaterialUncheckedUpdateInput = {};
+    if (input.input.text !== undefined) {
+        data.text = cleanRequiredText(input.input.text, "Material text", 500);
+    }
+    if (input.input.quantity !== undefined) {
+        data.quantity = cleanQuantity(input.input.quantity);
+    }
+    if (input.input.unit !== undefined) {
+        data.unit = cleanOptionalText(input.input.unit, "Unit", 40);
+    }
+    if (input.input.location !== undefined) {
+        data.location = cleanOptionalText(input.input.location, "Location", 120);
+    }
+    if (Object.keys(data).length === 0) throw new Error("No material changes provided");
+
+    const updated = await prisma.$transaction(async tx => {
+        const row = await tx.taskMaterial.update({
+            where: { id: input.materialId },
+            data,
+            select: MATERIAL_SELECT,
+        });
+        await tx.activityLog.create({
+            data: activityData({
+                projectId: existing.projectId,
+                actor: input.actor,
+                action: "update_task_material",
+                entityId: row.id,
+                entityName: row.text,
+                metadata: { taskId: row.taskId, fields: Object.keys(data) },
+            }),
+        });
+        return row;
+    });
+    return serializeMaterial(updated);
+}
+
+export async function setTaskMaterialStatusCore(input: {
+    materialId: string;
+    status: string;
+    resolutionNote?: string | null;
+    actor: TaskMaterialActor;
+}): Promise<TaskMaterialRow> {
+    assertMaterialStatus(input.status);
+    const note = cleanOptionalText(input.resolutionNote, "Resolution note", 500) ?? null;
+    if (input.status === "resolved" && !note) {
+        throw new Error("Resolved materials require a resolution note");
+    }
+    const existing = await materialContext(input.materialId);
+    const updated = await prisma.$transaction(async tx => {
+        const row = await tx.taskMaterial.update({
+            where: { id: input.materialId },
+            data: {
+                status: input.status,
+                resolutionNote: input.status === "pending" || input.status === "staged" ? null : note,
+                statusChangedById: input.actor.userId,
+                statusChangedAt: new Date(),
+            },
+            select: MATERIAL_SELECT,
+        });
+        await tx.activityLog.create({
+            data: activityData({
+                projectId: existing.projectId,
+                actor: input.actor,
+                action: "set_task_material_status",
+                entityId: row.id,
+                entityName: row.text,
+                metadata: {
+                    taskId: row.taskId,
+                    previousStatus: existing.material.status,
+                    status: row.status,
+                    resolutionNote: row.resolutionNote,
+                },
+            }),
+        });
+        return row;
+    });
+    return serializeMaterial(updated);
+}
+
+export async function deleteTaskMaterialCore(input: {
+    materialId: string;
+    actor: TaskMaterialActor;
+}): Promise<{ id: string; taskId: string; projectId: string }> {
+    const existing = await materialContext(input.materialId);
+    const canDelete = ["ADMIN", "MANAGER"].includes(input.actor.role)
+        || existing.material.createdById === input.actor.userId;
+    if (!canDelete) {
+        throw new Error("Only the creator, an admin, or a manager can delete this material");
+    }
+    await prisma.$transaction(async tx => {
+        await tx.taskMaterial.delete({ where: { id: input.materialId } });
+        await tx.activityLog.create({
+            data: activityData({
+                projectId: existing.projectId,
+                actor: input.actor,
+                action: "delete_task_material",
+                entityId: existing.material.id,
+                entityName: existing.material.text,
+                metadata: {
+                    taskId: existing.material.taskId,
+                    sourceKind: existing.material.sourceKind,
+                },
+            }),
+        });
+    });
+    return {
+        id: existing.material.id,
+        taskId: existing.material.taskId,
+        projectId: existing.projectId,
+    };
+}
+
+export async function importEstimateMaterialsCore(input: {
+    taskId: string;
+    actor: TaskMaterialActor;
+}): Promise<{ created: number }> {
+    return prisma.$transaction(async tx => {
+        await tx.$queryRaw`SELECT id FROM "ScheduleTask" WHERE id = ${input.taskId} FOR UPDATE`;
+        const task = await tx.scheduleTask.findUnique({
+            where: { id: input.taskId },
+            select: { projectId: true, estimateItemId: true, name: true },
+        });
+        if (!task) throw new Error("Task not found");
+        if (!task.projectId) throw new Error("Task is not attached to a project");
+        if (!task.estimateItemId) throw new Error("Task is not linked to an estimate item");
+
+        const estimate = await tx.estimate.findFirst({
+            ...canonicalContractEstimateQuery(task.projectId),
+            select: { id: true },
+        });
+        if (!estimate) throw new Error("No canonical contract estimate found");
+
+        const linkedRoot = await tx.estimateItem.findFirst({
+            where: { id: task.estimateItemId, estimateId: estimate.id },
+            select: { id: true },
+        });
+        if (!linkedRoot) {
+            throw new Error("Task estimate lineage is outside the canonical contract estimate");
+        }
+
+        const candidates = await tx.estimateItem.findMany({
+            where: {
+                estimateId: estimate.id,
+                type: "Material",
+                OR: [
+                    { id: linkedRoot.id },
+                    { parentId: linkedRoot.id },
+                ],
+            },
+            orderBy: [{ order: "asc" }, { createdAt: "asc" }, { id: "asc" }],
+            select: {
+                id: true,
+                name: true,
+                quantity: true,
+                budgetUnit: true,
+            },
+        });
+        const existingSourceIds = new Set((await tx.taskMaterial.findMany({
+            where: {
+                taskId: input.taskId,
+                sourceEstimateItemId: { in: candidates.map(candidate => candidate.id) },
+            },
+            select: { sourceEstimateItemId: true },
+        })).flatMap(row => row.sourceEstimateItemId ? [row.sourceEstimateItemId] : []));
+        const pendingCreates = candidates.filter(candidate => !existingSourceIds.has(candidate.id));
+        if (pendingCreates.length === 0) return { created: 0 };
+
+        const maxOrder = await tx.taskMaterial.aggregate({
+            where: { taskId: input.taskId },
+            _max: { order: true },
+        });
+        const firstOrder = (maxOrder._max.order ?? -1) + 1;
+        await tx.taskMaterial.createMany({
+            data: pendingCreates.map((candidate, index) => ({
+                taskId: input.taskId,
+                text: cleanRequiredText(candidate.name, "Material text", 500),
+                quantity: candidate.quantity,
+                unit: cleanOptionalText(candidate.budgetUnit, "Unit", 40),
+                status: "pending",
+                sourceKind: "estimate",
+                sourceEstimateItemId: candidate.id,
+                createdById: input.actor.userId,
+                order: firstOrder + index,
+            })),
+        });
+        await tx.activityLog.create({
+            data: {
+                projectId: task.projectId,
+                actorType: "TEAM",
+                actorName: input.actor.name,
+                action: "import_estimate_materials",
+                entityType: "schedule_task",
+                entityId: input.taskId,
+                entityName: task.name,
+                metadata: JSON.stringify({
+                    estimateId: estimate.id,
+                    sourceEstimateItemIds: pendingCreates.map(candidate => candidate.id),
+                    created: pendingCreates.length,
+                }),
+            },
+        });
+        return { created: pendingCreates.length };
+    });
+}
+
+function emptyCounts(): StagingCounts {
+    return { pending: 0, staged: 0, missing: 0 };
+}
+
+function addStatus(counts: StagingCounts, status: TaskMaterialStatus): void {
+    if (status === "pending" || status === "staged" || status === "missing") {
+        counts[status] += 1;
+    }
+}
+
+function assertDayISO(dayISO: string): void {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(dayISO)) throw new Error("Invalid staging day");
+    const parsed = new Date(`${dayISO}T00:00:00.000Z`);
+    if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== dayISO) {
+        throw new Error("Invalid staging day");
+    }
+}
+
+export async function getStagingQueueCore(dayISO: string): Promise<StagingQueue> {
+    assertDayISO(dayISO);
+    const rows = await prisma.taskMaterial.findMany({
+        where: {
+            task: {
+                project: { is: { status: "In Progress" } },
+            },
+        },
+        select: {
+            id: true,
+            text: true,
+            quantity: true,
+            unit: true,
+            location: true,
+            status: true,
+            resolutionNote: true,
+            order: true,
+            task: {
+                select: {
+                    id: true,
+                    name: true,
+                    startDate: true,
+                    endDate: true,
+                    type: true,
+                    order: true,
+                    project: {
+                        select: {
+                            id: true,
+                            name: true,
+                            location: true,
+                            color: true,
+                        },
+                    },
+                },
+            },
+        },
+    });
+
+    const groups = new Map<string, StagingProjectGroup>();
+    for (const row of rows) {
+        const project = row.task.project;
+        if (!project || !isTaskActiveOnDay({
+            type: row.task.type,
+            startDate: row.task.startDate.toISOString(),
+            endDate: row.task.endDate.toISOString(),
+        }, dayISO)) continue;
+        assertMaterialStatus(row.status);
+        let group = groups.get(project.id);
+        if (!group) {
+            group = {
+                projectId: project.id,
+                projectName: project.name,
+                projectLocation: project.location,
+                projectColor: project.color,
+                materials: [],
+                counts: emptyCounts(),
+            };
+            groups.set(project.id, group);
+        }
+        group.materials.push({
+            id: row.id,
+            taskId: row.task.id,
+            taskName: row.task.name,
+            text: row.text,
+            quantity: row.quantity === null ? null : Number(row.quantity),
+            unit: row.unit,
+            location: row.location,
+            status: row.status,
+            resolutionNote: row.resolutionNote,
+            order: row.order,
+        });
+        addStatus(group.counts, row.status);
+    }
+
+    const projects = [...groups.values()]
+        .map(group => ({
+            ...group,
+            materials: group.materials.sort((left, right) =>
+                left.taskName.localeCompare(right.taskName)
+                || left.order - right.order
+                || left.text.localeCompare(right.text)),
+        }))
+        .sort((left, right) => left.projectName.localeCompare(right.projectName));
+    const counts = projects.reduce((total, group) => ({
+        pending: total.pending + group.counts.pending,
+        staged: total.staged + group.counts.staged,
+        missing: total.missing + group.counts.missing,
+    }), emptyCounts());
+    return { dayISO, projects, counts };
+}


### PR DESCRIPTION
PR-C of the dispatch arc — the materials pipeline. The estimate is a source, not the list: tasks carry a human-confirmed staging checklist, and Chris gets a purpose-built queue.

## What's new
- **TaskMaterial**: structured checklist rows per task (text, qty/unit, shop/on-site/pickup location, pending → staged/missing/resolved with a required resolution note). Human work is sacred — estimate re-imports can never modify or remove a row someone touched (behaviorally proven). Every status change records who and when.
- **Drawer Materials section** with one-click "Import from estimate" (contract estimate only, deduplicated).
- **Dispatch cards** show "📦 N · M missing" badges (serializer carries three integers, nothing more).
- **`/company-dashboard/staging`** — Chris's page: mobile-first, defaults to *tomorrow* ("Load the truck and jobsite before the crew arrives"), grouped by job with addresses, big touch checkboxes, Missing-with-note, live progress summary. No financial data anywhere on it.
- The 3 PM lock cadence deliberately waits for PR-D (it belongs with the digest scheduler).

## Verification
- New DB-backed behavioral suite ALL PASS (auth, sacred rows, dedup, day boundaries) + all six standing gates green (publish suite 18/18 untouched)
- Independent checker quoted the enforcement paths (delete permissions, resolved-note rule, serializer-leanness assertion) and confirmed schema/apply-script parity + RLS shape
- Browser on Shop: staging page rendered tomorrow's items grouped under Shop's address; ticked one Staged → "1 of 2 staged" + DB row shows staged with the session actor recorded; fixtures cleaned
- One review fix: house hover-reveal pattern completed (pointer-events pair) on the materials row actions

Implemented by GPT-5.6-sol (xhigh); independently gate-checked; reviewed and browser-verified by Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)