### PR TITLE
Project drawer replaces the bar popover (owner feedback)

### DIFF
--- a/scripts/verify-schedule-board-render-contract.ts
+++ b/scripts/verify-schedule-board-render-contract.ts
@@ -45,6 +45,9 @@ const companyDashboardSource = src("../src/app/company-dashboard/CompanyDashboar
 // CompanyDashboardClient (which imports ScheduleBoard -> …View -> ProjectBar).
 const crewPickersSource = src("../src/app/company-dashboard/schedule-board/CrewPickers.tsx");
 const drawerSource = src("../src/app/company-dashboard/schedule-board/BoardTaskDrawer.tsx");
+const projectDrawerSource = src("../src/app/company-dashboard/schedule-board/BoardProjectDrawer.tsx");
+const drawerShellSource = src("../src/app/company-dashboard/schedule-board/BoardDrawerShell.tsx");
+const projectTaskOverflowSource = src("../src/app/company-dashboard/schedule-board/ProjectTaskOverflow.tsx");
 const taskCreationDialogSource = src("../src/components/TaskCreationDialog.tsx");
 const detailPanelSource = src("../src/app/projects/[id]/schedule/TaskDetailPanel.tsx");
 const scheduleBoardDirectory = new URL("../src/app/company-dashboard/schedule-board/", import.meta.url);
@@ -323,7 +326,8 @@ assert.match(boardSource, /catch \(chunkError: any\) \{/, "chunk failures are is
 assert.match(boardSource, /chunk\.map\(change => \(\{ taskId: change\.taskId, ok: false as const, error: message \}\)\)/, "a rejected chunk synthesizes failures for its own tasks only");
 assert.match(boardSource, /const markerResult = await updateProjectStartDateAction\(projectId, draft\.targetStart, false\);\s*\n\s*const shiftResult = await shiftNotStartedTasksAction\(projectId, draft\.deltaDays\)/, "In Progress shift choice moves the marker AND the not-started work");
 assert.match(popoverSource, /VIEWPORT_MARGIN_PX/);
-assert.match(projectBarSource, /import \{ FloatingPopover \} from "\.\/FloatingPopover"/);
+assert.doesNotMatch(projectBarSource, /FloatingPopover/, "ProjectBar must not import or render the removed project popover");
+assert.match(projectTaskOverflowSource, /import \{ FloatingPopover \} from "\.\/FloatingPopover"/, "the unchanged +N task overflow keeps its popover in an isolated component");
 assert.match(taskBlockSource, /import \{ FloatingPopover \} from "\.\/FloatingPopover"/);
 assert.doesNotMatch(projectBarSource, /<details/, "the project bar's Actions menu must no longer be a clipped native <details>");
 assert.doesNotMatch(taskBlockSource, /<details/, "the task block's date menu must no longer be a clipped native <details>");
@@ -339,7 +343,8 @@ for (const source of [monthSource, timelineSource]) {
 assert.match(layoutSource, /export const MAX_TASK_LANES = 3/);
 assert.match(layoutSource, /export function assignTaskLanes/);
 assert.match(projectBarSource, /assignTaskLanes\(taskLaneInput\)/);
-assert.match(projectBarSource, /hiddenTasks\.length > 0/, "a +N overflow affordance must exist for tasks beyond the lane cap");
+assert.match(projectBarSource, /<ProjectTaskOverflow projectName=\{project\.name\} tasks=\{hiddenTasks\} \/>/, "a +N overflow affordance must exist for tasks beyond the lane cap");
+assert.match(projectTaskOverflowSource, /if \(tasks\.length === 0\) return null;/, "the extracted +N overflow must only render for tasks beyond the lane cap");
 assert.match(taskBlockSource, /laneTop\?: number/);
 assert.match(taskBlockSource, /laneHeight\?: number/);
 
@@ -377,14 +382,17 @@ assert.match(projectBarSource, /function handleContextMenu\(event: ReactMouseEve
 assert.match(taskBlockSource, /onContextMenu=\{handleContextMenu\}/, "TaskBlockSegment must wire a contextmenu handler");
 assert.match(taskBlockSource, /function handleContextMenu\(event: ReactMouseEvent<HTMLDivElement>\) \{\s*\n\s*if \(!canEdit \|\| isPending\) return;/, "TaskBlockSegment's context menu must be canEdit-gated");
 // Keyboard equivalent (ContextMenu key / Shift+F10) on both bar/block.
-assert.match(projectBarSource, /event\.key === "ContextMenu" \|\| \(event\.key === "F10" && event\.shiftKey\)/, "ProjectBar must open its menu on the ContextMenu key / Shift+F10");
+assert.match(projectBarSource, /event\.key === "ContextMenu" \|\| \(event\.key === "F10" && event\.shiftKey\)/, "ProjectBar must open its drawer on the ContextMenu key / Shift+F10");
 assert.match(taskBlockSource, /event\.key === "ContextMenu" \|\| \(event\.key === "F10" && event\.shiftKey\)/, "TaskBlockSegment must open its menu on the ContextMenu key / Shift+F10");
-// Only one schedule-board menu open at a time, including click vs context
-// menu — the shared exclusive-menu coordinator, registered by every menu.
-for (const source of [projectBarSource, taskBlockSource, monthSource, timelineSource]) {
+// Only one schedule-board menu/drawer is open at a time, including click vs
+// context activation — quick menus keep their registrations and both drawers
+// inherit the same coordination through their shared shell.
+for (const source of [taskBlockSource, monthSource, timelineSource, projectTaskOverflowSource]) {
     assert.match(source, /activateExclusiveMenu\(close\)/, "every schedule-board menu must register with the exclusive-menu coordinator on open");
     assert.match(source, /deactivateExclusiveMenu\(close\)/, "every schedule-board menu must deregister with the exclusive-menu coordinator on close");
 }
+assert.match(drawerShellSource, /activateExclusiveMenu\(close\)/, "the shared drawer shell must register with the exclusive-menu coordinator");
+assert.match(drawerShellSource, /deactivateExclusiveMenu\(close\)/, "the shared drawer shell must deregister with the exclusive-menu coordinator");
 // Empty day cell "Schedule here…" routes through the SAME function the tray
 // drop handler calls (onTrayProjectDrop) — never a second scheduling path.
 assert.match(monthSource, /onTrayProjectDrop\(project, dayContextMenu\.date\)/, "Month's Schedule-here must route through the existing tray-drop function");
@@ -396,33 +404,32 @@ assert.match(timelineSource, /No unscheduled projects/, "Timeline's Schedule-her
 assert.match(taskBlockSource, /import \{ addTaskComment, deleteScheduleTask \} from "@\/lib\/actions"/);
 assert.match(taskBlockSource, /await deleteScheduleTask\(task\.id\)/);
 assert.match(taskBlockSource, /Deletes now — not part of unsaved changes/, "Delete task's confirm copy must explicitly say it is immediate, not draft-mode");
-// Project bar: Remove from schedule only for Waiting to Start, through the
+// Project drawer: Remove from schedule only for Waiting to Start, through the
 // existing updateProjectStartDateAction(projectId, null, false) path.
-assert.match(projectBarSource, /project\.status === "Waiting to Start" &&[\s\S]{0,700}Remove from schedule/, "Remove from schedule must only render for Waiting-to-Start projects");
-assert.match(projectBarSource, /await updateProjectStartDateAction\(project\.id, null, false\)/, "Remove from schedule must use the existing updateProjectStartDateAction(projectId, null, false) path");
+assert.match(projectDrawerSource, /project\.status === "Waiting to Start" &&[\s\S]{0,900}Remove from schedule/, "Remove from schedule must only render for Waiting-to-Start projects");
+assert.match(projectDrawerSource, /await updateProjectStartDateAction\(project\.id, null, false\)/, "Remove from schedule must use the existing updateProjectStartDateAction(projectId, null, false) path");
 // Color… reuses the ORIGINAL schedule palette (PRESET_COLORS), not a
 // re-invented swatch list.
-assert.match(projectBarSource, /import \{ addDays, formatDate, parseUTCDate, PRESET_COLORS \} from "@\/app\/projects\/\[id\]\/schedule\/schedule-utils"/);
-assert.match(projectBarSource, /PRESET_COLORS\.map\(swatch =>/, "the Color… grid must be built from PRESET_COLORS");
+assert.match(projectDrawerSource, /PRESET_COLORS[\s\S]*from "@\/app\/projects\/\[id\]\/schedule\/schedule-utils"/);
+assert.match(projectDrawerSource, /PRESET_COLORS\.map\(swatch =>/, "the drawer Color section must be built from PRESET_COLORS");
 // Project crew…/Task crew… reuse the SAME pickers as the Schedule & crew
 // table (via the extracted CrewPickers module), never a rebuilt picker.
 // Crew-picker rebuild (item 5): the schedule-board menu instances render the
 // shared CrewChecklist INLINE (variant="inline") — no nested popover inside
 // the bar/block's own FloatingPopover menu, which was the double-scrollbar bug.
-assert.match(projectBarSource, /import \{ CrewPicker \} from "\.\/CrewPickers"/);
-assert.match(projectBarSource, /<CrewPicker projectId=\{project\.id\} crew=\{project\.crew\} teamMembers=\{teamMembers\} variant="inline" \/>/);
+assert.match(projectDrawerSource, /import \{ CrewPicker \} from "\.\/CrewPickers"/);
+assert.match(projectDrawerSource, /<CrewPicker[\s\S]{0,240}projectId=\{project\.id\}[\s\S]{0,240}variant="inline"[\s\S]{0,240}layout="list"/, "the project drawer must use the shared serialized picker in list layout");
 assert.match(taskBlockSource, /import \{ TaskCrewPicker \} from "\.\/CrewPickers"/);
 assert.match(taskBlockSource, /<TaskCrewPicker task=\{task\} teamMembers=\{teamMembers\} variant="inline" \/>/);
 
-// ── Item 6: a bar click toggles its menu, never navigates ──
-// PR-0 activation seam: block/bar chrome is replaced by root activation.
+// ── Item 6: root activation routes to the right drawer ──
 assert.doesNotMatch(taskBlockSource, /aria-label=\{`Task actions for /, "TaskBlockSegment must not render the old ellipsis action button");
 assert.doesNotMatch(taskBlockSource, />\s*\u22ef\s*<\/button>/, "TaskBlockSegment must not render a vertical-ellipsis button");
 assert.doesNotMatch(taskBlockSource, /actionTriggerRef/, "the removed task action button must not leave a trigger ref behind");
 assert.match(taskBlockSource, /function handleBlockActivate\(event: ReactMouseEvent<HTMLDivElement> \| KeyboardEvent<HTMLElement>\) \{/);
 assert.match(taskBlockSource, /if \(!canEdit \|\| isPending\) return;\s*\n\s*if \(\(event\.target as HTMLElement\)\.closest\("a,button,input,summary,form,details"\)\) return;/, "task block activation must reuse the old action-button edit gates and ignore interactive descendants");
 assert.match(taskBlockSource, /onClick=\{handleBlockActivate\}/, "the task block root click must route through the named activation seam");
-assert.match(taskBlockSource, /handleBlockActivate[\s\S]{0,400}event\.stopPropagation\(\);/, "block activation must stop propagation — the parent bar's click opens the PROJECT menu and would instantly replace the task menu via the exclusive-menu coordinator");
+assert.match(taskBlockSource, /handleBlockActivate[\s\S]{0,400}event\.stopPropagation\(\);/, "block activation must stop propagation so the parent bar's project drawer does not replace the task drawer");
 assert.match(taskBlockSource, /mode === "move" && activeMode === null && \(event\.key === " " \|\| event\.key === "Enter"\)[\s\S]{0,250}handleBlockActivate\(event\);/, "Enter/Space on a non-editing task block must route through the activation seam");
 assert.match(taskBlockSource, /<FloatingPopover open=\{menuOpen\} anchorRef=\{rootRef\} anchorPoint=\{menuAnchorPoint\}/, "keyboard-opened task menus must anchor to the block rect while pointer-opened menus may use a point");
 
@@ -431,17 +438,16 @@ assert.doesNotMatch(projectBarSource, />\s*Actions\s*<\/button>/, "ProjectBar mu
 assert.doesNotMatch(projectBarSource, /actionTriggerRef/, "the removed project Actions chip must not leave a trigger ref behind");
 assert.match(projectBarSource, /const rootRef = useRef<HTMLDivElement>\(null\)/);
 assert.match(projectBarSource, /ref=\{rootRef\}[\s\S]{0,1200}onClick=\{handleBarClick\}/, "ProjectBar's root ref and existing click activation must stay wired");
-assert.match(projectBarSource, /<FloatingPopover open=\{menuOpen\} anchorRef=\{rootRef\} anchorPoint=\{menuAnchorPoint\}/, "keyboard-opened project menus must anchor to the bar rect while pointer-opened menus may use a point");
+assert.doesNotMatch(projectBarSource, /menuOpen|menuView|menuAnchorPoint|openMenu/, "all project-menu state and view switching must be gone");
 
-// A bar click still toggles its menu and never navigates; pointer activation
-// opens at the click point, while keyboard activation falls back to rootRef.
+// Project-bar activation always routes through the lifted drawer seam.
 assert.match(projectBarSource, /function handleBarClick\(/);
-// Item 1 (2026-07-22) replaced the bare `setMenuOpen(value => !value)` toggle
-// with explicit open/close (via `openMenu`, which also resets the menu's
-// view/anchor state) — still a toggle in effect, just no longer a one-liner.
-assert.match(projectBarSource, /if \(menuOpen\) \{\s*setMenuOpen\(false\);\s*\} else \{\s*openMenu\(\{ x: event\.clientX, y: event\.clientY \}\);\s*\}/, "a bar click must still toggle the menu open/closed and pointer-open at the click point");
+assert.match(projectBarSource, /function handleBarClick\([\s\S]{0,500}onProjectActivate\(project\.id\)/, "plain project-bar clicks must open the project drawer");
+assert.match(projectBarSource, /if \(!editing && \(event\.key === " " \|\| event\.key === "Enter"\)\) \{[\s\S]{0,160}onProjectActivate\(project\.id\)/, "Enter/Space must open the project drawer");
+assert.match(projectBarSource, /function handleContextMenu\([\s\S]{0,500}onProjectActivate\(project\.id\)/, "right-click must open the project drawer");
+assert.match(projectBarSource, /event\.key === "ContextMenu" \|\| \(event\.key === "F10" && event\.shiftKey\)[\s\S]{0,220}onProjectActivate\(project\.id\)/, "ContextMenu/Shift+F10 must open the project drawer");
 assert.doesNotMatch(projectBarSource, /onClick=\{.*router\.push|onClick=\{.*navigate/, "the bar itself must never navigate on click");
-assert.match(projectBarSource, />\s*Open project\s*<\/Link>/, "Open project must be a menu item inside the Actions dropdown");
+assert.match(projectDrawerSource, /Open project/, "Open project must move into the project drawer header");
 
 // ── Item 7: crew picker hygiene (FINANCE exclusion + name disambiguation) ──
 // Owner call 2026-07-23: schedulable people = FIELD_CREW only (no admins or
@@ -474,7 +480,7 @@ assert.match(dialogSource, /Move the start marker AND shift all Not Started task
 assert.match(boardSource, /<ShiftConfirmDialog[\s\S]*?intent=\{confirmIntent\}[\s\S]*?onChoice=\{handleMoveChoice\}[\s\S]*?onCancel=\{cancelConfirmedMove\}/);
 
 // ── Money-path invariants: unchanged by this feature round ──
-for (const source of [boardSource, monthSource, timelineSource, projectBarSource, taskBlockSource, popoverSource, availabilityPanelSource, crewPickersSource]) {
+for (const source of [boardSource, monthSource, timelineSource, projectBarSource, projectDrawerSource, drawerShellSource, projectTaskOverflowSource, taskBlockSource, popoverSource, availabilityPanelSource, crewPickersSource]) {
     assert.doesNotMatch(source, /PaymentSchedule\.(update|create|delete)|EstimatePaymentSchedule\.(update|create|delete)|ChangeOrderPaymentSchedule\.(update|create|delete)/);
     assert.doesNotMatch(source, /\bfetch\s*\(/);
 }
@@ -498,8 +504,8 @@ const plannedLabelIndex = availabilityPanelSource.indexOf("Planned $/day");
 assert.ok(plannedRowGuardIndex >= 0 && plannedLabelIndex > plannedRowGuardIndex, "the planned-$/day footer row must be gated behind canSeeFinancials");
 assert.doesNotMatch(availabilityPanelSource, /\bprisma\b|getCashflowOutlook|getChangeOrderOverlayRows|getCalendarOverlays|getCompanyDashboardData/, "the availability panel must derive from serialized CompanyDashboardData only, never a direct query or money-fetch function");
 assert.match(availabilityPanelSource, /distanceMilesFromShop/, "far-job awareness must read the serialized distanceMilesFromShop field");
-assert.match(projectBarSource, /project\.distanceMilesFromShop != null/);
-assert.match(projectBarSource, /mi from shop/, "the Actions popover must surface the shop distance line");
+assert.match(projectDrawerSource, /project\.distanceMilesFromShop != null/);
+assert.match(projectDrawerSource, /mi from shop/, "the project drawer header must surface the shop distance line");
 // The crew-mode toggle is now owned by ScheduleBoard so the panel's
 // drill-down can force it on even when Timeline is already mounted.
 assert.match(timelineSource, /export const CREW_MODE_STORAGE_KEY/);
@@ -511,29 +517,27 @@ assert.match(boardSource, /onDrillDown=\{drillDownToCrewTimeline\}/);
 // "Edit dates…" — the standalone "Set end date…" item and its own menu view
 // are GONE; the "dates" view now carries both fields. ──
 assert.doesNotMatch(projectBarSource, /Set end date…/, "the standalone \"Set end date…\" menu item must be removed");
-assert.doesNotMatch(projectBarSource, /"main" \| "dates" \| "crew" \| "color" \| "end-date"/, "BarMenuView must no longer carry a separate end-date view");
-assert.match(projectBarSource, /type BarMenuView = "main" \| "dates" \| "crew" \| "color";/);
+assert.doesNotMatch(projectBarSource, /BarMenuView|setMenuView/, "ProjectBar must carry no menu view state");
 // "Edit dates…" is no longer canMoveProject-gated at the menu-item level (a
 // Substantial Completion project can't move its start, but must still be
 // able to set an end date) — the Start FIELD inside the view stays gated.
 assert.doesNotMatch(projectBarSource, /\{canMoveProject && \(\s*<button type="button" onClick=\{\(\) => setMenuView\("dates"\)\}/, "the Edit dates… menu item itself must not be canMoveProject-gated");
-assert.match(projectBarSource, /\{menuView === "dates" && \(/, "the merged dates view must not require canMoveProject to render at all");
-assert.match(projectBarSource, /\{canMoveProject && \(\s*<div>\s*<label[\s\S]{0,300}Start date/, "the Start date FIELD inside the merged view stays canMoveProject-gated");
-assert.match(projectBarSource, /htmlFor=\{`bar-project-enddate-\$\{project\.id\}`\}>End date/, "the merged view must contain an End date field");
-assert.match(projectBarSource, /Joins unsaved changes — Save to commit\./, "the Start field needs a caption distinguishing it from the immediate End write");
-assert.match(projectBarSource, /Saves immediately\./, "the End field needs a caption distinguishing it from the draft Start write");
-assert.match(projectBarSource, /Clear end date/, "the merged view keeps a Clear end date affordance");
+assert.match(projectDrawerSource, /\{canMoveProject && \(\s*<div>\s*<label[\s\S]{0,300}Start date/, "the Start date field inside the drawer stays canMoveProject-gated");
+assert.match(projectDrawerSource, />End date<\/label>/, "the drawer Dates section must contain an End date field");
+assert.match(projectDrawerSource, /Joins unsaved changes — Save to commit\./, "the Start field needs a caption distinguishing it from the immediate End write");
+assert.match(projectDrawerSource, /Saves immediately\./, "the End field needs a caption distinguishing it from the draft Start write");
+assert.match(projectDrawerSource, /Clear end date/, "the drawer keeps a Clear end date affordance");
 // Submit behavior: Start routes through the EXISTING draft path
 // (onMoveCommit -> draftProjectMove); End calls updateProjectEndDateAction
 // (via submitEndDate) immediately and ONLY when it actually changed.
-const handleDateSubmitStart = projectBarSource.indexOf("function handleDateSubmit(");
-const handleDateSubmitEnd = projectBarSource.indexOf("function submitColor(", handleDateSubmitStart);
-const handleDateSubmitBody = projectBarSource.slice(handleDateSubmitStart, handleDateSubmitEnd);
+const handleDateSubmitStart = projectDrawerSource.indexOf("function handleDateSubmit(");
+const handleDateSubmitEnd = projectDrawerSource.indexOf("function submitEndDate(", handleDateSubmitStart);
+const handleDateSubmitBody = projectDrawerSource.slice(handleDateSubmitStart, handleDateSubmitEnd);
 assert.ok(handleDateSubmitStart >= 0, "handleDateSubmit must exist");
 assert.match(handleDateSubmitBody, /onMoveCommit\(project, targetStart\)/, "a start change must route through the existing draft path");
 assert.match(handleDateSubmitBody, /if \(endDateValue !== projectEndDate\) \{\s*\n\s*submitEndDate\(endDateValue \|\| null\);/, "an end change must fire submitEndDate ONLY when the value actually changed");
-assert.match(projectBarSource, /await updateProjectEndDateAction\(project\.id, value\);/, "the merged End field still routes through the existing updateProjectEndDateAction — no new action");
-assert.match(projectBarSource, /toast\.error\(err\?\.message \|\| "Failed to update end date"\)/, "end-date validation errors stay toasts");
+assert.match(projectDrawerSource, /await updateProjectEndDateAction\(project\.id, value\);/, "the drawer End field still routes through the existing updateProjectEndDateAction — no new action");
+assert.match(projectDrawerSource, /toast\.error\(err\?\.message \|\| "Failed to update end date"\)/, "end-date validation errors stay toasts");
 
 // ── Item 2: project-bar right-edge resize -> end date ──
 assert.match(projectBarSource, /onProjectEndResizeStart: ProjectEditCallbacks\["onProjectEndResizeStart"\]/, "ProjectBarProps must carry the end-resize callback");
@@ -619,7 +623,9 @@ for (const source of [monthSource, timelineSource, projectBarSource]) {
 assert.doesNotMatch(crewPickersSource, /max-h-64/, "CrewPickers must not bring its own max-height scroller — FloatingPopover owns scrolling");
 assert.doesNotMatch(crewPickersSource, /overflow-y-auto/, "CrewPickers must not bring its own scroll region — double scrollbar was the bug");
 assert.match(crewPickersSource, /function CrewChecklist\(/, "a single shared checklist presentation must exist");
-assert.match(crewPickersSource, /grid grid-cols-1 gap-1 sm:grid-cols-2/, "the checklist must be a two-column grid, not a single vertical list");
+assert.match(crewPickersSource, /layout\?: "compact" \| "list"/, "CrewChecklist must expose a list layout without forking the picker");
+assert.match(crewPickersSource, /layout === "list" \? "grid grid-cols-1 gap-1" : "grid grid-cols-1 gap-1 sm:grid-cols-2"/, "the drawer gets one row per person while compact popovers keep two columns");
+assert.match(crewPickersSource, /option\.tag/, "removable non-crew entries must expose a separate role/status tag in list layout");
 assert.match(crewPickersSource, /variant\?: "inline" \| "popover";/, "CrewPicker/TaskCrewPicker must accept the inline/popover variant");
 assert.match(crewPickersSource, /if \(variant === "inline"\) \{\s*\n\s*return <CrewChecklist/, "the inline variant must render the checklist directly with no nested trigger/popover of its own");
 assert.match(crewPickersSource, /<FloatingPopover open=\{open\} anchorRef=\{triggerRef\} onClose=\{\(\) => setOpen\(false\)\} width=\{320\}>/, "the popover variant (Schedule & crew table) must use FloatingPopover at width 320");
@@ -665,8 +671,8 @@ assert.match(boardSource, /draftTaskIds\.has\(openTaskId\)/, "direct task drafts
 assert.match(boardSource, /draftProjectIds\.has\(openTaskProjectId\)/, "project shifts that move the task must lock drawer date editing");
 assert.match(boardSource, /hasDraft=\{openTaskHasDraft\}/, "ScheduleBoard must pass the complete draft-date safety flag to the drawer");
 assert.match(boardSource, /onDeleted=\{handleDrawerTaskDeleted\}/, "drawer deletion must reconcile board-local task state");
-assert.match(drawerSource, /activeElement\.blur\(\)/, "outside-close must flush blur-saved drawer fields before unmounting");
-assert.match(drawerSource, /window\.setTimeout\(onClose, 0\)/, "outside-close must defer unmount until the blur handler runs");
+assert.match(drawerShellSource, /activeElement\.blur\(\)/, "outside-close must flush blur-saved drawer fields before unmounting");
+assert.match(drawerShellSource, /window\.setTimeout\(onClose, 0\)/, "outside-close must defer unmount until the blur handler runs");
 assert.match(drawerSource, /onDeleted\(id\)/, "successful drawer deletion must notify the board owner");
 assert.match(drawerSource, /This task has unsaved changes on the board — Save or Discard them first\./, "the drawer must explain the draft-date gate exactly");
 assert.match(detailPanelSource, /datesReadOnly\?: boolean;/, "the shared panel must support read-only dates without becoming board-specific");
@@ -677,6 +683,28 @@ const getTaskDetailEnd = actionsSource.indexOf("export async function", getTaskD
 const getTaskDetailBody = actionsSource.slice(getTaskDetailStart, getTaskDetailEnd);
 assert.ok(getTaskDetailStart >= 0, "getScheduleTaskDetail must exist");
 assert.match(getTaskDetailBody, /await assertScheduleTaskAccess\(taskId\);/, "task detail reads must use the canonical schedule-task authorization gate");
+
+// G0 project drawer: lifted project selection, shared shell, and one
+// all-visible list of the former project-menu capabilities.
+assert.match(boardSource, /const \[openProjectId, setOpenProjectId\] = useState<string \| null>\(null\)/, "ScheduleBoard must lift the selected project id beside the task id");
+assert.match(boardSource, /const handleProjectActivate = useCallback\(\(projectId: string\) => \{[\s\S]{0,220}setOpenProjectId\(projectId\)/, "the board must own one project activation handler");
+assert.equal((boardSource.match(/onProjectActivate=\{handleProjectActivate\}/g) ?? []).length, 2, "Month and Timeline must receive the one project activation handler");
+for (const source of [monthSource, timelineSource]) {
+    assert.match(source, /onProjectActivate=\{onProjectActivate\}/, "project drawer activation must be threaded through each ProjectBar render site");
+}
+assert.equal((boardSource.match(/<BoardProjectDrawer/g) ?? []).length, 1, "ScheduleBoard must own exactly one project drawer instance");
+assert.match(boardSource, /project=\{openProject\}/, "the project drawer must receive the selected serialized project");
+assert.match(drawerSource, /import \{ BoardDrawerShell \} from "\.\/BoardDrawerShell"/, "the task drawer must use the extracted shared shell");
+assert.match(projectDrawerSource, /import \{ BoardDrawerShell \} from "\.\/BoardDrawerShell"/, "the project drawer must use the exact same shell");
+assert.match(drawerShellSource, /w-\[min\(420px,calc\(100vw-1rem\)\)\]/, "both drawers must retain the task drawer's 420px responsive width");
+assert.match(drawerShellSource, /event\.key === "Escape"/, "the shared shell must close on Escape");
+assert.match(drawerShellSource, /document\.addEventListener\("pointerdown", onPointerDown, true\)/, "the shared shell must close from captured outside clicks");
+const projectHeaderIndex = projectDrawerSource.indexOf("Open project");
+const projectDatesIndex = projectDrawerSource.indexOf(">Dates<");
+const projectCrewIndex = projectDrawerSource.indexOf(">Project crew<");
+const projectColorIndex = projectDrawerSource.indexOf(">Color<");
+assert.ok(projectHeaderIndex >= 0 && projectDatesIndex > projectHeaderIndex && projectCrewIndex > projectDatesIndex && projectColorIndex > projectCrewIndex, "project drawer sections must stay in Header -> Dates -> Project crew -> Color order");
+assert.doesNotMatch(projectDrawerSource, /Back<\/button>|setMenuView|menuView/, "the project drawer must be one visible scrollable list with no sub-views or Back button");
 
 const updateTaskStart = actionsSource.indexOf("export async function updateScheduleTask(");
 const updateTaskEnd = actionsSource.indexOf("export async function", updateTaskStart + 1);
@@ -721,11 +749,11 @@ for (const [name, source] of [
 // Dispatch exceptions strip. Schedule geometry remains plain React/DOM.
 assert.match(boardSource, /<MotionConfig reducedMotion="user">/, "the schedule board must honor the user's reduced-motion preference");
 assert.match(boardSource, /data-motion-scope="status-change"/, "draft/refresh status changes must use the narrow status transition scope");
-assert.match(drawerSource, /<motion\.aside/, "the shared task drawer must animate its entrance");
+assert.match(drawerShellSource, /<motion\.aside/, "the shared drawer shell must animate both drawers' entrance");
 assert.match(dialogSource, /<motion\.div[\s\S]{0,220}data-motion-scope="dialog-enter"/, "the save-time confirmation dialog must animate its entrance");
 assert.match(taskCreationDialogSource, /<motion\.div[\s\S]{0,220}data-motion-scope="dialog-enter"/, "the shared creation dialog must animate its entrance");
 assert.match(dispatchStripSource, /<motion\.div[\s\S]{0,220}data-motion-scope="exceptions-strip"/, "the exceptions strip must use its narrow transition scope");
-assert.doesNotMatch(scheduleBoardSourceTree, /\s(?:layout|layoutId)=/, "layout and layoutId props are forbidden everywhere under schedule-board/");
+assert.doesNotMatch(scheduleBoardSourceTree, /<motion\.[^>]*\s(?:layout|layoutId)=/, "Framer Motion layout and layoutId props are forbidden everywhere under schedule-board/");
 assert.doesNotMatch(scheduleBoardSourceTree, /<motion\.[^>]*\sdrag(?:=|\s)/, "Motion drag props are forbidden everywhere under schedule-board/");
 for (const [name, source] of [
     ["TaskBlockSegment", taskBlockSource],

--- a/scripts/verify-schedule-board.ts
+++ b/scripts/verify-schedule-board.ts
@@ -768,9 +768,11 @@ async function main() {
         const monthSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/MonthBarsView.tsx", import.meta.url), "utf8");
         const timelineSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/TimelineView.tsx", import.meta.url), "utf8");
         const projectBarSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/ProjectBar.tsx", import.meta.url), "utf8");
+        const projectDrawerSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/BoardProjectDrawer.tsx", import.meta.url), "utf8");
+        const drawerShellSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/BoardDrawerShell.tsx", import.meta.url), "utf8");
         const taskBlockSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/TaskBlockSegment.tsx", import.meta.url), "utf8");
         const availabilityPanelSource = readFileSync(new URL("../src/app/company-dashboard/schedule-board/AvailabilityPanel.tsx", import.meta.url), "utf8");
-        const scheduleBoardSources = [boardSource, monthSource, timelineSource, projectBarSource, taskBlockSource, availabilityPanelSource];
+        const scheduleBoardSources = [boardSource, monthSource, timelineSource, projectBarSource, projectDrawerSource, drawerShellSource, taskBlockSource, availabilityPanelSource];
         check("source forwards canEdit through both views to ProjectBar", monthSource.includes("canEdit={data.canEdit}")
             && timelineSource.includes("canEdit={data.canEdit}"));
         check("source forwards canEdit from ProjectBar to TaskBlockSegment", projectBarSource.includes("<TaskBlockSegment")
@@ -792,8 +794,12 @@ async function main() {
             && availabilityPanelSource.indexOf("Planned $/day") > availabilityPanelSource.indexOf("{canSeeFinancials && ("));
         check("availability panel derives from the DashboardProjectRow/DashboardTaskRow shape already on data (no direct prisma access)",
             !/\bprisma\b/.test(availabilityPanelSource));
-        check("ProjectBar popover surfaces the shop distance line", projectBarSource.includes("project.distanceMilesFromShop != null")
-            && projectBarSource.includes("mi from shop"));
+        check("project drawer replaces the ProjectBar popover and surfaces the shop distance line",
+            !projectBarSource.includes("FloatingPopover")
+            && projectDrawerSource.includes("project.distanceMilesFromShop != null")
+            && projectDrawerSource.includes("mi from shop")
+            && projectDrawerSource.includes("layout=\"list\"")
+            && drawerShellSource.includes("w-[min(420px,calc(100vw-1rem))]"));
     } finally {
         let cleanupPassed = false;
         try {

--- a/src/app/company-dashboard/schedule-board/BoardDrawerShell.tsx
+++ b/src/app/company-dashboard/schedule-board/BoardDrawerShell.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useRef, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { motion } from "framer-motion";
+import { activateExclusiveMenu, deactivateExclusiveMenu } from "./menuCoordinator";
+
+interface BoardDrawerShellProps {
+    open: boolean;
+    ariaLabel: string;
+    onClose: () => void;
+    children: ReactNode;
+}
+
+export function BoardDrawerShell({ open, ariaLabel, onClose, children }: BoardDrawerShellProps) {
+    const drawerRef = useRef<HTMLElement | null>(null);
+
+    useEffect(() => {
+        if (!open) return;
+        const close = () => onClose();
+        activateExclusiveMenu(close);
+        return () => deactivateExclusiveMenu(close);
+    }, [open, onClose]);
+
+    useEffect(() => {
+        if (!open) return;
+        function onKeyDown(event: KeyboardEvent) {
+            if (event.key === "Escape") {
+                event.preventDefault();
+                onClose();
+            }
+        }
+        function onPointerDown(event: PointerEvent) {
+            // Let right-click reach a board item's context-menu path; its
+            // exclusive registration closes this drawer in the same turn.
+            if (event.button !== 0) return;
+            const target = event.target;
+            if (!(target instanceof Node) || drawerRef.current?.contains(target)) return;
+            const activeElement = document.activeElement;
+            if (activeElement instanceof HTMLElement && drawerRef.current?.contains(activeElement)) {
+                activeElement.blur();
+            }
+            event.preventDefault();
+            event.stopPropagation();
+            window.setTimeout(onClose, 0);
+        }
+        document.addEventListener("keydown", onKeyDown);
+        document.addEventListener("pointerdown", onPointerDown, true);
+        return () => {
+            document.removeEventListener("keydown", onKeyDown);
+            document.removeEventListener("pointerdown", onPointerDown, true);
+        };
+    }, [open, onClose]);
+
+    if (!open || typeof document === "undefined") return null;
+
+    return createPortal(
+        <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.16 }}
+            className="pointer-events-none fixed inset-0 z-[180] bg-slate-950/15"
+            aria-hidden={false}
+        >
+            <motion.aside
+                ref={drawerRef}
+                initial={{ x: 20, opacity: 0 }}
+                animate={{ x: 0, opacity: 1 }}
+                transition={{ duration: 0.18, ease: "easeOut" }}
+                role="dialog"
+                aria-modal="false"
+                aria-label={ariaLabel}
+                className="pointer-events-auto fixed inset-y-0 right-0 w-[min(420px,calc(100vw-1rem))] bg-white shadow-[-18px_0_45px_rgba(15,23,42,0.22)]"
+            >
+                {children}
+            </motion.aside>
+        </motion.div>,
+        document.body,
+    );
+}

--- a/src/app/company-dashboard/schedule-board/BoardProjectDrawer.tsx
+++ b/src/app/company-dashboard/schedule-board/BoardProjectDrawer.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useState, useTransition, type FormEvent } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import type { DashboardProjectRow } from "@/lib/schedule-core";
+import {
+    updateProjectColor,
+    updateProjectEndDateAction,
+    updateProjectStartDateAction,
+} from "@/lib/actions";
+import {
+    formatDate,
+    getFallbackProjectColor,
+    PRESET_COLORS,
+} from "@/app/projects/[id]/schedule/schedule-utils";
+import { getEffectiveProjectRange } from "./useBarLayout";
+import { BoardDrawerShell } from "./BoardDrawerShell";
+import { CrewPicker } from "./CrewPickers";
+
+interface BoardProjectDrawerProps {
+    project: DashboardProjectRow | null;
+    teamMembers: { id: string; name: string; email: string }[];
+    isPending: boolean;
+    onMoveCommit: (project: DashboardProjectRow, targetStart: string) => void;
+    onClose: () => void;
+}
+
+const STATUS_STYLES: Record<string, string> = {
+    "Waiting to Start": "bg-slate-100 text-slate-700",
+    "In Progress": "bg-blue-100 text-blue-700",
+    "Substantial Completion": "bg-green-100 text-green-700",
+    "Complete": "bg-green-100 text-green-700",
+};
+
+function ProjectDrawerContent({
+    project,
+    teamMembers,
+    isPending,
+    onMoveCommit,
+    onClose,
+}: Omit<BoardProjectDrawerProps, "project"> & { project: DashboardProjectRow }) {
+    const router = useRouter();
+    const projectRange = getEffectiveProjectRange(project);
+    const projectStart = projectRange ? formatDate(projectRange.start) : "";
+    const projectEndDate = project.endDate ? project.endDate.slice(0, 10) : "";
+    const canMoveProject = project.status === "Waiting to Start" || project.status === "In Progress";
+    const actionResetKey = `${project.id}:${isPending ? "pending" : "ready"}:${projectStart}:${projectEndDate}`;
+    const [targetStartDraft, setTargetStartDraft] = useState(() => ({ resetKey: actionResetKey, value: projectStart }));
+    const targetStart = targetStartDraft.resetKey === actionResetKey ? targetStartDraft.value : projectStart;
+    if (targetStartDraft.resetKey !== actionResetKey) {
+        setTargetStartDraft({ resetKey: actionResetKey, value: projectStart });
+    }
+    const [endDateDraft, setEndDateDraft] = useState(() => ({ resetKey: actionResetKey, value: projectEndDate }));
+    const endDateValue = endDateDraft.resetKey === actionResetKey ? endDateDraft.value : projectEndDate;
+    if (endDateDraft.resetKey !== actionResetKey) {
+        setEndDateDraft({ resetKey: actionResetKey, value: projectEndDate });
+    }
+    const [isColorPending, startColorTransition] = useTransition();
+    const [isEndDatePending, startEndDateTransition] = useTransition();
+    const [isRemovePending, startRemoveTransition] = useTransition();
+    const isDrawerActionPending = isColorPending || isEndDatePending || isRemovePending;
+    const projectColor = project.color || getFallbackProjectColor(project.id);
+
+    function handleDateSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (canMoveProject && targetStart && !isPending) {
+            onMoveCommit(project, targetStart);
+        }
+        if (endDateValue !== projectEndDate) {
+            submitEndDate(endDateValue || null);
+        }
+    }
+
+    function submitEndDate(value: string | null) {
+        startEndDateTransition(async () => {
+            try {
+                await updateProjectEndDateAction(project.id, value);
+                router.refresh();
+                toast.success(value ? "End date set" : "End date cleared");
+            } catch (err: any) {
+                toast.error(err?.message || "Failed to update end date");
+            }
+        });
+    }
+
+    function submitColor(color: string) {
+        startColorTransition(async () => {
+            try {
+                await updateProjectColor(project.id, color);
+                router.refresh();
+            } catch (err: any) {
+                toast.error(err?.message || "Failed to update color");
+            }
+        });
+    }
+
+    function handleRemoveFromSchedule() {
+        if (!window.confirm(`Remove "${project.name}" from the schedule? This clears its start date — the project moves back to Unscheduled.`)) return;
+        startRemoveTransition(async () => {
+            try {
+                await updateProjectStartDateAction(project.id, null, false);
+                router.refresh();
+                toast.success("Removed from schedule");
+                onClose();
+            } catch (err: any) {
+                toast.error(err?.message || "Failed to remove from schedule");
+            }
+        });
+    }
+
+    return (
+        <div className="flex h-full flex-col bg-white" aria-busy={isPending || isDrawerActionPending}>
+            <div className="flex items-start justify-between gap-4 border-b border-hui-border bg-slate-50 px-5 py-4">
+                <div className="min-w-0 flex-1">
+                    <div className="flex min-w-0 items-center gap-2">
+                        <span className="h-3 w-3 shrink-0 rounded-full ring-1 ring-black/10" style={{ backgroundColor: projectColor }} aria-hidden="true" />
+                        <h1 className="min-w-0 truncate text-base font-bold text-hui-textMain">{project.name}</h1>
+                    </div>
+                    <div className="mt-2 flex flex-wrap items-center gap-2">
+                        <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${STATUS_STYLES[project.status] ?? "bg-slate-100 text-slate-700"}`}>
+                            {project.status}
+                        </span>
+                        <Link href={`/projects/${project.id}`} className="text-xs font-semibold text-hui-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary">
+                            Open project →
+                        </Link>
+                    </div>
+                    {project.distanceMilesFromShop != null && (
+                        <p className="mt-1.5 text-xs text-hui-textMuted">≈{project.distanceMilesFromShop} mi from shop</p>
+                    )}
+                </div>
+                <button
+                    type="button"
+                    onClick={onClose}
+                    aria-label="Close project details"
+                    className="rounded-md p-1.5 text-slate-400 transition hover:bg-slate-200 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary"
+                >
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6 6 18M6 6l12 12" /></svg>
+                </button>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto">
+                <section className="border-b border-hui-border px-5 py-5">
+                    <h2 className="mb-4 text-sm font-semibold text-hui-textMain">Dates</h2>
+                    <form onSubmit={handleDateSubmit} className="space-y-4">
+                        {canMoveProject && (
+                            <div>
+                                <label className="block text-xs font-semibold uppercase tracking-wide text-hui-textMuted" htmlFor={`drawer-project-start-${project.id}`}>Start date</label>
+                                <input
+                                    id={`drawer-project-start-${project.id}`}
+                                    type="date"
+                                    value={targetStart}
+                                    onChange={event => setTargetStartDraft({ resetKey: actionResetKey, value: event.target.value })}
+                                    disabled={isPending || isDrawerActionPending}
+                                    className="hui-input mt-1 w-full"
+                                />
+                                <p className="mt-1 text-xs text-hui-textMuted">Joins unsaved changes — Save to commit.</p>
+                            </div>
+                        )}
+                        <div>
+                            <label className="block text-xs font-semibold uppercase tracking-wide text-hui-textMuted" htmlFor={`drawer-project-end-${project.id}`}>End date</label>
+                            <input
+                                id={`drawer-project-end-${project.id}`}
+                                type="date"
+                                value={endDateValue}
+                                onChange={event => setEndDateDraft({ resetKey: actionResetKey, value: event.target.value })}
+                                disabled={isDrawerActionPending}
+                                className="hui-input mt-1 w-full"
+                            />
+                            <p className="mt-1 text-xs text-hui-textMuted">Saves immediately.</p>
+                        </div>
+                        <div className="grid grid-cols-2 gap-2">
+                            <button type="button" disabled={isDrawerActionPending || !project.endDate} onClick={() => submitEndDate(null)} className="hui-btn hui-btn-secondary justify-center text-xs disabled:opacity-60">
+                                Clear end date
+                            </button>
+                            <button type="submit" disabled={isDrawerActionPending || (canMoveProject && (isPending || !targetStart))} className="hui-btn hui-btn-primary justify-center text-xs disabled:cursor-wait disabled:opacity-60">
+                                {isEndDatePending ? "Saving..." : "Save"}
+                            </button>
+                        </div>
+                        {project.status === "Waiting to Start" && (
+                            <div className="border-t border-hui-border pt-4">
+                                <button
+                                    type="button"
+                                    disabled={isDrawerActionPending || isPending}
+                                    onClick={handleRemoveFromSchedule}
+                                    className="w-full rounded-md px-3 py-2 text-left text-xs font-semibold text-red-600 transition hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 disabled:opacity-60"
+                                >
+                                    {isRemovePending ? "Removing..." : "Remove from schedule"}
+                                </button>
+                            </div>
+                        )}
+                    </form>
+                </section>
+
+                <section className="border-b border-hui-border px-5 py-5">
+                    <h2 className="mb-3 text-sm font-semibold text-hui-textMain">Project crew</h2>
+                    <CrewPicker
+                        projectId={project.id}
+                        crew={project.crew}
+                        teamMembers={teamMembers}
+                        variant="inline"
+                        layout="list"
+                    />
+                </section>
+
+                <section className="px-5 py-5">
+                    <h2 className="mb-3 text-sm font-semibold text-hui-textMain">Color</h2>
+                    <div className="grid grid-cols-8 gap-2">
+                        {PRESET_COLORS.map(swatch => {
+                            const isSelected = project.color?.toLowerCase() === swatch.toLowerCase();
+                            return (
+                                <button
+                                    key={swatch}
+                                    type="button"
+                                    disabled={isDrawerActionPending}
+                                    onClick={() => submitColor(swatch)}
+                                    className={`h-7 w-7 rounded-full transition hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary focus-visible:ring-offset-2 disabled:opacity-60 ${isSelected ? "ring-2 ring-slate-700 ring-offset-2" : `ring-1 ${swatch.toLowerCase() === "#ffffff" ? "ring-slate-400" : "ring-slate-200"}`}`}
+                                    style={{ backgroundColor: swatch }}
+                                    title={swatch}
+                                    aria-label={`Set project color to ${swatch}`}
+                                    aria-pressed={isSelected}
+                                />
+                            );
+                        })}
+                    </div>
+                </section>
+            </div>
+        </div>
+    );
+}
+
+export function BoardProjectDrawer(props: BoardProjectDrawerProps) {
+    return (
+        <BoardDrawerShell open={Boolean(props.project)} ariaLabel="Project details" onClose={props.onClose}>
+            {props.project && <ProjectDrawerContent {...props} project={props.project} />}
+        </BoardDrawerShell>
+    );
+}

--- a/src/app/company-dashboard/schedule-board/BoardTaskDrawer.tsx
+++ b/src/app/company-dashboard/schedule-board/BoardTaskDrawer.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
-import { motion } from "framer-motion";
 import { toast } from "sonner";
 import {
     addTaskComment,
@@ -28,7 +26,7 @@ import {
 } from "@/lib/actions";
 import TaskDetailPanel from "@/app/projects/[id]/schedule/TaskDetailPanel";
 import type { Comment, EstimateItemSummary, PunchItem, Subcontractor, Task, TeamMember } from "@/app/projects/[id]/schedule/schedule-types";
-import { activateExclusiveMenu, deactivateExclusiveMenu } from "./menuCoordinator";
+import { BoardDrawerShell } from "./BoardDrawerShell";
 
 type BoardTaskDrawerProps = {
     taskId: string | null;
@@ -46,7 +44,6 @@ function messageFromError(error: unknown, fallback: string) {
 
 export function BoardTaskDrawer({ taskId, hasDraft, hasCrewDraft, teamMembers, onClose, onSelectTask, onDeleted }: BoardTaskDrawerProps) {
     const router = useRouter();
-    const drawerRef = useRef<HTMLElement | null>(null);
     const requestRef = useRef(0);
     const [task, setTask] = useState<Task | null>(null);
     const [allTasks, setAllTasks] = useState<Task[]>([]);
@@ -99,43 +96,6 @@ export function BoardTaskDrawer({ taskId, hasDraft, hasCrewDraft, teamMembers, o
         return () => { requestRef.current += 1; };
     }, [taskId, refreshDetail]);
 
-    useEffect(() => {
-        if (!taskId) return;
-        const close = () => onClose();
-        activateExclusiveMenu(close);
-        return () => deactivateExclusiveMenu(close);
-    }, [taskId, onClose]);
-
-    useEffect(() => {
-        if (!taskId) return;
-        function onKeyDown(event: KeyboardEvent) {
-            if (event.key === "Escape") {
-                event.preventDefault();
-                onClose();
-            }
-        }
-        function onPointerDown(event: PointerEvent) {
-            // Let right-click reach TaskBlockSegment's context-menu path; its
-            // exclusive-menu registration closes this drawer in the same turn.
-            if (event.button !== 0) return;
-            const target = event.target;
-            if (!(target instanceof Node) || drawerRef.current?.contains(target)) return;
-            const activeElement = document.activeElement;
-            if (activeElement instanceof HTMLElement && drawerRef.current?.contains(activeElement)) {
-                activeElement.blur();
-            }
-            event.preventDefault();
-            event.stopPropagation();
-            window.setTimeout(onClose, 0);
-        }
-        document.addEventListener("keydown", onKeyDown);
-        document.addEventListener("pointerdown", onPointerDown, true);
-        return () => {
-            document.removeEventListener("keydown", onKeyDown);
-            document.removeEventListener("pointerdown", onPointerDown, true);
-        };
-    }, [taskId, onClose]);
-
     async function mutate(operation: () => Promise<unknown>, fallback: string, success?: string) {
         try {
             await operation();
@@ -148,27 +108,11 @@ export function BoardTaskDrawer({ taskId, hasDraft, hasCrewDraft, teamMembers, o
         }
     }
 
-    if (!taskId || typeof document === "undefined") return null;
+    if (!taskId) return null;
 
-    const content = (
-        <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.16 }}
-            className="pointer-events-none fixed inset-0 z-[180] bg-slate-950/15"
-            aria-hidden={false}
-        >
-            <motion.aside
-                ref={drawerRef}
-                initial={{ x: 20, opacity: 0 }}
-                animate={{ x: 0, opacity: 1 }}
-                transition={{ duration: 0.18, ease: "easeOut" }}
-                role="dialog"
-                aria-modal="false"
-                aria-label="Task details"
-                className="pointer-events-auto fixed inset-y-0 right-0 w-[min(420px,calc(100vw-1rem))] bg-white shadow-[-18px_0_45px_rgba(15,23,42,0.22)]"
-            >
-                {task && task.id === taskId ? (
+    return (
+        <BoardDrawerShell open ariaLabel="Task details" onClose={onClose}>
+            {task && task.id === taskId ? (
                     <TaskDetailPanel
                         task={task}
                         onClose={onClose}
@@ -241,10 +185,7 @@ export function BoardTaskDrawer({ taskId, hasDraft, hasCrewDraft, teamMembers, o
                             {isLoading || (!loadError && task?.id !== taskId) ? <div><div className="mx-auto h-7 w-7 animate-spin rounded-full border-2 border-indigo-200 border-t-indigo-600" /><p className="mt-3 text-xs text-hui-textMuted">Loading task…</p></div> : <div><p className="text-sm font-semibold text-hui-textMain">Could not open this task</p><p className="mt-1 text-xs text-hui-textMuted">{loadError}</p><button type="button" onClick={() => void refreshDetail()} className="hui-btn hui-btn-secondary mt-4 text-xs">Try again</button></div>}
                         </div>
                     </div>
-                )}
-            </motion.aside>
-        </motion.div>
+            )}
+        </BoardDrawerShell>
     );
-
-    return createPortal(content, document.body);
 }

--- a/src/app/company-dashboard/schedule-board/CrewPickers.tsx
+++ b/src/app/company-dashboard/schedule-board/CrewPickers.tsx
@@ -1,19 +1,14 @@
 "use client";
 
 // Extracted out of CompanyDashboardClient.tsx (item 1) so ProjectBar.tsx and
-// TaskBlockSegment.tsx can reuse the SAME crew pickers inside the new
-// context-menu "Project crew…" / "Task crew…" items, without a circular
+// TaskBlockSegment.tsx and BoardProjectDrawer.tsx can reuse the SAME crew
+// pickers without a circular
 // import (CompanyDashboardClient -> ScheduleBoard -> …View -> ProjectBar
 // would import back into CompanyDashboardClient otherwise). Behavior is
 // byte-identical to the original inline components.
 //
-// Rebuild (owner-feedback round, item 5): the picker used to bring its own
-// fixed-width, fixed-height, self-scrolling inner panel, nested inside the
-// schedule board's ALREADY-scrollable FloatingPopover menus (ProjectBar/
-// TaskBlockSegment's "crew" view) — a double scrollbar + horizontal overflow.
-// CrewChecklist is now a plain two-column grid with NO scroll/width of its
-// own — FloatingPopover is the one and only scroll owner everywhere a picker
-// renders.
+// The compact picker owns no scrolling; its surrounding popover does. The
+// project drawer opts into the single-column list layout and owns the scroll.
 
 import { useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
@@ -30,13 +25,13 @@ function initials(name: string): string {
 export interface CrewOption {
     id: string;
     label: string;
+    tag?: string;
 }
 
 // Shared checklist presentation — used both `variant="inline"` (rendered
-// directly inside an ALREADY-open schedule-board FloatingPopover, no nested
-// popover of its own) and `variant="popover"` (the Schedule & crew table's
-// own trigger + FloatingPopover). No selected-initials chip here — the
-// table/bar trigger button keeps summarizing initials on its own.
+// directly in an existing surface) and `variant="popover"` (the Schedule &
+// crew table's own trigger + FloatingPopover). No selected-initials chip here
+// — the table/bar trigger button keeps summarizing initials on its own.
 // Serializes full-list crew writes: instant optimistic UI, but requests go
 // out strictly in order (a later toggle's list can never be overtaken by an
 // earlier one racing through the locked server transaction). While one write
@@ -77,6 +72,7 @@ export function CrewChecklist({
     onToggle,
     leadUserId,
     onLeadChange,
+    layout = "compact",
 }: {
     legend: string;
     options: CrewOption[];
@@ -84,6 +80,7 @@ export function CrewChecklist({
     onToggle: (userId: string) => void;
     leadUserId?: string | null;
     onLeadChange?: (userId: string | null) => void;
+    layout?: "compact" | "list";
 }) {
     return (
         <fieldset className="m-0 min-w-0 border-0 p-0">
@@ -91,12 +88,12 @@ export function CrewChecklist({
             {options.length === 0 ? (
                 <p className="px-2 py-1 text-xs text-hui-textMuted">No active team members.</p>
             ) : (
-                <div className="grid grid-cols-1 gap-1 sm:grid-cols-2">
+                <div className={layout === "list" ? "grid grid-cols-1 gap-1" : "grid grid-cols-1 gap-1 sm:grid-cols-2"}>
                     {options.map(option => {
                         const isSelected = selected.includes(option.id);
                         const isLead = leadUserId === option.id;
                         return (
-                            <div key={option.id} className="flex min-h-11 min-w-0 items-center rounded-md px-2 py-1 hover:bg-slate-50 focus-within:ring-2 focus-within:ring-hui-primary">
+                            <div key={option.id} className={`flex min-w-0 items-center rounded-md px-2 hover:bg-slate-50 focus-within:ring-2 focus-within:ring-hui-primary ${layout === "list" ? "min-h-12 py-2" : "min-h-11 py-1"}`}>
                                 <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 py-1">
                                     <input
                                         type="checkbox"
@@ -104,7 +101,14 @@ export function CrewChecklist({
                                         onChange={() => onToggle(option.id)}
                                         className="h-4 w-4 shrink-0 accent-hui-primary"
                                     />
-                                    <span className="min-w-0 break-words text-sm text-hui-textMain">{option.label}</span>
+                                    <span className="min-w-0 break-words text-sm text-hui-textMain">
+                                        {option.label}{layout !== "list" && option.tag ? ` (${option.tag})` : ""}
+                                    </span>
+                                    {layout === "list" && option.tag && (
+                                        <span className="ml-auto shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-600">
+                                            {option.tag}
+                                        </span>
+                                    )}
                                 </label>
                                 {isSelected && onLeadChange && (
                                     <button
@@ -134,14 +138,15 @@ export function CrewPicker({
     crew,
     teamMembers,
     variant = "popover",
+    layout = "compact",
 }: {
     projectId: string;
     crew: PipelineCrewMember[];
     teamMembers: { id: string; name: string; email: string }[];
-    // "inline" (ProjectBar's "Project crew…" menu view — already inside a
-    // FloatingPopover) vs "popover" (Schedule & crew table — owns its own
-    // trigger + FloatingPopover).
+    // "inline" renders directly in an existing surface; "popover" owns its
+    // trigger and FloatingPopover.
     variant?: "inline" | "popover";
+    layout?: "compact" | "list";
 }) {
     const router = useRouter();
     const [open, setOpen] = useState(false);
@@ -179,12 +184,16 @@ export function CrewPicker({
     const unlistedAssigned = crew.filter(c => !teamMembers.some(m => m.id === c.id));
     const options = [
         ...teamMembers.map(m => ({ id: m.id, label: m.name || m.email })),
-        ...unlistedAssigned.map(c => ({ id: c.id, label: `${c.name} (${c.status !== "ACTIVATED" ? "inactive" : c.role.toLowerCase().replace("_", " ")})` })),
+        ...unlistedAssigned.map(c => ({
+            id: c.id,
+            label: c.name,
+            tag: c.status !== "ACTIVATED" ? "inactive" : c.role.toLowerCase().replace("_", " "),
+        })),
     ];
     const legend = `Project crew — ${selected.length} assigned`;
 
     if (variant === "inline") {
-        return <CrewChecklist legend={legend} options={options} selected={selected} onToggle={toggle} />;
+        return <CrewChecklist legend={legend} options={options} selected={selected} onToggle={toggle} layout={layout} />;
     }
 
     const selectedNames = options.filter(o => selected.includes(o.id));
@@ -227,7 +236,11 @@ export function TaskCrewPicker({
     const unlisted = task.assignments.filter(a => !teamMembers.some(m => m.id === a.userId));
     const options = [
         ...teamMembers.map(member => ({ id: member.id, label: member.name || member.email })),
-        ...unlisted.map(a => ({ id: a.userId, label: `${a.name} (${a.status !== "ACTIVATED" ? "inactive" : a.userRole.toLowerCase().replace("_", " ")})` })),
+        ...unlisted.map(a => ({
+            id: a.userId,
+            label: a.name,
+            tag: a.status !== "ACTIVATED" ? "inactive" : a.userRole.toLowerCase().replace("_", " "),
+        })),
     ];
     const legend = `Task crew — ${selected.length} assigned`;
 

--- a/src/app/company-dashboard/schedule-board/MonthBarsView.tsx
+++ b/src/app/company-dashboard/schedule-board/MonthBarsView.tsx
@@ -124,8 +124,8 @@ export function MonthBarsView({
     onCreateTask,
     teamMembers,
     isAnyDragActive,
-    onProjectMoveCommit,
     activeProjectKeyboardId,
+    onProjectActivate,
     onProjectPointerEditStart,
     onProjectKeyboardStart,
     onProjectKeyboardAdjust,
@@ -363,6 +363,7 @@ export function MonthBarsView({
                                                     draftTaskIds={draftTaskIds}
                                                     activeTaskKeyboardEdit={activeTaskKeyboardEdit}
                                                     activeProjectKeyboardId={activeProjectKeyboardId}
+                                                    onProjectActivate={onProjectActivate}
                                                     teamMembers={teamMembers}
                                                     isAnyDragActive={isAnyDragActive}
                                                     onProjectPointerEditStart={onProjectPointerEditStart}
@@ -370,7 +371,6 @@ export function MonthBarsView({
                                                     onProjectKeyboardAdjust={onProjectKeyboardAdjust}
                                                     onProjectKeyboardCommit={onProjectKeyboardCommit}
                                                     onProjectKeyboardCancel={onProjectKeyboardCancel}
-                                                    onMoveCommit={onProjectMoveCommit}
                                                     onProjectEndResizeStart={onProjectEndResizeStart}
                                                     onTaskPointerEditStart={onTaskPointerEditStart}
                                                     onTaskKeyboardStart={onTaskKeyboardStart}

--- a/src/app/company-dashboard/schedule-board/ProjectBar.tsx
+++ b/src/app/company-dashboard/schedule-board/ProjectBar.tsx
@@ -1,22 +1,16 @@
 "use client";
 
-import { createContext, useContext, useEffect, useRef, useState, useTransition, type FormEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type RefObject } from "react";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { toast } from "sonner";
+import { createContext, useContext, useRef, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type RefObject } from "react";
 import type {
     DashboardProjectRow,
     OverlayChangeOrderItem,
     OverlayIncomeItem,
 } from "@/lib/schedule-core";
-import { updateProjectColor, updateProjectEndDateAction, updateProjectStartDateAction } from "@/lib/actions";
-import { addDays, formatDate, parseUTCDate, PRESET_COLORS } from "@/app/projects/[id]/schedule/schedule-utils";
+import { addDays, formatDate, parseUTCDate } from "@/app/projects/[id]/schedule/schedule-utils";
 import { assignTaskLanes, getEffectiveProjectRange, type WeekSegment } from "./useBarLayout";
 import { MilestoneMarker } from "./MilestoneMarker";
 import { TaskBlockSegment, type ActiveTaskKeyboardEdit, type TaskEditCallbacks } from "./TaskBlockSegment";
-import { FloatingPopover } from "./FloatingPopover";
-import { CrewPicker } from "./CrewPickers";
-import { activateExclusiveMenu, deactivateExclusiveMenu } from "./menuCoordinator";
+import { ProjectTaskOverflow } from "./ProjectTaskOverflow";
 
 // Mini-lane sizing for overlapping tasks inside one project bar (item 5, and
 // the 2026-07-22 readability pass — 9px task labels were unreadable):
@@ -44,6 +38,7 @@ export function computeTaskLaneLayout(tasks: { id: string; startDate: string; en
 
 export interface ProjectEditCallbacks {
     activeProjectKeyboardId: string | null;
+    onProjectActivate: (_projectId: string) => void;
     onProjectPointerEditStart: (_project: DashboardProjectRow, _start: ProjectPointerEditStart) => void;
     onProjectKeyboardStart: (_project: DashboardProjectRow, _sourceElement: HTMLElement) => void;
     onProjectKeyboardAdjust: (_project: DashboardProjectRow, _deltaDays: number) => void;
@@ -75,19 +70,18 @@ export interface ProjectBarProps extends TaskEditCallbacks {
     timelineDayWidth?: number;
     timelineLeftInset?: number;
     timelineScrollContainerRef?: RefObject<HTMLDivElement | null>;
-    // Context-menu "Project crew…" / TaskBlockSegment's "Task crew…" (item 1)
-    // reuse the exact CrewPicker/TaskCrewPicker the Schedule & crew table uses.
+    // Threaded to TaskBlockSegment's retained task-crew quick menu.
     teamMembers: { id: string; name: string; email: string }[];
     // Suppresses every task's hover card while ANY schedule-board drag is
     // active (item 3) — threaded through to this bar's own task renders.
     isAnyDragActive: boolean;
     activeProjectKeyboardId: ProjectEditCallbacks["activeProjectKeyboardId"];
+    onProjectActivate: ProjectEditCallbacks["onProjectActivate"];
     onProjectPointerEditStart: ProjectEditCallbacks["onProjectPointerEditStart"];
     onProjectKeyboardStart: ProjectEditCallbacks["onProjectKeyboardStart"];
     onProjectKeyboardAdjust: ProjectEditCallbacks["onProjectKeyboardAdjust"];
     onProjectKeyboardCommit: ProjectEditCallbacks["onProjectKeyboardCommit"];
     onProjectKeyboardCancel: ProjectEditCallbacks["onProjectKeyboardCancel"];
-    onMoveCommit: ProjectEditCallbacks["onProjectMoveCommit"];
     onProjectEndResizeStart: ProjectEditCallbacks["onProjectEndResizeStart"];
 }
 
@@ -126,12 +120,6 @@ function initials(name: string): string {
     return name.trim().split(/\s+/).map(part => part[0]).join("").toUpperCase().slice(0, 2) || "?";
 }
 
-// The bar's Actions/context menu is a single FloatingPopover instance whose
-// CONTENT switches between a top-level list and each item's own sub-view
-// (item 1) — simpler and more robust than nesting flyout panels, and keeps
-// every item reachable by keyboard from the same panel.
-type BarMenuView = "main" | "dates" | "crew" | "color";
-
 export function ProjectBar({
     project,
     segment,
@@ -152,12 +140,12 @@ export function ProjectBar({
     teamMembers,
     isAnyDragActive,
     activeProjectKeyboardId,
+    onProjectActivate,
     onProjectPointerEditStart,
     onProjectKeyboardStart,
     onProjectKeyboardAdjust,
     onProjectKeyboardCommit,
     onProjectKeyboardCancel,
-    onMoveCommit,
     onProjectEndResizeStart,
     onTaskPointerEditStart,
     onTaskKeyboardStart,
@@ -168,54 +156,9 @@ export function ProjectBar({
     onTaskMoveBy,
     onActivate,
 }: ProjectBarProps) {
-    const router = useRouter();
     const gridStart = useContext(ProjectBarGridStartContext);
     const projectRange = getEffectiveProjectRange(project);
-    const projectStart = projectRange ? formatDate(projectRange.start) : "";
     const rootRef = useRef<HTMLDivElement>(null);
-    const [menuOpen, setMenuOpen] = useState(false);
-    const [menuAnchorPoint, setMenuAnchorPoint] = useState<{ x: number; y: number } | null>(null);
-    const [menuView, setMenuView] = useState<BarMenuView>("main");
-    const overflowTriggerRef = useRef<HTMLButtonElement>(null);
-    const [overflowOpen, setOverflowOpen] = useState(false);
-    const actionResetKey = `${isPending ? "pending" : "ready"}:${projectStart}`;
-    const [targetStartDraft, setTargetStartDraft] = useState(() => ({ resetKey: actionResetKey, value: projectStart }));
-    const targetStart = targetStartDraft.resetKey === actionResetKey ? targetStartDraft.value : projectStart;
-    if (targetStartDraft.resetKey !== actionResetKey) {
-        setTargetStartDraft({ resetKey: actionResetKey, value: projectStart });
-    }
-    const projectEndDate = project.endDate ? project.endDate.slice(0, 10) : "";
-    const [endDateDraft, setEndDateDraft] = useState(() => ({ resetKey: actionResetKey, value: projectEndDate }));
-    const endDateValue = endDateDraft.resetKey === actionResetKey ? endDateDraft.value : projectEndDate;
-    if (endDateDraft.resetKey !== actionResetKey) {
-        setEndDateDraft({ resetKey: actionResetKey, value: projectEndDate });
-    }
-    const [isColorPending, startColorTransition] = useTransition();
-    const [isEndDatePending, startEndDateTransition] = useTransition();
-    const [isRemovePending, startRemoveTransition] = useTransition();
-    useEffect(() => {
-        setMenuOpen(false);
-    }, [actionResetKey]);
-    // Only one schedule-board menu open at a time (item 1) — including across
-    // right-click/context-menu and bar-activation paths.
-    useEffect(() => {
-        if (!menuOpen) {
-            setMenuView("main");
-            setMenuAnchorPoint(null);
-            return;
-        }
-        const close = () => setMenuOpen(false);
-        activateExclusiveMenu(close);
-        return () => deactivateExclusiveMenu(close);
-    }, [menuOpen]);
-    // The "+N" overflow popover is a menu too — register it so opening any
-    // other menu (mouse OR keyboard) closes it, preserving one-menu-at-a-time.
-    useEffect(() => {
-        if (!overflowOpen) return;
-        const close = () => setOverflowOpen(false);
-        activateExclusiveMenu(close);
-        return () => deactivateExclusiveMenu(close);
-    }, [overflowOpen]);
     if (!gridStart || !projectRange) return null;
 
     const visibleStart = addDays(gridStart, segment.weekIndex * 7 + segment.startColumn);
@@ -266,7 +209,7 @@ export function ProjectBar({
     // Right-edge grab handle (item 2): a SEPARATE pointer-drag from the
     // whole-bar move above — stopPropagation so it wins over handlePointerDown
     // within its own hit area instead of also starting a move-drag. Available
-    // whenever the bar's Actions menu is (canEdit), independent of
+    // whenever the bar is editable, independent of
     // canMoveProject — a Substantial Completion project can't have its START
     // dragged, but its finish date is still editable, same as "Edit dates…".
     function handleEndResizePointerDown(event: ReactPointerEvent<HTMLDivElement>) {
@@ -286,29 +229,26 @@ export function ProjectBar({
         });
     }
 
-    function openMenu(anchorPoint: { x: number; y: number } | null) {
-        setMenuAnchorPoint(anchorPoint);
-        setMenuView("main");
-        setMenuOpen(true);
-    }
-
     function handleKeyboard(event: KeyboardEvent<HTMLDivElement>) {
         if (event.target !== event.currentTarget || isPending) return;
         const editing = activeProjectKeyboardId === project.id;
-        // ContextMenu key / Shift+F10: the keyboard equivalent of a right-click
-        // (item 1) — opens the same menu the Actions button opens, ref-anchored
-        // since there is no cursor position to anchor to.
+        // ContextMenu key / Shift+F10: the keyboard equivalent of a right-click.
         if (!editing && canEdit && (event.key === "ContextMenu" || (event.key === "F10" && event.shiftKey))) {
             event.preventDefault();
-            openMenu(null);
+            onProjectActivate(project.id);
             return;
         }
-        if (!canMoveProject) return;
-        if (!editing && (event.key === " " || event.key === "Enter")) {
+        if (!editing && canMoveProject && event.altKey && (event.key === " " || event.key === "Enter")) {
             event.preventDefault();
             onProjectKeyboardStart(project, event.currentTarget);
             return;
         }
+        if (!editing && (event.key === " " || event.key === "Enter")) {
+            event.preventDefault();
+            onProjectActivate(project.id);
+            return;
+        }
+        if (!canMoveProject) return;
         if (!editing) return;
         const step = event.shiftKey ? 7 : 1;
         if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
@@ -332,88 +272,17 @@ export function ProjectBar({
         if (!canEdit || isPending) return;
         if ((event.target as HTMLElement).closest("a,button,input,summary,form,details")) return;
         event.preventDefault();
-        openMenu({ x: event.clientX, y: event.clientY });
+        onProjectActivate(project.id);
     }
 
-    // Merged "Edit dates…" submit (item 1): a Start change and an End change
-    // are TWO INDEPENDENT writers fired from the same form. Start joins the
-    // existing draft system (onMoveCommit -> draftProjectMove — unsaved until
-    // Save); End calls updateProjectEndDateAction immediately and ONLY when
-    // it actually changed (the Clear button below fires the same action
-    // directly, unconditionally).
-    function handleDateSubmit(event: FormEvent<HTMLFormElement>) {
-        event.preventDefault();
-        if (canMoveProject && targetStart && !isPending) {
-            onMoveCommit(project, targetStart);
-        }
-        if (endDateValue !== projectEndDate) {
-            submitEndDate(endDateValue || null);
-        }
-        setMenuOpen(false);
-    }
-
-    function submitColor(color: string) {
-        startColorTransition(async () => {
-            try {
-                await updateProjectColor(project.id, color);
-                router.refresh();
-            } catch (err: any) {
-                toast.error(err?.message || "Failed to update color");
-            }
-        });
-        setMenuOpen(false);
-    }
-
-    // Immediate action (item 3) — NOT part of the board's draft-mode system;
-    // takes effect right away, unlike task/project START dates which route
-    // through Save.
-    function submitEndDate(value: string | null) {
-        startEndDateTransition(async () => {
-            try {
-                await updateProjectEndDateAction(project.id, value);
-                router.refresh();
-                toast.success(value ? "End date set" : "End date cleared");
-            } catch (err: any) {
-                toast.error(err?.message || "Failed to update end date");
-            }
-        });
-        setMenuOpen(false);
-    }
-
-    // Waiting-to-Start projects only (item 1) — immediate action through the
-    // EXISTING updateProjectStartDateAction(projectId, null, false) path,
-    // never offered for In Progress or any other status.
-    function handleRemoveFromSchedule() {
-        if (!window.confirm(`Remove "${project.name}" from the schedule? This clears its start date — the project moves back to Unscheduled.`)) return;
-        startRemoveTransition(async () => {
-            try {
-                await updateProjectStartDateAction(project.id, null, false);
-                router.refresh();
-                toast.success("Removed from schedule");
-            } catch (err: any) {
-                toast.error(err?.message || "Failed to remove from schedule");
-            }
-        });
-        setMenuOpen(false);
-    }
-
-    // A bare click on the bar (not a drag, and not on an interactive
-    // descendant like the name link or the Actions menu itself) toggles the
-    // Actions dropdown instead of doing nothing — the bar itself never
-    // navigates. An active drag calls preventDefault on pointermove once the
-    // threshold is crossed, which suppresses the browser's synthetic click,
-    // so this only fires for genuine clicks.
+    // A bare click opens the project drawer. An active drag calls preventDefault
+    // on pointermove once its threshold is crossed, suppressing the synthetic
+    // click so this only fires for genuine clicks.
     function handleBarClick(event: ReactMouseEvent<HTMLDivElement>) {
         if (!canEdit || isPending) return;
         if ((event.target as HTMLElement).closest("a,button,input,summary,form,details")) return;
-        if (menuOpen) {
-            setMenuOpen(false);
-        } else {
-            openMenu({ x: event.clientX, y: event.clientY });
-        }
+        onProjectActivate(project.id);
     }
-
-    const menuBusy = isColorPending || isEndDatePending || isRemovePending;
 
     return (
         <div
@@ -435,9 +304,9 @@ export function ProjectBar({
         >
             <div data-drag-project-title="true" className="absolute inset-x-0 top-0 z-10 flex h-[18px] min-w-0 items-center gap-1 px-1 text-[10px] leading-none">
                 {segment.continuesBefore && <span aria-hidden="true">‹</span>}
-                <Link href={`/projects/${project.id}`} title={projectTitle} className="min-w-0 flex-1 truncate font-semibold text-white outline-none hover:underline focus-visible:ring-2 focus-visible:ring-white">
+                <span title={projectTitle} className="min-w-0 flex-1 truncate font-semibold text-white">
                     {project.name}
-                </Link>
+                </span>
                 {project.crew.length > 0 && (
                     <span className="shrink-0 text-[9px] font-medium text-white/90" title={`Crew: ${crewLabel}`}>
                         {project.crew.slice(0, 3).map(member => initials(member.name)).join(" ")}{project.crew.length > 3 ? ` +${project.crew.length - 3}` : ""}
@@ -447,109 +316,6 @@ export function ProjectBar({
                     <span className="inline-flex min-w-4 shrink-0 items-center justify-center rounded-full bg-red-600 px-1 py-0.5 text-[9px] font-bold text-white" title={`Crew conflicts: ${conflictNames.join(", ")}`} aria-label={`${conflictNames.length} crew conflict${conflictNames.length === 1 ? "" : "s"}`}>
                         !{conflictNames.length}
                     </span>
-                )}
-                {canEdit && (
-                        <FloatingPopover open={menuOpen} anchorRef={rootRef} anchorPoint={menuAnchorPoint} onClose={() => setMenuOpen(false)} width={240}>
-                            {menuView === "main" && (
-                                <div className="space-y-1">
-                                    <Link
-                                        href={`/projects/${project.id}`}
-                                        className="block w-full rounded px-2 py-1.5 text-xs font-semibold text-hui-primary hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary"
-                                    >
-                                        Open project
-                                    </Link>
-                                    {project.distanceMilesFromShop != null && (
-                                        <p className="px-2 text-[10px] text-hui-textMuted">≈{project.distanceMilesFromShop} mi from shop</p>
-                                    )}
-                                    <button type="button" onClick={() => setMenuView("dates")} className="block w-full rounded px-2 py-1.5 text-left text-xs text-hui-textMain hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary">
-                                        Edit dates…
-                                    </button>
-                                    <button type="button" onClick={() => setMenuView("crew")} className="block w-full rounded px-2 py-1.5 text-left text-xs text-hui-textMain hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary">
-                                        Project crew…
-                                    </button>
-                                    <button type="button" onClick={() => setMenuView("color")} className="block w-full rounded px-2 py-1.5 text-left text-xs text-hui-textMain hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hui-primary">
-                                        Color…
-                                    </button>
-                                    {project.status === "Waiting to Start" && (
-                                        <button
-                                            type="button"
-                                            disabled={menuBusy}
-                                            onClick={handleRemoveFromSchedule}
-                                            className="block w-full rounded px-2 py-1.5 text-left text-xs text-red-600 hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 disabled:opacity-60"
-                                        >
-                                            Remove from schedule
-                                        </button>
-                                    )}
-                                </div>
-                            )}
-                            {menuView === "dates" && (
-                                <form onSubmit={handleDateSubmit} className="space-y-2">
-                                    <button type="button" onClick={() => setMenuView("main")} className="text-[10px] font-semibold text-hui-textMuted hover:text-hui-primary">← Back</button>
-                                    {canMoveProject && (
-                                        <div>
-                                            <label className="block text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted" htmlFor={`bar-project-date-${project.id}-${segment.weekIndex}`}>Start date</label>
-                                            <input
-                                                id={`bar-project-date-${project.id}-${segment.weekIndex}`}
-                                                type="date"
-                                                value={targetStart}
-                                                onChange={event => setTargetStartDraft({ resetKey: actionResetKey, value: event.target.value })}
-                                                disabled={isPending}
-                                                className="hui-input w-full px-2 py-1 text-xs"
-                                            />
-                                            <p className="mt-0.5 text-[9px] text-hui-textMuted">Joins unsaved changes — Save to commit.</p>
-                                        </div>
-                                    )}
-                                    <div>
-                                        <label className="block text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted" htmlFor={`bar-project-enddate-${project.id}`}>End date</label>
-                                        <input
-                                            id={`bar-project-enddate-${project.id}`}
-                                            type="date"
-                                            value={endDateValue}
-                                            onChange={event => setEndDateDraft({ resetKey: actionResetKey, value: event.target.value })}
-                                            disabled={isEndDatePending}
-                                            className="hui-input w-full px-2 py-1 text-xs"
-                                        />
-                                        <p className="mt-0.5 text-[9px] text-hui-textMuted">Saves immediately.</p>
-                                    </div>
-                                    <button type="button" disabled={isEndDatePending || !project.endDate} onClick={() => submitEndDate(null)} className="hui-btn hui-btn-secondary w-full text-[10px] disabled:opacity-60">
-                                        Clear end date
-                                    </button>
-                                    <button type="submit" disabled={isEndDatePending || (canMoveProject && (isPending || !targetStart))} className="hui-btn hui-btn-primary w-full text-xs disabled:cursor-wait disabled:opacity-60">
-                                        {isEndDatePending ? "Saving..." : "Save"}
-                                    </button>
-                                </form>
-                            )}
-                            {menuView === "crew" && (
-                                <div className="space-y-2">
-                                    <button type="button" onClick={() => setMenuView("main")} className="text-[10px] font-semibold text-hui-textMuted hover:text-hui-primary">← Back</button>
-                                    <p className="text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted">Project crew</p>
-                                    <CrewPicker projectId={project.id} crew={project.crew} teamMembers={teamMembers} variant="inline" />
-                                </div>
-                            )}
-                            {menuView === "color" && (
-                                <div className="space-y-2">
-                                    <button type="button" onClick={() => setMenuView("main")} className="text-[10px] font-semibold text-hui-textMuted hover:text-hui-primary">← Back</button>
-                                    <p className="text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted">Color</p>
-                                    <div className="grid grid-cols-8 gap-1.5">
-                                        {PRESET_COLORS.map(swatch => {
-                                            const isSelected = !!project.color && project.color.toLowerCase() === swatch.toLowerCase();
-                                            return (
-                                                <button
-                                                    key={swatch}
-                                                    type="button"
-                                                    disabled={isColorPending}
-                                                    onClick={() => submitColor(swatch)}
-                                                    className={`h-5 w-5 rounded-full transition hover:scale-110 disabled:opacity-60 ${isSelected ? "ring-2 ring-offset-1 ring-slate-700" : `ring-1 ${swatch.toLowerCase() === "#ffffff" ? "ring-slate-400" : "ring-slate-200"}`}`}
-                                                    style={{ backgroundColor: swatch }}
-                                                    title={swatch}
-                                                    aria-label={`Set project color to ${swatch}`}
-                                                />
-                                            );
-                                        })}
-                                    </div>
-                                </div>
-                            )}
-                        </FloatingPopover>
                 )}
                 {segment.continuesAfter && <span aria-hidden="true">›</span>}
             </div>
@@ -575,28 +341,7 @@ export function ProjectBar({
                     <span className="absolute inset-y-1 left-[9px] w-px bg-white/90" />
                 </div>
             )}
-            {hiddenTasks.length > 0 && (
-                <>
-                    <button
-                        ref={overflowTriggerRef}
-                        type="button"
-                        onClick={event => { event.stopPropagation(); setOverflowOpen(value => !value); }}
-                        aria-expanded={overflowOpen}
-                        className="absolute bottom-0 right-0 z-20 rounded-tl bg-black/40 px-1 text-[8px] font-bold text-white hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
-                        aria-label={`${hiddenTasks.length} more overlapping task${hiddenTasks.length === 1 ? "" : "s"} on ${project.name}`}
-                    >
-                        +{hiddenTasks.length}
-                    </button>
-                    <FloatingPopover open={overflowOpen} anchorRef={overflowTriggerRef} onClose={() => setOverflowOpen(false)} width={200}>
-                        <p className="text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted">Also running</p>
-                        <ul className="space-y-1">
-                            {hiddenTasks.map(task => (
-                                <li key={task.id} className="truncate text-xs text-hui-textMain" title={task.name}>{task.name}</li>
-                            ))}
-                        </ul>
-                    </FloatingPopover>
-                </>
-            )}
+            <ProjectTaskOverflow projectName={project.name} tasks={hiddenTasks} />
             <div className="absolute inset-x-0 bottom-0 overflow-visible rounded-b-md" style={{ height: taskStripHeight }}>
                 {project.tasks.filter(task => laneByTaskId.has(task.id)).map(task => (
                     <TaskBlockSegment

--- a/src/app/company-dashboard/schedule-board/ProjectTaskOverflow.tsx
+++ b/src/app/company-dashboard/schedule-board/ProjectTaskOverflow.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { DashboardProjectRow } from "@/lib/schedule-core";
+import { FloatingPopover } from "./FloatingPopover";
+import { activateExclusiveMenu, deactivateExclusiveMenu } from "./menuCoordinator";
+
+interface ProjectTaskOverflowProps {
+    projectName: string;
+    tasks: DashboardProjectRow["tasks"];
+}
+
+export function ProjectTaskOverflow({ projectName, tasks }: ProjectTaskOverflowProps) {
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(false);
+
+    useEffect(() => {
+        if (!open) return;
+        const close = () => setOpen(false);
+        activateExclusiveMenu(close);
+        return () => deactivateExclusiveMenu(close);
+    }, [open]);
+
+    if (tasks.length === 0) return null;
+
+    return (
+        <>
+            <button
+                ref={triggerRef}
+                type="button"
+                onClick={event => {
+                    event.stopPropagation();
+                    setOpen(value => !value);
+                }}
+                aria-expanded={open}
+                className="absolute bottom-0 right-0 z-20 rounded-tl bg-black/40 px-1 text-[8px] font-bold text-white hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                aria-label={`${tasks.length} more overlapping task${tasks.length === 1 ? "" : "s"} on ${projectName}`}
+            >
+                +{tasks.length}
+            </button>
+            <FloatingPopover open={open} anchorRef={triggerRef} onClose={() => setOpen(false)} width={200}>
+                <p className="text-[10px] font-semibold uppercase tracking-wide text-hui-textMuted">Also running</p>
+                <ul className="space-y-1">
+                    {tasks.map(task => (
+                        <li key={task.id} className="truncate text-xs text-hui-textMain" title={task.name}>{task.name}</li>
+                    ))}
+                </ul>
+            </FloatingPopover>
+        </>
+    );
+}

--- a/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
+++ b/src/app/company-dashboard/schedule-board/ScheduleBoard.tsx
@@ -26,6 +26,7 @@ import { AvailabilityPanel } from "./AvailabilityPanel";
 import { ShiftConfirmDialog, type ProjectMoveChoice } from "./ShiftConfirmDialog";
 import { UnscheduledTray } from "./UnscheduledTray";
 import { BoardTaskDrawer } from "./BoardTaskDrawer";
+import { BoardProjectDrawer } from "./BoardProjectDrawer";
 import TaskCreationDialog from "@/components/TaskCreationDialog";
 import {
     computeProjectEndResizeCandidate,
@@ -291,6 +292,7 @@ export function ScheduleBoard({
     const [showHours, setShowHours] = useState(false);
     const [boardView, setBoardView] = useState<BoardView>("month");
     const [openTaskId, setOpenTaskId] = useState<string | null>(null);
+    const [openProjectId, setOpenProjectId] = useState<string | null>(null);
     const [taskCreationOpen, setTaskCreationOpen] = useState(false);
     const [taskCreationDefaults, setTaskCreationDefaults] = useState<Partial<DispatchTaskCreationDefaults>>({});
     // Lifted from TimelineView (see CREW_MODE_STORAGE_KEY) so the
@@ -530,6 +532,14 @@ export function ScheduleBoard({
         },
         overlays: data.overlays ? previewOverlays : null,
     };
+    const openProject = openProjectId
+        ? [
+            ...boardData.pipeline.waitingToStart,
+            ...boardData.pipeline.scheduled,
+            ...boardData.pipeline.inProgress,
+            ...boardData.pipeline.substantialCompletion,
+        ].find(project => project.id === openProjectId) ?? null
+        : null;
 
     function setTaskKeyboardState(next: TaskKeyboardEditState | null) {
         taskKeyboardEditRef.current = next;
@@ -762,10 +772,19 @@ export function ScheduleBoard({
     }, []);
 
     const handleBlockActivate = useCallback((taskId: string) => {
+        setOpenProjectId(null);
         setOpenTaskId(taskId);
     }, []);
     const closeTaskDrawer = useCallback(() => setOpenTaskId(null), []);
-    const selectDrawerTask = useCallback((taskId: string) => setOpenTaskId(taskId), []);
+    const handleProjectActivate = useCallback((projectId: string) => {
+        setOpenTaskId(null);
+        setOpenProjectId(projectId);
+    }, []);
+    const closeProjectDrawer = useCallback(() => setOpenProjectId(null), []);
+    const selectDrawerTask = useCallback((taskId: string) => {
+        setOpenProjectId(null);
+        setOpenTaskId(taskId);
+    }, []);
     const handleDrawerTaskDeleted = useCallback((taskId: string) => {
         if (activeTaskPointerRef.current?.taskId === taskId) activeTaskPointerRef.current.cleanup();
         if (taskKeyboardEditRef.current?.taskId === taskId) {
@@ -2408,6 +2427,7 @@ export function ScheduleBoard({
                     teamMembers={data.teamMembers ?? []}
                     isAnyDragActive={isAnyDragActive}
                     activeProjectKeyboardId={projectKeyboardEdit?.projectId ?? null}
+                    onProjectActivate={handleProjectActivate}
                     onProjectPointerEditStart={handleProjectPointerEditStart}
                     onProjectKeyboardStart={handleProjectKeyboardStart}
                     onProjectKeyboardAdjust={handleProjectKeyboardAdjust}
@@ -2446,6 +2466,7 @@ export function ScheduleBoard({
                     teamMembers={data.teamMembers ?? []}
                     isAnyDragActive={isAnyDragActive}
                     activeProjectKeyboardId={projectKeyboardEdit?.projectId ?? null}
+                    onProjectActivate={handleProjectActivate}
                     onProjectPointerEditStart={handleProjectPointerEditStart}
                     onProjectKeyboardStart={handleProjectKeyboardStart}
                     onProjectKeyboardAdjust={handleProjectKeyboardAdjust}
@@ -2488,6 +2509,13 @@ export function ScheduleBoard({
                 onClose={closeTaskDrawer}
                 onSelectTask={selectDrawerTask}
                 onDeleted={handleDrawerTaskDeleted}
+            />
+            <BoardProjectDrawer
+                project={openProject}
+                teamMembers={data.teamMembers ?? []}
+                isPending={Boolean(openProject && (isSaving || combinedPendingProjectIds.has(openProject.id)))}
+                onMoveCommit={handleProjectMoveCommit}
+                onClose={closeProjectDrawer}
             />
             <TaskCreationDialog
                 open={taskCreationOpen}

--- a/src/app/company-dashboard/schedule-board/TaskBlockSegment.tsx
+++ b/src/app/company-dashboard/schedule-board/TaskBlockSegment.tsx
@@ -279,8 +279,8 @@ export function TaskBlockSegment({
         if (!canEdit || isPending) return;
         if ((event.target as HTMLElement).closest("a,button,input,summary,form,details")) return;
         // A block sits inside its project bar, whose own click opens the
-        // PROJECT menu — without this, the bar menu instantly replaces the
-        // task menu via the exclusive-menu coordinator.
+        // PROJECT drawer — without this, the bar activation instantly replaces
+        // the task menu via the exclusive-surface coordinator.
         event.stopPropagation();
         onActivate(task.id);
     }

--- a/src/app/company-dashboard/schedule-board/TimelineView.tsx
+++ b/src/app/company-dashboard/schedule-board/TimelineView.tsx
@@ -189,8 +189,8 @@ export function TimelineView({
     scrollToTodayNonce,
     teamMembers,
     isAnyDragActive,
-    onProjectMoveCommit,
     activeProjectKeyboardId,
+    onProjectActivate,
     onProjectPointerEditStart,
     onProjectKeyboardStart,
     onProjectKeyboardAdjust,
@@ -727,6 +727,7 @@ export function TimelineView({
                                                 draftTaskIds={draftTaskIds}
                                                 activeTaskKeyboardEdit={activeTaskKeyboardEdit}
                                                 activeProjectKeyboardId={activeProjectKeyboardId}
+                                                onProjectActivate={onProjectActivate}
                                                 timelineDayWidth={dayWidth}
                                                 timelineLeftInset={LABEL_WIDTH}
                                                 timelineScrollContainerRef={scrollContainerRef}
@@ -737,7 +738,6 @@ export function TimelineView({
                                                 onProjectKeyboardAdjust={onProjectKeyboardAdjust}
                                                 onProjectKeyboardCommit={onProjectKeyboardCommit}
                                                 onProjectKeyboardCancel={onProjectKeyboardCancel}
-                                                onMoveCommit={onProjectMoveCommit}
                                                 onProjectEndResizeStart={onProjectEndResizeStart}
                                                 onTaskPointerEditStart={onTaskPointerEditStart}
                                                 onTaskKeyboardStart={onTaskKeyboardStart}


### PR DESCRIPTION
Direct owner feedback with screenshots: the project bar's little menu and its cramped crew grid "needs to be a list on the open panel — remove the click and little menu, I like the sidebar panel, that's perfect."

## Changes
- Any activation of a project bar now opens a right-side drawer identical in style to the task drawer: header (name/status/link/distance), the unchanged Edit-dates form (start drafts, end saves immediately, shift flow intact, Remove-from-schedule included), **project crew as a proper single-column list** with full names and role tags, and the color swatches — everything visible at once, zero sub-menus.
- The FloatingPopover project menu is deleted; a shared `BoardDrawerShell` now backs both drawers. Project keyboard-move lives on Alt+Enter/Space.
- Task surfaces unchanged.

## Verification
- Render + layout contracts (assertions migrated intent-preserving), tsc, build, DB-backed board verifier — all green
- Browser: bar click opens the drawer with the full list (dates semantics labeled inline, 7 crew rows single-column, color row); the old popover no longer exists anywhere; no unintended crew writes (DB-checked)

Implemented by GPT-5.6-sol (xhigh) from the owner's screenshots; gates re-run and browser-verified by Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)