### PR TITLE
Portal: Domino's-style tracker, who's coming, curated photo feed

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1560,6 +1560,8 @@ model DailyLog {
   workPerformed      String          @db.Text
   materialsDelivered String?         @db.Text
   issues             String?         @db.Text
+  sharedToPortal     Boolean         @default(false)
+  sharedContentHash  String?
   photos             DailyLogPhoto[]
   createdAt          DateTime        @default(now())
   updatedAt          DateTime        @updatedAt
@@ -1573,6 +1575,7 @@ model DailyLogPhoto {
   dailyLog   DailyLog @relation(fields: [dailyLogId], references: [id], onDelete: Cascade)
   url        String
   caption    String?
+  sharedToPortal Boolean @default(false)
   createdAt  DateTime @default(now())
 }
 

--- a/scripts/apply-portal-tracker-schema.mjs
+++ b/scripts/apply-portal-tracker-schema.mjs
@@ -1,0 +1,47 @@
+// One-off additive migration for SPEC PR-E portal tracker curation.
+// Safe to re-run while the previous build is live.
+//
+// Run only through the release orchestrator:
+//   node scripts/apply-portal-tracker-schema.mjs
+//
+// Do not run this during implementation handoff. The new Prisma client selects
+// these columns immediately, so schema must be applied before deployment.
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+function resolveDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const file of [".env", ".env.local"]) {
+    if (!fs.existsSync(file)) continue;
+    const match = fs.readFileSync(file, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+    if (match) return match[1];
+  }
+  throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const prisma = new PrismaClient({
+  datasources: { db: { url: resolveDatabaseUrl() } },
+});
+
+const statements = [
+  `ALTER TABLE "DailyLog"
+     ADD COLUMN IF NOT EXISTS "sharedToPortal" BOOLEAN NOT NULL DEFAULT false,
+     ADD COLUMN IF NOT EXISTS "sharedContentHash" TEXT`,
+  `ALTER TABLE "DailyLogPhoto"
+     ADD COLUMN IF NOT EXISTS "sharedToPortal" BOOLEAN NOT NULL DEFAULT false`,
+
+  // Both tables are server-only. RLS with no policies denies direct
+  // anon/authenticated Data API access; server-side Prisma uses the owner role.
+  `ALTER TABLE "DailyLog" ENABLE ROW LEVEL SECURITY`,
+  `ALTER TABLE "DailyLogPhoto" ENABLE ROW LEVEL SECURITY`,
+];
+
+try {
+  for (const sql of statements) {
+    await prisma.$executeRawUnsafe(sql);
+    console.log("applied:", sql.split("\n")[0]);
+  }
+  console.log("Portal tracker schema applied successfully.");
+} finally {
+  await prisma.$disconnect();
+}

--- a/scripts/verify-portal-tracker.ts
+++ b/scripts/verify-portal-tracker.ts
@@ -1,0 +1,677 @@
+// Behavioral and render-contract verification for SPEC PR-E:
+// customer portal project tracker + curated updates.
+//
+// This verifier never applies schema. It runs pure/static checks everywhere,
+// then runs isolated DB fixtures only when DATABASE_URL is non-production or
+// ALLOW_PROD_VERIFY=1 explicitly opts into the guarded Supabase run.
+//
+// Usage:
+//   npx tsx scripts/verify-portal-tracker.ts
+//   $env:ALLOW_PROD_VERIFY="1"; npx tsx scripts/verify-portal-tracker.ts
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+
+import { prisma } from "../src/lib/prisma";
+import {
+    CLIENT_STAGES,
+    assertPortalProjectAccessCore,
+    buildPortalWhoIsComing,
+    buildProjectTracker,
+    computeDailyLogSharedContentHash,
+    getPortalProjectTrackerCore,
+    getPortalUpdatesFeedCore,
+    portalVisibilityAllows,
+    setDailyLogPortalShareCore,
+    type PortalTrackerTask,
+} from "../src/lib/portal-tracker";
+
+const RUN_ID = randomUUID().replaceAll("-", "").slice(0, 12);
+const FIXTURE_PREFIX = `PORTAL TRACKER VERIFY ${RUN_ID}`;
+const BASE_DATE = new Date("2042-04-06T12:00:00.000Z");
+let databaseTouched = false;
+
+function source(path: string): string {
+    return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
+function date(dayOffset: number): Date {
+    return new Date(BASE_DATE.getTime() + dayOffset * 86_400_000);
+}
+
+function trackerTask(
+    input: Partial<PortalTrackerTask> & Pick<PortalTrackerTask, "id" | "name">,
+): PortalTrackerTask {
+    return {
+        id: input.id,
+        name: input.name,
+        startDate: input.startDate ?? date(0),
+        endDate: input.endDate ?? input.startDate ?? date(0),
+        color: input.color ?? "#2563eb",
+        progress: input.progress ?? 0,
+        status: input.status ?? "Not Started",
+        type: input.type ?? "task",
+        order: input.order ?? 0,
+        costCodeName: input.costCodeName ?? null,
+        scheduledTime: input.scheduledTime ?? null,
+        confirmationStatus: input.confirmationStatus ?? null,
+        assignments: input.assignments ?? [],
+        subAssignments: input.subAssignments ?? [],
+    };
+}
+
+function normalizedKey(key: string): string {
+    return key.replace(/[^a-z0-9]/gi, "").toLowerCase();
+}
+
+const FORBIDDEN_PAYLOAD_KEYS = new Set([
+    "email",
+    "hourlyrate",
+    "burdenrate",
+    "rate",
+    "issues",
+    "blockedreason",
+    "weather",
+    "materials",
+    "materialsdelivered",
+    "crewonsite",
+    "author",
+    "createdby",
+    "internalnotes",
+    "estimatedhours",
+    "assignee",
+]);
+
+function assertClientSafeKeys(value: unknown, path = "payload"): void {
+    if (Array.isArray(value)) {
+        value.forEach((item, index) => assertClientSafeKeys(item, `${path}[${index}]`));
+        return;
+    }
+    if (!value || typeof value !== "object") return;
+
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+        assert.ok(
+            !FORBIDDEN_PAYLOAD_KEYS.has(normalizedKey(key)),
+            `${path}.${key} is forbidden in a portal payload`,
+        );
+        assertClientSafeKeys(child, `${path}.${key}`);
+    }
+}
+
+function loadDatabaseUrl(): string {
+    if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+    for (const file of [".env.local", ".env"]) {
+        if (!existsSync(file)) continue;
+        const match = readFileSync(file, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\r\n]+)"?/m);
+        if (match) {
+            process.env.DATABASE_URL = match[1];
+            return match[1];
+        }
+    }
+    return "";
+}
+
+function runPureCases(): void {
+    assert.deepEqual(
+        CLIENT_STAGES.map(stage => stage.label),
+        [
+            "Planning & Permits",
+            "Demo",
+            "Framing",
+            "Rough-ins",
+            "Drywall",
+            "Finishes",
+            "Punch list",
+            "Complete",
+        ],
+    );
+
+    const mapped = buildProjectTracker([
+        trackerTask({
+            id: "demo",
+            name: "Kitchen demolition",
+            status: "Complete",
+            progress: 100,
+            startDate: date(-4),
+        }),
+        trackerTask({
+            id: "rough",
+            name: "Run branch circuits",
+            costCodeName: "Electrical rough-in",
+            status: "In Progress",
+            progress: 50,
+            startDate: date(0),
+        }),
+        trackerTask({
+            id: "finish",
+            name: "Install custom cabinets",
+            status: "Not Started",
+            progress: 0,
+            startDate: date(3),
+        }),
+        trackerTask({
+            id: "punch",
+            name: "Final punch walk",
+            status: "Not Started",
+            progress: 0,
+            startDate: date(8),
+        }),
+    ]);
+    assert.equal(mapped.stages.find(stage => stage.label === "Demo")?.state, "complete");
+    assert.equal(mapped.stages.find(stage => stage.label === "Rough-ins")?.state, "current");
+    assert.equal(mapped.stages.find(stage => stage.label === "Rough-ins")?.pct, 50);
+    assert.equal(mapped.stages.find(stage => stage.label === "Finishes")?.state, "upcoming");
+    assert.equal(mapped.overallPct, 38);
+
+    const nearestFallback = buildProjectTracker([
+        trackerTask({
+            id: "fallback-demo",
+            name: "Demo",
+            status: "Complete",
+            progress: 100,
+            startDate: date(0),
+        }),
+        trackerTask({
+            id: "unmapped",
+            name: "Set temporary protection",
+            status: "Not Started",
+            progress: 0,
+            startDate: date(1),
+        }),
+        trackerTask({
+            id: "fallback-frame",
+            name: "Frame partition walls",
+            status: "Not Started",
+            progress: 0,
+            startDate: date(2),
+        }),
+    ]);
+    assert.equal(
+        nearestFallback.stages.find(stage => stage.label === "Demo")?.pct,
+        50,
+        "an equidistant unmatched task must use the earlier dated stage anchor",
+    );
+
+    const proportionalFallback = buildProjectTracker([
+        trackerTask({ id: "only-a", name: "Mobilize alpha", progress: 10, status: "In Progress", startDate: date(0) }),
+        trackerTask({ id: "only-b", name: "Mobilize beta", progress: 50, status: "In Progress", startDate: date(1) }),
+        trackerTask({ id: "only-c", name: "Mobilize gamma", progress: 90, status: "In Progress", startDate: date(2) }),
+    ]);
+    assert.equal(proportionalFallback.stages[0].pct, 10);
+    assert.equal(proportionalFallback.stages[4].pct, 50);
+    assert.equal(proportionalFallback.stages[7].pct, 90);
+    assert.equal(proportionalFallback.stages[0].state, "current");
+
+    const allComplete = buildProjectTracker([
+        trackerTask({ id: "done", name: "Project complete", status: "Complete", progress: 12 }),
+    ]);
+    assert.equal(allComplete.overallPct, 100);
+    assert.equal(allComplete.stages[7].state, "complete");
+
+    const visitors = buildPortalWhoIsComing([
+        trackerTask({
+            id: "crew-a",
+            name: "Install blocking",
+            startDate: date(0),
+            endDate: date(1),
+            assignments: [
+                { id: "a1", userId: "u1", firstName: "Amy" },
+                { id: "a2", userId: "u2", firstName: "Luis" },
+            ],
+            subAssignments: [{ id: "s1", companyName: "Red Point Electric" }],
+        }),
+        trackerTask({
+            id: "crew-b",
+            name: "Continue blocking",
+            startDate: date(0),
+            endDate: date(0),
+            assignments: [{ id: "a3", userId: "u1", firstName: "Amy" }],
+            subAssignments: [{ id: "s2", companyName: "Red Point Electric" }],
+        }),
+        trackerTask({
+            id: "inspection",
+            name: "Framing inspection",
+            type: "appointment",
+            startDate: date(2),
+            endDate: date(2),
+            scheduledTime: "09:30",
+            confirmationStatus: "confirmed",
+        }),
+        trackerTask({
+            id: "measure",
+            name: "Countertop template",
+            type: "appointment",
+            startDate: date(3),
+            endDate: date(3),
+            scheduledTime: "13:00",
+            confirmationStatus: "requested",
+        }),
+        trackerTask({
+            id: "outside-window",
+            name: "Later visit",
+            startDate: date(8),
+            endDate: date(8),
+            assignments: [{ id: "late", userId: "u3", firstName: "Late" }],
+        }),
+    ], BASE_DATE);
+    assert.deepEqual(visitors[0].crew, ["Amy", "Luis"]);
+    assert.deepEqual(visitors[0].subcontractors, ["Red Point Electric"]);
+    assert.equal(visitors[2].appointments[0].confirmationStatus, "confirmed");
+    assert.equal(visitors[3].appointments[0].confirmationStatus, "pending confirmation");
+    assert.ok(visitors.every(day => !day.crew.includes("Late")));
+
+    const hashA = computeDailyLogSharedContentHash("Installed blocking", ["photo-b", "photo-a"]);
+    const hashB = computeDailyLogSharedContentHash("Installed blocking", ["photo-a", "photo-b"]);
+    assert.equal(hashA, hashB, "shared photo order must not change the approval hash");
+    assert.notEqual(hashA, computeDailyLogSharedContentHash("Installed drywall", ["photo-a", "photo-b"]));
+    assert.notEqual(hashA, computeDailyLogSharedContentHash("Installed blocking", ["photo-a"]));
+
+    assert.equal(portalVisibilityAllows(null, "showSchedule"), true);
+    assert.equal(
+        portalVisibilityAllows(null, "showDailyLogs"),
+        false,
+        "missing visibility rows must preserve the existing daily-log default",
+    );
+    assert.equal(
+        portalVisibilityAllows(
+            { isPortalEnabled: true, showSchedule: true, showDailyLogs: true },
+            "showDailyLogs",
+        ),
+        true,
+    );
+    assert.equal(
+        portalVisibilityAllows(
+            { isPortalEnabled: false, showSchedule: true, showDailyLogs: true },
+            "showSchedule",
+        ),
+        false,
+    );
+
+    console.log("PASS pure stage mapping, fallback, state, visitor, and hash cases");
+}
+
+function runStaticContracts(): void {
+    const schemaSource = source("../prisma/schema.prisma");
+    const applySource = source("./apply-portal-tracker-schema.mjs");
+    const actionsSource = source("../src/lib/actions.ts");
+    const trackerSource = source("../src/lib/portal-tracker.ts");
+    const accessSource = source("../src/lib/portal-project-access.ts");
+    const portalPageSource = source("../src/app/portal/projects/[id]/page.tsx");
+    const trackerUiSource = source("../src/app/portal/projects/[id]/PortalProjectTracker.tsx");
+    const updatesUiSource = source("../src/app/portal/projects/[id]/PortalUpdatesFeed.tsx");
+    const dailyLogsPageSource = source("../src/app/projects/[id]/dailylogs/page.tsx");
+    const dailyLogsClientSource = source("../src/app/projects/[id]/dailylogs/DailyLogsClient.tsx");
+    const oldScheduleSource = source("../src/app/portal/projects/[id]/schedule/page.tsx");
+
+    assert.match(schemaSource, /sharedToPortal\s+Boolean\s+@default\(false\)/);
+    assert.match(schemaSource, /sharedContentHash\s+String\?/);
+    assert.ok(
+        (schemaSource.match(/sharedToPortal\s+Boolean\s+@default\(false\)/g) ?? []).length >= 2,
+        "DailyLog and DailyLogPhoto must both expose sharedToPortal",
+    );
+    for (const column of ["sharedToPortal", "sharedContentHash"]) {
+        assert.match(applySource, new RegExp(`ADD COLUMN IF NOT EXISTS "${column}"`));
+    }
+    assert.match(applySource, /ALTER TABLE "DailyLog" ENABLE ROW LEVEL SECURITY/);
+    assert.match(applySource, /ALTER TABLE "DailyLogPhoto" ENABLE ROW LEVEL SECURITY/);
+    assert.doesNotMatch(applySource, /CREATE POLICY/i);
+
+    assert.match(accessSource, /export async function assertPortalProjectAccessCore/);
+    assert.match(accessSource, /export async function assertPortalProjectAccess/);
+    const scheduleActionStart = actionsSource.indexOf("export async function getPortalScheduleTasks(");
+    const scheduleActionEnd = actionsSource.indexOf("export async function", scheduleActionStart + 1);
+    const scheduleActionBody = actionsSource.slice(scheduleActionStart, scheduleActionEnd);
+    assert.ok(scheduleActionStart >= 0);
+    assert.match(scheduleActionBody, /assertPortalProjectAccess\(/);
+    assert.match(scheduleActionBody, /getPortalScheduleTasksCore\(/);
+    assert.doesNotMatch(scheduleActionBody, /hourlyRate|burdenRate|email|blockedReason|materialsDelivered|issues/);
+    for (const safeAppointmentField of ["scheduledTime", "confirmationStatus"]) {
+        assert.match(trackerSource, new RegExp(`\\b${safeAppointmentField}\\b`));
+    }
+
+    const shareActionStart = actionsSource.indexOf("export async function setDailyLogPortalShare(");
+    const shareActionEnd = actionsSource.indexOf("export async function", shareActionStart + 1);
+    const shareActionBody = actionsSource.slice(shareActionStart, shareActionEnd);
+    assert.ok(shareActionStart >= 0, "setDailyLogPortalShare must exist");
+    assert.match(shareActionBody, /\["ADMIN", "MANAGER"\]/);
+    assert.match(shareActionBody, /assertDailyLogAccess\(/);
+    assert.match(shareActionBody, /setDailyLogPortalShareCore\(/);
+
+    const updateLogStart = actionsSource.indexOf("export async function updateDailyLog(");
+    const updateLogEnd = actionsSource.indexOf("export async function", updateLogStart + 1);
+    assert.match(actionsSource.slice(updateLogStart, updateLogEnd), /sharedContentHash/);
+    const deletePhotoStart = actionsSource.indexOf("export async function deleteDailyLogPhoto(");
+    const deletePhotoEnd = actionsSource.indexOf("export async function", deletePhotoStart + 1);
+    assert.match(actionsSource.slice(deletePhotoStart, deletePhotoEnd), /sharedContentHash/);
+
+    assert.match(portalPageSource, /getPortalProjectTracker\(/);
+    assert.match(portalPageSource, /getPortalUpdatesFeed\(/);
+    assert.match(portalPageSource, /<PortalProjectTracker/);
+    assert.match(portalPageSource, /<PortalUpdatesFeed/);
+    assert.doesNotMatch(portalPageSource, /dailyLogs:\s*\{/);
+    assert.doesNotMatch(portalPageSource, /prisma\.dailyLog/);
+    assert.doesNotMatch(portalPageSource, /log\.issues|log\.weather|log\.crewOnSite|log\.createdBy/);
+
+    assert.match(trackerUiSource, /MotionConfig/);
+    assert.match(trackerUiSource, /reducedMotion="user"/);
+    assert.match(trackerUiSource, /snap-x/);
+    assert.match(trackerUiSource, /--project-accent/);
+    assert.match(trackerUiSource, /Full schedule/);
+    assert.match(updatesUiSource, /Updates from the crew will appear here\./);
+    assert.match(updatesUiSource, /role="dialog"/);
+    assert.match(updatesUiSource, /grid-cols-2/);
+    assert.match(updatesUiSource, /motion\./);
+
+    assert.match(dailyLogsPageSource, /canManagePortalShare/);
+    assert.match(dailyLogsClientSource, /setDailyLogPortalShare/);
+    assert.match(dailyLogsClientSource, /canManagePortalShare/);
+    assert.match(dailyLogsClientSource, /role="switch"/);
+    assert.match(dailyLogsClientSource, /Share to portal/);
+    assert.match(dailyLogsClientSource, /portalShareValid/);
+
+    assert.match(oldScheduleSource, /getPortalScheduleTasks/);
+    assert.match(oldScheduleSource, /<PortalScheduleView/);
+
+    console.log("PASS schema, auth, allowlist, route, and render contracts");
+}
+
+async function runDatabaseCases(): Promise<void> {
+    const databaseUrl = loadDatabaseUrl();
+    if (!databaseUrl) {
+        throw new Error("[verify-portal-tracker] DATABASE_URL is required for DB-backed cases");
+    }
+    const hostname = new URL(databaseUrl).hostname.toLowerCase();
+    const isSupabase = hostname.includes("supabase.");
+    if (isSupabase && process.env.ALLOW_PROD_VERIFY !== "1") {
+        throw new Error(
+            "[verify-portal-tracker] REFUSING DB FIXTURES: DATABASE_URL points at Supabase. " +
+            "Set ALLOW_PROD_VERIFY=1 only when an isolated, cleanup-backed verification run is intended.",
+        );
+    }
+    databaseTouched = true;
+
+    const columns = await prisma.$queryRaw<Array<{ table_name: string; column_name: string }>>`
+        SELECT table_name, column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND (
+            (table_name = 'DailyLog' AND column_name IN ('sharedToPortal', 'sharedContentHash'))
+            OR (table_name = 'DailyLogPhoto' AND column_name = 'sharedToPortal')
+          )
+    `;
+    assert.deepEqual(
+        new Set(columns.map(row => `${row.table_name}.${row.column_name}`)),
+        new Set([
+            "DailyLog.sharedToPortal",
+            "DailyLog.sharedContentHash",
+            "DailyLogPhoto.sharedToPortal",
+        ]),
+        "portal tracker schema is not applied; run only the release orchestrator's apply script before this DB gate",
+    );
+
+    const collected = {
+        clientIds: [] as string[],
+        projectIds: [] as string[],
+        userIds: [] as string[],
+        subcontractorIds: [] as string[],
+    };
+
+    try {
+        const [ownerClient, otherClient] = await Promise.all([
+            prisma.client.create({
+                data: {
+                    name: `${FIXTURE_PREFIX} OWNER DELETE ME`,
+                    initials: "PO",
+                    email: `portal-owner-${RUN_ID}@example.invalid`,
+                },
+            }),
+            prisma.client.create({
+                data: {
+                    name: `${FIXTURE_PREFIX} OTHER DELETE ME`,
+                    initials: "PX",
+                    email: `portal-other-${RUN_ID}@example.invalid`,
+                },
+            }),
+        ]);
+        collected.clientIds.push(ownerClient.id, otherClient.id);
+
+        const [manager, crew] = await Promise.all([
+            prisma.user.create({
+                data: {
+                    name: `${FIXTURE_PREFIX} Manager`,
+                    email: `portal-manager-${RUN_ID}@example.invalid`,
+                    role: "MANAGER",
+                    status: "ACTIVATED",
+                },
+            }),
+            prisma.user.create({
+                data: {
+                    name: "Avery Carpenter",
+                    email: `portal-crew-${RUN_ID}@example.invalid`,
+                    role: "FIELD_CREW",
+                    status: "ACTIVATED",
+                },
+            }),
+        ]);
+        collected.userIds.push(manager.id, crew.id);
+
+        const subcontractor = await prisma.subcontractor.create({
+            data: {
+                companyName: `${FIXTURE_PREFIX} Red Point Electric`,
+                email: `portal-sub-${RUN_ID}@example.invalid`,
+                status: "ACTIVE",
+            },
+        });
+        collected.subcontractorIds.push(subcontractor.id);
+
+        const project = await prisma.project.create({
+            data: {
+                name: `${FIXTURE_PREFIX} PROJECT DELETE ME`,
+                clientId: ownerClient.id,
+                color: "#7c3aed",
+                status: "In Progress",
+                portalVisibility: {
+                    create: {
+                        isPortalEnabled: true,
+                        showSchedule: true,
+                        showDailyLogs: true,
+                    },
+                },
+            },
+        });
+        collected.projectIds.push(project.id);
+
+        await assertPortalProjectAccessCore({
+            projectId: project.id,
+            isStaff: false,
+            clientId: ownerClient.id,
+            visibility: "showSchedule",
+        });
+        await assert.rejects(
+            () => assertPortalProjectAccessCore({
+                projectId: project.id,
+                isStaff: false,
+                clientId: otherClient.id,
+                visibility: "showSchedule",
+            }),
+            /Unauthorized/,
+        );
+        await prisma.portalVisibility.update({
+            where: { projectId: project.id },
+            data: { showSchedule: false },
+        });
+        await assert.rejects(
+            () => assertPortalProjectAccessCore({
+                projectId: project.id,
+                isStaff: false,
+                clientId: ownerClient.id,
+                visibility: "showSchedule",
+            }),
+            /Unauthorized/,
+        );
+        await assertPortalProjectAccessCore({
+            projectId: project.id,
+            isStaff: true,
+            clientId: null,
+            visibility: "showSchedule",
+        });
+        await prisma.portalVisibility.update({
+            where: { projectId: project.id },
+            data: { showSchedule: true },
+        });
+        console.log("PASS DB owning-client, cross-client, visibility, and staff-preview authorization");
+
+        await prisma.scheduleTask.create({
+            data: {
+                projectId: project.id,
+                name: "Electrical rough-in",
+                startDate: date(0),
+                endDate: date(1),
+                status: "In Progress",
+                progress: 40,
+                order: 0,
+                assignments: { create: { userId: crew.id } },
+                subAssignments: { create: { subcontractorId: subcontractor.id } },
+            },
+        });
+        await prisma.scheduleTask.create({
+            data: {
+                projectId: project.id,
+                name: "Rough-in inspection",
+                startDate: date(2),
+                endDate: date(2),
+                status: "Not Started",
+                progress: 0,
+                type: "appointment",
+                scheduledTime: "10:15",
+                confirmationStatus: "requested",
+                order: 1,
+            },
+        });
+        const trackerPayload = await getPortalProjectTrackerCore(project.id, BASE_DATE);
+        assert.equal(trackerPayload.projectColor, "#7c3aed");
+        assert.equal(trackerPayload.whoIsComing[0].crew[0], "Avery");
+        assert.equal(trackerPayload.whoIsComing[0].subcontractors[0], `${FIXTURE_PREFIX} Red Point Electric`);
+        assert.equal(trackerPayload.whoIsComing[2].appointments[0].confirmationStatus, "pending confirmation");
+        assertClientSafeKeys(trackerPayload);
+        console.log("PASS DB tracker serialization and recursive allowlist");
+
+        const log = await prisma.dailyLog.create({
+            data: {
+                projectId: project.id,
+                createdById: manager.id,
+                date: date(0),
+                weather: "Confidential weather",
+                crewOnSite: "Private crew list",
+                workPerformed: "Installed blocking and completed inspection prep.",
+                issues: "Internal issue that must never reach the client.",
+                photos: {
+                    create: [
+                        { url: `https://example.invalid/${RUN_ID}/shared.jpg`, caption: "Blocking installed" },
+                        { url: `https://example.invalid/${RUN_ID}/private.jpg`, caption: "Internal only" },
+                    ],
+                },
+            },
+            include: { photos: true },
+        });
+        const sharedPhoto = log.photos[0];
+        const privatePhoto = log.photos[1];
+
+        await assert.rejects(
+            () => setDailyLogPortalShareCore(
+                log.id,
+                { shared: true, photoIds: [sharedPhoto.id] },
+                { userId: crew.id, role: "FIELD_CREW", name: crew.name ?? crew.email },
+            ),
+            /Forbidden/,
+        );
+
+        await setDailyLogPortalShareCore(
+            log.id,
+            { shared: true, photoIds: [sharedPhoto.id] },
+            { userId: manager.id, role: "MANAGER", name: manager.name ?? manager.email },
+        );
+        let feed = await getPortalUpdatesFeedCore(project.id);
+        assert.equal(feed.length, 1);
+        assert.deepEqual(feed[0].photos.map(photo => photo.url), [sharedPhoto.url]);
+        assert.ok(!feed[0].photos.some(photo => photo.url === privatePhoto.url));
+        assertClientSafeKeys(feed);
+
+        await prisma.dailyLog.update({
+            where: { id: log.id },
+            data: { workPerformed: "Edited work now requires approval." },
+        });
+        feed = await getPortalUpdatesFeedCore(project.id);
+        assert.equal(feed.length, 0, "a content-hash mismatch must hide the log");
+
+        await setDailyLogPortalShareCore(
+            log.id,
+            { shared: true, photoIds: [sharedPhoto.id] },
+            { userId: manager.id, role: "MANAGER", name: manager.name ?? manager.email },
+        );
+        feed = await getPortalUpdatesFeedCore(project.id);
+        assert.equal(feed.length, 1);
+        assert.equal(feed[0].workPerformed, "Edited work now requires approval.");
+        assert.deepEqual(feed[0].photos.map(photo => photo.url), [sharedPhoto.url]);
+
+        await setDailyLogPortalShareCore(
+            log.id,
+            { shared: false, photoIds: [] },
+            { userId: manager.id, role: "MANAGER", name: manager.name ?? manager.email },
+        );
+        feed = await getPortalUpdatesFeedCore(project.id);
+        assert.equal(feed.length, 0);
+        assert.equal(
+            await prisma.activityLog.count({
+                where: {
+                    projectId: project.id,
+                    entityType: "daily_log",
+                    entityId: log.id,
+                },
+            }),
+            3,
+        );
+        console.log("PASS DB share, invalidation, re-approval, unshared-photo, activity, and feed cases");
+    } finally {
+        if (collected.projectIds.length > 0) {
+            await prisma.project.deleteMany({ where: { id: { in: collected.projectIds } } });
+        }
+        if (collected.subcontractorIds.length > 0) {
+            await prisma.subcontractor.deleteMany({ where: { id: { in: collected.subcontractorIds } } });
+        }
+        if (collected.userIds.length > 0) {
+            await prisma.user.deleteMany({ where: { id: { in: collected.userIds } } });
+        }
+        if (collected.clientIds.length > 0) {
+            await prisma.client.deleteMany({ where: { id: { in: collected.clientIds } } });
+        }
+
+        assert.equal(
+            await prisma.project.count({ where: { name: { startsWith: FIXTURE_PREFIX } } }),
+            0,
+        );
+        assert.equal(
+            await prisma.client.count({ where: { name: { startsWith: FIXTURE_PREFIX } } }),
+            0,
+        );
+        console.log("PASS fixture cleanup");
+    }
+}
+
+async function main(): Promise<void> {
+    runPureCases();
+    runStaticContracts();
+    await runDatabaseCases();
+    console.log("portal tracker verification: PASS");
+}
+
+main()
+    .catch(error => {
+        console.error(error);
+        process.exitCode = 1;
+    })
+    .finally(async () => {
+        if (databaseTouched) {
+            await prisma.$disconnect().catch(() => undefined);
+        }
+    });

--- a/src/app/portal/projects/[id]/PortalProjectTracker.tsx
+++ b/src/app/portal/projects/[id]/PortalProjectTracker.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import Link from "next/link";
+import { motion, MotionConfig } from "framer-motion";
+import {
+    ArrowUpRight,
+    CalendarDays,
+    Check,
+    Clock3,
+    HardHat,
+    Wrench,
+} from "lucide-react";
+
+import type {
+    PortalDayVisitors,
+    PortalProjectTrackerPayload,
+} from "@/lib/portal-tracker";
+
+type TrackerStyle = CSSProperties & {
+    "--project-accent": string;
+};
+
+function parseDateOnly(date: string): Date {
+    return new Date(`${date}T12:00:00.000Z`);
+}
+
+function formatTaskDate(date: string): string {
+    return parseDateOnly(date).toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+    });
+}
+
+function dayLabel(date: string): { weekday: string; date: string } {
+    const value = parseDateOnly(date);
+    return {
+        weekday: value.toLocaleDateString("en-US", { weekday: "short" }),
+        date: value.toLocaleDateString("en-US", { month: "short", day: "numeric" }),
+    };
+}
+
+function hasVisitors(day: PortalDayVisitors): boolean {
+    return day.crew.length > 0
+        || day.subcontractors.length > 0
+        || day.appointments.length > 0;
+}
+
+export default function PortalProjectTracker({
+    projectId,
+    projectName,
+    data,
+}: {
+    projectId: string;
+    projectName: string;
+    data: PortalProjectTrackerPayload;
+}) {
+    const currentIndex = data.stages.findIndex(stage => stage.state === "current");
+    const visibleDays = data.whoIsComing.filter(hasVisitors);
+
+    return (
+        <MotionConfig reducedMotion="user">
+            <motion.section
+                aria-labelledby="project-route-heading"
+                style={{ "--project-accent": data.projectColor } as TrackerStyle}
+                initial={{ opacity: 0, y: 14 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.46, ease: [0.22, 1, 0.36, 1] }}
+                className="relative isolate overflow-hidden rounded-[1.75rem] border border-slate-200 bg-white shadow-[0_24px_70px_-46px_rgba(15,23,42,0.5)]"
+            >
+                <div
+                    aria-hidden="true"
+                    className="absolute inset-x-0 top-0 h-32 opacity-90"
+                    style={{
+                        background:
+                            "linear-gradient(135deg, color-mix(in srgb, var(--project-accent) 18%, white), white 64%)",
+                    }}
+                />
+                <div
+                    aria-hidden="true"
+                    className="absolute inset-x-0 top-0 h-32 opacity-25"
+                    style={{
+                        backgroundImage:
+                            "linear-gradient(90deg, color-mix(in srgb, var(--project-accent) 22%, transparent) 1px, transparent 1px), linear-gradient(color-mix(in srgb, var(--project-accent) 18%, transparent) 1px, transparent 1px)",
+                        backgroundSize: "24px 24px",
+                        maskImage: "linear-gradient(to bottom, black, transparent)",
+                    }}
+                />
+
+                <div className="relative px-4 pb-5 pt-5 sm:px-6 sm:pb-6 sm:pt-6 lg:px-8">
+                    <div className="flex items-start justify-between gap-4">
+                        <div className="min-w-0">
+                            <p
+                                className="mb-2 text-[0.68rem] font-extrabold uppercase tracking-[0.22em]"
+                                style={{ color: "var(--project-accent)" }}
+                            >
+                                Your project route
+                            </p>
+                            <h2
+                                id="project-route-heading"
+                                className="text-balance text-xl font-bold tracking-[-0.025em] text-slate-950 sm:text-2xl"
+                            >
+                                See what&apos;s done, what&apos;s moving, and what comes next.
+                            </h2>
+                            <p className="mt-1.5 max-w-2xl text-sm leading-6 text-slate-600">
+                                A simple view of {projectName}&apos;s major construction stages.
+                            </p>
+                        </div>
+
+                        <div
+                            className="relative flex h-16 w-16 shrink-0 rotate-2 flex-col items-center justify-center rounded-2xl border-2 bg-white/85 shadow-sm backdrop-blur sm:h-[4.5rem] sm:w-[4.5rem]"
+                            style={{ borderColor: "var(--project-accent)" }}
+                            aria-label={`${data.overallPct}% complete`}
+                        >
+                            <span className="text-xl font-black leading-none text-slate-950 sm:text-2xl">
+                                {data.overallPct}%
+                            </span>
+                            <span className="mt-1 text-[0.55rem] font-extrabold uppercase tracking-[0.14em] text-slate-500">
+                                complete
+                            </span>
+                        </div>
+                    </div>
+
+                    <div
+                        className="-mx-4 mt-6 overflow-x-auto px-4 pb-2 pt-2 [scrollbar-width:thin] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--project-accent)] focus-visible:ring-offset-2 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8"
+                        tabIndex={0}
+                        aria-label="Project stages. Scroll horizontally to see every stage."
+                    >
+                        <ol className="flex min-w-max snap-x snap-mandatory">
+                            {data.stages.map((stage, index) => {
+                                const isComplete = stage.state === "complete";
+                                const isCurrent = stage.state === "current";
+                                const connectorPct = isComplete
+                                    ? 100
+                                    : isCurrent
+                                        ? stage.pct
+                                        : 0;
+
+                                return (
+                                    <li
+                                        key={stage.label}
+                                        className="relative w-[7.6rem] snap-center px-2 text-center sm:w-[8.6rem]"
+                                    >
+                                        {index < data.stages.length - 1 && (
+                                            <div
+                                                aria-hidden="true"
+                                                className="absolute left-1/2 top-[1.38rem] h-1 w-full overflow-hidden rounded-full bg-slate-200"
+                                            >
+                                                <motion.div
+                                                    className="h-full origin-left rounded-full"
+                                                    initial={{ scaleX: 0 }}
+                                                    animate={{ scaleX: connectorPct / 100 }}
+                                                    transition={{
+                                                        duration: 0.72,
+                                                        delay: 0.08 + index * 0.05,
+                                                        ease: [0.22, 1, 0.36, 1],
+                                                    }}
+                                                    style={{
+                                                        backgroundColor: "var(--project-accent)",
+                                                        boxShadow:
+                                                            "0 0 14px color-mix(in srgb, var(--project-accent) 50%, transparent)",
+                                                    }}
+                                                />
+                                            </div>
+                                        )}
+
+                                        <motion.div
+                                            initial={{ scale: 0.88, opacity: 0 }}
+                                            animate={{ scale: 1, opacity: 1 }}
+                                            transition={{
+                                                duration: 0.32,
+                                                delay: 0.04 + index * 0.045,
+                                            }}
+                                            className="relative z-10 mx-auto flex h-12 w-12 items-center justify-center rounded-2xl border-2 bg-white"
+                                            style={{
+                                                borderColor: isComplete || isCurrent
+                                                    ? "var(--project-accent)"
+                                                    : "#cbd5e1",
+                                                backgroundColor: isComplete || isCurrent
+                                                    ? "var(--project-accent)"
+                                                    : "#ffffff",
+                                                color: isComplete || isCurrent ? "#ffffff" : "#64748b",
+                                                boxShadow: isCurrent
+                                                    ? "0 0 0 7px color-mix(in srgb, var(--project-accent) 16%, transparent), 0 10px 24px -12px var(--project-accent)"
+                                                    : "0 3px 10px -7px rgba(15, 23, 42, .45)",
+                                            }}
+                                            aria-current={isCurrent ? "step" : undefined}
+                                            aria-label={`${stage.label}: ${stage.state}, ${stage.pct}%`}
+                                        >
+                                            {isComplete ? (
+                                                <Check className="h-5 w-5" strokeWidth={3} aria-hidden="true" />
+                                            ) : isCurrent ? (
+                                                <HardHat className="h-5 w-5" strokeWidth={2.25} aria-hidden="true" />
+                                            ) : (
+                                                <span className="text-xs font-black">{index + 1}</span>
+                                            )}
+                                        </motion.div>
+
+                                        <p
+                                            className={`mt-3 text-[0.72rem] font-bold leading-4 ${
+                                                isCurrent ? "text-slate-950" : "text-slate-600"
+                                            }`}
+                                        >
+                                            {stage.label}
+                                        </p>
+                                        <p
+                                            className="mt-1 text-[0.62rem] font-bold uppercase tracking-[0.12em]"
+                                            style={{ color: isCurrent ? "var(--project-accent)" : "#94a3b8" }}
+                                        >
+                                            {isCurrent
+                                                ? `${stage.pct}% now`
+                                                : isComplete
+                                                    ? "Done"
+                                                    : index === currentIndex + 1
+                                                        ? "Next"
+                                                        : "Upcoming"}
+                                        </p>
+                                    </li>
+                                );
+                            })}
+                        </ol>
+                    </div>
+                </div>
+            </motion.section>
+
+            <div className="mt-4 grid gap-4 lg:grid-cols-[0.9fr_1.35fr]">
+                <motion.section
+                    aria-labelledby="whats-next-heading"
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.38, delay: 0.12 }}
+                    className="hui-card overflow-hidden p-0"
+                >
+                    <div className="flex items-center justify-between gap-3 border-b border-slate-100 px-4 py-4 sm:px-5">
+                        <div>
+                            <p className="text-[0.65rem] font-extrabold uppercase tracking-[0.18em] text-slate-400">
+                                On deck
+                            </p>
+                            <h3 id="whats-next-heading" className="mt-0.5 font-bold text-slate-950">
+                                What&apos;s next
+                            </h3>
+                        </div>
+                        <Link
+                            href={`/portal/projects/${projectId}/schedule`}
+                            className="inline-flex min-h-11 items-center gap-1.5 rounded-lg px-2.5 text-xs font-bold text-slate-600 transition hover:bg-slate-50 hover:text-slate-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--project-accent)]"
+                        >
+                            Full schedule
+                            <ArrowUpRight className="h-3.5 w-3.5" aria-hidden="true" />
+                        </Link>
+                    </div>
+
+                    {data.whatsNext.length > 0 ? (
+                        <ol className="divide-y divide-slate-100">
+                            {data.whatsNext.map((task, index) => (
+                                <li key={`${task.name}-${task.startDate}`} className="flex gap-3 px-4 py-4 sm:px-5">
+                                    <span
+                                        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl text-xs font-black text-white"
+                                        style={{ backgroundColor: "var(--project-accent)" }}
+                                        aria-hidden="true"
+                                    >
+                                        {index + 1}
+                                    </span>
+                                    <div className="min-w-0">
+                                        <p className="text-sm font-semibold leading-5 text-slate-900">{task.name}</p>
+                                        <p className="mt-1 flex items-center gap-1.5 text-xs text-slate-500">
+                                            <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
+                                            Starts {formatTaskDate(task.startDate)}
+                                        </p>
+                                    </div>
+                                </li>
+                            ))}
+                        </ol>
+                    ) : (
+                        <div className="px-5 py-7 text-sm leading-6 text-slate-500">
+                            No new task is queued yet. Your project team will add the next step here.
+                        </div>
+                    )}
+                </motion.section>
+
+                <motion.section
+                    aria-labelledby="coming-heading"
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.38, delay: 0.17 }}
+                    className="hui-card overflow-hidden p-0"
+                >
+                    <div className="border-b border-slate-100 px-4 py-4 sm:px-5">
+                        <p className="text-[0.65rem] font-extrabold uppercase tracking-[0.18em] text-slate-400">
+                            Next 7 days
+                        </p>
+                        <h3 id="coming-heading" className="mt-0.5 font-bold text-slate-950">
+                            Who&apos;s coming this week
+                        </h3>
+                    </div>
+
+                    {visibleDays.length > 0 ? (
+                        <div className="divide-y divide-slate-100">
+                            {visibleDays.map(day => {
+                                const label = dayLabel(day.date);
+                                return (
+                                    <div
+                                        key={day.date}
+                                        className="grid grid-cols-[3.4rem_1fr] gap-3 px-4 py-3.5 sm:grid-cols-[4.4rem_1fr] sm:px-5"
+                                    >
+                                        <div className="border-r border-slate-100 pr-3">
+                                            <p className="text-xs font-black uppercase tracking-wide text-slate-800">
+                                                {label.weekday}
+                                            </p>
+                                            <p className="mt-0.5 text-[0.68rem] text-slate-500">{label.date}</p>
+                                        </div>
+                                        <div className="flex min-w-0 flex-wrap gap-2">
+                                            {day.crew.map(name => (
+                                                <span
+                                                    key={`crew-${day.date}-${name}`}
+                                                    className="inline-flex min-h-8 items-center gap-1.5 rounded-full bg-slate-900 px-3 py-1 text-xs font-semibold text-white"
+                                                >
+                                                    <HardHat className="h-3.5 w-3.5" aria-hidden="true" />
+                                                    {name}
+                                                </span>
+                                            ))}
+                                            {day.subcontractors.map(company => (
+                                                <span
+                                                    key={`sub-${day.date}-${company}`}
+                                                    className="inline-flex min-h-8 items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700"
+                                                >
+                                                    <Wrench
+                                                        className="h-3.5 w-3.5"
+                                                        style={{ color: "var(--project-accent)" }}
+                                                        aria-hidden="true"
+                                                    />
+                                                    {company}
+                                                </span>
+                                            ))}
+                                            {day.appointments.map(appointment => (
+                                                <span
+                                                    key={`appointment-${day.date}-${appointment.name}-${appointment.scheduledTime}`}
+                                                    className="inline-flex min-h-8 flex-wrap items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-900"
+                                                >
+                                                    <Clock3 className="h-3.5 w-3.5" aria-hidden="true" />
+                                                    {appointment.scheduledTime || "Time to come"} · {appointment.name}
+                                                    {appointment.confirmationStatus === "pending confirmation" && (
+                                                        <span className="rounded-full bg-amber-100 px-1.5 py-0.5 text-[0.62rem] font-bold text-amber-800">
+                                                            pending confirmation
+                                                        </span>
+                                                    )}
+                                                </span>
+                                            ))}
+                                        </div>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    ) : (
+                        <div className="px-5 py-7 text-sm leading-6 text-slate-500">
+                            No crew visits or appointments are scheduled for the next seven days.
+                        </div>
+                    )}
+                </motion.section>
+            </div>
+        </MotionConfig>
+    );
+}

--- a/src/app/portal/projects/[id]/PortalUpdatesFeed.tsx
+++ b/src/app/portal/projects/[id]/PortalUpdatesFeed.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { AnimatePresence, motion, MotionConfig } from "framer-motion";
+import { Camera, X } from "lucide-react";
+
+import type { PortalUpdate } from "@/lib/portal-tracker";
+
+type UpdateStyle = CSSProperties & {
+    "--project-accent": string;
+};
+
+type LightboxPhoto = {
+    url: string;
+    caption: string | null;
+};
+
+function updateDate(value: string): { day: string; long: string } {
+    const date = new Date(value);
+    return {
+        day: date.toLocaleDateString("en-US", { month: "short", day: "numeric" }),
+        long: date.toLocaleDateString("en-US", {
+            weekday: "long",
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+        }),
+    };
+}
+
+export default function PortalUpdatesFeed({
+    updates,
+    projectColor,
+}: {
+    updates: PortalUpdate[];
+    projectColor: string;
+}) {
+    const [lightbox, setLightbox] = useState<LightboxPhoto | null>(null);
+    const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+    useEffect(() => {
+        if (!lightbox) return;
+        const previousOverflow = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+        closeButtonRef.current?.focus();
+
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") setLightbox(null);
+        };
+        window.addEventListener("keydown", onKeyDown);
+        return () => {
+            document.body.style.overflow = previousOverflow;
+            window.removeEventListener("keydown", onKeyDown);
+        };
+    }, [lightbox]);
+
+    if (updates.length === 0) {
+        return (
+            <div className="hui-card flex flex-col items-center justify-center px-6 py-16 text-center">
+                <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-100 text-slate-400">
+                    <Camera className="h-6 w-6" aria-hidden="true" />
+                </div>
+                <h3 className="text-base font-semibold text-hui-textMain">
+                    Updates from the crew will appear here.
+                </h3>
+                <p className="mt-1 max-w-md text-sm leading-6 text-hui-textMuted">
+                    Your project team shares selected progress notes and photos after reviewing them.
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <MotionConfig reducedMotion="user">
+            <div
+                className="relative space-y-4 pl-3 sm:pl-5"
+                style={{ "--project-accent": projectColor } as UpdateStyle}
+            >
+                <div
+                    aria-hidden="true"
+                    className="absolute bottom-8 left-[0.31rem] top-8 w-px sm:left-[0.81rem]"
+                    style={{
+                        background:
+                            "linear-gradient(to bottom, var(--project-accent), color-mix(in srgb, var(--project-accent) 15%, transparent))",
+                    }}
+                />
+
+                {updates.map((update, index) => {
+                    const formatted = updateDate(update.date);
+                    return (
+                        <motion.article
+                            key={update.id}
+                            initial={{ opacity: 0, y: 14 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{
+                                duration: 0.38,
+                                delay: Math.min(index * 0.06, 0.3),
+                                ease: [0.22, 1, 0.36, 1],
+                            }}
+                            className="relative rounded-2xl border border-slate-200 bg-white p-4 shadow-[0_14px_38px_-32px_rgba(15,23,42,0.75)] sm:p-5"
+                        >
+                            <span
+                                aria-hidden="true"
+                                className="absolute -left-[0.99rem] top-6 h-3 w-3 rounded-full border-[3px] border-white shadow-sm sm:-left-[1.49rem]"
+                                style={{ backgroundColor: "var(--project-accent)" }}
+                            />
+
+                            <header className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+                                <h3 className="text-base font-bold tracking-[-0.01em] text-slate-950">
+                                    {formatted.long}
+                                </h3>
+                                <span
+                                    className="rounded-full px-2.5 py-1 text-[0.62rem] font-extrabold uppercase tracking-[0.14em]"
+                                    style={{
+                                        color: "var(--project-accent)",
+                                        backgroundColor:
+                                            "color-mix(in srgb, var(--project-accent) 10%, white)",
+                                    }}
+                                >
+                                    {formatted.day}
+                                </span>
+                            </header>
+
+                            <p className="whitespace-pre-wrap text-sm leading-6 text-slate-700">
+                                {update.workPerformed}
+                            </p>
+
+                            {update.photos.length > 0 && (
+                                <div className="mt-4 grid grid-cols-2 gap-2.5 sm:grid-cols-3">
+                                    {update.photos.map((photo, photoIndex) => (
+                                        <button
+                                            key={`${photo.url}-${photoIndex}`}
+                                            type="button"
+                                            onClick={() => setLightbox(photo)}
+                                            className={`group relative overflow-hidden rounded-xl border border-slate-200 bg-slate-100 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--project-accent)] focus-visible:ring-offset-2 ${
+                                                update.photos.length === 1
+                                                    ? "col-span-2 aspect-[16/10] sm:col-span-2"
+                                                    : "aspect-square"
+                                            }`}
+                                            aria-label={`Open photo ${photoIndex + 1}${photo.caption ? `: ${photo.caption}` : ""}`}
+                                        >
+                                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                                            <img
+                                                src={photo.url}
+                                                alt={photo.caption || ""}
+                                                className="h-full w-full object-cover transition duration-500 group-hover:scale-[1.035]"
+                                            />
+                                            {photo.caption && (
+                                                <span className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-slate-950/80 to-transparent px-3 pb-2.5 pt-8 text-xs font-medium text-white">
+                                                    {photo.caption}
+                                                </span>
+                                            )}
+                                        </button>
+                                    ))}
+                                </div>
+                            )}
+                        </motion.article>
+                    );
+                })}
+            </div>
+
+            <AnimatePresence>
+                {lightbox && (
+                    <motion.div
+                        className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/90 p-4 backdrop-blur-sm"
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        onMouseDown={event => {
+                            if (event.target === event.currentTarget) setLightbox(null);
+                        }}
+                    >
+                        <motion.div
+                            role="dialog"
+                            aria-modal="true"
+                            aria-label={lightbox.caption || "Project update photo"}
+                            initial={{ opacity: 0, scale: 0.96 }}
+                            animate={{ opacity: 1, scale: 1 }}
+                            exit={{ opacity: 0, scale: 0.98 }}
+                            transition={{ duration: 0.2 }}
+                            className="relative flex max-h-[92vh] w-full max-w-5xl flex-col items-center"
+                        >
+                            <button
+                                ref={closeButtonRef}
+                                type="button"
+                                onClick={() => setLightbox(null)}
+                                className="absolute right-0 top-0 z-10 flex min-h-11 min-w-11 -translate-y-12 items-center justify-center rounded-full bg-white/10 text-white transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                                aria-label="Close photo"
+                            >
+                                <X className="h-6 w-6" aria-hidden="true" />
+                            </button>
+                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                            <img
+                                src={lightbox.url}
+                                alt={lightbox.caption || "Project update"}
+                                className="max-h-[82vh] max-w-full rounded-xl object-contain shadow-2xl"
+                            />
+                            {lightbox.caption && (
+                                <p className="mt-3 max-w-3xl text-center text-sm text-white/90">
+                                    {lightbox.caption}
+                                </p>
+                            )}
+                        </motion.div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </MotionConfig>
+    );
+}

--- a/src/app/portal/projects/[id]/page.tsx
+++ b/src/app/portal/projects/[id]/page.tsx
@@ -4,12 +4,18 @@ import { notFound } from "next/navigation";
 import StatusBadge, { StatusType } from "@/components/StatusBadge";
 import PortalPayButton from "@/components/PortalPayButton";
 import PortalProjectTabs, { type PortalTab } from "@/components/PortalProjectTabs";
-import { getPortalScheduleTasks, getPortalVisibility } from "@/lib/actions";
+import { getPortalVisibility } from "@/lib/actions";
 import { formatCurrency } from "@/lib/utils";
 import PortalVisitTracker from "@/components/PortalVisitTracker";
 import { resolveSessionClientId } from "@/lib/portal-auth";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
+import PortalProjectTracker from "./PortalProjectTracker";
+import PortalUpdatesFeed from "./PortalUpdatesFeed";
+import {
+    getPortalProjectTracker,
+    getPortalUpdatesFeed,
+} from "@/lib/portal-tracker";
 
 const ALLOWED_TABS = [
     "overview", "estimates", "schedule", "invoices",
@@ -74,23 +80,21 @@ export default async function PortalProjectDetail(props: {
                 where: { status: { not: 'Draft' } },
                 orderBy: { createdAt: 'desc' },
                 include: { estimate: { select: { id: true, code: true, title: true, status: true, totalAmount: true } } }
-            },
-            dailyLogs: {
-                orderBy: { date: 'desc' },
-                include: {
-                    photos: { orderBy: { createdAt: 'asc' } },
-                    createdBy: { select: { name: true, email: true } }
-                }
             }
         }
     });
 
     if (!project) return notFound();
 
-    const [settings, visibility, scheduleTasks, sharedRooms] = await Promise.all([
+    const visibility = await getPortalVisibility(projectId);
+    const [settings, trackerData, updatesFeed, sharedRooms] = await Promise.all([
         prisma.companySettings.findUnique({ where: { id: "singleton" } }),
-        getPortalVisibility(projectId),
-        getPortalScheduleTasks(projectId).catch(() => [] as any[]),
+        visibility.showSchedule
+            ? getPortalProjectTracker(projectId)
+            : Promise.resolve(null),
+        visibility.showDailyLogs
+            ? getPortalUpdatesFeed(projectId)
+            : Promise.resolve([]),
         prisma.roomDesign.findMany({
             where: { projectId, shareEnabled: true, shareToken: { not: null } },
             select: { id: true, name: true, shareToken: true, thumbnail: true, updatedAt: true },
@@ -107,7 +111,7 @@ export default async function PortalProjectDetail(props: {
                     </div>
                     <h2 className="text-2xl font-bold text-slate-800 mb-2">Access Suspended</h2>
                     <p className="text-slate-500 mb-6 max-w-md mx-auto">
-                        Your contractor has currently paused access to this project's dashboard. Please contact them directly if you need to review any project materials or estimates.
+                        Your contractor has currently paused access to this project&apos;s dashboard. Please contact them directly if you need to review any project materials or estimates.
                     </p>
                     <Link href="/portal" className="inline-flex justify-center items-center gap-2 hui-btn hui-btn-primary">
                         Return to My Hub
@@ -120,7 +124,7 @@ export default async function PortalProjectDetail(props: {
     // ---- Compute counts and tab config ----
     const estimateCount = project.estimates.filter((e: any) => e.approvedAt || ['Approved', 'Invoiced', 'Partially Paid', 'Paid'].includes(e.status)).length;
     const invoiceCount = project.invoices.length;
-    const updateCount = (project.dailyLogs || []).length;
+    const updateCount = updatesFeed.length;
     const changeOrderCount = (project.changeOrders || []).length;
 
     // All overview-derived data must respect the same visibility flag as the section it surfaces.
@@ -148,7 +152,7 @@ export default async function PortalProjectDetail(props: {
         { id: "estimates", label: "Estimates", count: estimateCount, visible: visibility.showEstimates && estimateCount > 0 },
         { id: "schedule", label: "Schedule", visible: visibility.showSchedule },
         { id: "invoices", label: "Invoices", count: invoiceCount, visible: visibility.showInvoices && invoiceCount > 0 },
-        { id: "updates", label: "Updates", count: updateCount, visible: visibility.showDailyLogs && updateCount > 0 },
+        { id: "updates", label: "Updates", count: updateCount || undefined, visible: visibility.showDailyLogs },
         { id: "files", label: "Files", visible: visibility.showFiles },
         { id: "selections", label: "Selections", visible: visibility.showSelections },
         { id: "designs", label: "Designs", visible: visibility.showMoodBoards || sharedRooms.length > 0 },
@@ -169,27 +173,6 @@ export default async function PortalProjectDetail(props: {
             ? `/portal/projects/${projectId}`
             : `/portal/projects/${projectId}?tab=${t.id}`,
     }));
-
-    // ---- Schedule summary for Overview + Schedule tab ----
-    const isTaskComplete = (t: any) => (t.progress ?? 0) >= 100 || t.status === 'Complete';
-    const totalTasks = scheduleTasks.length;
-    const completedTasks = scheduleTasks.filter(isTaskComplete).length;
-    const inProgressTask = scheduleTasks.find((t: any) =>
-        !isTaskComplete(t) && ((t.progress ?? 0) > 0 || t.status === 'In Progress')
-    );
-    const upcomingTasks = scheduleTasks
-        .filter((t: any) => !isTaskComplete(t))
-        .slice()
-        .sort((a: any, b: any) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime())
-        .slice(0, 4);
-    const overallProgress = totalTasks > 0
-        ? Math.round((completedTasks / totalTasks) * 100)
-        : 0;
-
-    const latestLog = (visibility.showDailyLogs && project.dailyLogs && project.dailyLogs.length > 0)
-        ? project.dailyLogs[0]
-        : null;
-    const hasScheduleData = visibility.showSchedule && totalTasks > 0;
 
     return (
         <div className="max-w-5xl mx-auto">
@@ -238,6 +221,14 @@ export default async function PortalProjectDetail(props: {
             >
                 {activeTab === "overview" && (
                     <div className="space-y-6">
+                        {trackerData && (
+                            <PortalProjectTracker
+                                projectId={projectId}
+                                projectName={project.name}
+                                data={trackerData}
+                            />
+                        )}
+
                         {/* Payment Due callout */}
                         {pendingPayments.length > 0 && (
                             <div className="bg-green-50 border border-green-200 rounded-xl p-5 md:p-6">
@@ -307,71 +298,11 @@ export default async function PortalProjectDetail(props: {
                             </div>
                         )}
 
-                        {/* Schedule + Latest Update row */}
-                        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            {/* Schedule mini summary */}
-                            {hasScheduleData && (
-                                <Link
-                                    href={`/portal/projects/${projectId}?tab=schedule`}
-                                    className="hui-card p-5 hover:shadow-md hover:border-blue-300 transition"
-                                >
-                                    <div className="flex items-center justify-between mb-3">
-                                        <h3 className="font-semibold text-hui-textMain flex items-center gap-2">
-                                            <svg className="w-5 h-5 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
-                                            Schedule
-                                        </h3>
-                                        <span className="text-xs font-semibold text-blue-500">{overallProgress}%</span>
-                                    </div>
-                                    <div className="w-full bg-slate-100 rounded-full h-2 mb-3">
-                                        <div className="bg-blue-500 h-2 rounded-full transition-all" style={{ width: `${overallProgress}%` }} />
-                                    </div>
-                                    <p className="text-sm text-hui-textMuted">
-                                        {completedTasks} of {totalTasks} tasks complete
-                                        {inProgressTask && <> · Now: <span className="text-hui-textMain font-medium">{inProgressTask.name}</span></>}
-                                    </p>
-                                </Link>
-                            )}
-
-                            {/* Latest update preview */}
-                            {visibility.showDailyLogs && latestLog && (
-                                <Link
-                                    href={`/portal/projects/${projectId}?tab=updates`}
-                                    className="hui-card p-5 hover:shadow-md hover:border-purple-300 transition"
-                                >
-                                    <div className="flex items-center justify-between mb-2">
-                                        <h3 className="font-semibold text-hui-textMain flex items-center gap-2">
-                                            <svg className="w-5 h-5 text-purple-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
-                                            Latest Update
-                                        </h3>
-                                        <span className="text-xs text-hui-textMuted">{new Date(latestLog.date).toLocaleDateString()}</span>
-                                    </div>
-                                    <p className="text-sm text-hui-textMain line-clamp-2 mb-3">
-                                        {latestLog.workPerformed}
-                                    </p>
-                                    {latestLog.photos && latestLog.photos.length > 0 && (
-                                        <div className="flex gap-2">
-                                            {latestLog.photos.slice(0, 4).map((photo: any) => (
-                                                <div key={photo.id} className="w-12 h-12 rounded overflow-hidden border border-slate-200 shrink-0">
-                                                    <img src={photo.url} alt="" className="w-full h-full object-cover" />
-                                                </div>
-                                            ))}
-                                            {latestLog.photos.length > 4 && (
-                                                <div className="w-12 h-12 rounded bg-slate-50 border border-slate-200 flex items-center justify-center text-xs font-semibold text-slate-500">
-                                                    +{latestLog.photos.length - 4}
-                                                </div>
-                                            )}
-                                        </div>
-                                    )}
-                                </Link>
-                            )}
-                        </div>
-
                         {/* Empty overview fallback — based on what would actually render */}
                         {pendingPayments.length === 0
                             && sentEstimatesAwaitingSignature.length === 0
                             && pendingChangeOrders.length === 0
-                            && !latestLog
-                            && !hasScheduleData
+                            && !trackerData
                             && (
                                 <div className="hui-card p-8 text-center">
                                     <div className="w-12 h-12 bg-blue-50 rounded-full flex items-center justify-center mx-auto mb-3">
@@ -416,60 +347,17 @@ export default async function PortalProjectDetail(props: {
                 )}
 
                 {activeTab === "schedule" && (
-                    <div className="space-y-4">
-                        {totalTasks === 0 ? (
-                            <div className="bg-hui-background border border-hui-border rounded-lg p-6 text-center text-hui-textMuted text-sm">
-                                No schedule shared yet.
-                            </div>
-                        ) : (
-                            <>
-                                <div className="hui-card p-5">
-                                    <div className="flex items-center justify-between mb-2">
-                                        <h3 className="font-semibold text-hui-textMain">Overall Progress</h3>
-                                        <span className="text-sm font-semibold text-blue-600">{overallProgress}%</span>
-                                    </div>
-                                    <div className="w-full bg-slate-100 rounded-full h-3 mb-2">
-                                        <div className="bg-blue-500 h-3 rounded-full transition-all" style={{ width: `${overallProgress}%` }} />
-                                    </div>
-                                    <p className="text-sm text-hui-textMuted">
-                                        {completedTasks} of {totalTasks} tasks complete
-                                        {inProgressTask && (
-                                            <> · Now: <span className="text-hui-textMain font-medium">{inProgressTask.name}</span></>
-                                        )}
-                                    </p>
-                                </div>
-
-                                {upcomingTasks.length > 0 && (
-                                    <div className="hui-card p-5">
-                                        <h3 className="font-semibold text-hui-textMain mb-3">Upcoming Tasks</h3>
-                                        <ul className="divide-y divide-hui-border">
-                                            {upcomingTasks.map((task: any) => (
-                                                <li key={task.id} className="py-3 flex items-center justify-between gap-3">
-                                                    <div className="min-w-0">
-                                                        <p className="text-sm font-medium text-hui-textMain truncate">{task.name}</p>
-                                                        <p className="text-xs text-hui-textMuted">
-                                                            {new Date(task.startDate).toLocaleDateString()} – {new Date(task.endDate).toLocaleDateString()}
-                                                        </p>
-                                                    </div>
-                                                    <span className="text-xs px-2 py-1 rounded-full font-medium bg-slate-100 text-slate-600 shrink-0">
-                                                        {task.status || "Not Started"}
-                                                    </span>
-                                                </li>
-                                            ))}
-                                        </ul>
-                                    </div>
-                                )}
-
-                                <Link
-                                    href={`/portal/projects/${projectId}/schedule`}
-                                    className="inline-flex items-center gap-1.5 text-sm font-semibold text-blue-600 hover:text-blue-700 transition"
-                                >
-                                    View full timeline
-                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" /></svg>
-                                </Link>
-                            </>
-                        )}
-                    </div>
+                    trackerData ? (
+                        <PortalProjectTracker
+                            projectId={projectId}
+                            projectName={project.name}
+                            data={trackerData}
+                        />
+                    ) : (
+                        <div className="hui-card p-8 text-center text-sm text-hui-textMuted">
+                            No schedule shared yet.
+                        </div>
+                    )
                 )}
 
                 {activeTab === "invoices" && (
@@ -536,74 +424,10 @@ export default async function PortalProjectDetail(props: {
                 )}
 
                 {activeTab === "updates" && (
-                    <div className="space-y-4">
-                        {project.dailyLogs.map((log: any) => (
-                            <div key={log.id} className="hui-card p-5 border-l-4 border-l-purple-500">
-                                <div className="flex items-start justify-between mb-3 border-b border-slate-100 pb-3 flex-wrap gap-2">
-                                    <div>
-                                        <h3 className="font-bold text-hui-textMain text-base md:text-lg">
-                                            {new Date(log.date).toLocaleDateString("en-US", { weekday: "long", year: "numeric", month: "long", day: "numeric" })}
-                                        </h3>
-                                        <p className="text-xs text-hui-textMuted mt-1">
-                                            Logged by {log.createdBy.name || log.createdBy.email}
-                                        </p>
-                                    </div>
-                                    <div className="flex items-center gap-2 flex-wrap">
-                                        {log.weather && (
-                                            <span className="inline-flex items-center gap-1 text-xs bg-blue-50 text-blue-700 px-2 py-1 rounded-full border border-blue-100">
-                                                ☁️ {log.weather}
-                                            </span>
-                                        )}
-                                        {log.crewOnSite && (
-                                            <span className="inline-flex items-center gap-1 text-xs bg-green-50 text-green-700 px-2 py-1 rounded-full border border-green-100">
-                                                👥 Crew on Site
-                                            </span>
-                                        )}
-                                    </div>
-                                </div>
-
-                                <div className="space-y-4">
-                                    <div>
-                                        <p className="text-xs font-bold text-hui-textMuted uppercase tracking-wider mb-1">Work Performed</p>
-                                        <div className="text-sm text-hui-textMain bg-slate-50 p-3 rounded-lg border border-slate-100 whitespace-pre-wrap leading-relaxed">
-                                            {log.workPerformed}
-                                        </div>
-                                    </div>
-
-                                    {log.materialsDelivered && (
-                                        <div>
-                                            <p className="text-xs font-bold text-amber-600 uppercase tracking-wider mb-1">Materials Delivered</p>
-                                            <div className="text-sm text-hui-textMain bg-amber-50/50 p-3 rounded-lg border border-amber-100/50 whitespace-pre-wrap">
-                                                {log.materialsDelivered}
-                                            </div>
-                                        </div>
-                                    )}
-
-                                    {log.issues && (
-                                        <div>
-                                            <p className="text-xs font-bold text-red-600 uppercase tracking-wider mb-1">⚠️ Issues / Delays</p>
-                                            <div className="text-sm text-hui-textMain bg-red-50/50 p-3 rounded-lg border border-red-100/50 whitespace-pre-wrap">
-                                                {log.issues}
-                                            </div>
-                                        </div>
-                                    )}
-
-                                    {log.photos && log.photos.length > 0 && (
-                                        <div>
-                                            <p className="text-xs font-bold text-hui-textMuted uppercase tracking-wider mb-2">Photos</p>
-                                            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
-                                                {log.photos.map((photo: any) => (
-                                                    <div key={photo.id} className="relative aspect-square rounded-lg overflow-hidden border border-slate-200">
-                                                        <img src={photo.url} alt="Daily Log Image" className="w-full h-full object-cover" />
-                                                    </div>
-                                                ))}
-                                            </div>
-                                        </div>
-                                    )}
-                                </div>
-                            </div>
-                        ))}
-                    </div>
+                    <PortalUpdatesFeed
+                        updates={updatesFeed}
+                        projectColor={trackerData?.projectColor ?? project.color ?? "#4c9a2a"}
+                    />
                 )}
 
                 {activeTab === "files" && (

--- a/src/app/projects/[id]/dailylogs/DailyLogsClient.tsx
+++ b/src/app/projects/[id]/dailylogs/DailyLogsClient.tsx
@@ -2,7 +2,13 @@
 
 import { useState, useTransition, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { createDailyLog, deleteDailyLog, deleteDailyLogPhoto, createSuggestedChangeOrder } from "@/lib/actions";
+import {
+    createDailyLog,
+    deleteDailyLog,
+    deleteDailyLogPhoto,
+    createSuggestedChangeOrder,
+    setDailyLogPortalShare,
+} from "@/lib/actions";
 import { toast } from "sonner";
 
 // Weather icons mapping
@@ -48,6 +54,7 @@ type DailyLogPhoto = {
     url: string;
     caption: string | null;
     createdAt: string;
+    sharedToPortal: boolean;
 };
 
 type DailyLog = {
@@ -62,6 +69,10 @@ type DailyLog = {
     createdBy: { id: string; name: string | null; email: string };
     createdAt: string;
     updatedAt: string;
+    sharedToPortal: boolean;
+    sharedContentHash: string | null;
+    sharedPhotoIds: string[];
+    portalShareValid: boolean;
 };
 
 type CoSuggestion = {
@@ -85,14 +96,23 @@ interface Props {
     logs: DailyLog[];
     currentUserId: string;
     currentUserName: string;
+    canManagePortalShare: boolean;
 }
 
-export default function DailyLogsClient({ projectId, projectName, logs, currentUserId, currentUserName }: Props) {
+export default function DailyLogsClient({
+    projectId,
+    projectName,
+    logs,
+    currentUserId,
+    currentUserName,
+    canManagePortalShare,
+}: Props) {
     const router = useRouter();
     const [showForm, setShowForm] = useState(false);
     const [expandedLogId, setExpandedLogId] = useState<string | null>(null);
     const [isPending, startTransition] = useTransition();
     const [deletingId, setDeletingId] = useState<string | null>(null);
+    const [sharingLogId, setSharingLogId] = useState<string | null>(null);
     const [photoLightbox, setPhotoLightbox] = useState<{ url: string; caption: string | null } | null>(null);
     const [exporting, setExporting] = useState(false);
     const [isGeneratingAI, setIsGeneratingAI] = useState(false);
@@ -274,6 +294,30 @@ export default function DailyLogsClient({ projectId, projectName, logs, currentU
         } finally {
             setDeletingId(null);
         }
+    };
+
+    const handlePortalShare = async (
+        log: DailyLog,
+        shared: boolean,
+        photoIds = log.sharedPhotoIds,
+    ) => {
+        setSharingLogId(log.id);
+        try {
+            await setDailyLogPortalShare(log.id, { shared, photoIds });
+            toast.success(shared ? "Daily log shared to portal" : "Daily log removed from portal");
+            router.refresh();
+        } catch (error) {
+            toast.error(error instanceof Error ? error.message : "Failed to update portal sharing");
+        } finally {
+            setSharingLogId(null);
+        }
+    };
+
+    const handlePortalPhotoToggle = async (log: DailyLog, photoId: string) => {
+        const nextPhotoIds = log.sharedPhotoIds.includes(photoId)
+            ? log.sharedPhotoIds.filter(id => id !== photoId)
+            : [...log.sharedPhotoIds, photoId];
+        await handlePortalShare(log, true, nextPhotoIds);
     };
 
     const handleExportPdf = async () => {
@@ -697,6 +741,35 @@ export default function DailyLogsClient({ projectId, projectName, logs, currentU
                                                                                             alt={photo.caption || "Daily log photo"}
                                                                                             className="w-full h-full object-cover"
                                                                                         />
+                                                                                        {canManagePortalShare && log.portalShareValid && (
+                                                                                            <button
+                                                                                                type="button"
+                                                                                                onClick={(event) => {
+                                                                                                    event.stopPropagation();
+                                                                                                    void handlePortalPhotoToggle(log, photo.id);
+                                                                                                }}
+                                                                                                disabled={sharingLogId === log.id}
+                                                                                                className={`absolute right-1.5 top-1.5 flex h-11 w-11 items-center justify-center rounded-full border-2 shadow-lg transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
+                                                                                                    log.sharedPhotoIds.includes(photo.id)
+                                                                                                        ? "border-white bg-emerald-600 text-white"
+                                                                                                        : "border-white bg-slate-950/65 text-white"
+                                                                                                } disabled:cursor-wait disabled:opacity-60`}
+                                                                                                aria-label={
+                                                                                                    log.sharedPhotoIds.includes(photo.id)
+                                                                                                        ? "Remove photo from portal update"
+                                                                                                        : "Share photo in portal update"
+                                                                                                }
+                                                                                                aria-pressed={log.sharedPhotoIds.includes(photo.id)}
+                                                                                            >
+                                                                                                {log.sharedPhotoIds.includes(photo.id) ? (
+                                                                                                    <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
+                                                                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="m5 12 4 4L19 6" />
+                                                                                                    </svg>
+                                                                                                ) : (
+                                                                                                    <span className="h-4 w-4 rounded-full border-2 border-current" aria-hidden="true" />
+                                                                                                )}
+                                                                                            </button>
+                                                                                        )}
                                                                                         {photo.caption && (
                                                                                             <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent p-2">
                                                                                                 <p className="text-[10px] text-white truncate">{photo.caption}</p>
@@ -709,11 +782,50 @@ export default function DailyLogsClient({ projectId, projectName, logs, currentU
                                                                     )}
 
                                                                     {/* Actions */}
-                                                                    <div className="flex items-center justify-end gap-2 pt-3 border-t border-slate-100">
+                                                                    <div className="flex flex-col gap-3 border-t border-slate-100 pt-3 sm:flex-row sm:items-center sm:justify-between">
+                                                                        {canManagePortalShare && (
+                                                                            <div className="flex min-w-0 items-center gap-3">
+                                                                                <button
+                                                                                    type="button"
+                                                                                    role="switch"
+                                                                                    aria-checked={log.portalShareValid}
+                                                                                    aria-label="Share to portal"
+                                                                                    disabled={sharingLogId === log.id}
+                                                                                    onClick={(event) => {
+                                                                                        event.stopPropagation();
+                                                                                        void handlePortalShare(log, !log.portalShareValid);
+                                                                                    }}
+                                                                                    className={`relative h-7 w-12 shrink-0 rounded-full transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary focus-visible:ring-offset-2 ${
+                                                                                        log.portalShareValid ? "bg-emerald-600" : "bg-slate-300"
+                                                                                    } disabled:cursor-wait disabled:opacity-60`}
+                                                                                >
+                                                                                    <span
+                                                                                        className={`absolute top-1 h-5 w-5 rounded-full bg-white shadow-sm transition-transform ${
+                                                                                            log.portalShareValid ? "translate-x-6" : "translate-x-1"
+                                                                                        }`}
+                                                                                        aria-hidden="true"
+                                                                                    />
+                                                                                </button>
+                                                                                <div className="min-w-0">
+                                                                                    <p className="text-xs font-semibold text-hui-textMain">
+                                                                                        Share to portal
+                                                                                    </p>
+                                                                                    <p className="text-[0.68rem] leading-4 text-hui-textMuted">
+                                                                                        {sharingLogId === log.id
+                                                                                            ? "Updating client view…"
+                                                                                            : log.portalShareValid
+                                                                                                ? `${log.sharedPhotoIds.length} selected photo${log.sharedPhotoIds.length === 1 ? "" : "s"}`
+                                                                                                : log.sharedToPortal
+                                                                                                    ? "Needs re-approval after edits"
+                                                                                                    : "Text only until you select photos"}
+                                                                                    </p>
+                                                                                </div>
+                                                                            </div>
+                                                                        )}
                                                                         <button
                                                                             onClick={(e) => { e.stopPropagation(); handleDelete(log.id); }}
                                                                             disabled={deletingId === log.id}
-                                                                            className="text-xs text-red-500 hover:text-red-700 hover:bg-red-50 px-3 py-1.5 rounded transition"
+                                                                            className="min-h-11 self-end rounded px-3 py-1.5 text-xs text-red-500 transition hover:bg-red-50 hover:text-red-700 disabled:opacity-60 sm:self-auto"
                                                                         >
                                                                             {deletingId === log.id ? "Deleting..." : "Delete Log"}
                                                                         </button>

--- a/src/app/projects/[id]/dailylogs/page.tsx
+++ b/src/app/projects/[id]/dailylogs/page.tsx
@@ -17,7 +17,10 @@ export default async function DailyLogsPage({ params }: { params: Promise<{ id: 
 
     const session = await getServerSession(authOptions);
     const user = session?.user?.email
-        ? await prisma.user.findUnique({ where: { email: session.user.email }, select: { id: true, name: true } })
+        ? await prisma.user.findUnique({
+            where: { email: session.user.email },
+            select: { id: true, name: true, role: true },
+        })
         : null;
 
     const logs = await getDailyLogs(id);
@@ -29,6 +32,7 @@ export default async function DailyLogsPage({ params }: { params: Promise<{ id: 
             logs={JSON.parse(JSON.stringify(logs))}
             currentUserId={user?.id || ""}
             currentUserName={user?.name || "Unknown"}
+            canManagePortalShare={["ADMIN", "MANAGER"].includes(user?.role || "")}
         />
     );
 }

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -48,6 +48,12 @@ import {
     type TaskMaterialUpdateInput,
     type TaskMaterialStatus,
 } from "./task-materials-core";
+import { assertPortalProjectAccess } from "./portal-project-access";
+import {
+    computeDailyLogSharedContentHash,
+    getPortalScheduleTasksCore,
+    setDailyLogPortalShareCore,
+} from "./portal-tracker";
 
 type NotificationToggleKey = "newLead" | "estimateViewed" | "estimateSigned" | "contractSigned" | "invoiceViewed" | "paymentReceived" | "messageReceived";
 
@@ -6778,81 +6784,9 @@ export async function getStagingQueue(dayISO: string) {
 }
 
 export async function getPortalScheduleTasks(projectId: string) {
-    // Hardened (dispatch-arc foundation): portal schedule details require staff access or an owning client with schedule visibility.
-    const session = await getSessionOrDev();
-    const role = ((session?.user as any)?.role as string | null) ?? null;
-    const isStaff = role === "ADMIN" || role === "MANAGER";
-
-    if (!isStaff) {
-        const sessionClientId = await resolveSessionClientId();
-        if (!sessionClientId) throw new Error("Unauthorized");
-
-        const project = await prisma.project.findFirst({
-            where: { id: projectId, clientId: sessionClientId },
-            select: { id: true },
-        });
-        if (!project) throw new Error("Unauthorized");
-
-        const visibility = await prisma.portalVisibility.findUnique({
-            where: { projectId },
-        });
-        // Match getPortalVisibility defaults: a missing record enables the portal and schedule.
-        if (visibility && (!visibility.isPortalEnabled || !visibility.showSchedule)) {
-            throw new Error("Unauthorized");
-        }
-    }
-
-    const tasks = await prisma.scheduleTask.findMany({
-        where: { projectId },
-        orderBy: { order: "asc" },
-        select: {
-            id: true,
-            name: true,
-            startDate: true,
-            endDate: true,
-            color: true,
-            progress: true,
-            status: true,
-            type: true,
-            order: true,
-            dependencies: { select: { id: true, predecessorId: true, dependentId: true } },
-            assignments: {
-                select: {
-                    id: true,
-                    userId: true,
-                    user: { select: { name: true } },
-                },
-            },
-            subAssignments: {
-                select: {
-                    id: true,
-                    subcontractor: { select: { companyName: true } },
-                },
-            },
-        },
-    });
-
-    return tasks.map(task => ({
-        id: task.id,
-        name: task.name,
-        startDate: task.startDate,
-        endDate: task.endDate,
-        color: task.color,
-        progress: task.progress,
-        status: task.status,
-        type: task.type,
-        order: task.order,
-        dependencies: task.dependencies,
-        assignments: task.assignments.map(assignment => ({
-            id: assignment.id,
-            userId: assignment.userId,
-            firstName: assignment.user.name?.trim().split(/\s+/)[0] || "Crew",
-        })),
-        subAssignments: task.subAssignments.map(assignment => ({
-            id: assignment.id,
-            companyName: assignment.subcontractor.companyName,
-        })),
-    }));
+    // Client-safe allowlist shared by the simple tracker and the full schedule.
+    await assertPortalProjectAccess(projectId, "showSchedule");
+    return getPortalScheduleTasksCore(projectId);
 }
 
 export async function getDashboardTasks(projectId: string) {
@@ -9836,13 +9770,29 @@ async function assertDailyLogAccess(projectId: string) {
 export async function getDailyLogs(projectId: string) {
     // Hardened (dispatch-arc foundation): require daily-log permission and project access before reading logs.
     await assertDailyLogAccess(projectId);
-    return await prisma.dailyLog.findMany({
+    const logs = await prisma.dailyLog.findMany({
         where: { projectId },
         orderBy: { date: "desc" },
         include: {
             createdBy: { select: { id: true, name: true, email: true } },
             photos: { orderBy: { createdAt: "asc" } },
         },
+    });
+    return logs.map(log => {
+        const sharedPhotoIds = log.photos
+            .filter(photo => photo.sharedToPortal)
+            .map(photo => photo.id);
+        const currentHash = computeDailyLogSharedContentHash(
+            log.workPerformed,
+            sharedPhotoIds,
+        );
+        return {
+            ...log,
+            sharedPhotoIds,
+            portalShareValid: log.sharedToPortal
+                && Boolean(log.sharedContentHash)
+                && log.sharedContentHash === currentHash,
+        };
     });
 }
 
@@ -9912,7 +9862,12 @@ export async function updateDailyLog(id: string, data: {
     if (data.date !== undefined) updateData.date = new Date(data.date);
     if (data.weather !== undefined) updateData.weather = data.weather || null;
     if (data.crewOnSite !== undefined) updateData.crewOnSite = data.crewOnSite || null;
-    if (data.workPerformed !== undefined) updateData.workPerformed = data.workPerformed;
+    if (data.workPerformed !== undefined) {
+        updateData.workPerformed = data.workPerformed;
+        // Content approval is a snapshot. Any work-text edit requires a
+        // manager to re-share, even if the new string happens to be similar.
+        updateData.sharedContentHash = null;
+    }
     if (data.materialsDelivered !== undefined) updateData.materialsDelivered = data.materialsDelivered || null;
     if (data.issues !== undefined) updateData.issues = data.issues || null;
 
@@ -9958,14 +9913,54 @@ export async function deleteDailyLogPhoto(photoId: string) {
     // Hardened (dispatch-arc foundation): authorize against the photo's persisted log project before deleting.
     const photo = await prisma.dailyLogPhoto.findUnique({
         where: { id: photoId },
-        include: { dailyLog: { select: { projectId: true } } },
+        include: { dailyLog: { select: { id: true, projectId: true } } },
     });
     if (!photo) return { success: false };
     await assertDailyLogAccess(photo.dailyLog.projectId);
 
-    await prisma.dailyLogPhoto.delete({ where: { id: photoId } });
+    await prisma.$transaction(async tx => {
+        await tx.dailyLogPhoto.delete({ where: { id: photoId } });
+        if (photo.sharedToPortal) {
+            await tx.dailyLog.update({
+                where: { id: photo.dailyLog.id },
+                data: { sharedContentHash: null },
+            });
+        }
+    });
     revalidatePath(`/projects/${photo.dailyLog.projectId}/dailylogs`);
     return { success: true };
+}
+
+export async function setDailyLogPortalShare(
+    logId: string,
+    input: { shared: boolean; photoIds: string[] },
+) {
+    const session = await getSessionOrDev();
+    const role = ((session?.user as any)?.role as string | null) ?? null;
+    if (!role || !["ADMIN", "MANAGER"].includes(role)) throw new Error("Forbidden");
+
+    const target = await prisma.dailyLog.findUnique({
+        where: { id: logId },
+        select: { projectId: true },
+    });
+    if (!target) throw new Error("Daily log not found");
+    await assertDailyLogAccess(target.projectId);
+
+    const userId = ((session?.user as any)?.id as string | null) ?? null;
+    const actorName = session?.user?.name || session?.user?.email || "Team member";
+    const result = await setDailyLogPortalShareCore(
+        logId,
+        input,
+        {
+            userId: userId || "session",
+            role,
+            name: actorName,
+        },
+    );
+
+    revalidatePath(`/projects/${target.projectId}/dailylogs`);
+    revalidatePath(`/portal/projects/${target.projectId}`);
+    return result;
 }
 
 // =============================================

--- a/src/lib/portal-project-access.ts
+++ b/src/lib/portal-project-access.ts
@@ -1,0 +1,83 @@
+import { getSessionOrDev } from "@/lib/auth";
+import { resolveSessionClientId } from "@/lib/portal-auth";
+import { prisma } from "@/lib/prisma";
+
+export type PortalVisibilityKey = "showSchedule" | "showDailyLogs";
+
+export type PortalProjectAccessInput = {
+    projectId: string;
+    isStaff: boolean;
+    clientId: string | null;
+    visibility: PortalVisibilityKey;
+};
+
+type PortalVisibilityAccess = {
+    isPortalEnabled: boolean;
+    showSchedule: boolean;
+    showDailyLogs: boolean;
+};
+
+export function portalVisibilityAllows(
+    visibility: PortalVisibilityAccess | null,
+    visibilityKey: PortalVisibilityKey,
+): boolean {
+    if (!visibility) return visibilityKey === "showSchedule";
+    return visibility.isPortalEnabled && visibility[visibilityKey];
+}
+
+/**
+ * Session-free portal ownership/visibility assertion.
+ *
+ * Verification scripts call this core with explicit identities; runtime
+ * surfaces must call assertPortalProjectAccess, which derives identity from
+ * the authenticated session or client magic-link cookie.
+ */
+export async function assertPortalProjectAccessCore({
+    projectId,
+    isStaff,
+    clientId,
+    visibility: visibilityKey,
+}: PortalProjectAccessInput): Promise<void> {
+    // Staff preview is intentionally allowed even while a client-facing
+    // section is disabled, matching the established schedule behavior.
+    if (isStaff) return;
+    if (!clientId) throw new Error("Unauthorized");
+
+    const project = await prisma.project.findFirst({
+        where: { id: projectId, clientId },
+        select: { id: true },
+    });
+    if (!project) throw new Error("Unauthorized");
+
+    const visibility = await prisma.portalVisibility.findUnique({
+        where: { projectId },
+        select: {
+            isPortalEnabled: true,
+            showSchedule: true,
+            showDailyLogs: true,
+        },
+    });
+
+    // Keep the established defaults: schedule is on when no row exists, while
+    // daily logs require an explicit opt-in.
+    if (!portalVisibilityAllows(visibility, visibilityKey)) {
+        throw new Error("Unauthorized");
+    }
+}
+
+export async function assertPortalProjectAccess(
+    projectId: string,
+    visibility: PortalVisibilityKey,
+): Promise<void> {
+    const session = await getSessionOrDev();
+    const role = ((session?.user as { role?: string } | undefined)?.role ?? null);
+    const isStaff = role === "ADMIN" || role === "MANAGER";
+    const clientId = isStaff ? null : await resolveSessionClientId();
+
+    await assertPortalProjectAccessCore({
+        projectId,
+        isStaff,
+        clientId,
+        visibility,
+    });
+}

--- a/src/lib/portal-tracker.ts
+++ b/src/lib/portal-tracker.ts
@@ -1,0 +1,616 @@
+import { createHash } from "node:crypto";
+
+import { prisma } from "@/lib/prisma";
+import {
+    assertPortalProjectAccess,
+    assertPortalProjectAccessCore,
+    portalVisibilityAllows,
+    type PortalProjectAccessInput,
+} from "@/lib/portal-project-access";
+
+export { assertPortalProjectAccessCore, portalVisibilityAllows };
+export type { PortalProjectAccessInput };
+
+export type ClientStageState = "complete" | "current" | "upcoming";
+
+export type ClientStageDefinition = {
+    label: string;
+    matchers: readonly string[];
+};
+
+export const CLIENT_STAGES = [
+    {
+        label: "Planning & Permits",
+        matchers: [
+            "plan", "permit", "design", "preconstruction", "pre-construction",
+            "engineering", "architect", "site prep", "mobilization",
+        ],
+    },
+    {
+        label: "Demo",
+        matchers: ["demo", "demolition", "tear out", "tear-out", "removal", "abatement"],
+    },
+    {
+        label: "Framing",
+        matchers: ["frame", "framing", "structural", "sheathing", "carpentry"],
+    },
+    {
+        label: "Rough-ins",
+        matchers: [
+            "rough", "plumb", "electric", "hvac", "mechanical", "duct",
+            "wiring", "low voltage", "low-voltage",
+        ],
+    },
+    {
+        label: "Drywall",
+        matchers: ["drywall", "sheetrock", "gypsum", "insulation", "taping", "texture", "mud"],
+    },
+    {
+        label: "Finishes",
+        matchers: [
+            "finish", "paint", "tile", "cabinet", "floor", "counter", "trim",
+            "fixture", "appliance", "millwork", "backsplash",
+        ],
+    },
+    {
+        label: "Punch list",
+        matchers: [
+            "punch", "inspection", "touch up", "touch-up", "cleanup", "clean up",
+            "final walk", "correction",
+        ],
+    },
+    {
+        label: "Complete",
+        matchers: ["complete", "completion", "closeout", "close out", "handover", "handoff"],
+    },
+] as const satisfies readonly ClientStageDefinition[];
+
+export type PortalTrackerAssignment = {
+    id: string;
+    userId: string;
+    firstName: string;
+};
+
+export type PortalTrackerSubAssignment = {
+    id: string;
+    companyName: string;
+};
+
+export type PortalTrackerDependency = {
+    id: string;
+    predecessorId: string;
+    dependentId: string;
+};
+
+export type PortalTrackerTask = {
+    id: string;
+    name: string;
+    startDate: Date | string;
+    endDate: Date | string;
+    color: string;
+    progress: number;
+    status: string;
+    type: string;
+    order: number;
+    costCodeName: string | null;
+    scheduledTime: string | null;
+    confirmationStatus: string | null;
+    assignments: PortalTrackerAssignment[];
+    subAssignments: PortalTrackerSubAssignment[];
+    dependencies?: PortalTrackerDependency[];
+};
+
+export type ProjectTrackerStage = {
+    label: string;
+    state: ClientStageState;
+    pct: number;
+};
+
+export type ProjectTracker = {
+    stages: ProjectTrackerStage[];
+    overallPct: number;
+};
+
+export type PortalAppointment = {
+    name: string;
+    date: string;
+    scheduledTime: string | null;
+    confirmationStatus: "confirmed" | "pending confirmation";
+};
+
+export type PortalDayVisitors = {
+    date: string;
+    crew: string[];
+    subcontractors: string[];
+    appointments: PortalAppointment[];
+};
+
+export type PortalNextTask = {
+    name: string;
+    startDate: string;
+};
+
+export type PortalProjectTrackerPayload = ProjectTracker & {
+    projectColor: string;
+    whatsNext: PortalNextTask[];
+    whoIsComing: PortalDayVisitors[];
+};
+
+export type PortalUpdatePhoto = {
+    url: string;
+    caption: string | null;
+};
+
+export type PortalUpdate = {
+    id: string;
+    date: string;
+    workPerformed: string;
+    photos: PortalUpdatePhoto[];
+};
+
+export type PortalShareActor = {
+    userId: string;
+    role: string;
+    name: string;
+};
+
+export type PortalShareInput = {
+    shared: boolean;
+    photoIds: string[];
+};
+
+function toDate(value: Date | string): Date {
+    return value instanceof Date ? value : new Date(value);
+}
+
+function dateKey(value: Date | string): string {
+    return toDate(value).toISOString().slice(0, 10);
+}
+
+function isComplete(task: PortalTrackerTask): boolean {
+    return task.status.trim().toLowerCase() === "complete" || task.progress >= 100;
+}
+
+function normalizedProgress(task: PortalTrackerTask): number {
+    if (isComplete(task)) return 100;
+    return Math.max(0, Math.min(100, Math.round(task.progress || 0)));
+}
+
+function isStarted(task: PortalTrackerTask): boolean {
+    const status = task.status.trim().toLowerCase();
+    return !isComplete(task)
+        && (
+            normalizedProgress(task) > 0
+            || status === "in progress"
+            || status === "active"
+            || status === "blocked"
+        );
+}
+
+function stageMatchIndex(task: PortalTrackerTask): number | null {
+    const haystack = `${task.name} ${task.costCodeName ?? ""}`.toLowerCase();
+    const index = CLIENT_STAGES.findIndex(stage =>
+        stage.matchers.some(matcher => haystack.includes(matcher)),
+    );
+    return index >= 0 ? index : null;
+}
+
+function chronologicalTasks(tasks: readonly PortalTrackerTask[]): PortalTrackerTask[] {
+    return [...tasks].sort((a, b) => {
+        const dateDelta = toDate(a.startDate).getTime() - toDate(b.startDate).getTime();
+        if (dateDelta !== 0) return dateDelta;
+        const orderDelta = a.order - b.order;
+        if (orderDelta !== 0) return orderDelta;
+        return a.id.localeCompare(b.id);
+    });
+}
+
+/**
+ * Assigns every task to the eight client stages.
+ *
+ * Fallback: an unmatched task inherits the stage of the closest keyword-
+ * matched task in chronological order (earlier anchor wins a tie). When the
+ * project has no keyword matches at all, chronological tasks are distributed
+ * proportionally across the ordered stages so the tracker remains useful for
+ * custom task naming.
+ */
+function assignStageIndexes(tasks: readonly PortalTrackerTask[]): Map<string, number> {
+    const sorted = chronologicalTasks(tasks);
+    const direct = sorted.map(stageMatchIndex);
+    const anchors = direct
+        .map((stageIndex, taskIndex) => stageIndex === null ? null : { taskIndex, stageIndex })
+        .filter((anchor): anchor is { taskIndex: number; stageIndex: number } => anchor !== null);
+    const assigned = new Map<string, number>();
+
+    sorted.forEach((task, taskIndex) => {
+        const directStage = direct[taskIndex];
+        if (directStage !== null) {
+            assigned.set(task.id, directStage);
+            return;
+        }
+
+        if (anchors.length > 0) {
+            const nearest = anchors.reduce((best, candidate) => {
+                const bestDistance = Math.abs(best.taskIndex - taskIndex);
+                const candidateDistance = Math.abs(candidate.taskIndex - taskIndex);
+                return candidateDistance < bestDistance ? candidate : best;
+            });
+            assigned.set(task.id, nearest.stageIndex);
+            return;
+        }
+
+        const proportionalIndex = sorted.length <= 1
+            ? 0
+            : Math.round((taskIndex * (CLIENT_STAGES.length - 1)) / (sorted.length - 1));
+        assigned.set(task.id, proportionalIndex);
+    });
+
+    return assigned;
+}
+
+export function buildProjectTracker(tasks: readonly PortalTrackerTask[]): ProjectTracker {
+    const assigned = assignStageIndexes(tasks);
+    const tasksByStage = CLIENT_STAGES.map((_, stageIndex) =>
+        tasks.filter(task => assigned.get(task.id) === stageIndex),
+    );
+
+    const totalTaskProgress = tasks.reduce((sum, task) => sum + normalizedProgress(task), 0);
+    const overallPct = tasks.length === 0
+        ? 0
+        : Math.round(totalTaskProgress / tasks.length);
+    const allProjectTasksComplete = tasks.length > 0 && tasks.every(isComplete);
+
+    let currentIndex = tasksByStage.findIndex(stageTasks =>
+        stageTasks.length > 0
+        && stageTasks.some(task => !isComplete(task))
+        && stageTasks.some(isStarted),
+    );
+    if (currentIndex < 0) {
+        currentIndex = tasksByStage.findIndex(stageTasks =>
+            stageTasks.length > 0 && stageTasks.some(task => !isComplete(task)),
+        );
+    }
+    if (currentIndex < 0 && tasks.length === 0) currentIndex = 0;
+
+    const stages = CLIENT_STAGES.map((stage, index): ProjectTrackerStage => {
+        const stageTasks = tasksByStage[index];
+        const stageComplete = stageTasks.length > 0 && stageTasks.every(isComplete);
+        const emptyButPassed = currentIndex > index && stageTasks.length === 0;
+        const complete = allProjectTasksComplete || stageComplete || emptyButPassed;
+        const pct = complete
+            ? 100
+            : stageTasks.length > 0
+                ? Math.round(stageTasks.reduce((sum, task) => sum + normalizedProgress(task), 0) / stageTasks.length)
+                : 0;
+
+        return {
+            label: stage.label,
+            state: complete ? "complete" : index === currentIndex ? "current" : "upcoming",
+            pct,
+        };
+    });
+
+    return { stages, overallPct };
+}
+
+function startOfUtcDay(value: Date): Date {
+    return new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate()));
+}
+
+function addUtcDays(value: Date, days: number): Date {
+    const result = new Date(value.getTime());
+    result.setUTCDate(result.getUTCDate() + days);
+    return result;
+}
+
+function addDeduped(map: Map<string, string>, value: string): void {
+    const clean = value.trim();
+    if (!clean) return;
+    const key = clean.toLocaleLowerCase();
+    if (!map.has(key)) map.set(key, clean);
+}
+
+export function buildPortalWhoIsComing(
+    tasks: readonly PortalTrackerTask[],
+    now = new Date(),
+): PortalDayVisitors[] {
+    const start = startOfUtcDay(now);
+
+    return Array.from({ length: 7 }, (_, offset): PortalDayVisitors => {
+        const day = addUtcDays(start, offset);
+        const dayTime = day.getTime();
+        const dayIso = day.toISOString().slice(0, 10);
+        const crew = new Map<string, string>();
+        const subcontractors = new Map<string, string>();
+        const appointments: PortalAppointment[] = [];
+
+        for (const task of tasks) {
+            if (task.type === "appointment") {
+                if (dateKey(task.startDate) === dayIso) {
+                    appointments.push({
+                        name: task.name,
+                        date: dayIso,
+                        scheduledTime: task.scheduledTime,
+                        confirmationStatus: task.confirmationStatus === "confirmed"
+                            ? "confirmed"
+                            : "pending confirmation",
+                    });
+                }
+                continue;
+            }
+
+            const taskStart = startOfUtcDay(toDate(task.startDate)).getTime();
+            const taskEnd = startOfUtcDay(toDate(task.endDate)).getTime();
+            if (dayTime < taskStart || dayTime > taskEnd || isComplete(task)) continue;
+
+            task.assignments.forEach(assignment => addDeduped(crew, assignment.firstName));
+            task.subAssignments.forEach(assignment =>
+                addDeduped(subcontractors, assignment.companyName),
+            );
+        }
+
+        return {
+            date: dayIso,
+            crew: [...crew.values()].sort((a, b) => a.localeCompare(b)),
+            subcontractors: [...subcontractors.values()].sort((a, b) => a.localeCompare(b)),
+            appointments: appointments.sort((a, b) =>
+                (a.scheduledTime ?? "99:99").localeCompare(b.scheduledTime ?? "99:99")
+                || a.name.localeCompare(b.name),
+            ),
+        };
+    });
+}
+
+export function computeDailyLogSharedContentHash(
+    workPerformed: string,
+    photoIds: readonly string[],
+): string {
+    const canonical = JSON.stringify({
+        workPerformed,
+        photoIds: [...new Set(photoIds)].sort(),
+    });
+    return createHash("sha256").update(canonical).digest("hex");
+}
+
+function sanitizeProjectColor(color: string | null): string {
+    const candidate = color?.trim() ?? "";
+    return /^#[0-9a-f]{6}$/i.test(candidate) ? candidate : "#4c9a2a";
+}
+
+function clientTaskName(name: string): string {
+    const clean = name
+        .replace(/^\s*\d{1,3}[\s_.:/-]+/, "")
+        .replace(/^\s*[A-Z]{1,4}-\d{1,4}[\s:./-]+/i, "")
+        .trim();
+    return clean || name.trim();
+}
+
+export async function getPortalScheduleTasksCore(projectId: string): Promise<PortalTrackerTask[]> {
+    const tasks = await prisma.scheduleTask.findMany({
+        where: { projectId },
+        orderBy: [{ order: "asc" }, { startDate: "asc" }],
+        select: {
+            id: true,
+            name: true,
+            startDate: true,
+            endDate: true,
+            color: true,
+            progress: true,
+            status: true,
+            type: true,
+            order: true,
+            scheduledTime: true,
+            confirmationStatus: true,
+            dependencies: {
+                select: {
+                    id: true,
+                    predecessorId: true,
+                    dependentId: true,
+                },
+            },
+            estimateItem: {
+                select: {
+                    costCode: { select: { name: true } },
+                },
+            },
+            assignments: {
+                select: {
+                    id: true,
+                    userId: true,
+                    user: { select: { name: true } },
+                },
+            },
+            subAssignments: {
+                select: {
+                    id: true,
+                    subcontractor: { select: { companyName: true } },
+                },
+            },
+        },
+    });
+
+    return tasks.map(task => ({
+        id: task.id,
+        name: task.name,
+        startDate: task.startDate,
+        endDate: task.endDate,
+        color: task.color,
+        progress: task.progress,
+        status: task.status,
+        type: task.type,
+        order: task.order,
+        costCodeName: task.estimateItem?.costCode?.name ?? null,
+        scheduledTime: task.scheduledTime,
+        confirmationStatus: task.confirmationStatus,
+        dependencies: task.dependencies,
+        assignments: task.assignments.map(assignment => ({
+            id: assignment.id,
+            userId: assignment.userId,
+            firstName: assignment.user.name?.trim().split(/\s+/)[0] || "Crew",
+        })),
+        subAssignments: task.subAssignments.map(assignment => ({
+            id: assignment.id,
+            companyName: assignment.subcontractor.companyName,
+        })),
+    }));
+}
+
+export async function getPortalProjectTrackerCore(
+    projectId: string,
+    now = new Date(),
+): Promise<PortalProjectTrackerPayload> {
+    const [project, tasks] = await Promise.all([
+        prisma.project.findUnique({
+            where: { id: projectId },
+            select: { color: true },
+        }),
+        getPortalScheduleTasksCore(projectId),
+    ]);
+    if (!project) throw new Error("Project not found");
+
+    const tracker = buildProjectTracker(tasks);
+    const whatsNext = chronologicalTasks(tasks)
+        .filter(task =>
+            task.type !== "appointment"
+            && !isComplete(task)
+            && !isStarted(task),
+        )
+        .slice(0, 2)
+        .map(task => ({
+            name: clientTaskName(task.name),
+            startDate: dateKey(task.startDate),
+        }));
+
+    return {
+        projectColor: sanitizeProjectColor(project.color),
+        ...tracker,
+        whatsNext,
+        whoIsComing: buildPortalWhoIsComing(tasks, now),
+    };
+}
+
+export async function getPortalProjectTracker(
+    projectId: string,
+): Promise<PortalProjectTrackerPayload> {
+    await assertPortalProjectAccess(projectId, "showSchedule");
+    return getPortalProjectTrackerCore(projectId);
+}
+
+export async function getPortalUpdatesFeedCore(projectId: string): Promise<PortalUpdate[]> {
+    const logs = await prisma.dailyLog.findMany({
+        where: { projectId, sharedToPortal: true },
+        orderBy: [{ date: "desc" }, { createdAt: "desc" }],
+        select: {
+            id: true,
+            date: true,
+            workPerformed: true,
+            sharedContentHash: true,
+            photos: {
+                where: { sharedToPortal: true },
+                orderBy: { createdAt: "asc" },
+                select: {
+                    id: true,
+                    url: true,
+                    caption: true,
+                },
+            },
+        },
+    });
+
+    return logs.flatMap(log => {
+        const currentHash = computeDailyLogSharedContentHash(
+            log.workPerformed,
+            log.photos.map(photo => photo.id),
+        );
+        if (!log.sharedContentHash || log.sharedContentHash !== currentHash) return [];
+
+        return [{
+            id: log.id,
+            date: log.date.toISOString(),
+            workPerformed: log.workPerformed,
+            photos: log.photos.map(photo => ({
+                url: photo.url,
+                caption: photo.caption,
+            })),
+        }];
+    });
+}
+
+export async function getPortalUpdatesFeed(projectId: string): Promise<PortalUpdate[]> {
+    await assertPortalProjectAccess(projectId, "showDailyLogs");
+    return getPortalUpdatesFeedCore(projectId);
+}
+
+export async function setDailyLogPortalShareCore(
+    logId: string,
+    input: PortalShareInput,
+    actor: PortalShareActor,
+): Promise<{ shared: boolean; portalShareValid: boolean; sharedPhotoIds: string[] }> {
+    if (!["ADMIN", "MANAGER"].includes(actor.role)) throw new Error("Forbidden");
+
+    const log = await prisma.dailyLog.findUnique({
+        where: { id: logId },
+        select: {
+            id: true,
+            projectId: true,
+            workPerformed: true,
+            photos: { select: { id: true } },
+        },
+    });
+    if (!log) throw new Error("Daily log not found");
+
+    const validPhotoIds = new Set(log.photos.map(photo => photo.id));
+    const selectedPhotoIds = input.shared
+        ? [...new Set(input.photoIds)].filter(photoId => validPhotoIds.has(photoId)).sort()
+        : [];
+    if (input.shared && selectedPhotoIds.length !== new Set(input.photoIds).size) {
+        throw new Error("One or more photos do not belong to this daily log");
+    }
+
+    const sharedContentHash = input.shared
+        ? computeDailyLogSharedContentHash(log.workPerformed, selectedPhotoIds)
+        : null;
+
+    await prisma.$transaction(async tx => {
+        await tx.dailyLogPhoto.updateMany({
+            where: { dailyLogId: log.id },
+            data: { sharedToPortal: false },
+        });
+        if (selectedPhotoIds.length > 0) {
+            await tx.dailyLogPhoto.updateMany({
+                where: { dailyLogId: log.id, id: { in: selectedPhotoIds } },
+                data: { sharedToPortal: true },
+            });
+        }
+        await tx.dailyLog.update({
+            where: { id: log.id },
+            data: {
+                sharedToPortal: input.shared,
+                sharedContentHash,
+            },
+        });
+        await tx.activityLog.create({
+            data: {
+                projectId: log.projectId,
+                actorType: "TEAM",
+                actorName: actor.name,
+                action: input.shared
+                    ? "share_daily_log_to_portal"
+                    : "unshare_daily_log_from_portal",
+                entityType: "daily_log",
+                entityId: log.id,
+                entityName: `Daily log ${log.id}`,
+                metadata: JSON.stringify({
+                    shared: input.shared,
+                    photoCount: selectedPhotoIds.length,
+                }),
+            },
+        });
+    });
+
+    return {
+        shared: input.shared,
+        portalShareValid: input.shared,
+        sharedPhotoIds: selectedPhotoIds,
+    };
+}


### PR DESCRIPTION
PR-E of the dispatch arc — the client-facing payoff. Owner's brief: "like the dominoes make a pizza thing," fewer clicks, who's expected on site, and the crew's daily-log photos posted in a curated way.

## What's new
- **The tracker**: eight plain-English stages derived from the real schedule, current stage glowing in the project's color, animated progress, mobile scroll-snap. Zero clicks to answer "where's my project?"
- **What's next + Who's coming this week**: next tasks in plain language with dates; day-grouped chips for crew first names, sub companies ("Red Point Electric"), and inspections/appointments with their time and a "pending confirmation" badge. Live from the same rows the master board manages.
- **Updates feed**: shared daily logs with selected photos, lightbox included. The safety valve: any edit to shared content automatically unshares it (content hash) until an ADMIN/MANAGER re-approves. Internal fields (issues, weather, crew list, author) can never serialize — enforced by a recursive payload-key assertion in the verifier.
- Portal ownership auth consolidated into one shared helper used by every portal read.

## Verification
- New DB-backed suite ALL PASS + all seven standing gates green (18/18 publish, board, materials untouched)
- Independent checker quoted the auth helper consolidation, the minimal hash-invalidation touchpoints, schema parity, and the motion scope
- Visual review note: portal pages require a real session by design, so the look is verified by build + component review — **owner should eyeball the staff preview on any project portal after deploy** and direct styling iterations

Implemented by GPT-5.6-sol (xhigh); independently gate-checked; reviewed by Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)