### PR TITLE
MCP schedule tools + single-use write confirmations

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -976,6 +976,19 @@ model TaskAssignment {
   @@unique([taskId, userId])
 }
 
+model McpConfirmation {
+  id         String    @id @default(cuid())
+  token      String    @unique
+  toolName   String
+  argsHash   String
+  preview    String
+  createdAt  DateTime  @default(now())
+  expiresAt  DateTime
+  consumedAt DateTime?
+
+  @@index([expiresAt])
+}
+
 model Subcontractor {
   id            String  @id @default(cuid())
   companyName   String

--- a/scripts/apply-mcp-confirmations-schema.mjs
+++ b/scripts/apply-mcp-confirmations-schema.mjs
@@ -1,0 +1,69 @@
+// One-off additive migration for SPEC-f single-use MCP confirmations.
+// Safe to re-run while the previous build is live.
+//
+// Run only through the release orchestrator:
+//   node scripts/apply-mcp-confirmations-schema.mjs
+//
+// Do not run this during implementation handoff. The MCP schedule tools use
+// McpConfirmation immediately, so this schema must be applied before deploy.
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+function resolveDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const file of [".env", ".env.local"]) {
+    if (!fs.existsSync(file)) continue;
+    const match = fs.readFileSync(file, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+    if (match) return match[1];
+  }
+  throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const prisma = new PrismaClient({
+  datasources: { db: { url: resolveDatabaseUrl() } },
+});
+
+const statements = [
+  `CREATE TABLE IF NOT EXISTS "McpConfirmation" (
+     "id" TEXT NOT NULL,
+     "token" TEXT NOT NULL,
+     "toolName" TEXT NOT NULL,
+     "argsHash" TEXT NOT NULL,
+     "preview" TEXT NOT NULL,
+     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+     "expiresAt" TIMESTAMP(3) NOT NULL,
+     "consumedAt" TIMESTAMP(3),
+     CONSTRAINT "McpConfirmation_pkey" PRIMARY KEY ("id"),
+     CONSTRAINT "McpConfirmation_token_key" UNIQUE ("token")
+   )`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'McpConfirmation_token_key'
+         AND conrelid = '"McpConfirmation"'::regclass
+     ) THEN
+       ALTER TABLE "McpConfirmation"
+         ADD CONSTRAINT "McpConfirmation_token_key" UNIQUE ("token");
+     END IF;
+   END $$`,
+  `CREATE INDEX IF NOT EXISTS "McpConfirmation_expiresAt_idx"
+     ON "McpConfirmation" ("expiresAt")`,
+
+  // Server-only table. RLS with no policies denies anon/authenticated access
+  // through Supabase's exposed Data API. Prisma uses the database-owner
+  // server connection, and this script intentionally does not FORCE RLS.
+  `ALTER TABLE "McpConfirmation" ENABLE ROW LEVEL SECURITY`,
+];
+
+try {
+  for (const sql of statements) {
+    await prisma.$executeRawUnsafe(sql);
+    console.log("applied:", sql.split("\n")[0]);
+  }
+  console.log("McpConfirmation schema applied successfully.");
+} catch (error) {
+  console.error("Migration failed:", error);
+  process.exitCode = 1;
+} finally {
+  await prisma.$disconnect();
+}

--- a/scripts/verify-mcp-schedule-tools.ts
+++ b/scripts/verify-mcp-schedule-tools.ts
@@ -1,0 +1,561 @@
+// Behavioral verification for SPEC-f MCP schedule tools.
+//
+// This verifier never applies schema. The release orchestrator must run
+// scripts/apply-mcp-confirmations-schema.mjs before the DB cases can pass.
+//
+// Usage against Supabase:
+//   $env:ALLOW_PROD_VERIFY="1"
+//   npx tsx --env-file=.env.local scripts/verify-mcp-schedule-tools.ts
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+
+import { prisma } from "../src/lib/prisma";
+
+const DAY = 86_400_000;
+const BASE = Date.UTC(2048, 4, 4);
+const RUN_ID = randomUUID().replaceAll("-", "").slice(0, 12);
+const FIXTURE_PREFIX = `MCP SCHEDULE VERIFY ${RUN_ID}`;
+
+function day(offset: number): Date {
+    return new Date(BASE + offset * DAY);
+}
+
+function dayKey(offset: number): string {
+    return day(offset).toISOString().slice(0, 10);
+}
+
+function source(path: string): string {
+    return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
+function loadDatabaseUrl(): string {
+    if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+    for (const file of [".env.local", ".env"]) {
+        if (!existsSync(file)) continue;
+        const match = readFileSync(file, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\r\n]+)"?/m);
+        if (match) {
+            process.env.DATABASE_URL = match[1];
+            return match[1];
+        }
+    }
+    return "";
+}
+
+async function rejectsWith(run: () => Promise<unknown>, pattern: RegExp): Promise<void> {
+    let message = "";
+    try {
+        await run();
+    } catch (error) {
+        message = String((error as Error)?.message ?? error);
+    }
+    assert.match(message, pattern);
+}
+
+function normalizedKey(key: string): string {
+    return key.replace(/[^a-z0-9]/gi, "").toLowerCase();
+}
+
+const FORBIDDEN_AVAILABILITY_KEYS = new Set([
+    "email",
+    "rate",
+    "hourlyrate",
+    "burdenrate",
+    "burdenedhourlyrate",
+    "cost",
+    "amount",
+    "total",
+    "budget",
+    "revenue",
+    "contractvalue",
+    "financials",
+]);
+
+function assertNoFinancialKeys(value: unknown, path = "availability"): void {
+    if (Array.isArray(value)) {
+        value.forEach((child, index) => assertNoFinancialKeys(child, `${path}[${index}]`));
+        return;
+    }
+    if (!value || typeof value !== "object") return;
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+        // materialCounts.{pending,staged,missing,resolved,total} are item
+        // COUNTS, not money — the one sanctioned "total" in MCP output.
+        if (path.endsWith(".materialCounts") && normalizedKey(key) === "total") continue;
+        assert.ok(
+            !FORBIDDEN_AVAILABILITY_KEYS.has(normalizedKey(key)),
+            `${path}.${key} is forbidden in MCP availability output`,
+        );
+        assertNoFinancialKeys(child, `${path}.${key}`);
+    }
+}
+
+function confirmationToken(result: any): string {
+    assert.equal(result.confirmationRequired, true);
+    assert.equal(typeof result.preview, "string");
+    assert.ok(result.preview.length > 0);
+    assert.match(result.confirmToken, /^[a-f0-9]{64}$/);
+    assert.ok(Date.parse(result.expiresAt) > Date.now());
+    return result.confirmToken;
+}
+
+async function main() {
+    const databaseUrl = loadDatabaseUrl();
+    if (databaseUrl.includes("supabase.c") && process.env.ALLOW_PROD_VERIFY !== "1") {
+        console.error(
+            "[verify-mcp-schedule-tools] REFUSING TO RUN: DATABASE_URL points at Supabase.\n" +
+            "This script creates and deletes verification fixtures.\n" +
+            "Set ALLOW_PROD_VERIFY=1 to opt in.",
+        );
+        process.exit(1);
+    }
+
+    // This file is intentionally the first implementation artifact. Its first
+    // pre-implementation run must fail here, before any production module or
+    // schema change exists.
+    const coreUrl = new URL("../src/lib/mcp-schedule-tools.ts", import.meta.url);
+    assert.ok(
+        existsSync(coreUrl),
+        "src/lib/mcp-schedule-tools.ts does not exist yet (expected RED before implementation)",
+    );
+
+    const routeSource = source("../src/app/api/mcp/[transport]/route.ts");
+    const schemaSource = source("../prisma/schema.prisma");
+    const coreSource = source("../src/lib/mcp-schedule-tools.ts");
+    const taskCoreSource = source("../src/lib/schedule-task-core.ts");
+    const applySource = source("./apply-mcp-confirmations-schema.mjs");
+
+    // Static schema/security and registry contract.
+    assert.match(schemaSource, /model McpConfirmation \{/);
+    for (const field of [
+        "token",
+        "toolName",
+        "argsHash",
+        "preview",
+        "createdAt",
+        "expiresAt",
+        "consumedAt",
+    ]) {
+        assert.match(schemaSource, new RegExp(`\\b${field}\\b`), `McpConfirmation must include ${field}`);
+    }
+    assert.match(schemaSource, /\btoken\s+String\s+@unique/);
+    assert.match(applySource, /CREATE TABLE IF NOT EXISTS "McpConfirmation"/);
+    assert.match(applySource, /ENABLE ROW LEVEL SECURITY/);
+    assert.doesNotMatch(applySource, /CREATE POLICY/i, "server-only confirmations must have no anon/authenticated policy");
+    assert.match(coreSource, /randomBytes\(32\)\.toString\("hex"\)/);
+    assert.match(coreSource, /createHash\("sha256"\)/);
+    assert.match(coreSource, /consumedAt:\s*null/);
+    assert.match(coreSource, /expiresAt:\s*\{\s*gt:/);
+    assert.match(coreSource, /updateMany\(/);
+    assert.match(coreSource, /prisma\.\$transaction\(/);
+    assert.match(taskCoreSource, /Prisma\.TransactionClient/);
+
+    for (const toolName of [
+        "get_project_schedule",
+        "plan_schedule",
+        "update_task_dates",
+        "set_task_status",
+        "assign_task_crew",
+        "list_crew_availability",
+        "set_project_start_date",
+        "generate_project_schedule",
+        "assign_project_crew",
+        "apply_change_order_to_schedule",
+    ]) {
+        assert.match(routeSource, new RegExp(`"${toolName}"`), `${toolName} must stay registered`);
+    }
+    for (const adapter of [
+        "getProjectSchedule",
+        "planSchedule",
+        "updateTaskDates",
+        "setTaskStatus",
+        "assignTaskCrew",
+        "listCrewAvailability",
+        "setProjectStartDateWithConfirmation",
+        "generateProjectScheduleWithConfirmation",
+        "assignProjectCrewWithConfirmation",
+        "applyChangeOrderToScheduleWithConfirmation",
+    ]) {
+        assert.match(routeSource, new RegExp(`\\b${adapter}\\b`), `route must delegate to ${adapter}`);
+    }
+    assert.match(routeSource, /YYYY-MM-DD/);
+    assert.match(routeSource, /confirmation token|confirmToken/i);
+    assert.match(routeSource, /serverInfo:\s*\{\s*name:\s*"probuild",\s*version:\s*"(?!1\.10\.0)[^"]+"/);
+
+    // Customer-facing send tools deliberately stay on the established HMAC
+    // flow; schedule writers must not call that stateless helper.
+    assert.match(routeSource, /function mintPreviewToken/);
+    assert.match(routeSource, /function verifyPreviewToken/);
+    const scheduleStart = routeSource.indexOf('"get_company_schedule"');
+    const scheduleRegistry = routeSource.slice(scheduleStart);
+    assert.doesNotMatch(scheduleRegistry, /mintPreviewToken|verifyPreviewToken/);
+    console.log("PASS static confirmation schema, RLS, registry, and delegation contracts");
+
+    const tools: any = await import("../src/lib/mcp-schedule-tools");
+    const confirmationDelegate = (prisma as any).mcpConfirmation;
+
+    // Fails cleanly with P2021 until the release orchestrator applies the new
+    // table. No fixture is written before this schema readiness check.
+    await confirmationDelegate.findFirst({ select: { id: true } });
+
+    const collected = {
+        clientIds: [] as string[],
+        projectIds: [] as string[],
+        userIds: [] as string[],
+        confirmationTokens: [] as string[],
+    };
+    let cleanupPassed = false;
+
+    try {
+        const client = await prisma.client.create({
+            data: {
+                name: `${FIXTURE_PREFIX} CLIENT DELETE ME`,
+                initials: "MS",
+                email: `mcp-schedule-client-${RUN_ID}@example.invalid`,
+            },
+        });
+        collected.clientIds.push(client.id);
+
+        const alice = await prisma.user.create({
+            data: {
+                email: `alice-${RUN_ID}@example.invalid`,
+                name: "Alice Johnson",
+                role: "FIELD_CREW",
+                status: "ACTIVATED",
+            },
+        });
+        const bob = await prisma.user.create({
+            data: {
+                email: `bob-${RUN_ID}@example.invalid`,
+                name: "Bob Stone",
+                role: "FIELD_CREW",
+                status: "ACTIVATED",
+            },
+        });
+        const samOne = await prisma.user.create({
+            data: {
+                email: `sam-one-${RUN_ID}@example.invalid`,
+                name: "Sam Rivera",
+                role: "FIELD_CREW",
+                status: "ACTIVATED",
+            },
+        });
+        const samTwo = await prisma.user.create({
+            data: {
+                email: `sam-two-${RUN_ID}@example.invalid`,
+                name: "Sam Taylor",
+                role: "FIELD_CREW",
+                status: "ACTIVATED",
+            },
+        });
+        collected.userIds.push(alice.id, bob.id, samOne.id, samTwo.id);
+
+        const project = await prisma.project.create({
+            data: {
+                name: `${FIXTURE_PREFIX} PROJECT DELETE ME`,
+                clientId: client.id,
+                status: "In Progress",
+                startDate: day(0),
+                endDate: day(20),
+                color: "#2563eb",
+                crew: { connect: [{ id: alice.id }, { id: bob.id }] },
+            },
+        });
+        collected.projectIds.push(project.id);
+
+        const lifecycleTask = await prisma.scheduleTask.create({
+            data: {
+                projectId: project.id,
+                name: "Lifecycle probe",
+                startDate: day(1),
+                endDate: day(3),
+                status: "Not Started",
+            },
+        });
+        const expiredTask = await prisma.scheduleTask.create({
+            data: {
+                projectId: project.id,
+                name: "Expired probe",
+                startDate: day(2),
+                endDate: day(4),
+                status: "Not Started",
+            },
+        });
+        const tamperTask = await prisma.scheduleTask.create({
+            data: {
+                projectId: project.id,
+                name: "Tamper probe",
+                startDate: day(3),
+                endDate: day(5),
+                status: "Not Started",
+            },
+        });
+        const concurrentTask = await prisma.scheduleTask.create({
+            data: {
+                projectId: project.id,
+                name: "Concurrent probe",
+                startDate: day(4),
+                endDate: day(6),
+                status: "Not Started",
+            },
+        });
+
+        // Confirmation lifecycle: happy path consumes once, replay fails.
+        const happyArgs = { taskId: lifecycleTask.id, startDate: dayKey(5), endDate: dayKey(7) };
+        const happyPreview = await tools.updateTaskDates(happyArgs);
+        const happyToken = confirmationToken(happyPreview);
+        collected.confirmationTokens.push(happyToken);
+        const happy = await tools.updateTaskDates({ ...happyArgs, confirmToken: happyToken });
+        assert.equal(happy.confirmed, true);
+        const lifecycleAfter = await prisma.scheduleTask.findUniqueOrThrow({ where: { id: lifecycleTask.id } });
+        assert.equal(lifecycleAfter.startDate.toISOString().slice(0, 10), dayKey(5));
+        assert.ok((await confirmationDelegate.findUniqueOrThrow({ where: { token: happyToken } })).consumedAt);
+        await rejectsWith(
+            () => tools.updateTaskDates({ ...happyArgs, confirmToken: happyToken }),
+            /already used|consumed|confirmation/i,
+        );
+
+        // Expired tokens fail without mutating the task.
+        const expiredArgs = { taskId: expiredTask.id, startDate: dayKey(6), endDate: dayKey(8) };
+        const expiredPreview = await tools.updateTaskDates(expiredArgs);
+        const expiredToken = confirmationToken(expiredPreview);
+        collected.confirmationTokens.push(expiredToken);
+        await confirmationDelegate.update({
+            where: { token: expiredToken },
+            data: { expiresAt: new Date(Date.now() - 1_000) },
+        });
+        await rejectsWith(
+            () => tools.updateTaskDates({ ...expiredArgs, confirmToken: expiredToken }),
+            /expired/i,
+        );
+        assert.equal(
+            (await prisma.scheduleTask.findUniqueOrThrow({ where: { id: expiredTask.id } })).startDate.toISOString().slice(0, 10),
+            dayKey(2),
+        );
+
+        // A token is bound to canonical arguments.
+        const tamperArgs = { taskId: tamperTask.id, startDate: dayKey(7), endDate: dayKey(9) };
+        const tamperPreview = await tools.updateTaskDates(tamperArgs);
+        const tamperToken = confirmationToken(tamperPreview);
+        collected.confirmationTokens.push(tamperToken);
+        await rejectsWith(
+            () => tools.updateTaskDates({ ...tamperArgs, endDate: dayKey(10), confirmToken: tamperToken }),
+            /arguments|tamper|match|confirmation/i,
+        );
+        assert.equal(
+            (await prisma.scheduleTask.findUniqueOrThrow({ where: { id: tamperTask.id } })).startDate.toISOString().slice(0, 10),
+            dayKey(3),
+        );
+
+        // Concurrent double-consume: the claim and schedule mutation share one
+        // transaction, so exactly one contender commits.
+        const concurrentArgs = { taskId: concurrentTask.id, startDate: dayKey(8), endDate: dayKey(10) };
+        const concurrentPreview = await tools.updateTaskDates(concurrentArgs);
+        const concurrentToken = confirmationToken(concurrentPreview);
+        collected.confirmationTokens.push(concurrentToken);
+        const contenders = await Promise.allSettled([
+            tools.updateTaskDates({ ...concurrentArgs, confirmToken: concurrentToken }),
+            tools.updateTaskDates({ ...concurrentArgs, confirmToken: concurrentToken }),
+        ]);
+        assert.equal(contenders.filter(result => result.status === "fulfilled").length, 1);
+        assert.equal(contenders.filter(result => result.status === "rejected").length, 1);
+        console.log("PASS confirmation happy path, replay, expiry, tamper, and concurrent single-consume");
+
+        // Bulk creation resolves first and full names, preserves lead role, and
+        // creates every task inside the confirmation transaction.
+        const planArgs = {
+            projectId: project.id,
+            tasks: [
+                {
+                    name: "Demo kitchen",
+                    startDate: dayKey(10),
+                    endDate: dayKey(12),
+                    crewNames: ["Alice", "Bob Stone"],
+                    leadName: "Alice Johnson",
+                    doneWhen: "Kitchen is cleared and swept",
+                    estimatedHours: 16,
+                },
+                {
+                    name: "Owner walkthrough",
+                    startDate: dayKey(12),
+                    endDate: dayKey(12),
+                    type: "appointment",
+                    scheduledTime: "14:30",
+                    crewNames: ["Bob"],
+                },
+            ],
+        };
+        const planPreview = await tools.planSchedule(planArgs);
+        const planToken = confirmationToken(planPreview);
+        collected.confirmationTokens.push(planToken);
+        assert.match(planPreview.preview, /Demo kitchen/);
+        assert.match(planPreview.preview, /Owner walkthrough/);
+        assert.match(planPreview.preview, /Alice Johnson/);
+        const planned = await tools.planSchedule({ ...planArgs, confirmToken: planToken });
+        assert.equal(planned.confirmed, true);
+        assert.equal(planned.created.length, 2);
+        const demo = await prisma.scheduleTask.findFirstOrThrow({
+            where: { projectId: project.id, name: "Demo kitchen" },
+            include: { assignments: true },
+        });
+        assert.equal(demo.assignments.length, 2);
+        assert.equal(demo.assignments.find(assignment => assignment.role === "lead")?.userId, alice.id);
+
+        await rejectsWith(
+            () => tools.planSchedule({
+                projectId: project.id,
+                tasks: [{
+                    name: "Ambiguous crew probe",
+                    startDate: dayKey(13),
+                    endDate: dayKey(14),
+                    crewNames: ["Sam"],
+                }],
+            }),
+            /ambiguous.*Sam Rivera.*Sam Taylor|Sam Rivera.*Sam Taylor.*ambiguous/i,
+        );
+
+        // A failure discovered during execution rolls back earlier creates.
+        const atomicArgs = {
+            projectId: project.id,
+            tasks: [
+                { name: "Atomic first", startDate: dayKey(14), endDate: dayKey(15) },
+                { name: "Atomic second", startDate: dayKey(15), endDate: dayKey(16), crewNames: ["Bob"] },
+            ],
+        };
+        const atomicPreview = await tools.planSchedule(atomicArgs);
+        const atomicToken = confirmationToken(atomicPreview);
+        collected.confirmationTokens.push(atomicToken);
+        await prisma.user.update({ where: { id: bob.id }, data: { status: "DISABLED" } });
+        await rejectsWith(
+            () => tools.planSchedule({ ...atomicArgs, confirmToken: atomicToken }),
+            /ACTIVATED|crew/i,
+        );
+        await prisma.user.update({ where: { id: bob.id }, data: { status: "ACTIVATED" } });
+        assert.equal(
+            await prisma.scheduleTask.count({
+                where: { projectId: project.id, name: { in: ["Atomic first", "Atomic second"] } },
+            }),
+            0,
+        );
+        console.log("PASS plan_schedule bulk create, crew resolution, ambiguity, and transaction rollback");
+
+        // Thin wrappers retain the canonical domain rules.
+        await rejectsWith(
+            () => tools.setTaskStatus({ taskId: demo.id, status: "Blocked" }),
+            /Blocked tasks require a reason/i,
+        );
+        const blockedArgs = { taskId: demo.id, status: "Blocked", blockedReason: "Waiting for inspection" };
+        const blockedPreview = await tools.setTaskStatus(blockedArgs);
+        const blockedToken = confirmationToken(blockedPreview);
+        collected.confirmationTokens.push(blockedToken);
+        await tools.setTaskStatus({ ...blockedArgs, confirmToken: blockedToken });
+        assert.equal((await prisma.scheduleTask.findUniqueOrThrow({ where: { id: demo.id } })).blockedReason, "Waiting for inspection");
+
+        await rejectsWith(
+            () => tools.updateTaskDates({ taskId: demo.id, startDate: dayKey(18), endDate: dayKey(17) }),
+            /end date/i,
+        );
+
+        const crewArgs = {
+            taskId: demo.id,
+            crewNames: ["Bob Stone"],
+            leadName: "Bob",
+        };
+        const crewPreview = await tools.assignTaskCrew(crewArgs);
+        const crewToken = confirmationToken(crewPreview);
+        collected.confirmationTokens.push(crewToken);
+        const crewResult = await tools.assignTaskCrew({ ...crewArgs, confirmToken: crewToken });
+        assert.equal(crewResult.assignments.length, 1);
+        assert.equal(crewResult.assignments[0].userId, bob.id);
+        assert.equal(crewResult.assignments[0].role, "lead");
+        console.log("PASS status, dates, and task-crew wrappers enforce canonical rules");
+
+        await prisma.taskMaterial.create({
+            data: {
+                taskId: demo.id,
+                text: "Dust barrier",
+                status: "pending",
+                sourceKind: "manual",
+            },
+        });
+        await prisma.taskMaterial.create({
+            data: {
+                taskId: demo.id,
+                text: "Floor protection",
+                status: "staged",
+                sourceKind: "manual",
+            },
+        });
+        const projectSchedule = await tools.getProjectSchedule({ jobName: project.name });
+        assertNoFinancialKeys(projectSchedule);
+        assert.equal(projectSchedule.projectId, project.id);
+        const demoRead = projectSchedule.tasks.find((task: any) => task.id === demo.id);
+        assert.ok(demoRead);
+        assert.deepEqual(demoRead.materialCounts, { pending: 1, staged: 1, missing: 0, resolved: 0, total: 2 });
+        assert.equal(demoRead.leadName, "Bob Stone");
+        assert.equal(demoRead.doneWhen, "Kitchen is cleared and swept");
+
+        const availability = await tools.listCrewAvailability({ startDate: dayKey(10), days: 7 });
+        assertNoFinancialKeys(availability);
+        assert.ok(Array.isArray(availability.crew));
+        assert.ok(availability.crew.every((member: any) => member.days.length === 7));
+        const aliceAvailability = availability.crew.find((member: any) => member.userId === alice.id);
+        // Alice stays in the roster (ACTIVATED FIELD_CREW) even though the
+        // crew-wrapper test above reassigned "Demo kitchen" to Bob only —
+        // so the BOOKED expectation belongs to Bob, and Alice reads free.
+        assert.ok(aliceAvailability);
+        assert.ok(aliceAvailability.days.every((entry: any) => !entry.bookedTasks.includes("Demo kitchen")));
+        const bobAvailability = availability.crew.find((member: any) => member.userId === bob.id);
+        assert.ok(bobAvailability);
+        assert.ok(
+            bobAvailability.days.some((entry: any) =>
+                entry.status === "booked" && entry.bookedTasks.includes("Demo kitchen"),
+            ),
+        );
+        console.log("PASS project schedule detail/material counts and financial-free crew availability");
+    } finally {
+        try {
+            if (collected.confirmationTokens.length > 0) {
+                await confirmationDelegate.deleteMany({
+                    where: { token: { in: collected.confirmationTokens } },
+                });
+            }
+            if (collected.projectIds.length > 0) {
+                await prisma.project.deleteMany({ where: { id: { in: collected.projectIds } } });
+            }
+            if (collected.userIds.length > 0) {
+                await prisma.user.deleteMany({ where: { id: { in: collected.userIds } } });
+            }
+            if (collected.clientIds.length > 0) {
+                await prisma.client.deleteMany({ where: { id: { in: collected.clientIds } } });
+            }
+
+            const [confirmationsLeft, clientsLeft, projectsLeft, usersLeft] = await Promise.all([
+                confirmationDelegate.count({ where: { token: { in: collected.confirmationTokens } } }),
+                prisma.client.count({ where: { id: { in: collected.clientIds } } }),
+                prisma.project.count({ where: { id: { in: collected.projectIds } } }),
+                prisma.user.count({ where: { id: { in: collected.userIds } } }),
+            ]);
+            cleanupPassed = confirmationsLeft === 0 && clientsLeft === 0 && projectsLeft === 0 && usersLeft === 0;
+        } catch (error) {
+            console.error("Fixture cleanup error:", error);
+        }
+        console.log(`${cleanupPassed ? "PASS" : "FAIL"} fixture cleanup`);
+    }
+
+    assert.equal(cleanupPassed, true);
+    console.log("mcp-schedule-tools verification: PASS");
+}
+
+main()
+    .catch(error => {
+        console.error("mcp-schedule-tools verification: FAIL");
+        console.error(error);
+        process.exitCode = 1;
+    })
+    .finally(async () => {
+        try {
+            await prisma.$disconnect();
+        } catch {
+            // Static RED and missing-schema failures can happen before Prisma connects.
+        }
+    });

--- a/scripts/verify-phase3-co-schedule.ts
+++ b/scripts/verify-phase3-co-schedule.ts
@@ -153,7 +153,7 @@ async function main() {
         pass("(a) approveEstimate wires the post-commit auto-generator", approveBody.includes("autoGenerateScheduleForApprovedEstimate"));
         pass("(a) dashboard generation passes requireEmptyProject true", /generateProjectScheduleAction[\s\S]*?requireEmptyProject:\s*true/.test(actionsSource));
         const scheduleCoreSource = fs.readFileSync(new URL("../src/lib/schedule-core.ts", import.meta.url), "utf8");
-        const setDateBody = scheduleCoreSource.slice(scheduleCoreSource.indexOf("export async function setProjectStartDate"), scheduleCoreSource.indexOf("export interface CashflowBucket"));
+        const setDateBody = scheduleCoreSource.slice(scheduleCoreSource.indexOf("async function runSetProjectStartDate"), scheduleCoreSource.indexOf("export interface CashflowBucket"));
         const autoBody = scheduleCoreSource.slice(scheduleCoreSource.indexOf("export async function autoGenerateScheduleForApprovedEstimate"), scheduleCoreSource.indexOf("export class CoSchedulePreconditionError"));
         const importerBody = actionsSource.slice(actionsSource.indexOf("export async function importEstimateToSchedule"), actionsSource.indexOf("export async function generateProjectScheduleAction"));
         pass("(a) every automatic caller requires an empty project", setDateBody.includes("requireEmptyProject: true") && autoBody.includes("requireEmptyProject: true"));
@@ -370,6 +370,7 @@ async function main() {
         const billingSource = fs.readFileSync(new URL("../src/lib/billing-core.ts", import.meta.url), "utf8");
         const mcpSource = fs.readFileSync(new URL("../src/app/api/mcp/[transport]/route.ts", import.meta.url), "utf8");
         const dashboardSource = fs.readFileSync(new URL("../src/app/company-dashboard/CompanyDashboardClient.tsx", import.meta.url), "utf8");
+        const crewPickersSource = fs.readFileSync(new URL("../src/app/company-dashboard/schedule-board/CrewPickers.tsx", import.meta.url), "utf8");
         const coApplyStart = scheduleSource.indexOf("export async function applyChangeOrderToSchedule");
         const coApplyEnd = scheduleSource.indexOf("export async function setTaskCrew", coApplyStart);
         const coApplyBody = scheduleSource.slice(coApplyStart, coApplyEnd);
@@ -384,9 +385,9 @@ async function main() {
         const mcpGeneratorBody = mcpSource.slice(mcpSource.indexOf('"generate_project_schedule"'), mcpSource.indexOf('"assign_project_crew"'));
         pass("(f) MCP generator preserves explicit merge semantics", !mcpGeneratorBody.includes("requireEmptyProject"));
         pass("(f) MCP schedule read exposes unapplied CO details", mcpSource.includes("unappliedChangeOrders"));
-        pass("(f) MCP advertises contract version 1.9.0", mcpSource.includes('version: "1.9.0"'));
+        pass("(f) MCP advertises contract version 1.11.0", mcpSource.includes('version: "1.11.0"'));
         pass("(f) MCP instructions explain automatic and explicit CO application", mcpSource.includes("change orders adjust the schedule") && mcpSource.includes("deductions never auto-remove tasks"));
-        pass("(f) dashboard includes expandable task rows and task crew action", dashboardSource.includes("aria-expanded") && dashboardSource.includes("updateTaskCrewAction"));
+        pass("(f) dashboard includes expandable task rows and task crew action", dashboardSource.includes("aria-expanded") && crewPickersSource.includes("updateTaskCrewAction"));
         pass("(f) dashboard includes Apply CO control", dashboardSource.includes("applyChangeOrderToScheduleAction") && dashboardSource.includes("Apply CO"));
         pass("(f) hover controls are keyboard/touch accessible", dashboardSource.includes("focus:opacity-100") && dashboardSource.includes("[@media(hover:none)]:opacity-100") && dashboardSource.includes("pointer-events-none") && dashboardSource.includes("focus:pointer-events-auto"));
         pass("(f) ADMIN views distinguish projected CO money", dashboardSource.includes("coProjected") && dashboardSource.includes("Projected CO"));

--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -33,6 +33,7 @@ const cellActivationSource = src("../src/app/company-dashboard/schedule-board/em
 const popoverSource = src("../src/app/company-dashboard/schedule-board/FloatingPopover.tsx");
 const actionsSource = src("../src/lib/actions.ts");
 const coreSource = src("../src/lib/schedule-core.ts");
+const taskCoreSource = src("../src/lib/schedule-task-core.ts");
 const dispatchIntentSource = src("../src/lib/dispatch-intent.ts");
 const dispatchPublicationSource = src("../src/lib/dispatch-publication.ts");
 const weatherSource = src("../src/lib/weather.ts");
@@ -274,12 +275,12 @@ assert.match(characterizedTaskPointerBody, /sourceOffsetX: drag\.originX - drag\
 assert.match(characterizedEndResizeBody, /sourceOffsetX: drag\.originX - drag\.startX/, "project end-resize ghosts stay anchored to their autoscrolled source");
 
 // ── Item 1: crew ACTIVATED validation is added-only ──
-const setProjectCrewStart = coreSource.indexOf("export async function setProjectCrew");
+const setProjectCrewStart = coreSource.indexOf("async function runSetProjectCrew");
 const setProjectCrewEnd = coreSource.indexOf("export interface CrewConflictPair", setProjectCrewStart);
 const setProjectCrewBody = coreSource.slice(setProjectCrewStart, setProjectCrewEnd);
 assert.match(setProjectCrewBody, /toConnect\.map\(id => byId\.get\(id\)!\)\.filter\(u => u\.status !== "ACTIVATED"\)/);
 assert.ok(setProjectCrewBody.indexOf("toConnect = wanted.filter") < setProjectCrewBody.indexOf("notActivated ="), "toConnect must be computed before the ACTIVATED check runs against it");
-const setTaskCrewBody = coreSource.slice(coreSource.indexOf("export async function setTaskCrew"));
+const setTaskCrewBody = coreSource.slice(coreSource.indexOf("async function runSetTaskCrew"));
 assert.match(setTaskCrewBody, /toAdd\.map\(id => byId\.get\(id\)!\)\.filter\(u => u\.status !== "ACTIVATED"\)/);
 
 // ── Item 3: floating popovers escape clipping via a portal ──
@@ -680,9 +681,10 @@ assert.match(getTaskDetailBody, /await assertScheduleTaskAccess\(taskId\);/, "ta
 const updateTaskStart = actionsSource.indexOf("export async function updateScheduleTask(");
 const updateTaskEnd = actionsSource.indexOf("export async function", updateTaskStart + 1);
 const updateTaskBody = actionsSource.slice(updateTaskStart, updateTaskEnd);
-assert.match(updateTaskBody, /nextStatus === "Blocked"/, "the mutation core must enforce Blocked as a domain invariant");
-assert.match(updateTaskBody, /Blocked tasks require a reason/, "Blocked must reject an empty reason server-side");
-assert.match(updateTaskBody, /updateData\.blockedReason = null/, "moving away from Blocked must clear its reason");
+assert.match(updateTaskBody, /updateScheduleTaskInTransaction\(/, "the authenticated action must delegate to the canonical mutation core");
+assert.match(taskCoreSource, /nextStatus === "Blocked"/, "the mutation core must enforce Blocked as a domain invariant");
+assert.match(taskCoreSource, /Blocked tasks require a reason/, "Blocked must reject an empty reason server-side");
+assert.match(taskCoreSource, /updateData\.blockedReason = null/, "moving away from Blocked must clear its reason");
 
 // Board creation is one proper shared modal and reuses the exact crew checklist
 // presentation used by the quick menus, including the lead-star affordance.
@@ -945,8 +947,9 @@ assert.match(taskCreationDialogSource, /estimateItemId\?: string/);
 const createScheduleTaskStart = actionsSource.indexOf("export async function createScheduleTask(");
 const createScheduleTaskEnd = actionsSource.indexOf("export async function updateScheduleTask(", createScheduleTaskStart);
 const createScheduleTaskBody = actionsSource.slice(createScheduleTaskStart, createScheduleTaskEnd);
-assert.match(createScheduleTaskBody, /estimateItemId\?: string \| null/);
-assert.match(createScheduleTaskBody, /estimateItemId,/, "Task Bank creation must persist its normalized estimate-item back-link");
+assert.match(createScheduleTaskBody, /createScheduleTaskInTransaction\(/, "the authenticated action must delegate to the canonical transaction-aware creator");
+assert.match(taskCoreSource, /estimateItemId\?: string \| null/);
+assert.match(taskCoreSource, /estimateItemId,/, "Task Bank creation must persist its normalized estimate-item back-link");
 
 // A crew draft gates only immediate user-assignment controls in the drawer.
 assert.match(boardSource, /const openTaskHasCrewDraft = Boolean\(openTaskId && crewDrafts\[openTaskId\]\)/);

--- a/scripts/verify-schedule-board.ts
+++ b/scripts/verify-schedule-board.ts
@@ -518,6 +518,7 @@ async function main() {
             && /UPDATE "ScheduleTask"[\s\S]*?RETURNING "id", "startDate", "endDate"/.test(scheduleCoreSource));
 
         const actionsSource = readFileSync(new URL("../src/lib/actions.ts", import.meta.url), "utf8");
+        const scheduleTaskCoreSource = readFileSync(new URL("../src/lib/schedule-task-core.ts", import.meta.url), "utf8");
         const actionStart = actionsSource.indexOf("export async function shiftNotStartedTasksAction");
         const actionEnd = actionsSource.indexOf("export async function generateProjectScheduleAction", actionStart);
         const actionBody = actionsSource.slice(actionStart, actionEnd);
@@ -533,11 +534,11 @@ async function main() {
         check("canonical task action preserves schedule permission and project access for date mutations", canonicalTaskActionStart >= 0
             && canonicalTaskActionBody.includes("await assertScheduleTaskAccess(taskId)")
             && !canonicalTaskActionBody.includes('["ADMIN", "MANAGER"].includes(user.role)')
-            && canonicalTaskActionBody.includes("parseStartDateInput")
-            && canonicalTaskActionBody.includes('SELECT id FROM "Project"')
-            && canonicalTaskActionBody.includes('SELECT id FROM "ScheduleTask"')
-            && canonicalTaskActionBody.includes("persistedTask.type === \"milestone\"")
-            && canonicalTaskActionBody.includes('revalidatePath("/company-dashboard")'));
+            && canonicalTaskActionBody.includes("updateScheduleTaskInTransaction(")
+            && canonicalTaskActionBody.includes('revalidatePath("/company-dashboard")')
+            && scheduleTaskCoreSource.includes("parseStartDateInput")
+            && scheduleTaskCoreSource.includes("lockTaskAssignmentParent(tx, taskId")
+            && scheduleTaskCoreSource.includes('persisted.type === "milestone"'));
         const companyTaskAdapterStart = actionsSource.indexOf("export async function updateCompanyScheduleTaskDatesAction");
         const companyTaskAdapterEnd = actionsSource.indexOf("export async function updateProjectStatus", companyTaskAdapterStart);
         const companyTaskAdapterBody = actionsSource.slice(companyTaskAdapterStart, companyTaskAdapterEnd);
@@ -721,12 +722,12 @@ async function main() {
         check("teamMembers.burdenedHourlyRate is exactly hourlyRate + burdenRate, rounded to 2dp",
             soloNamedEntry?.role === "FIELD_CREW" && soloNamedEntry?.burdenedHourlyRate === 30.85);
 
-        const scheduleCoreCrewStart = scheduleCoreSource.indexOf("export async function setProjectCrew");
+        const scheduleCoreCrewStart = scheduleCoreSource.indexOf("async function runSetProjectCrew");
         const scheduleCoreCrewEnd = scheduleCoreSource.indexOf("export interface CrewConflictPair", scheduleCoreCrewStart);
         const scheduleCoreCrewBody = scheduleCoreSource.slice(scheduleCoreCrewStart, scheduleCoreCrewEnd);
         check("source validates ACTIVATED only for users being added to project crew",
             scheduleCoreCrewBody.includes("toConnect.map(id => byId.get(id)!).filter(u => u.status !== \"ACTIVATED\")"));
-        const scheduleCoreTaskCrewStart = scheduleCoreSource.indexOf("export async function setTaskCrew");
+        const scheduleCoreTaskCrewStart = scheduleCoreSource.indexOf("async function runSetTaskCrew");
         const scheduleCoreTaskCrewBody = scheduleCoreSource.slice(scheduleCoreTaskCrewStart);
         check("source validates ACTIVATED only for users being added to task crew",
             scheduleCoreTaskCrewBody.includes("toAdd.map(id => byId.get(id)!).filter(u => u.status !== \"ACTIVATED\")"));

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -5,9 +5,21 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { createEstimateFromPhases, updateEstimateFromPhases, templateToPhases, estimateToPhases, CLOSED_PROJECT_STATUSES, CLOSED_LEAD_STAGES } from "@/lib/gpt-estimate";
 import { getProjectBilling, sendMilestoneInvoicesCore, resendInvoiceCore, createChangeOrderDraft, billChangeOrderCore, sendChangeOrderToClientCore, listReceivables, createInvoiceFromEstimateGuarded } from "@/lib/billing-core";
-import { applyChangeOrderToSchedule, getCompanyPipeline, getStartCalendar, getUnappliedChangeOrders, setProjectStartDate, parseStartDateInput, generateScheduleFromEstimate, setProjectCrew, getCrewConflicts } from "@/lib/schedule-core";
+import { getCompanyPipeline, getStartCalendar, getUnappliedChangeOrders, getCrewConflicts } from "@/lib/schedule-core";
 import { coTaxRate, coTaxLabel } from "@/lib/co-tax";
 import { ALLOWED_FILE_EXTENSIONS, fileExtension, mimeTypeForFileName, saveProjectFile } from "@/lib/project-files";
+import {
+    applyChangeOrderToScheduleWithConfirmation,
+    assignProjectCrewWithConfirmation,
+    assignTaskCrew,
+    generateProjectScheduleWithConfirmation,
+    getProjectSchedule,
+    listCrewAvailability,
+    planSchedule,
+    setProjectStartDateWithConfirmation,
+    setTaskStatus,
+    updateTaskDates,
+} from "@/lib/mcp-schedule-tools";
 
 // MCP connector for ChatGPT (streamable HTTP at POST /api/mcp/mcp).
 //
@@ -1215,6 +1227,152 @@ const handler = createMcpHandler(
         );
 
         server.registerTool(
+            "get_project_schedule",
+            {
+                title: "Get one project's detailed schedule",
+                annotations: { readOnlyHint: true },
+                description:
+                    "Returns every task for exactly one project, including YYYY-MM-DD dates, status, progress, crew names and lead, task/appointment fields, completion criteria, and material counts. " +
+                    "Pass exactly one of projectId or the project's exact jobName. This read-only tool never returns rates or financial data.",
+                inputSchema: {
+                    projectId: z.string().max(50).optional().describe("Exact project id from list_projects, find_job, or get_company_schedule"),
+                    jobName: z.string().trim().min(1).max(300).optional().describe("Exact project name, case-insensitive; use projectId if names are duplicated"),
+                },
+            },
+            async args => {
+                try {
+                    return textResult(await getProjectSchedule(args));
+                } catch (e: any) {
+                    return { ...textResult({ error: e?.message ?? "Failed to get project schedule" }), isError: true };
+                }
+            },
+        );
+
+        server.registerTool(
+            "plan_schedule",
+            {
+                title: "Plan and bulk-create project schedule tasks",
+                description:
+                    "Creates 1–50 tasks atomically on a project. Dates must be real YYYY-MM-DD values; scheduledTime is 24-hour HH:MM and appointment-only. " +
+                    "crewNames and leadName match ACTIVATED users by exact full name or first name; ambiguous names return candidates, and leadName must also appear in crewNames. " +
+                    "TWO-STEP, SINGLE-USE: first call without confirmToken, show the complete task/date/crew preview, then call again with the returned 64-character confirmation token only after explicit user approval. Any invalid task rolls back the whole plan.",
+                inputSchema: {
+                    projectId: z.string().max(50).describe("Target project id"),
+                    tasks: z.array(z.object({
+                        name: z.string().trim().min(1).max(300),
+                        startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD"),
+                        endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD"),
+                        type: z.enum(["task", "milestone", "appointment"]).optional(),
+                        crewNames: z.array(z.string().trim().min(1).max(200)).max(50).optional(),
+                        leadName: z.string().trim().min(1).max(200).optional(),
+                        doneWhen: z.string().max(2000).optional(),
+                        scheduledTime: z.string().regex(/^(?:[01]\d|2[0-3]):[0-5]\d$/, "Use 24-hour HH:MM").optional(),
+                        estimatedHours: z.number().min(0).max(100_000).optional(),
+                    })).min(1).max(50),
+                    confirmToken: z.string().length(64).optional().describe("Single-use token from this exact plan_schedule preview"),
+                },
+            },
+            async args => {
+                try {
+                    return textResult(await planSchedule(args));
+                } catch (e: any) {
+                    return { ...textResult({ error: e?.message ?? "Failed to plan schedule" }), isError: true };
+                }
+            },
+        );
+
+        server.registerTool(
+            "update_task_dates",
+            {
+                title: "Update a schedule task's dates",
+                description:
+                    "Moves one task's startDate and/or endDate. Dates must use YYYY-MM-DD; normal tasks require endDate after startDate and milestones stay on one day. " +
+                    "TWO-STEP, SINGLE-USE: call without confirmToken for the exact before/after preview, obtain user approval, then repeat the same arguments with that token.",
+                inputSchema: {
+                    taskId: z.string().max(50),
+                    startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD").optional(),
+                    endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD").optional(),
+                    confirmToken: z.string().length(64).optional(),
+                },
+            },
+            async args => {
+                try {
+                    return textResult(await updateTaskDates(args));
+                } catch (e: any) {
+                    return { ...textResult({ error: e?.message ?? "Failed to update task dates" }), isError: true };
+                }
+            },
+        );
+
+        server.registerTool(
+            "set_task_status",
+            {
+                title: "Set a schedule task's status",
+                description:
+                    "Sets status to Not Started, In Progress, Complete, or Blocked. Blocked requires a non-empty blockedReason; moving away from Blocked clears it. " +
+                    "TWO-STEP, SINGLE-USE: call without confirmToken for a preview, show it to the user, then repeat the exact arguments with the returned token after approval.",
+                inputSchema: {
+                    taskId: z.string().max(50),
+                    status: z.enum(["Not Started", "In Progress", "Complete", "Blocked"]),
+                    blockedReason: z.string().trim().max(2000).optional(),
+                    confirmToken: z.string().length(64).optional(),
+                },
+            },
+            async args => {
+                try {
+                    return textResult(await setTaskStatus(args));
+                } catch (e: any) {
+                    return { ...textResult({ error: e?.message ?? "Failed to set task status" }), isError: true };
+                }
+            },
+        );
+
+        server.registerTool(
+            "assign_task_crew",
+            {
+                title: "Replace a task's crew and lead",
+                description:
+                    "Replaces one task's complete crew list using ACTIVATED first-name or exact full-name matches; ambiguous names return candidates. leadName is optional but must also appear in crewNames. " +
+                    "TWO-STEP, SINGLE-USE: call without confirmToken for the replacement preview, show it to the user, then repeat the exact arguments with the token after approval.",
+                inputSchema: {
+                    taskId: z.string().max(50),
+                    crewNames: z.array(z.string().trim().min(1).max(200)).max(50),
+                    leadName: z.string().trim().min(1).max(200).optional(),
+                    confirmToken: z.string().length(64).optional(),
+                },
+            },
+            async args => {
+                try {
+                    return textResult(await assignTaskCrew(args));
+                } catch (e: any) {
+                    return { ...textResult({ error: e?.message ?? "Failed to assign task crew" }), isError: true };
+                }
+            },
+        );
+
+        server.registerTool(
+            "list_crew_availability",
+            {
+                title: "List field-crew availability",
+                annotations: { readOnlyHint: true },
+                description:
+                    "For each ACTIVATED FIELD_CREW member and each requested day, returns booked task names or free. startDate must be YYYY-MM-DD and days must be 1–14. " +
+                    "This read-only output deliberately excludes emails, rates, costs, budgets, and every other financial field.",
+                inputSchema: {
+                    startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD"),
+                    days: z.number().int().min(1).max(14),
+                },
+            },
+            async args => {
+                try {
+                    return textResult(await listCrewAvailability(args));
+                } catch (e: any) {
+                    return { ...textResult({ error: e?.message ?? "Failed to list crew availability" }), isError: true };
+                }
+            },
+        );
+
+        server.registerTool(
             "set_project_start_date",
             {
                 title: "Move (or clear) a project's company start date",
@@ -1224,22 +1382,17 @@ const handler = createMcpHandler(
                     "milestones shift on both mirrors (estimate + invoice side) — EXCEPT any milestone group already pushed to QuickBooks, " +
                     "which is skipped entirely and reported in skippedQbMilestones for manual/QB-side fixing. In-progress projects only move " +
                     "the marker (tasks never shift). Closed projects are refused. Pass startDate null to clear the marker (tasks untouched). " +
-                    "Internal and reversible — no customer email, no preview token needed.",
+                    "TWO-STEP, SINGLE-USE: call without confirmToken for the effect preview, show it to the user, then repeat the exact arguments with that token after approval.",
                 inputSchema: {
                     projectId: z.string().max(50).describe("Project id from get_company_schedule or list_projects"),
                     startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD (no time component)").nullable().describe("New start date as YYYY-MM-DD; null clears the start marker"),
                     shiftJobTasks: z.boolean().optional().describe("Shift the job's tasks and linked milestones by the same delta (default true)"),
+                    confirmToken: z.string().length(64).optional().describe("Single-use token from this exact preview"),
                 },
             },
-            async ({ projectId, startDate, shiftJobTasks }) => {
+            async args => {
                 try {
-                    const result = await setProjectStartDate({
-                        projectId,
-                        startDate: startDate === null ? null : parseStartDateInput(startDate),
-                        shiftJobTasks: shiftJobTasks ?? true,
-                        actor: { type: "SYSTEM", name: "ChatGPT connector" },
-                    });
-                    return textResult(result);
+                    return textResult(await setProjectStartDateWithConfirmation(args));
                 } catch (e: any) {
                     return { ...textResult({ error: e?.message ?? "Failed to set project start date" }), isError: true };
                 }
@@ -1256,20 +1409,16 @@ const handler = createMcpHandler(
                     "payment milestones to them. Preconditions: the estimate must be Approved, Invoiced, Partially Paid, or Paid, " +
                     "owned by a PROJECT (not a lead), and the project must have a start date first (set_project_start_date). " +
                     "mode 'merge' (default) skips items already task-linked; 'regenerate' deletes untouched generated tasks and rebuilds. " +
-                    "Idempotent — safe to re-run.",
+                    "TWO-STEP, SINGLE-USE: call without confirmToken for a preview, then repeat the exact arguments with that token only after explicit approval.",
                 inputSchema: {
                     estimateId: z.string().max(50).describe("Estimate id (from find_job or list_project_billing) — must be Approved+ and on a project with a start date"),
                     mode: z.enum(["merge", "regenerate"]).optional().describe("'merge' (default) fills gaps; 'regenerate' rebuilds untouched generated tasks"),
+                    confirmToken: z.string().length(64).optional(),
                 },
             },
-            async ({ estimateId, mode }) => {
+            async args => {
                 try {
-                    const result = await generateScheduleFromEstimate({
-                        estimateId,
-                        mode: mode ?? "merge",
-                        actor: { type: "SYSTEM", name: "ChatGPT connector" },
-                    });
-                    return textResult(result);
+                    return textResult(await generateProjectScheduleWithConfirmation(args));
                 } catch (e: any) {
                     return { ...textResult({ error: e?.message ?? "Failed to generate schedule" }), isError: true };
                 }
@@ -1283,20 +1432,16 @@ const handler = createMcpHandler(
                 description:
                     "Replaces the project's crew with exactly the given user ids (connect/disconnect diff — re-running with the " +
                     "same list is a no-op). Every id must be an ACTIVATED team member. Crew drives the company-calendar chips and " +
-                    "the crewConflicts block in get_company_schedule (double-bookings across overlapping project windows).",
+                    "the crewConflicts block in get_company_schedule. TWO-STEP, SINGLE-USE: preview first, then repeat the exact arguments with confirmToken after approval.",
                 inputSchema: {
                     projectId: z.string().max(50).describe("Project id from get_company_schedule or list_projects"),
                     userIds: z.array(z.string().max(50)).max(50).describe("ACTIVATED user ids to assign — the FULL crew (not a delta); empty array clears the crew"),
+                    confirmToken: z.string().length(64).optional(),
                 },
             },
-            async ({ projectId, userIds }) => {
+            async args => {
                 try {
-                    const result = await setProjectCrew({
-                        projectId,
-                        userIds,
-                        actor: { type: "SYSTEM", name: "ChatGPT connector" },
-                    });
-                    return textResult(result);
+                    return textResult(await assignProjectCrewWithConfirmation(args));
                 } catch (e: any) {
                     return { ...textResult({ error: e?.message ?? "Failed to assign crew" }), isError: true };
                 }
@@ -1310,20 +1455,17 @@ const handler = createMcpHandler(
                 description:
                     "Adds an Approved change order's positive-scope tasks and payment milestones to its project's schedule. " +
                     "Deductions are reported for manual trimming and never remove existing tasks automatically. " +
-                    "Default merge mode is idempotent; regenerate rebuilds only untouched CO-generated task subtrees.",
+                    "Default merge mode is idempotent; regenerate rebuilds only untouched CO-generated task subtrees. " +
+                    "TWO-STEP, SINGLE-USE: preview first, then repeat the exact arguments with confirmToken after approval.",
                 inputSchema: {
                     changeOrderId: z.string().max(50).describe("Approved change-order id"),
                     mode: z.enum(["merge", "regenerate"]).optional().describe("'merge' (default) applies once; 'regenerate' rebuilds only untouched generated work"),
+                    confirmToken: z.string().length(64).optional(),
                 },
             },
-            async ({ changeOrderId, mode }) => {
+            async args => {
                 try {
-                    const result = await applyChangeOrderToSchedule({
-                        changeOrderId,
-                        mode: mode ?? "merge",
-                        actor: { type: "SYSTEM", name: "ChatGPT connector" },
-                    });
-                    return textResult(result);
+                    return textResult(await applyChangeOrderToScheduleWithConfirmation(args));
                 } catch (e: any) {
                     return { ...textResult({ error: e?.message ?? "Failed to apply change order to schedule" }), isError: true };
                 }
@@ -1331,7 +1473,7 @@ const handler = createMcpHandler(
         );
     },
     {
-        serverInfo: { name: "probuild", version: "1.10.0" },
+        serverInfo: { name: "probuild", version: "1.11.0" },
         capabilities: { tools: {} },
         instructions:
             "ProBuild is Golden Touch Remodeling's construction management system. " +
@@ -1355,6 +1497,9 @@ const handler = createMcpHandler(
             "Uploads default to internal visibility; only pass visibility 'shared' (customer-visible in the portal) when the user explicitly asks. " +
             "SCHEDULING: get_company_schedule answers 'what jobs are waiting to start?' and lists upcoming project starts (plus lead expected starts) " +
             "for the next N days, with each project's crew and a crewConflicts block (double-bookings across overlapping project windows). " +
+            "get_project_schedule returns one job's task-level plan; list_crew_availability returns only field-crew bookings/free days and never rates or financials. " +
+            "plan_schedule bulk-creates up to 50 tasks; update_task_dates, set_task_status, and assign_task_crew refine individual tasks. " +
+            "Every schedule-writing tool uses a single-use TWO-STEP confirmation: call without confirmToken, show the returned preview, and only repeat the exact arguments with that token after explicit user approval. Never self-confirm. " +
             "set_project_start_date moves a project's company start date — for a project still Waiting to Start it also shifts " +
             "the job's tasks and linked milestones by the same delta (pass shiftJobTasks false to move only the marker); milestone groups already pushed " +
             "to QuickBooks are never shifted and come back in skippedQbMilestones for manual fixing. " +

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -18,7 +18,6 @@ import { enqueueMilestonePaid, drainPaymentNotifications } from "./payment-outbo
 import { deleteChangeOrderCore, updateChangeOrderCore } from "./change-order-core";
 import { approveChangeOrderWithSignature } from "./change-order-approval";
 import { applyChangeOrderToSchedule, autoGenerateScheduleForApprovedEstimate, canonicalContractEstimateQuery, deriveEstimateItemHours, setProjectStartDate, shiftNotStartedTasks, parseStartDateInput, generateScheduleFromEstimate, setProjectCrew, setTaskCrew, lockTaskAssignmentParent, touchTaskAssignmentRevision } from "./schedule-core";
-import { CLOSED_PROJECT_STATUSES } from "./gpt-estimate";
 import type { ShiftNotStartedTasksResult } from "./schedule-core";
 import type { ChangeOrderUpdateInput } from "./change-order-core";
 import { emptyDoc } from "@/lib/studio/doc";
@@ -54,6 +53,13 @@ import {
     getPortalScheduleTasksCore,
     setDailyLogPortalShareCore,
 } from "./portal-tracker";
+import {
+    createScheduleTaskInTransaction,
+    setTaskLeadInTransaction,
+    updateScheduleTaskInTransaction,
+    type CreateScheduleTaskInput,
+    type UpdateScheduleTaskInput,
+} from "./schedule-task-core";
 
 type NotificationToggleKey = "newLead" | "estimateViewed" | "estimateSigned" | "contractSigned" | "invoiceViewed" | "paymentReceived" | "messageReceived";
 
@@ -6530,30 +6536,6 @@ export async function countersignContractAsCompany(contractId: string, signerNam
 // Schedule Tasks
 // ────────────────────────────────────────────────
 
-const SCHEDULE_TASK_TYPES = ["task", "milestone", "appointment"] as const;
-const SCHEDULE_CONFIRMATION_STATUSES = ["planned", "requested", "confirmed"] as const;
-const SCHEDULE_TIME_PATTERN = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
-type ScheduleTaskType = typeof SCHEDULE_TASK_TYPES[number];
-type ScheduleConfirmationStatus = typeof SCHEDULE_CONFIRMATION_STATUSES[number];
-
-function assertScheduleTaskType(type: string): asserts type is ScheduleTaskType {
-    if (!(SCHEDULE_TASK_TYPES as readonly string[]).includes(type)) throw new Error("Invalid schedule task type");
-}
-
-function normalizeScheduledTime(value: string | null | undefined): string | null {
-    const normalized = value?.trim() || null;
-    if (normalized && !SCHEDULE_TIME_PATTERN.test(normalized)) {
-        throw new Error("Scheduled time must use 24-hour HH:MM format");
-    }
-    return normalized;
-}
-
-function assertConfirmationStatus(value: string): asserts value is ScheduleConfirmationStatus {
-    if (!(SCHEDULE_CONFIRMATION_STATUSES as readonly string[]).includes(value)) {
-        throw new Error("Invalid appointment confirmation status");
-    }
-}
-
 export async function getScheduleTasks(projectId: string) {
     // Hardened (dispatch-arc foundation): internal schedule details require an authenticated team session.
     const session = await getSessionOrDev();
@@ -6903,308 +6885,39 @@ function buildTaskCommentCreateData(taskId: string, text: string, author: TaskCo
     };
 }
 
-export async function createScheduleTask(projectId: string, data: {
-    name: string;
-    startDate: string;
-    endDate: string;
-    color?: string;
-    status?: string;
-    assignee?: string;
-    parentId?: string;
-    type?: ScheduleTaskType;
-    estimateItemId?: string | null;
-    crewIds?: string[];
-    leadUserId?: string | null;
-    estimatedHours?: number | null;
-    doneWhen?: string | null;
-    note?: string;
-    scheduledTime?: string | null;
-    confirmationStatus?: ScheduleConfirmationStatus | null;
-}) {
+export async function createScheduleTask(projectId: string, data: CreateScheduleTaskInput) {
     const user = await assertScheduleProjectAccess(projectId);
-    const type = data.type ?? "task";
-    assertScheduleTaskType(type);
-    if (data.status === "Blocked") throw new Error("Blocked tasks require a reason");
-    const startDate = parseStartDateInput(data.startDate);
-    const requestedEndDate = parseStartDateInput(data.endDate);
-    const endDate = type === "milestone" ? startDate : requestedEndDate;
-    if (type !== "milestone" && endDate < startDate) {
-        throw new Error("Task end date cannot be before its start date");
-    }
-    if (data.estimatedHours != null && (!Number.isFinite(data.estimatedHours) || data.estimatedHours < 0)) {
-        throw new Error("Estimated hours must be zero or greater");
-    }
-
-    const scheduledTime = normalizeScheduledTime(data.scheduledTime);
-    if (data.confirmationStatus) assertConfirmationStatus(data.confirmationStatus);
-    if (type !== "appointment" && (scheduledTime || data.confirmationStatus)) {
-        throw new Error("Scheduled time and confirmation status are appointment-only fields");
-    }
-    const confirmationStatus = type === "appointment" ? (data.confirmationStatus ?? "planned") : null;
-    const estimateItemId = data.estimateItemId?.trim() || null;
-    const crewIds = [...new Set((data.crewIds ?? []).filter(Boolean))];
-    const leadUserId = data.leadUserId ?? null;
-    if (leadUserId && !crewIds.includes(leadUserId)) throw new Error("Task lead must be assigned to the crew");
     const note = data.note?.trim() || null;
     const commentAuthor = note ? await resolveTaskCommentAuthor() : null;
-    const task = await withTxRetry(() => prisma.$transaction(async (tx) => {
-        await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${projectId} FOR UPDATE`;
-        const estimateItem = estimateItemId
-            ? await tx.estimateItem.findUnique({
-                where: { id: estimateItemId },
-                select: {
-                    id: true,
-                    type: true,
-                    quantity: true,
-                    budgetUnit: true,
-                    estimate: { select: { projectId: true } },
-                    scheduleTask: { select: { id: true, name: true } },
-                    _count: { select: { subItems: true } },
-                },
-            })
-            : null;
-        if (estimateItemId) {
-            if (!estimateItem || estimateItem.estimate.projectId !== projectId) {
-                throw new Error("Estimate item does not belong to this project");
-            }
-            if (estimateItem.type === "Section") {
-                throw new Error("Estimate sections cannot be scheduled as tasks");
-            }
-            if (estimateItem.scheduleTask) {
-                throw new Error(`Already linked to "${estimateItem.scheduleTask.name}"`);
-            }
-        }
-        const maxOrder = await tx.scheduleTask.aggregate({
-            where: { projectId },
-            _max: { order: true },
-        });
-        if (crewIds.length > 0) {
-            const activeCrew = await tx.user.findMany({
-                where: { id: { in: crewIds }, status: "ACTIVATED" },
-                select: { id: true },
-            });
-            if (activeCrew.length !== crewIds.length) throw new Error("Task crew members must be ACTIVATED users");
-        }
-        const createData: any = {
+    const task = await withTxRetry(() => prisma.$transaction(tx =>
+        createScheduleTaskInTransaction(
+            tx,
             projectId,
-            name: data.name,
-            startDate,
-            endDate,
-            color: data.color || getDefaultColorForTaskName(data.name) || "#4c9a2a",
-            status: data.status || "Not Started",
-            assignee: data.assignee || null,
-            parentId: data.parentId || null,
-            order: (maxOrder._max.order ?? -1) + 1,
-            type,
-            estimateItemId,
-            estimatedHours: data.estimatedHours ?? (estimateItem
-                ? deriveEstimateItemHours({
-                    quantity: estimateItem.quantity,
-                    budgetUnit: estimateItem.budgetUnit,
-                    childCount: estimateItem._count.subItems,
-                })
-                : null),
-            doneWhen: data.doneWhen?.trim() || null,
-            scheduledTime,
-            confirmationStatus,
-        };
-        const created = await tx.scheduleTask.create({ data: createData });
-        if (crewIds.length > 0) {
-            await tx.taskAssignment.createMany({
-                data: crewIds.map(userId => ({ taskId: created.id, userId, role: userId === leadUserId ? "lead" : "assigned" })),
-            });
-        }
-        if (note && commentAuthor) {
-            await tx.taskComment.create({ data: buildTaskCommentCreateData(created.id, note, commentAuthor) });
-        }
-        await tx.activityLog.create({
-            data: {
-                projectId,
-                actorType: "TEAM",
-                actorName: user.name || user.email,
-                action: "created_schedule_task",
-                entityType: "task",
-                entityId: created.id,
-                entityName: created.name,
-                metadata: JSON.stringify({
-                    name: data.name,
-                    startDate: startDate.toISOString().slice(0, 10),
-                    endDate: endDate.toISOString().slice(0, 10),
-                    color: createData.color,
-                    status: createData.status,
-                    type,
-                    estimateItemId,
-                    crewIds,
-                    leadUserId,
-                    estimatedHours: createData.estimatedHours,
-                    doneWhen: createData.doneWhen,
-                    note,
-                    scheduledTime,
-                    confirmationStatus,
-                }),
-            },
-        });
-        return created;
-    }));
+            data,
+            { type: "TEAM", name: user.name || user.email },
+            commentAuthor,
+        ),
+    ));
     revalidatePath("/company-dashboard");
     revalidatePath(`/projects/${projectId}/schedule`);
     return task;
 }
 
-export async function updateScheduleTask(taskId: string, data: {
-    name?: string;
-    startDate?: string;
-    endDate?: string;
-    color?: string;
-    progress?: number;
-    status?: string;
-    assignee?: string;
-    order?: number;
-    estimatedHours?: number | null;
-    type?: ScheduleTaskType;
-    estimateItemId?: string | null;
-    doneWhen?: string | null;
-    blockedReason?: string | null;
-    scheduledTime?: string | null;
-    confirmationStatus?: ScheduleConfirmationStatus | null;
-}) {
-    const hasDatePatch = data.startDate !== undefined || data.endDate !== undefined;
+export async function updateScheduleTask(taskId: string, data: UpdateScheduleTaskInput) {
     const { user, projectId } = await assertScheduleTaskAccess(taskId);
-    const persistedDispatchState = await prisma.scheduleTask.findUnique({
-        where: { id: taskId },
-        select: { type: true, status: true, blockedReason: true },
-    });
-    if (!persistedDispatchState) throw new Error("Task not found");
-    if (data.type !== undefined) assertScheduleTaskType(data.type);
-    const nextType = data.type ?? persistedDispatchState.type;
-    const nextStatus = data.status ?? persistedDispatchState.status;
-    const updateData: any = {};
-    if (data.name !== undefined) updateData.name = data.name;
-    if (data.color !== undefined) updateData.color = data.color;
-    if (data.progress !== undefined) updateData.progress = data.progress;
-    if (data.status !== undefined) updateData.status = data.status;
-    if (data.assignee !== undefined) updateData.assignee = data.assignee;
-    if (data.order !== undefined) updateData.order = data.order;
-    if (data.estimatedHours !== undefined) updateData.estimatedHours = data.estimatedHours;
-    if (data.type !== undefined) updateData.type = data.type;
-    if (data.doneWhen !== undefined) updateData.doneWhen = data.doneWhen?.trim() || null;
-    if (data.status !== undefined || data.blockedReason !== undefined) {
-        if (nextStatus === "Blocked") {
-            const reasonSource = data.blockedReason !== undefined ? data.blockedReason : persistedDispatchState.blockedReason;
-            const reason = reasonSource?.trim();
-            if (!reason) throw new Error("Blocked tasks require a reason");
-            updateData.blockedReason = reason;
-        } else {
-            updateData.blockedReason = null;
-        }
-    }
-    if (data.scheduledTime !== undefined) {
-        const scheduledTime = normalizeScheduledTime(data.scheduledTime);
-        if (nextType !== "appointment" && scheduledTime) {
-            throw new Error("Scheduled time is only available for appointments");
-        }
-        updateData.scheduledTime = scheduledTime;
-    }
-    if (data.confirmationStatus !== undefined) {
-        if (data.confirmationStatus) assertConfirmationStatus(data.confirmationStatus);
-        if (nextType !== "appointment" && data.confirmationStatus) {
-            throw new Error("Confirmation status is only available for appointments");
-        }
-        updateData.confirmationStatus = data.confirmationStatus;
-    }
-    if (data.type !== undefined && data.type !== "appointment") {
-        updateData.scheduledTime = null;
-        updateData.confirmationStatus = null;
-    }
-    if (data.estimateItemId !== undefined) {
-        updateData.estimateItemId = data.estimateItemId;
-        if (data.estimateItemId) {
-            const existing = await prisma.scheduleTask.findFirst({
-                where: { estimateItemId: data.estimateItemId, id: { not: taskId } },
-                select: { id: true, name: true },
-            });
-            if (existing) throw new Error(`Already linked to "${existing.name}"`);
-            const item = await prisma.estimateItem.findUnique({
-                where: { id: data.estimateItemId },
-                select: { type: true, quantity: true, budgetUnit: true },
-            });
-            if (item && (item.type === "Labor" || item.budgetUnit === "hours")) {
-                updateData.estimatedHours = item.quantity || null;
-            }
-        }
-    }
-    if (hasDatePatch) {
-        const suppliedStartDate = data.startDate === undefined ? null : parseStartDateInput(data.startDate);
-        const suppliedEndDate = data.endDate === undefined ? null : parseStartDateInput(data.endDate);
-        const task = await withTxRetry(() => prisma.$transaction(async (tx) => {
-            // Canonical lock family: parent Project first, then the task row.
-            await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${projectId} FOR UPDATE`;
-            await tx.$queryRaw`SELECT id FROM "ScheduleTask" WHERE id = ${taskId} FOR UPDATE`;
-            const persistedTask = await tx.scheduleTask.findUnique({
-                where: { id: taskId },
-                select: {
-                    id: true, name: true, projectId: true, type: true,
-                    startDate: true, endDate: true,
-                    project: { select: { status: true } },
-                },
-            });
-            if (!persistedTask) throw new Error("Task not found");
-            if (!persistedTask.projectId || persistedTask.projectId !== projectId) {
-                throw new Error("Task moved to another project; refresh and retry");
-            }
-            if (!persistedTask.project) throw new Error("Task is not attached to a project");
-            if (CLOSED_PROJECT_STATUSES.includes(persistedTask.project.status)) {
-                throw new Error(`Cannot update a task on a closed project (${persistedTask.project.status})`);
-            }
-            if (data.type !== undefined && data.type !== persistedTask.type) {
-                throw new Error("Change task type separately before editing its dates");
-            }
-
-            const startDate = suppliedStartDate ?? persistedTask.startDate;
-            const requestedEndDate = suppliedEndDate ?? persistedTask.endDate;
-            const endDate = persistedTask.type === "milestone" ? startDate : requestedEndDate;
-            if (persistedTask.type !== "milestone" && endDate <= startDate) {
-                throw new Error("Task end date must be after its start date");
-            }
-
-            const saved = await tx.scheduleTask.update({
-                where: { id: taskId },
-                data: { ...updateData, startDate, endDate },
-            });
-            await tx.activityLog.create({
-                data: {
-                    projectId,
-                    actorType: "TEAM",
-                    actorName: user.name || user.email,
-                    action: "updated_company_schedule_task_dates",
-                    entityType: "task",
-                    entityId: taskId,
-                    entityName: persistedTask.name,
-                    metadata: JSON.stringify({
-                        previousStartDate: persistedTask.startDate.toISOString().slice(0, 10),
-                        previousEndDate: persistedTask.endDate.toISOString().slice(0, 10),
-                        startDate: startDate.toISOString().slice(0, 10),
-                        endDate: endDate.toISOString().slice(0, 10),
-                        type: persistedTask.type,
-                    }),
-                },
-            });
-            return saved;
-        }));
-        revalidatePath("/company-dashboard");
-        revalidatePath(`/projects/${task.projectId}/schedule`);
-        return task;
-    }
-
-    const task = await prisma.scheduleTask.update({
-        where: { id: taskId },
-        data: updateData,
-    });
+    const task = await withTxRetry(() => prisma.$transaction(tx =>
+        updateScheduleTaskInTransaction(
+            tx,
+            taskId,
+            data,
+            { type: "TEAM", name: user.name || user.email },
+            projectId,
+        ),
+    ));
     revalidatePath("/company-dashboard");
-    revalidatePath(`/projects/${task.projectId}/schedule`);
+    revalidatePath(`/projects/${projectId}/schedule`);
     return task;
 }
-
 export async function deleteScheduleTask(taskId: string) {
     await assertScheduleTaskAccess(taskId);
     const task = await prisma.scheduleTask.delete({ where: { id: taskId } });
@@ -7503,56 +7216,19 @@ export async function unassignUserFromTask(taskId: string, userId: string) {
 
 export async function setTaskLead(taskId: string, userId: string | null) {
     const { user, projectId } = await assertScheduleTaskAccess(taskId);
-    const assignments = await withTxRetry(() => prisma.$transaction(async (tx) => {
-        await lockTaskAssignmentParent(tx, taskId, projectId);
-        const task = await tx.scheduleTask.findUnique({
-            where: { id: taskId },
-            select: {
-                id: true,
-                name: true,
-                projectId: true,
-                assignments: { select: { userId: true, role: true } },
-            },
-        });
-        if (!task || task.projectId !== projectId) throw new Error("Task not found");
-        if (userId && !task.assignments.some(assignment => assignment.userId === userId)) {
-            throw new Error("Task lead must be assigned to the crew");
-        }
-        const previousLeadUserId = task.assignments.find(assignment => assignment.role === "lead")?.userId ?? null;
-        await tx.taskAssignment.updateMany({
-            where: { taskId, role: "lead" },
-            data: { role: "assigned" },
-        });
-        if (userId) {
-            await tx.taskAssignment.update({
-                where: { taskId_userId: { taskId, userId } },
-                data: { role: "lead" },
-            });
-        }
-        await touchTaskAssignmentRevision(tx, taskId);
-        await tx.activityLog.create({
-            data: {
-                projectId,
-                actorType: "TEAM",
-                actorName: user.name || user.email,
-                action: "set_task_lead",
-                entityType: "task",
-                entityId: taskId,
-                entityName: task.name,
-                metadata: JSON.stringify({ previousLeadUserId, leadUserId: userId }),
-            },
-        });
-        return tx.taskAssignment.findMany({
-            where: { taskId },
-            orderBy: { createdAt: "asc" },
-            include: { user: { select: { id: true, name: true, email: true } } },
-        });
-    }));
+    const assignments = await withTxRetry(() => prisma.$transaction(tx =>
+        setTaskLeadInTransaction(
+            tx,
+            taskId,
+            userId,
+            { type: "TEAM", name: user.name || user.email },
+            projectId,
+        ),
+    ));
     revalidatePath("/company-dashboard");
     revalidatePath(`/projects/${projectId}/schedule`);
     return assignments;
 }
-
 export async function assignSubToTask(taskId: string, subcontractorId: string) {
     await assertScheduleTaskAccess(taskId);
     const assignment = await prisma.subTaskAssignment.create({

--- a/src/lib/mcp-schedule-tools.ts
+++ b/src/lib/mcp-schedule-tools.ts
@@ -1,0 +1,752 @@
+import { createHash, randomBytes } from "node:crypto";
+import { Prisma } from "@prisma/client";
+
+import { addDays } from "@/app/projects/[id]/schedule/schedule-utils";
+import { prisma } from "./prisma";
+import {
+    applyChangeOrderToScheduleInTransaction,
+    canonicalContractEstimateQuery,
+    generateScheduleFromEstimateInTransaction,
+    parseStartDateInput,
+    setProjectCrewInTransaction,
+    setProjectStartDateInTransaction,
+    setTaskCrewInTransaction,
+    type ScheduleActor,
+} from "./schedule-core";
+import {
+    SCHEDULE_TASK_STATUSES,
+    SCHEDULE_TASK_TYPES,
+    createScheduleTaskInTransaction,
+    setTaskLeadInTransaction,
+    updateScheduleTaskInTransaction,
+    type CreateScheduleTaskInput,
+    type ScheduleTaskStatus,
+    type ScheduleTaskType,
+} from "./schedule-task-core";
+import { withTxRetry } from "./tx-retry";
+
+const CONFIRMATION_TTL_MS = 10 * 60 * 1_000;
+const MCP_ACTOR: ScheduleActor = { type: "SYSTEM", name: "ChatGPT connector" };
+
+type CanonicalValue =
+    | null
+    | boolean
+    | number
+    | string
+    | CanonicalValue[]
+    | { [key: string]: CanonicalValue };
+
+export interface McpConfirmationPreview {
+    confirmationRequired: true;
+    preview: string;
+    confirmToken: string;
+    expiresAt: string;
+    instruction: string;
+}
+
+export interface PlanScheduleTaskInput {
+    name: string;
+    startDate: string;
+    endDate: string;
+    type?: ScheduleTaskType;
+    crewNames?: string[];
+    leadName?: string;
+    doneWhen?: string;
+    scheduledTime?: string;
+    estimatedHours?: number;
+}
+
+function canonicalize(value: unknown): CanonicalValue {
+    if (value === null) return null;
+    if (value instanceof Date) return value.toISOString();
+    if (Array.isArray(value)) return value.map(item => canonicalize(item));
+    if (typeof value === "object") {
+        const output: { [key: string]: CanonicalValue } = {};
+        for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+            const child = (value as Record<string, unknown>)[key];
+            if (child !== undefined) output[key] = canonicalize(child);
+        }
+        return output;
+    }
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+        return value;
+    }
+    throw new Error(`Unsupported confirmation argument type: ${typeof value}`);
+}
+
+export function canonicalJson(value: unknown): string {
+    return JSON.stringify(canonicalize(value));
+}
+
+export function scheduleArgsHash(value: unknown): string {
+    return createHash("sha256").update(canonicalJson(value)).digest("hex");
+}
+
+async function issueConfirmation(
+    toolName: string,
+    args: unknown,
+    preview: string,
+): Promise<McpConfirmationPreview> {
+    const token = randomBytes(32).toString("hex");
+    const expiresAt = new Date(Date.now() + CONFIRMATION_TTL_MS);
+    await prisma.mcpConfirmation.create({
+        data: {
+            token,
+            toolName,
+            argsHash: scheduleArgsHash(args),
+            preview,
+            expiresAt,
+        },
+    });
+    return {
+        confirmationRequired: true,
+        preview,
+        confirmToken: token,
+        expiresAt: expiresAt.toISOString(),
+        instruction:
+            "Show this preview to the user. Call the same tool again with this confirmToken only after explicit approval. The token is single-use and expires in 10 minutes.",
+    };
+}
+
+async function executeConfirmed<T extends Record<string, unknown>>(
+    toolName: string,
+    args: unknown,
+    confirmToken: string,
+    // eslint-disable-next-line no-unused-vars
+    write: (tx: Prisma.TransactionClient) => Promise<T>,
+): Promise<T & { confirmed: true }> {
+    const argsHash = scheduleArgsHash(args);
+    return withTxRetry(() => prisma.$transaction(async tx => {
+        const row = await tx.mcpConfirmation.findUnique({
+            where: { token: confirmToken },
+            select: {
+                toolName: true,
+                argsHash: true,
+                expiresAt: true,
+                consumedAt: true,
+            },
+        });
+        if (!row) throw new Error("Invalid schedule confirmation token");
+        if (row.toolName !== toolName || row.argsHash !== argsHash) {
+            throw new Error("Confirmation token does not match this tool and its arguments; request a new preview");
+        }
+        if (row.expiresAt <= new Date()) throw new Error("Schedule confirmation token has expired");
+        if (row.consumedAt) throw new Error("Schedule confirmation token was already used");
+
+        const claim = await tx.mcpConfirmation.updateMany({
+            where: {
+                token: confirmToken,
+                toolName,
+                argsHash,
+                expiresAt: { gt: new Date() },
+                consumedAt: null,
+            },
+            data: { consumedAt: new Date() },
+        });
+        if (claim.count !== 1) {
+            throw new Error("Schedule confirmation token was already consumed by another request");
+        }
+
+        const result = await write(tx);
+        return { ...result, confirmed: true as const };
+    }));
+}
+
+function cleanCrewNames(names: string[] | undefined): string[] {
+    return [...new Set((names ?? []).map(name => name.trim()).filter(Boolean))];
+}
+
+async function resolveCrewNames(
+    tx: Prisma.TransactionClient,
+    names: string[],
+): Promise<{ id: string; name: string }[]> {
+    if (names.length === 0) return [];
+    const users = await tx.user.findMany({
+        where: { status: "ACTIVATED" },
+        orderBy: [{ name: "asc" }, { id: "asc" }],
+        select: { id: true, name: true, email: true },
+    });
+    const resolved: { id: string; name: string }[] = [];
+    for (const raw of names) {
+        const needle = raw.trim().toLocaleLowerCase();
+        const fullMatches = users.filter(user => (user.name ?? "").trim().toLocaleLowerCase() === needle);
+        const matches = fullMatches.length > 0
+            ? fullMatches
+            : users.filter(user => (user.name ?? "").trim().split(/\s+/)[0]?.toLocaleLowerCase() === needle);
+        if (matches.length === 0) {
+            throw new Error(`No ACTIVATED crew member matches "${raw}"`);
+        }
+        if (matches.length > 1) {
+            throw new Error(
+                `Crew name "${raw}" is ambiguous. Candidates: ${matches
+                    .map(user => `${user.name || user.email} (${user.id})`)
+                    .join(", ")}`,
+            );
+        }
+        const match = matches[0];
+        if (!resolved.some(user => user.id === match.id)) {
+            resolved.push({ id: match.id, name: match.name || match.email });
+        }
+    }
+    return resolved;
+}
+
+function validatePlannedTask(task: PlanScheduleTaskInput): void {
+    if (!task.name.trim()) throw new Error("Task name is required");
+    const type = task.type ?? "task";
+    if (!(SCHEDULE_TASK_TYPES as readonly string[]).includes(type)) {
+        throw new Error(`Invalid schedule task type "${type}"`);
+    }
+    const startDate = parseStartDateInput(task.startDate);
+    const endDate = parseStartDateInput(task.endDate);
+    if (type !== "milestone" && endDate < startDate) {
+        throw new Error("Task end date cannot be before its start date");
+    }
+    if (task.estimatedHours != null && (!Number.isFinite(task.estimatedHours) || task.estimatedHours < 0)) {
+        throw new Error("Estimated hours must be zero or greater");
+    }
+    if (task.scheduledTime !== undefined) {
+        if (type !== "appointment") throw new Error("Scheduled time is only available for appointments");
+        if (!/^(?:[01]\d|2[0-3]):[0-5]\d$/.test(task.scheduledTime.trim())) {
+            throw new Error("Scheduled time must use 24-hour HH:MM format");
+        }
+    }
+}
+
+async function resolvePlanTask(
+    tx: Prisma.TransactionClient,
+    task: PlanScheduleTaskInput,
+): Promise<{ create: CreateScheduleTaskInput; crew: { id: string; name: string }[]; lead: { id: string; name: string } | null }> {
+    validatePlannedTask(task);
+    const crewNames = cleanCrewNames(task.crewNames);
+    const crew = await resolveCrewNames(tx, crewNames);
+    const lead = task.leadName
+        ? (await resolveCrewNames(tx, [task.leadName]))[0]
+        : null;
+    if (lead && !crew.some(member => member.id === lead.id)) {
+        throw new Error(`Task lead "${task.leadName}" must also appear in crewNames`);
+    }
+    return {
+        create: {
+            name: task.name.trim(),
+            startDate: task.startDate,
+            endDate: task.endDate,
+            type: task.type,
+            crewIds: crew.map(member => member.id),
+            leadUserId: lead?.id ?? null,
+            doneWhen: task.doneWhen,
+            scheduledTime: task.scheduledTime,
+            estimatedHours: task.estimatedHours,
+        },
+        crew,
+        lead,
+    };
+}
+
+async function resolveProject(input: { projectId?: string; jobName?: string }) {
+    if ((input.projectId ? 1 : 0) + (input.jobName ? 1 : 0) !== 1) {
+        throw new Error("Provide exactly one of projectId or jobName");
+    }
+    if (input.projectId) {
+        const project = await prisma.project.findUnique({
+            where: { id: input.projectId },
+            select: { id: true, name: true, status: true, startDate: true, endDate: true },
+        });
+        if (!project) throw new Error("Project not found");
+        return project;
+    }
+    const projects = await prisma.project.findMany({
+        where: { name: { equals: input.jobName!.trim(), mode: "insensitive" } },
+        take: 3,
+        orderBy: { createdAt: "desc" },
+        select: { id: true, name: true, status: true, startDate: true, endDate: true },
+    });
+    if (projects.length === 0) throw new Error(`No project named "${input.jobName}"`);
+    if (projects.length > 1) {
+        throw new Error(`Project name "${input.jobName}" is ambiguous; use projectId`);
+    }
+    return projects[0];
+}
+
+export async function getProjectSchedule(input: { projectId?: string; jobName?: string }) {
+    const project = await resolveProject(input);
+    const tasks = await prisma.scheduleTask.findMany({
+        where: { projectId: project.id },
+        orderBy: [{ order: "asc" }, { startDate: "asc" }, { id: "asc" }],
+        select: {
+            id: true,
+            name: true,
+            startDate: true,
+            endDate: true,
+            status: true,
+            progress: true,
+            type: true,
+            doneWhen: true,
+            scheduledTime: true,
+            confirmationStatus: true,
+            estimatedHours: true,
+            assignments: {
+                orderBy: { createdAt: "asc" },
+                select: {
+                    role: true,
+                    user: { select: { id: true, name: true, email: true } },
+                },
+            },
+        },
+    });
+    const taskIds = tasks.map(task => task.id);
+    const materialRows = taskIds.length > 0
+        ? await prisma.taskMaterial.groupBy({
+            by: ["taskId", "status"],
+            where: { taskId: { in: taskIds } },
+            _count: { id: true },
+        })
+        : [];
+    const materialCounts = new Map<string, { pending: number; staged: number; missing: number; resolved: number; total: number }>();
+    for (const row of materialRows) {
+        const counts = materialCounts.get(row.taskId) ?? {
+            pending: 0,
+            staged: 0,
+            missing: 0,
+            resolved: 0,
+            total: 0,
+        };
+        if (row.status === "pending" || row.status === "staged" || row.status === "missing" || row.status === "resolved") {
+            counts[row.status] = row._count.id;
+        }
+        counts.total += row._count.id;
+        materialCounts.set(row.taskId, counts);
+    }
+    return {
+        projectId: project.id,
+        jobName: project.name,
+        status: project.status,
+        startDate: project.startDate?.toISOString().slice(0, 10) ?? null,
+        endDate: project.endDate?.toISOString().slice(0, 10) ?? null,
+        tasks: tasks.map(task => {
+            const crew = task.assignments.map(assignment => ({
+                userId: assignment.user.id,
+                name: assignment.user.name || assignment.user.email,
+                role: assignment.role,
+            }));
+            return {
+                id: task.id,
+                name: task.name,
+                startDate: task.startDate.toISOString().slice(0, 10),
+                endDate: task.endDate.toISOString().slice(0, 10),
+                status: task.status,
+                progress: task.progress,
+                type: task.type,
+                doneWhen: task.doneWhen,
+                scheduledTime: task.scheduledTime,
+                confirmationStatus: task.confirmationStatus,
+                estimatedHours: task.estimatedHours,
+                crew,
+                leadName: crew.find(member => member.role === "lead")?.name ?? null,
+                materialCounts: materialCounts.get(task.id) ?? {
+                    pending: 0,
+                    staged: 0,
+                    missing: 0,
+                    resolved: 0,
+                    total: 0,
+                },
+            };
+        }),
+    };
+}
+
+export async function planSchedule(input: {
+    projectId: string;
+    tasks: PlanScheduleTaskInput[];
+    confirmToken?: string;
+}) {
+    if (input.tasks.length === 0) throw new Error("plan_schedule requires at least one task");
+    if (input.tasks.length > 50) throw new Error("plan_schedule accepts at most 50 tasks");
+    const args = { projectId: input.projectId, tasks: input.tasks };
+
+    if (!input.confirmToken) {
+        const resolved = await prisma.$transaction(async tx => {
+            const project = await tx.project.findUnique({
+                where: { id: input.projectId },
+                select: { id: true, name: true },
+            });
+            if (!project) throw new Error("Project not found");
+            const tasks = [];
+            for (const task of input.tasks) tasks.push(await resolvePlanTask(tx, task));
+            return { project, tasks };
+        });
+        const preview = [
+            `Create ${resolved.tasks.length} schedule task${resolved.tasks.length === 1 ? "" : "s"} on "${resolved.project.name}":`,
+            ...resolved.tasks.map((task, index) => {
+                const source = input.tasks[index];
+                const crew = task.crew.map(member => member.name).join(", ") || "unassigned";
+                return `${index + 1}. ${source.name.trim()} — ${source.startDate} to ${source.endDate}; crew: ${crew}${task.lead ? `; lead: ${task.lead.name}` : ""}`;
+            }),
+        ].join("\n");
+        return issueConfirmation("plan_schedule", args, preview);
+    }
+
+    return executeConfirmed("plan_schedule", args, input.confirmToken, async tx => {
+        const project = await tx.project.findUnique({
+            where: { id: input.projectId },
+            select: { id: true },
+        });
+        if (!project) throw new Error("Project not found");
+        const created = [];
+        for (const task of input.tasks) {
+            const resolved = await resolvePlanTask(tx, task);
+            created.push(await createScheduleTaskInTransaction(tx, input.projectId, resolved.create, MCP_ACTOR));
+        }
+        return {
+            projectId: input.projectId,
+            created: created.map(task => ({
+                id: task.id,
+                name: task.name,
+                startDate: task.startDate.toISOString().slice(0, 10),
+                endDate: task.endDate.toISOString().slice(0, 10),
+            })),
+        };
+    });
+}
+
+async function validateTaskDates(input: { taskId: string; startDate?: string; endDate?: string }) {
+    if (input.startDate === undefined && input.endDate === undefined) {
+        throw new Error("Provide startDate and/or endDate");
+    }
+    const task = await prisma.scheduleTask.findUnique({
+        where: { id: input.taskId },
+        select: { id: true, name: true, type: true, startDate: true, endDate: true },
+    });
+    if (!task) throw new Error("Task not found");
+    const startDate = input.startDate === undefined ? task.startDate : parseStartDateInput(input.startDate);
+    const requestedEndDate = input.endDate === undefined ? task.endDate : parseStartDateInput(input.endDate);
+    const endDate = task.type === "milestone" ? startDate : requestedEndDate;
+    if (task.type !== "milestone" && endDate <= startDate) {
+        throw new Error("Task end date must be after its start date");
+    }
+    return { task, startDate, endDate };
+}
+
+export async function updateTaskDates(input: {
+    taskId: string;
+    startDate?: string;
+    endDate?: string;
+    confirmToken?: string;
+}) {
+    const args = { taskId: input.taskId, startDate: input.startDate, endDate: input.endDate };
+    if (!input.confirmToken) {
+        const { task, startDate, endDate } = await validateTaskDates(args);
+        return issueConfirmation(
+            "update_task_dates",
+            args,
+            `Move "${task.name}" from ${task.startDate.toISOString().slice(0, 10)}–${task.endDate.toISOString().slice(0, 10)} to ${startDate.toISOString().slice(0, 10)}–${endDate.toISOString().slice(0, 10)}.`,
+        );
+    }
+    return executeConfirmed("update_task_dates", args, input.confirmToken, async tx => {
+        const task = await updateScheduleTaskInTransaction(tx, input.taskId, {
+            startDate: input.startDate,
+            endDate: input.endDate,
+        }, MCP_ACTOR);
+        return {
+            taskId: task.id,
+            startDate: task.startDate.toISOString().slice(0, 10),
+            endDate: task.endDate.toISOString().slice(0, 10),
+        };
+    });
+}
+
+export async function setTaskStatus(input: {
+    taskId: string;
+    status: ScheduleTaskStatus;
+    blockedReason?: string;
+    confirmToken?: string;
+}) {
+    if (!(SCHEDULE_TASK_STATUSES as readonly string[]).includes(input.status)) {
+        throw new Error(`Invalid schedule task status "${input.status}"`);
+    }
+    const blockedReason = input.blockedReason?.trim();
+    if (input.status === "Blocked" && !blockedReason) throw new Error("Blocked tasks require a reason");
+    const args = { taskId: input.taskId, status: input.status, blockedReason };
+    if (!input.confirmToken) {
+        const task = await prisma.scheduleTask.findUnique({
+            where: { id: input.taskId },
+            select: { name: true, status: true },
+        });
+        if (!task) throw new Error("Task not found");
+        return issueConfirmation(
+            "set_task_status",
+            args,
+            `Change "${task.name}" from ${task.status} to ${input.status}${blockedReason ? ` — ${blockedReason}` : ""}.`,
+        );
+    }
+    return executeConfirmed("set_task_status", args, input.confirmToken, async tx => {
+        const task = await updateScheduleTaskInTransaction(tx, input.taskId, {
+            status: input.status,
+            blockedReason,
+        }, MCP_ACTOR);
+        return { taskId: task.id, status: task.status, blockedReason: task.blockedReason };
+    });
+}
+
+export async function assignTaskCrew(input: {
+    taskId: string;
+    crewNames: string[];
+    leadName?: string;
+    confirmToken?: string;
+}) {
+    const crewNames = cleanCrewNames(input.crewNames);
+    const args = { taskId: input.taskId, crewNames, leadName: input.leadName?.trim() || undefined };
+    const resolve = async (tx: Prisma.TransactionClient) => {
+        const task = await tx.scheduleTask.findUnique({
+            where: { id: input.taskId },
+            select: { id: true, name: true },
+        });
+        if (!task) throw new Error("Task not found");
+        const crew = await resolveCrewNames(tx, crewNames);
+        const lead = input.leadName ? (await resolveCrewNames(tx, [input.leadName]))[0] : null;
+        if (lead && !crew.some(member => member.id === lead.id)) {
+            throw new Error(`Task lead "${input.leadName}" must also appear in crewNames`);
+        }
+        return { task, crew, lead };
+    };
+
+    if (!input.confirmToken) {
+        const resolved = await prisma.$transaction(resolve);
+        return issueConfirmation(
+            "assign_task_crew",
+            args,
+            `Replace crew on "${resolved.task.name}" with ${resolved.crew.map(member => member.name).join(", ") || "nobody"}${resolved.lead ? `; lead: ${resolved.lead.name}` : ""}.`,
+        );
+    }
+    return executeConfirmed("assign_task_crew", args, input.confirmToken, async tx => {
+        const resolved = await resolve(tx);
+        await setTaskCrewInTransaction(tx, {
+            taskId: input.taskId,
+            userIds: resolved.crew.map(member => member.id),
+            actor: MCP_ACTOR,
+        });
+        const assignments = await setTaskLeadInTransaction(
+            tx,
+            input.taskId,
+            resolved.lead?.id ?? null,
+            MCP_ACTOR,
+        );
+        return {
+            taskId: input.taskId,
+            assignments: assignments.map(assignment => ({
+                id: assignment.id,
+                userId: assignment.userId,
+                name: assignment.user.name || assignment.user.email,
+                role: assignment.role,
+            })),
+        };
+    });
+}
+
+export async function listCrewAvailability(input: { startDate: string; days: number }) {
+    const startDate = parseStartDateInput(input.startDate);
+    if (!Number.isSafeInteger(input.days) || input.days < 1 || input.days > 14) {
+        throw new Error("days must be a whole number from 1 through 14");
+    }
+    const endDate = addDays(startDate, input.days);
+    const [crew, assignments] = await Promise.all([
+        prisma.user.findMany({
+            where: { status: "ACTIVATED", role: "FIELD_CREW" },
+            orderBy: [{ name: "asc" }, { id: "asc" }],
+            select: { id: true, name: true },
+        }),
+        prisma.taskAssignment.findMany({
+            where: {
+                user: { status: "ACTIVATED", role: "FIELD_CREW" },
+                task: {
+                    projectId: { not: null },
+                    OR: [
+                        { type: "milestone", startDate: { gte: startDate, lt: endDate } },
+                        { type: { not: "milestone" }, startDate: { lt: endDate }, endDate: { gt: startDate } },
+                    ],
+                },
+            },
+            select: {
+                userId: true,
+                task: { select: { id: true, name: true, type: true, startDate: true, endDate: true } },
+            },
+        }),
+    ]);
+    const days = Array.from({ length: input.days }, (_, index) => addDays(startDate, index));
+    return {
+        startDate: input.startDate,
+        days: input.days,
+        crew: crew.map(member => ({
+            userId: member.id,
+            name: member.name || "Unnamed crew member",
+            days: days.map(date => {
+                const next = addDays(date, 1);
+                const bookedTasks = assignments
+                    .filter(assignment => assignment.userId === member.id)
+                    .filter(assignment => {
+                        const taskEnd = assignment.task.type === "milestone"
+                            ? addDays(assignment.task.startDate, 1)
+                            : assignment.task.endDate;
+                        return assignment.task.startDate < next && taskEnd > date;
+                    })
+                    .map(assignment => assignment.task.name)
+                    .filter((name, index, all) => all.indexOf(name) === index);
+                return {
+                    date: date.toISOString().slice(0, 10),
+                    status: bookedTasks.length > 0 ? "booked" : "free",
+                    bookedTasks,
+                };
+            }),
+        })),
+    };
+}
+
+export async function setProjectStartDateWithConfirmation(input: {
+    projectId: string;
+    startDate: string | null;
+    shiftJobTasks?: boolean;
+    confirmToken?: string;
+}) {
+    if (input.startDate !== null) parseStartDateInput(input.startDate);
+    const args = {
+        projectId: input.projectId,
+        startDate: input.startDate,
+        shiftJobTasks: input.shiftJobTasks ?? true,
+    };
+    if (!input.confirmToken) {
+        const project = await prisma.project.findUnique({
+            where: { id: input.projectId },
+            select: { name: true, startDate: true, _count: { select: { scheduleTasks: true } } },
+        });
+        if (!project) throw new Error("Project not found");
+        return issueConfirmation(
+            "set_project_start_date",
+            args,
+            `Set "${project.name}" start date from ${project.startDate?.toISOString().slice(0, 10) ?? "unset"} to ${input.startDate ?? "unset"}${args.shiftJobTasks ? `; up to ${project._count.scheduleTasks} schedule tasks may shift with the job` : "; tasks will stay in place"}.`,
+        );
+    }
+    return executeConfirmed("set_project_start_date", args, input.confirmToken, async tx => {
+        const result = await setProjectStartDateInTransaction(tx, {
+            projectId: input.projectId,
+            startDate: input.startDate === null ? null : parseStartDateInput(input.startDate),
+            shiftJobTasks: args.shiftJobTasks,
+            actor: MCP_ACTOR,
+        });
+        if (input.startDate !== null) {
+            const taskCount = await tx.scheduleTask.count({ where: { projectId: input.projectId } });
+            const qualifying = await tx.estimate.findFirst({
+                ...canonicalContractEstimateQuery(input.projectId),
+                select: { id: true, code: true },
+            });
+            if (taskCount === 0 && qualifying) {
+                const generated = await generateScheduleFromEstimateInTransaction(tx, {
+                    estimateId: qualifying.id,
+                    mode: "merge",
+                    requireEmptyProject: true,
+                    actor: MCP_ACTOR,
+                });
+                result.notes.push(`Schedule auto-generated from estimate ${qualifying.code} (${generated.created.length} tasks).`);
+            }
+        }
+        return result as unknown as Record<string, unknown>;
+    });
+}
+
+export async function generateProjectScheduleWithConfirmation(input: {
+    estimateId: string;
+    mode?: "merge" | "regenerate";
+    confirmToken?: string;
+}) {
+    const args = { estimateId: input.estimateId, mode: input.mode ?? "merge" };
+    if (!input.confirmToken) {
+        const estimate = await prisma.estimate.findUnique({
+            where: { id: input.estimateId },
+            select: {
+                code: true,
+                status: true,
+                project: { select: { name: true, startDate: true, _count: { select: { scheduleTasks: true } } } },
+                _count: { select: { items: true, paymentSchedules: true } },
+            },
+        });
+        if (!estimate) throw new Error("Estimate not found");
+        if (!estimate.project) throw new Error("Estimate is not attached to a project");
+        return issueConfirmation(
+            "generate_project_schedule",
+            args,
+            `${args.mode === "regenerate" ? "Regenerate" : "Merge"} the schedule for "${estimate.project.name}" from estimate ${estimate.code}: ${estimate._count.items} estimate lines and ${estimate._count.paymentSchedules} payment milestones; ${estimate.project._count.scheduleTasks} tasks currently exist.`,
+        );
+    }
+    return executeConfirmed("generate_project_schedule", args, input.confirmToken, async tx =>
+        generateScheduleFromEstimateInTransaction(tx, {
+            estimateId: input.estimateId,
+            mode: args.mode,
+            actor: MCP_ACTOR,
+        }) as unknown as Promise<Record<string, unknown>>,
+    );
+}
+
+export async function assignProjectCrewWithConfirmation(input: {
+    projectId: string;
+    userIds: string[];
+    confirmToken?: string;
+}) {
+    const userIds = [...new Set(input.userIds)];
+    const args = { projectId: input.projectId, userIds };
+    if (!input.confirmToken) {
+        const [project, users] = await Promise.all([
+            prisma.project.findUnique({
+                where: { id: input.projectId },
+                select: { name: true },
+            }),
+            prisma.user.findMany({
+                where: { id: { in: userIds } },
+                select: { id: true, name: true, email: true, status: true },
+            }),
+        ]);
+        if (!project) throw new Error("Project not found");
+        const found = new Set(users.map(user => user.id));
+        const missing = userIds.filter(id => !found.has(id));
+        if (missing.length > 0) throw new Error(`Unknown user id(s): ${missing.join(", ")}`);
+        return issueConfirmation(
+            "assign_project_crew",
+            args,
+            `Replace project crew on "${project.name}" with ${users.map(user => user.name || user.email).join(", ") || "nobody"}.`,
+        );
+    }
+    return executeConfirmed("assign_project_crew", args, input.confirmToken, async tx =>
+        setProjectCrewInTransaction(tx, { projectId: input.projectId, userIds, actor: MCP_ACTOR }) as unknown as Promise<Record<string, unknown>>,
+    );
+}
+
+export async function applyChangeOrderToScheduleWithConfirmation(input: {
+    changeOrderId: string;
+    mode?: "merge" | "regenerate";
+    confirmToken?: string;
+}) {
+    const args = { changeOrderId: input.changeOrderId, mode: input.mode ?? "merge" };
+    if (!input.confirmToken) {
+        const changeOrder = await prisma.changeOrder.findUnique({
+            where: { id: input.changeOrderId },
+            select: {
+                code: true,
+                title: true,
+                status: true,
+                project: { select: { name: true } },
+                _count: { select: { items: true, paymentSchedules: true } },
+            },
+        });
+        if (!changeOrder) throw new Error("Change order not found");
+        return issueConfirmation(
+            "apply_change_order_to_schedule",
+            args,
+            `${args.mode === "regenerate" ? "Regenerate" : "Apply"} ${changeOrder.code} "${changeOrder.title}" on "${changeOrder.project.name}" to the schedule: ${changeOrder._count.items} items and ${changeOrder._count.paymentSchedules} milestones.`,
+        );
+    }
+    return executeConfirmed("apply_change_order_to_schedule", args, input.confirmToken, async tx =>
+        applyChangeOrderToScheduleInTransaction(tx, {
+            changeOrderId: input.changeOrderId,
+            mode: args.mode,
+            actor: MCP_ACTOR,
+        }) as unknown as Promise<Record<string, unknown>>,
+    );
+}

--- a/src/lib/schedule-core.ts
+++ b/src/lib/schedule-core.ts
@@ -1064,16 +1064,24 @@ export interface GenerateScheduleResult {
  * SUBTREE — a protected descendant keeps the whole subtree (never a cascade
  * through protected work).
  */
-export async function generateScheduleFromEstimate(input: {
+export interface GenerateScheduleInput {
     estimateId: string;
     mode?: "merge" | "regenerate";
     requireEmptyProject?: boolean;
     actor: ScheduleActor;
-}): Promise<GenerateScheduleResult> {
+}
+
+interface InternalGenerateScheduleInput extends GenerateScheduleInput {
+    transaction?: Prisma.TransactionClient;
+}
+
+async function runGenerateScheduleFromEstimate(
+    input: InternalGenerateScheduleInput,
+): Promise<GenerateScheduleResult> {
     const mode = input.mode ?? "merge";
     if (mode !== "merge" && mode !== "regenerate") throw new Error(`Unknown generation mode "${mode}"`);
 
-    return withTxRetry(() => prisma.$transaction(async (tx) => {
+    const execute = async (tx: Prisma.TransactionClient) => {
         // Lock-then-read, mirroring setProjectStartDate exactly: resolve the
         // project id with a minimal read, take the Project row lock, and ONLY
         // THEN re-read the full estimate (items, paymentSchedules — clones are
@@ -1510,7 +1518,23 @@ export async function generateScheduleFromEstimate(input: {
         });
 
         return { estimateCode: estimate.code, created: createdRows, skipped, milestonesLinked, notes };
-    }));
+    };
+    return input.transaction
+        ? execute(input.transaction)
+        : withTxRetry(() => prisma.$transaction(execute));
+}
+
+export async function generateScheduleFromEstimate(
+    input: GenerateScheduleInput,
+): Promise<GenerateScheduleResult> {
+    return runGenerateScheduleFromEstimate(input);
+}
+
+export async function generateScheduleFromEstimateInTransaction(
+    tx: Prisma.TransactionClient,
+    input: GenerateScheduleInput,
+): Promise<GenerateScheduleResult> {
+    return runGenerateScheduleFromEstimate({ ...input, transaction: tx });
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1528,12 +1552,20 @@ export interface ProjectCrewMember {
  * Every id must be an ACTIVATED user. Idempotent; writes a "set_project_crew"
  * ActivityLog row.
  */
-export async function setProjectCrew(input: {
+export interface SetProjectCrewInput {
     projectId: string;
     userIds: string[];
     actor: ScheduleActor;
-}): Promise<{ projectId: string; crew: ProjectCrewMember[] }> {
-    return withTxRetry(() => prisma.$transaction(async (tx) => {
+}
+
+interface InternalSetProjectCrewInput extends SetProjectCrewInput {
+    transaction?: Prisma.TransactionClient;
+}
+
+async function runSetProjectCrew(
+    input: InternalSetProjectCrewInput,
+): Promise<{ projectId: string; crew: ProjectCrewMember[] }> {
+    const execute = async (tx: Prisma.TransactionClient) => {
         await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${input.projectId} FOR UPDATE`;
         const project = await tx.project.findUnique({
             where: { id: input.projectId },
@@ -1590,7 +1622,23 @@ export async function setProjectCrew(input: {
             projectId: input.projectId,
             crew: wanted.map(id => ({ id, name: byId.get(id)!.name || byId.get(id)!.email })),
         };
-    }));
+    };
+    return input.transaction
+        ? execute(input.transaction)
+        : withTxRetry(() => prisma.$transaction(execute));
+}
+
+export async function setProjectCrew(
+    input: SetProjectCrewInput,
+): Promise<{ projectId: string; crew: ProjectCrewMember[] }> {
+    return runSetProjectCrew(input);
+}
+
+export async function setProjectCrewInTransaction(
+    tx: Prisma.TransactionClient,
+    input: SetProjectCrewInput,
+): Promise<{ projectId: string; crew: ProjectCrewMember[] }> {
+    return runSetProjectCrew({ ...input, transaction: tx });
 }
 
 export interface CrewConflictPair {
@@ -2574,15 +2622,23 @@ export interface ApplyChangeOrderResult {
  * tasks exist (linking still converges); "regenerate" rebuilds only
  * provenance-tagged subtrees passing the P2 full eligibility predicate.
  */
-export async function applyChangeOrderToSchedule(input: {
+export interface ApplyChangeOrderScheduleInput {
     changeOrderId: string;
     mode?: "merge" | "regenerate";
     actor: ScheduleActor;
-}): Promise<ApplyChangeOrderResult> {
+}
+
+interface InternalApplyChangeOrderScheduleInput extends ApplyChangeOrderScheduleInput {
+    transaction?: Prisma.TransactionClient;
+}
+
+async function runApplyChangeOrderToSchedule(
+    input: InternalApplyChangeOrderScheduleInput,
+): Promise<ApplyChangeOrderResult> {
     const mode = input.mode ?? "merge";
     if (mode !== "merge" && mode !== "regenerate") throw new Error(`Unknown mode "${mode}"`);
 
-    return withTxRetry(() => prisma.$transaction(async (tx) => {
+    const execute = async (tx: Prisma.TransactionClient) => {
         // Lock-then-read (same discipline as generation and start-date moves).
         const coRef = await tx.changeOrder.findUnique({
             where: { id: input.changeOrderId },
@@ -2996,7 +3052,23 @@ export async function applyChangeOrderToSchedule(input: {
         });
 
         return { changeOrderCode: co.code, projectId, created: createdRows, skipped, milestonesLinked, notes };
-    }));
+    };
+    return input.transaction
+        ? execute(input.transaction)
+        : withTxRetry(() => prisma.$transaction(execute));
+}
+
+export async function applyChangeOrderToSchedule(
+    input: ApplyChangeOrderScheduleInput,
+): Promise<ApplyChangeOrderResult> {
+    return runApplyChangeOrderToSchedule(input);
+}
+
+export async function applyChangeOrderToScheduleInTransaction(
+    tx: Prisma.TransactionClient,
+    input: ApplyChangeOrderScheduleInput,
+): Promise<ApplyChangeOrderResult> {
+    return runApplyChangeOrderToSchedule({ ...input, transaction: tx });
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -3008,12 +3080,26 @@ export async function applyChangeOrderToSchedule(input: {
  * id must be an ACTIVATED user (same validation as setProjectCrew); role stays
  * "assigned". Idempotent; writes a "set_task_crew" ActivityLog row.
  */
-export async function setTaskCrew(input: {
+export interface SetTaskCrewInput {
     taskId: string;
     userIds: string[];
     actor: ScheduleActor;
-}): Promise<{ taskId: string; projectId: string; assignments: { id: string; userId: string; name: string }[] }> {
-    return withTxRetry(() => prisma.$transaction(async (tx) => {
+}
+
+export interface SetTaskCrewResult {
+    taskId: string;
+    projectId: string;
+    assignments: { id: string; userId: string; name: string; role: string }[];
+}
+
+interface InternalSetTaskCrewInput extends SetTaskCrewInput {
+    transaction?: Prisma.TransactionClient;
+}
+
+async function runSetTaskCrew(
+    input: InternalSetTaskCrewInput,
+): Promise<SetTaskCrewResult> {
+    const execute = async (tx: Prisma.TransactionClient) => {
         const lockedParent = await lockTaskAssignmentParent(tx, input.taskId);
         const task = await tx.scheduleTask.findUnique({
             where: { id: input.taskId },
@@ -3072,12 +3158,31 @@ export async function setTaskCrew(input: {
 
         const final = await tx.taskAssignment.findMany({
             where: { taskId: input.taskId },
-            select: { id: true, userId: true, user: { select: { name: true, email: true } } },
+            select: { id: true, userId: true, role: true, user: { select: { name: true, email: true } } },
         });
         return {
             taskId: input.taskId,
             projectId: task.projectId,
-            assignments: final.map(a => ({ id: a.id, userId: a.userId, name: a.user.name || a.user.email })),
+            assignments: final.map(a => ({
+                id: a.id,
+                userId: a.userId,
+                name: a.user.name || a.user.email,
+                role: a.role,
+            })),
         };
-    }));
+    };
+    return input.transaction
+        ? execute(input.transaction)
+        : withTxRetry(() => prisma.$transaction(execute));
+}
+
+export async function setTaskCrew(input: SetTaskCrewInput): Promise<SetTaskCrewResult> {
+    return runSetTaskCrew(input);
+}
+
+export async function setTaskCrewInTransaction(
+    tx: Prisma.TransactionClient,
+    input: SetTaskCrewInput,
+): Promise<SetTaskCrewResult> {
+    return runSetTaskCrew({ ...input, transaction: tx });
 }

--- a/src/lib/schedule-task-core.ts
+++ b/src/lib/schedule-task-core.ts
@@ -1,0 +1,443 @@
+import { Prisma } from "@prisma/client";
+
+import { getDefaultColorForTaskName } from "@/app/projects/[id]/schedule/schedule-utils";
+import { CLOSED_PROJECT_STATUSES } from "./gpt-estimate";
+import {
+    deriveEstimateItemHours,
+    lockTaskAssignmentParent,
+    parseStartDateInput,
+    touchTaskAssignmentRevision,
+    type ScheduleActor,
+} from "./schedule-core";
+
+export const SCHEDULE_TASK_TYPES = ["task", "milestone", "appointment"] as const;
+export const SCHEDULE_CONFIRMATION_STATUSES = ["planned", "requested", "confirmed"] as const;
+export const SCHEDULE_TASK_STATUSES = ["Not Started", "In Progress", "Complete", "Blocked"] as const;
+const SCHEDULE_TIME_PATTERN = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
+
+export type ScheduleTaskType = typeof SCHEDULE_TASK_TYPES[number];
+export type ScheduleConfirmationStatus = typeof SCHEDULE_CONFIRMATION_STATUSES[number];
+export type ScheduleTaskStatus = typeof SCHEDULE_TASK_STATUSES[number];
+
+export interface ScheduleTaskCommentAuthor {
+    userId: string | null;
+    fallbackLabel: string;
+}
+
+export interface CreateScheduleTaskInput {
+    name: string;
+    startDate: string;
+    endDate: string;
+    color?: string;
+    status?: string;
+    assignee?: string;
+    parentId?: string;
+    type?: ScheduleTaskType;
+    estimateItemId?: string | null;
+    crewIds?: string[];
+    leadUserId?: string | null;
+    estimatedHours?: number | null;
+    doneWhen?: string | null;
+    note?: string;
+    scheduledTime?: string | null;
+    confirmationStatus?: ScheduleConfirmationStatus | null;
+}
+
+export interface UpdateScheduleTaskInput {
+    name?: string;
+    startDate?: string;
+    endDate?: string;
+    color?: string;
+    progress?: number;
+    status?: string;
+    assignee?: string;
+    order?: number;
+    estimatedHours?: number | null;
+    type?: ScheduleTaskType;
+    estimateItemId?: string | null;
+    doneWhen?: string | null;
+    blockedReason?: string | null;
+    scheduledTime?: string | null;
+    confirmationStatus?: ScheduleConfirmationStatus | null;
+}
+
+function assertScheduleTaskType(type: string): asserts type is ScheduleTaskType {
+    if (!(SCHEDULE_TASK_TYPES as readonly string[]).includes(type)) {
+        throw new Error("Invalid schedule task type");
+    }
+}
+
+function assertScheduleTaskStatus(status: string): asserts status is ScheduleTaskStatus {
+    if (!(SCHEDULE_TASK_STATUSES as readonly string[]).includes(status)) {
+        throw new Error(`Invalid schedule task status "${status}"`);
+    }
+}
+
+function normalizeScheduledTime(value: string | null | undefined): string | null {
+    const normalized = value?.trim() || null;
+    if (normalized && !SCHEDULE_TIME_PATTERN.test(normalized)) {
+        throw new Error("Scheduled time must use 24-hour HH:MM format");
+    }
+    return normalized;
+}
+
+function assertConfirmationStatus(value: string): asserts value is ScheduleConfirmationStatus {
+    if (!(SCHEDULE_CONFIRMATION_STATUSES as readonly string[]).includes(value)) {
+        throw new Error("Invalid appointment confirmation status");
+    }
+}
+
+function taskCommentCreateData(
+    taskId: string,
+    text: string,
+    author: ScheduleTaskCommentAuthor,
+) {
+    return {
+        taskId,
+        text,
+        userId: author.userId,
+        subcontractorName: author.userId ? null : author.fallbackLabel,
+    };
+}
+
+export async function createScheduleTaskInTransaction(
+    tx: Prisma.TransactionClient,
+    projectId: string,
+    data: CreateScheduleTaskInput,
+    actor: ScheduleActor,
+    commentAuthor?: ScheduleTaskCommentAuthor | null,
+) {
+    const name = data.name.trim();
+    if (!name) throw new Error("Task name is required");
+    const type = data.type ?? "task";
+    assertScheduleTaskType(type);
+    if (data.status !== undefined) assertScheduleTaskStatus(data.status);
+    if (data.status === "Blocked") throw new Error("Blocked tasks require a reason");
+
+    const startDate = parseStartDateInput(data.startDate);
+    const requestedEndDate = parseStartDateInput(data.endDate);
+    const endDate = type === "milestone" ? startDate : requestedEndDate;
+    if (type !== "milestone" && endDate < startDate) {
+        throw new Error("Task end date cannot be before its start date");
+    }
+    if (data.estimatedHours != null && (!Number.isFinite(data.estimatedHours) || data.estimatedHours < 0)) {
+        throw new Error("Estimated hours must be zero or greater");
+    }
+
+    const scheduledTime = normalizeScheduledTime(data.scheduledTime);
+    if (data.confirmationStatus) assertConfirmationStatus(data.confirmationStatus);
+    if (type !== "appointment" && (scheduledTime || data.confirmationStatus)) {
+        throw new Error("Scheduled time and confirmation status are appointment-only fields");
+    }
+    const confirmationStatus = type === "appointment" ? (data.confirmationStatus ?? "planned") : null;
+    const estimateItemId = data.estimateItemId?.trim() || null;
+    const crewIds = [...new Set((data.crewIds ?? []).filter(Boolean))];
+    const leadUserId = data.leadUserId ?? null;
+    if (leadUserId && !crewIds.includes(leadUserId)) {
+        throw new Error("Task lead must be assigned to the crew");
+    }
+    const note = data.note?.trim() || null;
+
+    await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${projectId} FOR UPDATE`;
+    const project = await tx.project.findUnique({ where: { id: projectId }, select: { id: true } });
+    if (!project) throw new Error("Project not found");
+
+    const estimateItem = estimateItemId
+        ? await tx.estimateItem.findUnique({
+            where: { id: estimateItemId },
+            select: {
+                id: true,
+                type: true,
+                quantity: true,
+                budgetUnit: true,
+                estimate: { select: { projectId: true } },
+                scheduleTask: { select: { id: true, name: true } },
+                _count: { select: { subItems: true } },
+            },
+        })
+        : null;
+    if (estimateItemId) {
+        if (!estimateItem || estimateItem.estimate.projectId !== projectId) {
+            throw new Error("Estimate item does not belong to this project");
+        }
+        if (estimateItem.type === "Section") {
+            throw new Error("Estimate sections cannot be scheduled as tasks");
+        }
+        if (estimateItem.scheduleTask) {
+            throw new Error(`Already linked to "${estimateItem.scheduleTask.name}"`);
+        }
+    }
+
+    const maxOrder = await tx.scheduleTask.aggregate({
+        where: { projectId },
+        _max: { order: true },
+    });
+    if (crewIds.length > 0) {
+        const activeCrew = await tx.user.findMany({
+            where: { id: { in: crewIds }, status: "ACTIVATED" },
+            select: { id: true },
+        });
+        if (activeCrew.length !== crewIds.length) {
+            throw new Error("Task crew members must be ACTIVATED users");
+        }
+    }
+
+    const createData: Prisma.ScheduleTaskUncheckedCreateInput = {
+        projectId,
+        name,
+        startDate,
+        endDate,
+        color: data.color || getDefaultColorForTaskName(name) || "#4c9a2a",
+        status: data.status || "Not Started",
+        assignee: data.assignee || null,
+        parentId: data.parentId || null,
+        order: (maxOrder._max.order ?? -1) + 1,
+        type,
+        estimateItemId,
+        estimatedHours: data.estimatedHours ?? (estimateItem
+            ? deriveEstimateItemHours({
+                quantity: estimateItem.quantity,
+                budgetUnit: estimateItem.budgetUnit,
+                childCount: estimateItem._count.subItems,
+            })
+            : null),
+        doneWhen: data.doneWhen?.trim() || null,
+        scheduledTime,
+        confirmationStatus,
+    };
+    const created = await tx.scheduleTask.create({ data: createData });
+    if (crewIds.length > 0) {
+        await tx.taskAssignment.createMany({
+            data: crewIds.map(userId => ({
+                taskId: created.id,
+                userId,
+                role: userId === leadUserId ? "lead" : "assigned",
+            })),
+        });
+    }
+    if (note && commentAuthor) {
+        await tx.taskComment.create({
+            data: taskCommentCreateData(created.id, note, commentAuthor),
+        });
+    }
+    await tx.activityLog.create({
+        data: {
+            projectId,
+            actorType: actor.type,
+            actorName: actor.name,
+            action: "created_schedule_task",
+            entityType: "task",
+            entityId: created.id,
+            entityName: created.name,
+            metadata: JSON.stringify({
+                name,
+                startDate: startDate.toISOString().slice(0, 10),
+                endDate: endDate.toISOString().slice(0, 10),
+                color: createData.color,
+                status: createData.status,
+                type,
+                estimateItemId,
+                crewIds,
+                leadUserId,
+                estimatedHours: createData.estimatedHours,
+                doneWhen: createData.doneWhen,
+                note,
+                scheduledTime,
+                confirmationStatus,
+            }),
+        },
+    });
+    return created;
+}
+
+export async function updateScheduleTaskInTransaction(
+    tx: Prisma.TransactionClient,
+    taskId: string,
+    data: UpdateScheduleTaskInput,
+    actor: ScheduleActor,
+    expectedProjectId?: string,
+) {
+    const locked = await lockTaskAssignmentParent(tx, taskId, expectedProjectId);
+    const persisted = await tx.scheduleTask.findUnique({
+        where: { id: taskId },
+        select: {
+            id: true,
+            name: true,
+            projectId: true,
+            type: true,
+            status: true,
+            blockedReason: true,
+            startDate: true,
+            endDate: true,
+            project: { select: { status: true } },
+        },
+    });
+    if (!persisted || persisted.projectId !== locked.projectId) throw new Error("Task not found");
+
+    if (data.type !== undefined) assertScheduleTaskType(data.type);
+    if (data.status !== undefined) assertScheduleTaskStatus(data.status);
+    const nextType = data.type ?? persisted.type;
+    const nextStatus = data.status ?? persisted.status;
+    const updateData: Prisma.ScheduleTaskUncheckedUpdateInput = {};
+
+    if (data.name !== undefined) {
+        const name = data.name.trim();
+        if (!name) throw new Error("Task name is required");
+        updateData.name = name;
+    }
+    if (data.color !== undefined) updateData.color = data.color;
+    if (data.progress !== undefined) updateData.progress = data.progress;
+    if (data.status !== undefined) updateData.status = data.status;
+    if (data.assignee !== undefined) updateData.assignee = data.assignee;
+    if (data.order !== undefined) updateData.order = data.order;
+    if (data.estimatedHours !== undefined) {
+        if (data.estimatedHours != null && (!Number.isFinite(data.estimatedHours) || data.estimatedHours < 0)) {
+            throw new Error("Estimated hours must be zero or greater");
+        }
+        updateData.estimatedHours = data.estimatedHours;
+    }
+    if (data.type !== undefined) updateData.type = data.type;
+    if (data.doneWhen !== undefined) updateData.doneWhen = data.doneWhen?.trim() || null;
+    if (data.status !== undefined || data.blockedReason !== undefined) {
+        if (nextStatus === "Blocked") {
+            const reasonSource = data.blockedReason !== undefined ? data.blockedReason : persisted.blockedReason;
+            const reason = reasonSource?.trim();
+            if (!reason) throw new Error("Blocked tasks require a reason");
+            updateData.blockedReason = reason;
+        } else {
+            updateData.blockedReason = null;
+        }
+    }
+    if (data.scheduledTime !== undefined) {
+        const scheduledTime = normalizeScheduledTime(data.scheduledTime);
+        if (nextType !== "appointment" && scheduledTime) {
+            throw new Error("Scheduled time is only available for appointments");
+        }
+        updateData.scheduledTime = scheduledTime;
+    }
+    if (data.confirmationStatus !== undefined) {
+        if (data.confirmationStatus) assertConfirmationStatus(data.confirmationStatus);
+        if (nextType !== "appointment" && data.confirmationStatus) {
+            throw new Error("Confirmation status is only available for appointments");
+        }
+        updateData.confirmationStatus = data.confirmationStatus;
+    }
+    if (data.type !== undefined && data.type !== "appointment") {
+        updateData.scheduledTime = null;
+        updateData.confirmationStatus = null;
+    }
+    if (data.estimateItemId !== undefined) {
+        updateData.estimateItemId = data.estimateItemId;
+        if (data.estimateItemId) {
+            const existing = await tx.scheduleTask.findFirst({
+                where: { estimateItemId: data.estimateItemId, id: { not: taskId } },
+                select: { id: true, name: true },
+            });
+            if (existing) throw new Error(`Already linked to "${existing.name}"`);
+            const item = await tx.estimateItem.findUnique({
+                where: { id: data.estimateItemId },
+                select: { type: true, quantity: true, budgetUnit: true },
+            });
+            if (item && (item.type === "Labor" || item.budgetUnit === "hours")) {
+                updateData.estimatedHours = item.quantity || null;
+            }
+        }
+    }
+
+    const hasDatePatch = data.startDate !== undefined || data.endDate !== undefined;
+    if (hasDatePatch) {
+        if (!persisted.project) throw new Error("Task is not attached to a project");
+        if (CLOSED_PROJECT_STATUSES.includes(persisted.project.status)) {
+            throw new Error(`Cannot update a task on a closed project (${persisted.project.status})`);
+        }
+        if (data.type !== undefined && data.type !== persisted.type) {
+            throw new Error("Change task type separately before editing its dates");
+        }
+        const startDate = data.startDate === undefined ? persisted.startDate : parseStartDateInput(data.startDate);
+        const requestedEndDate = data.endDate === undefined ? persisted.endDate : parseStartDateInput(data.endDate);
+        const endDate = persisted.type === "milestone" ? startDate : requestedEndDate;
+        if (persisted.type !== "milestone" && endDate <= startDate) {
+            throw new Error("Task end date must be after its start date");
+        }
+        updateData.startDate = startDate;
+        updateData.endDate = endDate;
+    }
+
+    const saved = await tx.scheduleTask.update({
+        where: { id: taskId },
+        data: updateData,
+    });
+    if (hasDatePatch) {
+        await tx.activityLog.create({
+            data: {
+                projectId: locked.projectId,
+                actorType: actor.type,
+                actorName: actor.name,
+                action: "updated_company_schedule_task_dates",
+                entityType: "task",
+                entityId: taskId,
+                entityName: persisted.name,
+                metadata: JSON.stringify({
+                    previousStartDate: persisted.startDate.toISOString().slice(0, 10),
+                    previousEndDate: persisted.endDate.toISOString().slice(0, 10),
+                    startDate: saved.startDate.toISOString().slice(0, 10),
+                    endDate: saved.endDate.toISOString().slice(0, 10),
+                    type: persisted.type,
+                }),
+            },
+        });
+    }
+    return saved;
+}
+
+export async function setTaskLeadInTransaction(
+    tx: Prisma.TransactionClient,
+    taskId: string,
+    userId: string | null,
+    actor: ScheduleActor,
+    expectedProjectId?: string,
+) {
+    const locked = await lockTaskAssignmentParent(tx, taskId, expectedProjectId);
+    const task = await tx.scheduleTask.findUnique({
+        where: { id: taskId },
+        select: {
+            id: true,
+            name: true,
+            projectId: true,
+            assignments: { select: { userId: true, role: true } },
+        },
+    });
+    if (!task || task.projectId !== locked.projectId) throw new Error("Task not found");
+    if (userId && !task.assignments.some(assignment => assignment.userId === userId)) {
+        throw new Error("Task lead must be assigned to the crew");
+    }
+    const previousLeadUserId = task.assignments.find(assignment => assignment.role === "lead")?.userId ?? null;
+    await tx.taskAssignment.updateMany({
+        where: { taskId, role: "lead" },
+        data: { role: "assigned" },
+    });
+    if (userId) {
+        await tx.taskAssignment.update({
+            where: { taskId_userId: { taskId, userId } },
+            data: { role: "lead" },
+        });
+    }
+    await touchTaskAssignmentRevision(tx, taskId);
+    await tx.activityLog.create({
+        data: {
+            projectId: locked.projectId,
+            actorType: actor.type,
+            actorName: actor.name,
+            action: "set_task_lead",
+            entityType: "task",
+            entityId: taskId,
+            entityName: task.name,
+            metadata: JSON.stringify({ previousLeadUserId, leadUserId: userId }),
+        },
+    });
+    return tx.taskAssignment.findMany({
+        where: { taskId },
+        orderBy: { createdAt: "asc" },
+        include: { user: { select: { id: true, name: true, email: true } } },
+    });
+}


### PR DESCRIPTION
PR-F of the dispatch arc — Richard plans jobs by talking to his ChatGPT, and every AI-driven schedule write now requires a real, single-use confirmation.

## What's new
- **`plan_schedule`**: "Hoppe bath: demo 3 days starting Aug 3, then rough-ins…" becomes up to 50 tasks in one atomic call — crew resolved by name (ambiguity returns candidates), all-or-nothing.
- **`get_project_schedule` / `list_crew_availability`**: read tools with material counts and booked/free days — recursively asserted financial-free.
- **`update_task_dates` / `set_task_status` / `assign_task_crew`**: thin wrappers over the canonical core (same rules as the UI: Blocked needs a reason, single lead).
- **The security upgrade**: single-use, database-tracked confirmation tokens (argsHash-bound, 10-minute expiry, consumed inside the write transaction — a race gets exactly one winner, live-proven). This replaces the replayable stateless pattern on schedule writers and closes a plan-review finding: three existing writers had **no confirmation at all**. Money-path send tools deliberately untouched.

## Verification
- New DB-backed suite ALL PASS + the entire regression battery re-run green (publish 18/18, board, materials, portal tracker, phase-3 CO suite 65/65)
- Independent checker quoted the conditional-UPDATE consume mechanism, the migration boundary, and the zero-raw-writes claim; its one finding (payload scan gap) fixed and re-proven, plus one test self-contradiction corrected
- Schema applied to prod ahead of merge per protocol

Implemented by GPT-5.6-sol (xhigh); independently gate-checked; reviewed by Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)