### PR TITLE
feat(security): move sensitive documents to a private storage bucket

### DIFF
--- a/docs/STORAGE-AUDIT.md
+++ b/docs/STORAGE-AUDIT.md
@@ -1,0 +1,90 @@
+# Supabase Storage — Public Bucket Audit & Private-Doc Migration
+
+**Audited:** 2026-07-27 · **Project:** `ghzdbzdnwjxazvmcefbh`
+
+## Finding
+
+Both storage buckets are **public**:
+
+| Bucket | `public` | Size limit | MIME allowlist |
+|---|---|---|---|
+| `project-files` | **true** | none | none |
+| `room-designer-assets` | **true** | 10 MB | images + gltf + json |
+
+**Exposure is confirmed, not theoretical.** An unauthenticated GET (no `apikey`, no `Authorization`) to a real client e-signature object returned **HTTP 200, 6,260 bytes, `image/png`** — the actual signature. Object paths are hard to guess (cuid + timestamp + uuid), but URLs leak through emails, the Google Drive mirror, portal HTML, and browser history, so path secrecy is not an access control.
+
+## What lives in `project-files`
+
+| Prefix | Contents | Sensitivity |
+|---|---|---|
+| `signatures/contracts/`, `signatures/change-orders/` | Client / contractor / company e-signature PNGs | **High** |
+| `projects/{id}/signed/`, `leads/{id}/signed/` | Signed estimate PDFs (`*_Signed_Estimate_*.pdf`) | **High** |
+| `projects/{id}/`, `leads/{id}/` — **flat** | Executed contract PDFs (`*_Executed_Contract_*.pdf`), interleaved with ordinary project files | **High** |
+| `projects/{id}/intermediate/` | Client-signed contract PDFs awaiting countersign | **High** |
+| `tax-certs/{clientId}/` | WA reseller / exemption certificates | **High** |
+| `subcontractors/{id}/coi/` | Certificates of Insurance | Medium |
+| `receipts/` | Vendor receipt images | Medium |
+| `projects/{id}/`, `leads/{id}/` | Project & lead files, AI room renders | Medium |
+| `estimate-pdfs/`, `estimates/{id}/` | Estimate PDFs + attachments | Medium |
+| `vendors/` (purchase orders), `takeoffs/{id}/` | PO attachments, takeoff photos | Low–Medium |
+| `task-comments/{proj}/{task}/` | Field progress photos | Low–Medium |
+| `company/letterhead_*` | Letterhead image | Low |
+| `rooms/`, `*/rooms/*.usdz` | USDZ room exports for AR | Low |
+
+`room-designer-assets` holds only the code-seeded studio catalog (`manifest.json`, `models/`, `textures/`, `thumbnails/`) — shared, non-customer, procedurally generated. **Stays public by design.**
+
+## Decision (2026-07-27)
+
+Owner call: most of this content does not justify a migration. Scope is narrowed to the three categories that carry legal/PII liability:
+
+- **In scope:** `signatures/` (contracts + change orders), signed estimate PDFs (`*/signed/`), executed contract PDFs (`*_Executed_Contract_*.pdf`, flat in the project/lead prefix), intermediate signed contracts (`*/intermediate/`), and `tax-certs/`
+- **Out of scope, staying public:** letterhead, task photos, takeoffs, room USDZ/renders, receipts, COIs, general project/lead files, and all of `room-designer-assets`
+
+**Explicit non-goal: no new login for clients.** The `public` flag is per-bucket, so the in-scope prefixes move to a **separate private bucket**; `project-files` keeps serving everything else unchanged. Signed URLs are minted server-side by the page already rendering the document, so the client experience is identical — magic-link contract links and `/share/room/[token]` keep working with no account, no password. The auth gating a signed URL is the auth that already exists (magic link / portal session / NextAuth), not new auth.
+
+## Complication: the signed PDFs live in a shared table
+
+Executed contract PDFs and signed estimate PDFs are **not** held in dedicated columns — each is a row in **`ProjectFile.url`**, the same table that holds all the ordinary, deliberately-public project files. Two consequences:
+
+1. **Migration is row-selected, not prefix-selected.** Executed contracts sit flat in `projects/{id}/` next to ordinary uploads, so they can only be identified by the `_Executed_Contract_*.pdf` name our own code generates. A coincidental client filename match is a benign false positive (the file merely becomes private), which is the right way to err. Signed estimates are cleaner — they live under a dedicated `signed/` prefix and are filed into a "Signed Documents" folder.
+2. **The file browser is in the blast radius.** Because one table now mixes secure refs and public URLs, every `ProjectFile.url` read site must resolve **per row** rather than pass the value straight through.
+
+The `secure:` scheme prefix is what makes this safe: a row is self-describing, so mixed state inside one table (and mid-migration state generally) is unambiguous.
+
+## Why signed URLs and not storage RLS
+
+Supabase storage RLS evaluates the **Supabase Auth JWT**. ProBuild authenticates end users via NextAuth + Prisma, so a storage policy would have no end-user identity to key on. Correct tools here are short-lived server-minted signed URLs (`createSignedUrl`), or a service-key download for server-side consumers that need bytes rather than a URL (PDF generation, Drive mirror).
+
+## Migration shape
+
+Ordering matters: the public bucket is never flipped, and originals are deleted only after the new path is verified in production.
+
+1. **New private bucket** — additive, nothing reads it yet.
+2. **Resolution layer** — a helper that accepts any of the three stored shapes (legacy inline `data:` URL, absolute public URL, relative path) and returns something renderable. Server-side consumers download bytes via the service key instead of fetching a URL.
+3. **Writers** store a relative path in the private bucket; readers resolve at render time.
+4. **Copy** existing in-scope objects into the private bucket (originals left in place).
+5. **Backfill** the in-scope columns to relative paths.
+6. **Deploy + verify** on prod.
+7. **Only then delete** the public-bucket originals — this is the step that actually closes the exposure, and the only destructive one.
+
+Rollback before step 7 is a code revert; the public originals are still serving.
+
+## Production runbook
+
+Run in this order. Steps 1–3 are reversible; step 6 is not.
+
+1. **Create the private bucket** — `secure-docs`, `public: false`, 25 MB limit, no MIME allowlist (a MIME allowlist would add a new upload-rejection failure mode without adding privacy). *Done 2026-07-27.* Verified: anonymous read → HTTP 400, server-minted signed URL → HTTP 200.
+2. **Deploy the code** — `npm run build` clean, then `vercel --prod` from the main checkout (not a worktree). Safe to deploy BEFORE migrating: every reader accepts legacy shapes, so untouched rows keep resolving against the still-public originals. New documents start landing in the private bucket immediately.
+3. **Dry-run the migration** — `node scripts/migrate-secure-docs.mjs` (dry run is the default). Read the per-column summary. Investigate any `missing-object` or `corruptDestination` count before proceeding.
+4. **Migrate** — `node scripts/migrate-secure-docs.mjs --apply`. Copies only; never deletes. Idempotent, CAS-guarded, and verifies destination size matches source before updating a row.
+5. **Verify on prod** — walk each surface: portal contract signing page renders signatures; a generated/countersigned contract PDF still embeds signatures; the Signing History modal; project + portal file browsers; a client tax-exempt cert link; change-order signature display; an executed-contract email (PDF arrives as an attachment — the public download link was deliberately removed). Then re-run the exposure probe: an unauthenticated GET of a migrated signature URL must now fail.
+6. **Purge the public originals** — `node scripts/purge-migrated-public-docs.mjs --apply --i-understand-this-deletes-public-originals`. **This is the step that actually closes the exposure**, and the only destructive one. It refuses to delete any original whose secure copy is missing, zero-byte, or size-mismatched. Do not run it until step 5 is signed off.
+
+Rollback before step 6 is a code revert — the public originals are still serving, so nothing is lost.
+
+## Gotchas carried in from prior work
+
+- `isOwnSignatureStorageUrl()` in `src/lib/signature-storage.ts` is an **SSRF allowlist** gating the server-side signature fetch in `pdf.ts`. It is pinned to `project-files`; moving buckets requires updating it. Do not remove it.
+- Legacy **inline `data:` URL signatures still exist in prod** — `scripts/backfill-signature-storage.mjs` was never run. Any resolver must pass data-URLs through untouched.
+- `Estimate.signatureUrl` stores a raw client-supplied data-URL and was deliberately never moved to Storage, so estimate signatures are not in the bucket at all.
+- `persistSignature()` fails loud (throws) when Storage is unconfigured on the pgbouncer pooler, and falls back to a data-URL off-pooler so e2e/CI stay green. Preserve that behavior.

--- a/e2e/money-pipeline.spec.ts
+++ b/e2e/money-pipeline.spec.ts
@@ -62,13 +62,6 @@ test.describe("Change-order signature object ownership", () => {
         uploadOptions.push(options);
         return { error: null };
       },
-      getPublicUrl(path) {
-        return {
-          data: {
-            publicUrl: `https://example.supabase.co/storage/v1/object/public/project-files/${path}`,
-          },
-        };
-      },
       async remove(paths) {
         removed.push([...paths]);
         return { error: null };
@@ -89,68 +82,20 @@ test.describe("Change-order signature object ownership", () => {
       "signatures/change-orders/test/client/1721218400000_owned-test-id.png",
     ]);
     expect(uploadOptions).toEqual([{ contentType: "image/png", upsert: false }]);
-    expect(owned.url).toContain(uploaded[0]);
+    expect(owned.url).toBe(
+      "secure:signatures/change-orders/test/client/1721218400000_owned-test-id.png",
+    );
 
     await Promise.all([owned.discard(), owned.discard(), owned.discard()]);
 
     expect(removed).toEqual([[uploaded[0]]]);
   });
 
-  test("missing public URL compensating-deletes the uploaded object", async () => {
-    const uploaded: string[] = [];
-    const removed: string[][] = [];
-    const bucket: SignatureStorageBucket = {
-      async upload(path) {
-        uploaded.push(path);
-        return { error: null };
-      },
-      getPublicUrl() {
-        return { data: {} };
-      },
-      async remove(paths) {
-        removed.push([...paths]);
-        return { error: null };
-      },
-    };
-
-    await expect(
-      persistOwnedSignature(signatureDataUrl, "change-orders/test/client", {
-        getBucket: () => bucket,
-        now: () => 1_721_218_400_000,
-        randomId: () => "url-failure-id",
-      }),
-    ).rejects.toThrow("Couldn't save your signature");
-
-    expect(removed).toEqual([[uploaded[0]]]);
-  });
-
-  test("thrown public URL construction compensating-deletes the uploaded object", async () => {
-    const uploaded: string[] = [];
-    const removed: string[][] = [];
-    const bucket: SignatureStorageBucket = {
-      async upload(path) {
-        uploaded.push(path);
-        return { error: null };
-      },
-      getPublicUrl() {
-        throw new Error("url construction failed");
-      },
-      async remove(paths) {
-        removed.push([...paths]);
-        return { error: null };
-      },
-    };
-
-    await expect(
-      persistOwnedSignature(signatureDataUrl, "change-orders/test/client", {
-        getBucket: () => bucket,
-        now: () => 1_721_218_400_000,
-        randomId: () => "url-throw-id",
-      }),
-    ).rejects.toThrow("Couldn't save your signature");
-
-    expect(removed).toEqual([[uploaded[0]]]);
-  });
+  // The two tests that used to live here ("missing public URL compensating-deletes...",
+  // "thrown public URL construction compensating-deletes...") exercised getPublicUrl()
+  // failing after a successful upload. Now that the stored reference is derived locally
+  // (toSecureRef(storagePath)) instead of asking Storage to construct an address, that
+  // failure mode no longer exists — there's nothing left to compensate for.
 
   test("late upload success after deadline is removed before the error returns", async () => {
     let settleUpload!: (result: { error: unknown | null }) => void;
@@ -158,9 +103,6 @@ test.describe("Change-order signature object ownership", () => {
     const bucket: SignatureStorageBucket = {
       upload() {
         return new Promise((resolve) => { settleUpload = resolve; });
-      },
-      getPublicUrl() {
-        throw new Error("must not construct a URL for a timed-out upload");
       },
       async remove(paths) {
         removed.push([...paths]);

--- a/scripts/migrate-secure-docs.mjs
+++ b/scripts/migrate-secure-docs.mjs
@@ -1,0 +1,438 @@
+// One-time migration: move sensitive documents out of the PUBLIC `project-files` bucket
+// into the PRIVATE `secure-docs` bucket, and rewrite the owning DB column to the
+// `secure:<storage-path>` scheme defined in src/lib/secure-storage.ts.
+//
+// This script COPIES — it never deletes the public original. Run
+// scripts/purge-migrated-public-docs.mjs separately (and only after verifying the
+// migration in production) to remove the now-redundant public copies.
+//
+// In scope:
+//   Contract.signatureUrl / contractorSignatureUrl / companySignatureUrl   (URLs)
+//   Contract.signedPdfPath / originalPdfPath                              (bare paths)
+//   ContractSigningRecord.signatureUrl                                    (URL)
+//   ChangeOrder.clientSignatureUrl / companySignatureUrl                  (URLs)
+//   Client.taxExemptCertUrl                                               (URL)
+//   ProjectFile.url — ROW-SELECTED: only rows whose storage path looks like an
+//     executed contract or a signed estimate PDF (see isInScopeProjectFilePath below).
+//     ProjectFile mixes sensitive and ordinary project files, so most rows are left alone.
+//
+// SAFE TO RE-RUN:
+//   - Values already `secure:`-prefixed are left untouched (counted as skipped-already).
+//   - Inline `data:` values are left untouched (they're not in Storage at all).
+//   - Before trusting a destination object as already-migrated (and before the CAS
+//     update), its size is fetched via the storage info() API and compared against the
+//     source object's size. A destination that's missing, zero-byte, or size-mismatched
+//     is re-copied (overwrite) and re-verified — it is never assumed intact just because
+//     it exists. If it's still not intact after a re-copy, the row is left alone and
+//     counted as corrupt-destination, not silently treated as migrated.
+//   - The DB write is a compare-and-swap (only fires if the column still holds the exact
+//     value we read), so a concurrent re-sign is never clobbered.
+//   - Missing source objects are logged and the DB row is left alone — never point a
+//     column at a secure ref that doesn't exist.
+//
+// Usage:
+//   node scripts/migrate-secure-docs.mjs            # dry run — read-only preview, no writes
+//   node scripts/migrate-secure-docs.mjs --apply     # copy objects + rewrite columns
+//
+// Requires (read from env or .env / .env.local):
+//   DATABASE_URL          Supabase transaction pooler URL (must include ?pgbouncer=true)
+//   SUPABASE_URL          Supabase project URL
+//   SUPABASE_SERVICE_KEY  Supabase service role key
+//
+// Both storage credentials are required even for a dry run: the preview checks whether
+// each source object actually exists in `project-files` (a read-only metadata request) so
+// the missing-object count in the summary is real, not guessed.
+//
+// This script does NOT create the `secure-docs` bucket — it must already exist.
+import { PrismaClient } from "@prisma/client";
+import { createClient } from "@supabase/supabase-js";
+import fs from "node:fs";
+
+const PUBLIC_BUCKET = "project-files";
+const SECURE_BUCKET = "secure-docs";
+const SECURE_SCHEME = "secure:";
+
+const APPLY = process.argv.includes("--apply");
+
+function envFromFiles(key) {
+  if (process.env[key]) return process.env[key];
+  for (const f of [".env", ".env.local"]) {
+    if (!fs.existsSync(f)) continue;
+    const m = fs.readFileSync(f, "utf8").match(new RegExp(`^${key}\\s*=\\s*"?([^"\\n]+)"?`, "m"));
+    if (m) return m[1];
+  }
+  return undefined;
+}
+
+const DATABASE_URL = envFromFiles("DATABASE_URL");
+if (!DATABASE_URL) throw new Error("DATABASE_URL not found in env or .env files");
+if (!DATABASE_URL.includes("pgbouncer=true")) {
+  console.warn("⚠ DATABASE_URL has no pgbouncer=true — expected the Supabase transaction pooler. Continuing.");
+}
+
+const SUPABASE_URL = envFromFiles("SUPABASE_URL");
+const SUPABASE_SERVICE_KEY = envFromFiles("SUPABASE_SERVICE_KEY");
+if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+  throw new Error("SUPABASE_URL and SUPABASE_SERVICE_KEY are required (dry run still needs read access to check object existence)");
+}
+
+const prisma = new PrismaClient({ datasources: { db: { url: DATABASE_URL } } });
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+
+// { table, column, kind: "url" | "path" }
+const TARGETS = [
+  { table: "Contract", column: "signatureUrl", kind: "url" },
+  { table: "Contract", column: "contractorSignatureUrl", kind: "url" },
+  { table: "Contract", column: "companySignatureUrl", kind: "url" },
+  { table: "Contract", column: "signedPdfPath", kind: "path" },
+  { table: "Contract", column: "originalPdfPath", kind: "path" },
+  { table: "ContractSigningRecord", column: "signatureUrl", kind: "url" },
+  { table: "ChangeOrder", column: "clientSignatureUrl", kind: "url" },
+  { table: "ChangeOrder", column: "companySignatureUrl", kind: "url" },
+  { table: "Client", column: "taxExemptCertUrl", kind: "url" },
+];
+
+function firstLine(e) {
+  return (e?.message || e || "").toString().split("\n")[0];
+}
+
+function truncate(v, n = 120) {
+  const s = (v ?? "").toString();
+  return s.length > n ? `${s.slice(0, n)}…` : s;
+}
+
+function isSecureRef(value) {
+  return typeof value === "string" && value.startsWith(SECURE_SCHEME);
+}
+
+function isDataUrl(value) {
+  return typeof value === "string" && value.startsWith("data:");
+}
+
+function toSecureRef(path) {
+  return `${SECURE_SCHEME}${path}`;
+}
+
+/**
+ * Parse one of our own public `project-files` object URLs into a storage path.
+ * Mirrors parseOwnStorageUrl() in src/lib/secure-storage.ts (duplicated here because this
+ * is a plain Node script, not a TS import) — refuses anything that isn't our own project's
+ * public object URL, and anything containing "..".
+ */
+function parsePublicUrl(value) {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "https:") return null;
+    if (!parsed.hostname.endsWith(".supabase.co") && !parsed.hostname.endsWith(".supabase.in")) return null;
+    const ourRef = new URL(SUPABASE_URL).hostname.split(".")[0];
+    if (ourRef && !parsed.hostname.startsWith(`${ourRef}.`)) return null;
+    const prefix = `/storage/v1/object/public/${PUBLIC_BUCKET}/`;
+    if (!parsed.pathname.startsWith(prefix)) return null;
+    const rest = parsed.pathname.slice(prefix.length);
+    if (!rest) return null;
+    const path = decodeURIComponent(rest);
+    if (path.includes("..")) return null;
+    return path;
+  } catch {
+    return null;
+  }
+}
+
+function deriveBarePath(value) {
+  if (typeof value !== "string" || !value) return null;
+  if (value.startsWith("/") || value.includes("..")) return null;
+  return value;
+}
+
+function deriveUrlPath(value) {
+  if (typeof value !== "string" || !value) return null;
+  if (/^https?:\/\//i.test(value)) return parsePublicUrl(value);
+  // Defensive fallback — these columns are documented as storing absolute URLs, but treat
+  // a bare-path value the same way signedPdfPath/originalPdfPath are handled if one ever
+  // shows up.
+  return deriveBarePath(value);
+}
+
+// ProjectFile row-selection: only executed-contract / signed-estimate / intermediate
+// signed-contract PDFs are in scope. Everything else in this table (photos, letterhead,
+// takeoffs, general uploads) is left alone.
+function isInScopeProjectFilePath(path) {
+  if (path.includes("_Executed_Contract_")) return true;
+  if (/^(projects|leads)\/[^/]+\/signed\//.test(path)) return true;
+  if (path.includes("/intermediate/") && path.toLowerCase().endsWith(".pdf")) return true;
+  return false;
+}
+
+/**
+ * Fetch an object's size (in bytes) via the storage info() API — verified available on the
+ * installed @supabase/storage-js@2.99.0 (node_modules/@supabase/storage-js/src/packages/
+ * StorageFileApi.ts, also present in the compiled dist/index.cjs actually loaded at
+ * runtime): `.info(path)` returns `{ data: { size, ... } }` on success or
+ * `{ data: null, error }` for a missing object or any other failure. Used instead of
+ * exists() so a pre-existing destination's integrity (non-zero, matches source size) can
+ * actually be verified rather than just its presence.
+ *
+ * Returns null when the object doesn't exist or the metadata can't be fetched for any
+ * reason — callers must treat null as "can't verify", never as a size of 0.
+ */
+async function getObjectSize(bucket, path) {
+  const { data, error } = await supabase.storage.from(bucket).info(path);
+  if (error) {
+    console.warn(`    info() check failed for ${bucket}/${path}: ${firstLine(error)}`);
+    return null;
+  }
+  return typeof data?.size === "number" ? data.size : null;
+}
+
+/**
+ * Copy `path` from the public bucket into secure-docs at the same path, overwriting any
+ * existing (e.g. corrupt) destination object.
+ * Tries the storage API's cross-bucket copy() first (supported by the installed
+ * @supabase/supabase-js — storage-js's copy() accepts { destinationBucket }, verified
+ * against node_modules/@supabase/storage-js @2.99.0). Falls back to download+upload if
+ * copy() is unavailable on the client or the call fails for any reason (e.g. a
+ * self-hosted Storage API that doesn't support cross-bucket copy). The fallback uses
+ * upsert:true because this is also called to replace a zero-byte/size-mismatched
+ * destination left behind by a crashed prior run.
+ */
+async function copyToSecureBucket(path) {
+  const publicApi = supabase.storage.from(PUBLIC_BUCKET);
+  if (typeof publicApi.copy === "function") {
+    const { error } = await publicApi.copy(path, path, { destinationBucket: SECURE_BUCKET });
+    if (!error) return { ok: true, method: "copy" };
+    console.warn(`    copy() failed (${firstLine(error)}) — falling back to download+upload`);
+  }
+  const { data: blob, error: downloadError } = await publicApi.download(path);
+  if (downloadError) return { ok: false, error: downloadError };
+  const arrayBuffer = await blob.arrayBuffer();
+  const { error: uploadError } = await supabase.storage
+    .from(SECURE_BUCKET)
+    .upload(path, Buffer.from(arrayBuffer), {
+      contentType: blob.type || "application/octet-stream",
+      upsert: true,
+    });
+  if (uploadError) return { ok: false, error: uploadError, method: "download-upload" };
+  return { ok: true, method: "download-upload" };
+}
+
+function emptyStats(label) {
+  return {
+    label,
+    scanned: 0,
+    migrated: 0,
+    skippedAlready: 0,
+    skippedDataUrl: 0,
+    missingObject: 0,
+    skippedChanged: 0,
+    corruptDestination: 0,
+    failed: 0,
+  };
+}
+
+/** Shared per-row migration: existence/integrity checks, copy, CAS update. Mutates `stats`. */
+async function migrateOneRow({ table, column, id, originalValue, path, stats, label }) {
+  const sourceSize = await getObjectSize(PUBLIC_BUCKET, path);
+  if (sourceSize === null) {
+    stats.missingObject++;
+    console.warn(`  ⚠ ${label} id=${id}: object missing from ${PUBLIC_BUCKET} at "${path}" — DB left unchanged`);
+    return;
+  }
+
+  if (!APPLY) {
+    stats.migrated++; // "would migrate" in dry run
+    return;
+  }
+
+  // A pre-existing destination only counts as already-migrated if it's genuinely intact —
+  // non-zero size AND matching the source's size. A zero-byte or truncated destination from
+  // a crashed prior run must never be trusted on the strength of exists() alone.
+  let destSize = await getObjectSize(SECURE_BUCKET, path);
+  let intact = destSize !== null && destSize > 0 && destSize === sourceSize;
+
+  if (!intact) {
+    if (destSize !== null) {
+      console.warn(
+        `  ⚠ ${label} id=${id}: destination ${SECURE_BUCKET}/${path} exists but is not intact ` +
+          `(size=${destSize}, expected=${sourceSize}) — re-copying`
+      );
+    }
+    const copyResult = await copyToSecureBucket(path);
+    if (!copyResult.ok) {
+      stats.failed++;
+      console.error(`  ✗ ${label} id=${id}: copy to ${SECURE_BUCKET} failed — ${firstLine(copyResult.error)}`);
+      return;
+    }
+    destSize = await getObjectSize(SECURE_BUCKET, path);
+    intact = destSize !== null && destSize > 0 && destSize === sourceSize;
+  }
+
+  if (!intact) {
+    stats.corruptDestination++;
+    console.error(
+      `  ✗ ${label} id=${id}: destination ${SECURE_BUCKET}/${path} still not intact after copy ` +
+        `(size=${destSize}, expected=${sourceSize}) — DB left unchanged`
+    );
+    return;
+  }
+
+  const secureValue = toSecureRef(path);
+  const affected = await prisma.$executeRawUnsafe(
+    `UPDATE "${table}" SET "${column}" = $1 WHERE "id" = $2 AND "${column}" = $3`,
+    secureValue,
+    id,
+    originalValue
+  );
+  if (affected === 0) {
+    stats.skippedChanged++;
+    console.warn(`  ↷ ${label} id=${id}: row changed since read — DB left unchanged (object is already copied, safe to re-run)`);
+  } else {
+    stats.migrated++;
+    console.log(`  ✓ ${label} id=${id}: migrated → secure:${path}`);
+  }
+}
+
+async function processColumnTarget(t) {
+  const label = `${t.table}.${t.column}`;
+  let rows;
+  try {
+    rows = await prisma.$queryRawUnsafe(`SELECT "id", "${t.column}" AS val FROM "${t.table}" WHERE "${t.column}" IS NOT NULL`);
+  } catch (e) {
+    console.log(`• ${label}: skipped (${firstLine(e)})`);
+    return { ...emptyStats(label), skippedColumn: true };
+  }
+
+  const stats = emptyStats(label);
+  for (const row of rows) {
+    stats.scanned++;
+    const value = row.val;
+    if (isSecureRef(value)) {
+      stats.skippedAlready++;
+      continue;
+    }
+    if (isDataUrl(value)) {
+      stats.skippedDataUrl++;
+      continue;
+    }
+    const path = t.kind === "path" ? deriveBarePath(value) : deriveUrlPath(value);
+    if (!path) {
+      stats.failed++;
+      console.error(`  ✗ ${label} id=${row.id}: not a recognized own-storage reference — "${truncate(value)}"`);
+      continue;
+    }
+    await migrateOneRow({ table: t.table, column: t.column, id: row.id, originalValue: value, path, stats, label });
+  }
+
+  logColumnSummary(stats);
+  return stats;
+}
+
+async function processProjectFile() {
+  const label = "ProjectFile.url";
+  let rows;
+  try {
+    rows = await prisma.$queryRawUnsafe(
+      `SELECT "id", "url" AS val FROM "ProjectFile" WHERE "url" IS NOT NULL AND ("url" LIKE '%_Executed_Contract_%' OR "url" LIKE '%/signed/%' OR "url" LIKE '%/intermediate/%')`
+    );
+  } catch (e) {
+    console.log(`• ${label}: skipped (${firstLine(e)})`);
+    return { ...emptyStats(label), skippedColumn: true };
+  }
+
+  const stats = emptyStats(label);
+  for (const row of rows) {
+    const value = row.val;
+    // The SQL LIKE filter above is a superset of the real selection rule (it's just a
+    // substring match) — already-secure/data rows can still match on substring, and are
+    // worth counting so re-runs show accurate skipped-already numbers.
+    if (isSecureRef(value)) {
+      stats.scanned++;
+      stats.skippedAlready++;
+      continue;
+    }
+    if (isDataUrl(value)) {
+      stats.scanned++;
+      stats.skippedDataUrl++;
+      continue;
+    }
+    const path = deriveUrlPath(value);
+    if (!path) {
+      stats.scanned++;
+      stats.failed++;
+      console.error(`  ✗ ${label} id=${row.id}: not a recognized own-storage reference — "${truncate(value)}"`);
+      continue;
+    }
+    // Enforce the real selection rule precisely before doing anything else — the LIKE
+    // filter above is intentionally loose, this regex is the actual scope boundary.
+    if (!isInScopeProjectFilePath(path)) continue;
+
+    stats.scanned++;
+    console.log(`  • matched ProjectFile id=${row.id} path="${path}"`);
+    await migrateOneRow({ table: "ProjectFile", column: "url", id: row.id, originalValue: value, path, stats, label });
+  }
+
+  logColumnSummary(stats);
+  return stats;
+}
+
+function logColumnSummary(s) {
+  console.log(
+    `• ${s.label}: scanned=${s.scanned} migrated=${s.migrated} skipped-already=${s.skippedAlready} ` +
+      `skipped-data-url=${s.skippedDataUrl} missing-object=${s.missingObject} skipped-changed=${s.skippedChanged} ` +
+      `corrupt-destination=${s.corruptDestination} failed=${s.failed}` +
+      (APPLY ? "" : " (dry run — no writes)")
+  );
+}
+
+(async () => {
+  console.log(APPLY ? "Migration mode: APPLY (copying objects + rewriting columns)\n" : "Migration mode: DRY RUN (pass --apply to write)\n");
+
+  const publicApi = supabase.storage.from(PUBLIC_BUCKET);
+  console.log(
+    typeof publicApi.copy === "function"
+      ? "Cross-bucket copy: storage.copy() with { destinationBucket } is supported by the installed @supabase/supabase-js — using it as the primary mechanism, with download+upload as fallback.\n"
+      : "Cross-bucket copy: storage.copy() is NOT available on the installed client — using download+upload for every object.\n"
+  );
+
+  const summaries = [];
+  for (const t of TARGETS) {
+    summaries.push(await processColumnTarget(t));
+  }
+  summaries.push(await processProjectFile());
+
+  const totals = summaries.reduce(
+    (a, s) => ({
+      scanned: a.scanned + (s.scanned || 0),
+      migrated: a.migrated + (s.migrated || 0),
+      skippedAlready: a.skippedAlready + (s.skippedAlready || 0),
+      skippedDataUrl: a.skippedDataUrl + (s.skippedDataUrl || 0),
+      missingObject: a.missingObject + (s.missingObject || 0),
+      skippedChanged: a.skippedChanged + (s.skippedChanged || 0),
+      corruptDestination: a.corruptDestination + (s.corruptDestination || 0),
+      failed: a.failed + (s.failed || 0),
+    }),
+    {
+      scanned: 0,
+      migrated: 0,
+      skippedAlready: 0,
+      skippedDataUrl: 0,
+      missingObject: 0,
+      skippedChanged: 0,
+      corruptDestination: 0,
+      failed: 0,
+    }
+  );
+  console.log(
+    `\nTotals: scanned=${totals.scanned} migrated=${totals.migrated} skipped-already=${totals.skippedAlready} ` +
+      `skipped-data-url=${totals.skippedDataUrl} missing-object=${totals.missingObject} skipped-changed=${totals.skippedChanged} ` +
+      `corrupt-destination=${totals.corruptDestination} failed=${totals.failed}` +
+      (APPLY ? "" : " (dry run)")
+  );
+  if (totals.failed > 0 || totals.corruptDestination > 0) process.exitCode = 1;
+})()
+  .catch((e) => {
+    console.error("Migration failed:", e);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/purge-migrated-public-docs.mjs
+++ b/scripts/purge-migrated-public-docs.mjs
@@ -1,0 +1,284 @@
+// DESTRUCTIVE final step of the secure-docs migration. Run ONLY after
+// scripts/migrate-secure-docs.mjs has been run --apply in production and the migration has
+// been verified (documents still open correctly, no unexpected missing-object/failed rows).
+//
+// For every in-scope DB column whose value is now a `secure:<path>` ref, this deletes the
+// ORIGINAL object at the same path from the PUBLIC `project-files` bucket. It never touches
+// a row whose DB value isn't a `secure:` ref, and it never deletes from `secure-docs`.
+//
+// Same column scope as scripts/migrate-secure-docs.mjs:
+//   Contract.signatureUrl / contractorSignatureUrl / companySignatureUrl / signedPdfPath / originalPdfPath
+//   ContractSigningRecord.signatureUrl
+//   ChangeOrder.clientSignatureUrl / companySignatureUrl
+//   Client.taxExemptCertUrl
+//   ProjectFile.url (any row already holding a `secure:` ref — no extra path-pattern
+//     filtering needed here, since only rows migrate-secure-docs.mjs touched, or new
+//     executed-contract PDFs uploaded straight to secure-docs via uploadSecureDoc(), can
+//     ever hold one)
+//
+// Safety:
+//   - Dry run by default. Actually deleting requires BOTH --apply AND
+//     --i-understand-this-deletes-public-originals. Passing only one refuses to run at all.
+//   - Before deleting a public original, the corresponding secure-docs object's SIZE is
+//     fetched via the storage info() API and required to be non-zero AND to match the size
+//     of the public original still on disk. A missing, zero-byte, or size-mismatched
+//     secure-docs copy is never trusted just because exists() says "yes" — the deletion is
+//     refused and logged loudly, never delete a public original that would leave the
+//     document unreachable or leave only a corrupt copy behind.
+//   - If the public original is already gone (e.g. never existed there — new executed
+//     contracts upload straight to secure-docs), that's logged as "already gone", not a
+//     failure, and nothing is deleted.
+//
+// Usage:
+//   node scripts/purge-migrated-public-docs.mjs                                                # dry run
+//   node scripts/purge-migrated-public-docs.mjs --apply --i-understand-this-deletes-public-originals   # delete
+//
+// Requires (read from env or .env / .env.local):
+//   DATABASE_URL          Supabase transaction pooler URL (must include ?pgbouncer=true)
+//   SUPABASE_URL          Supabase project URL
+//   SUPABASE_SERVICE_KEY  Supabase service role key
+import { PrismaClient } from "@prisma/client";
+import { createClient } from "@supabase/supabase-js";
+import fs from "node:fs";
+
+const PUBLIC_BUCKET = "project-files";
+const SECURE_BUCKET = "secure-docs";
+const SECURE_SCHEME = "secure:";
+
+const HAS_APPLY = process.argv.includes("--apply");
+const HAS_CONFIRM = process.argv.includes("--i-understand-this-deletes-public-originals");
+if (HAS_APPLY !== HAS_CONFIRM) {
+  console.error(
+    "Refusing to run: pass BOTH --apply and --i-understand-this-deletes-public-originals to delete public originals, " +
+      "or neither for a dry run."
+  );
+  process.exit(1);
+}
+const WILL_DELETE = HAS_APPLY && HAS_CONFIRM;
+
+function envFromFiles(key) {
+  if (process.env[key]) return process.env[key];
+  for (const f of [".env", ".env.local"]) {
+    if (!fs.existsSync(f)) continue;
+    const m = fs.readFileSync(f, "utf8").match(new RegExp(`^${key}\\s*=\\s*"?([^"\\n]+)"?`, "m"));
+    if (m) return m[1];
+  }
+  return undefined;
+}
+
+const DATABASE_URL = envFromFiles("DATABASE_URL");
+if (!DATABASE_URL) throw new Error("DATABASE_URL not found in env or .env files");
+if (!DATABASE_URL.includes("pgbouncer=true")) {
+  console.warn("⚠ DATABASE_URL has no pgbouncer=true — expected the Supabase transaction pooler. Continuing.");
+}
+
+const SUPABASE_URL = envFromFiles("SUPABASE_URL");
+const SUPABASE_SERVICE_KEY = envFromFiles("SUPABASE_SERVICE_KEY");
+if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+  throw new Error("SUPABASE_URL and SUPABASE_SERVICE_KEY are required (dry run still needs read access to check object existence)");
+}
+
+const prisma = new PrismaClient({ datasources: { db: { url: DATABASE_URL } } });
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+
+const TARGETS = [
+  { table: "Contract", column: "signatureUrl" },
+  { table: "Contract", column: "contractorSignatureUrl" },
+  { table: "Contract", column: "companySignatureUrl" },
+  { table: "Contract", column: "signedPdfPath" },
+  { table: "Contract", column: "originalPdfPath" },
+  { table: "ContractSigningRecord", column: "signatureUrl" },
+  { table: "ChangeOrder", column: "clientSignatureUrl" },
+  { table: "ChangeOrder", column: "companySignatureUrl" },
+  { table: "Client", column: "taxExemptCertUrl" },
+  { table: "ProjectFile", column: "url" },
+];
+
+function firstLine(e) {
+  return (e?.message || e || "").toString().split("\n")[0];
+}
+
+/** Storage path inside SECURE_BUCKET, or null when `value` isn't a secure ref (mirrors
+ *  secureRefPath() in src/lib/secure-storage.ts). */
+function secureRefPath(value) {
+  if (typeof value !== "string" || !value.startsWith(SECURE_SCHEME)) return null;
+  const path = value.slice(SECURE_SCHEME.length);
+  if (!path || path.startsWith("/") || path.includes("..")) return null;
+  return path;
+}
+
+/**
+ * Fetch an object's size (in bytes) via the storage info() API — verified available on the
+ * installed @supabase/storage-js@2.99.0 (node_modules/@supabase/storage-js/src/packages/
+ * StorageFileApi.ts, also present in the compiled dist/index.cjs actually loaded at
+ * runtime): `.info(path)` returns `{ data: { size, ... } }` on success or
+ * `{ data: null, error }` for a missing object or any other failure. Used instead of
+ * exists() so the secure-docs copy's integrity can actually be verified before its public
+ * original is destroyed.
+ *
+ * Returns null when the object doesn't exist or the metadata can't be fetched for any
+ * reason — callers must treat null as "can't verify", never as a size of 0.
+ */
+async function getObjectSize(bucket, path) {
+  const { data, error } = await supabase.storage.from(bucket).info(path);
+  if (error) {
+    console.warn(`    info() check failed for ${bucket}/${path}: ${firstLine(error)}`);
+    return null;
+  }
+  return typeof data?.size === "number" ? data.size : null;
+}
+
+function emptyStats(label) {
+  return {
+    label,
+    scanned: 0,
+    deleted: 0,
+    wouldDelete: 0,
+    alreadyGone: 0,
+    refusedMissingSecureCopy: 0,
+    refusedCorruptSecureCopy: 0,
+    refusedSizeMismatch: 0,
+    failed: 0,
+  };
+}
+
+async function processTarget(t) {
+  const label = `${t.table}.${t.column}`;
+  let rows;
+  try {
+    rows = await prisma.$queryRawUnsafe(
+      `SELECT "id", "${t.column}" AS val FROM "${t.table}" WHERE "${t.column}" LIKE '${SECURE_SCHEME}%'`
+    );
+  } catch (e) {
+    console.log(`• ${label}: skipped (${firstLine(e)})`);
+    return { ...emptyStats(label), skippedColumn: true };
+  }
+
+  const stats = emptyStats(label);
+  for (const row of rows) {
+    stats.scanned++;
+    const path = secureRefPath(row.val);
+    if (!path) {
+      // Malformed secure ref (leading slash, "..", empty) — refuse to touch anything for it.
+      stats.failed++;
+      console.error(`  ✗ ${label} id=${row.id}: malformed secure ref "${row.val}" — skipped`);
+      continue;
+    }
+
+    const secureSize = await getObjectSize(SECURE_BUCKET, path);
+    if (secureSize === null) {
+      stats.refusedMissingSecureCopy++;
+      console.error(
+        `  ⚠ REFUSING to delete ${label} id=${row.id}: no object at ${SECURE_BUCKET}/${path} — ` +
+          `deleting the public original would make this document unreachable. Re-run migrate-secure-docs.mjs first.`
+      );
+      continue;
+    }
+    if (secureSize === 0) {
+      stats.refusedCorruptSecureCopy++;
+      console.error(
+        `  ⚠ REFUSING to delete ${label} id=${row.id}: ${SECURE_BUCKET}/${path} is zero-byte — ` +
+          `deleting the public original would leave only a corrupt copy behind. Re-run migrate-secure-docs.mjs first.`
+      );
+      continue;
+    }
+
+    const publicSize = await getObjectSize(PUBLIC_BUCKET, path);
+    if (publicSize === null) {
+      stats.alreadyGone++;
+      console.log(`  · ${label} id=${row.id}: ${PUBLIC_BUCKET}/${path} already gone — nothing to delete`);
+      continue;
+    }
+
+    if (publicSize !== secureSize) {
+      stats.refusedSizeMismatch++;
+      console.error(
+        `  ⚠ REFUSING to delete ${label} id=${row.id}: size mismatch between ${PUBLIC_BUCKET}/${path} ` +
+          `(${publicSize}b) and ${SECURE_BUCKET}/${path} (${secureSize}b) — the secure copy may be corrupt. ` +
+          `Re-run migrate-secure-docs.mjs first.`
+      );
+      continue;
+    }
+
+    if (!WILL_DELETE) {
+      stats.wouldDelete++;
+      console.log(`  (dry run) would delete ${PUBLIC_BUCKET}/${path} (${label} id=${row.id})`);
+      continue;
+    }
+
+    const { error } = await supabase.storage.from(PUBLIC_BUCKET).remove([path]);
+    if (error) {
+      stats.failed++;
+      console.error(`  ✗ ${label} id=${row.id}: delete of ${PUBLIC_BUCKET}/${path} failed — ${firstLine(error)}`);
+      continue;
+    }
+    stats.deleted++;
+    console.log(`  ✓ ${label} id=${row.id}: deleted ${PUBLIC_BUCKET}/${path}`);
+  }
+
+  console.log(
+    `• ${label}: scanned=${stats.scanned} deleted=${stats.deleted} would-delete=${stats.wouldDelete} ` +
+      `already-gone=${stats.alreadyGone} refused-missing-secure-copy=${stats.refusedMissingSecureCopy} ` +
+      `refused-corrupt-secure-copy=${stats.refusedCorruptSecureCopy} refused-size-mismatch=${stats.refusedSizeMismatch} ` +
+      `failed=${stats.failed}`
+  );
+  return stats;
+}
+
+(async () => {
+  console.log(
+    WILL_DELETE
+      ? "Purge mode: APPLY (deleting public originals — this is IRREVERSIBLE)\n"
+      : "Purge mode: DRY RUN (pass --apply --i-understand-this-deletes-public-originals to delete)\n"
+  );
+
+  const summaries = [];
+  for (const t of TARGETS) {
+    summaries.push(await processTarget(t));
+  }
+
+  const totals = summaries.reduce(
+    (a, s) => ({
+      scanned: a.scanned + (s.scanned || 0),
+      deleted: a.deleted + (s.deleted || 0),
+      wouldDelete: a.wouldDelete + (s.wouldDelete || 0),
+      alreadyGone: a.alreadyGone + (s.alreadyGone || 0),
+      refusedMissingSecureCopy: a.refusedMissingSecureCopy + (s.refusedMissingSecureCopy || 0),
+      refusedCorruptSecureCopy: a.refusedCorruptSecureCopy + (s.refusedCorruptSecureCopy || 0),
+      refusedSizeMismatch: a.refusedSizeMismatch + (s.refusedSizeMismatch || 0),
+      failed: a.failed + (s.failed || 0),
+    }),
+    {
+      scanned: 0,
+      deleted: 0,
+      wouldDelete: 0,
+      alreadyGone: 0,
+      refusedMissingSecureCopy: 0,
+      refusedCorruptSecureCopy: 0,
+      refusedSizeMismatch: 0,
+      failed: 0,
+    }
+  );
+  console.log(
+    `\nTotals: scanned=${totals.scanned} deleted=${totals.deleted} would-delete=${totals.wouldDelete} ` +
+      `already-gone=${totals.alreadyGone} refused-missing-secure-copy=${totals.refusedMissingSecureCopy} ` +
+      `refused-corrupt-secure-copy=${totals.refusedCorruptSecureCopy} refused-size-mismatch=${totals.refusedSizeMismatch} ` +
+      `failed=${totals.failed}`
+  );
+  console.log(`\n${WILL_DELETE ? "Objects deleted from the public bucket:" : "Objects that WOULD be deleted (dry run):"} ${WILL_DELETE ? totals.deleted : totals.wouldDelete}`);
+  if (
+    totals.failed > 0 ||
+    totals.refusedMissingSecureCopy > 0 ||
+    totals.refusedCorruptSecureCopy > 0 ||
+    totals.refusedSizeMismatch > 0
+  ) {
+    process.exitCode = 1;
+  }
+})()
+  .catch((e) => {
+    console.error("Purge failed:", e);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -6,6 +6,7 @@ import { getSupabase, STORAGE_BUCKET } from "@/lib/supabase";
 import { hasPermission } from "@/lib/permissions";
 import { authorizeFileScope, isAncestorFinancial } from "@/lib/file-auth";
 import { ALLOWED_FILE_EXTENSIONS } from "@/lib/project-files";
+import { resolveDocUrl, isSecureRef, removeSecureDoc } from "@/lib/secure-storage";
 
 export const maxDuration = 60;
 export const dynamic = "force-dynamic";
@@ -85,10 +86,11 @@ export async function GET(req: NextRequest) {
             return true;
         });
 
-        const filesWithEffective = filtered.map((f: FileWithFolder) => ({
+        const filesWithEffective = await Promise.all(filtered.map(async (f: FileWithFolder) => ({
             ...f,
+            url: await resolveDocUrl(f.url),
             effectiveVisibility: effectiveVisibility(f),
-        }));
+        })));
 
         return NextResponse.json({ folders, files: filesWithEffective });
     } catch (err: any) {
@@ -318,14 +320,22 @@ export async function DELETE(req: NextRequest) {
                 return NextResponse.json({ error: "No permission to delete financial files" }, { status: 403 });
             }
 
-            const supabase = getSupabase();
-            if (supabase) {
-                const url = file.url;
-                const bucketPrefix = `/storage/v1/object/public/${STORAGE_BUCKET}/`;
-                const pathIdx = url.indexOf(bucketPrefix);
-                if (pathIdx >= 0) {
-                    const storagePath = url.substring(pathIdx + bucketPrefix.length);
-                    await supabase.storage.from(STORAGE_BUCKET).remove([storagePath]);
+            if (isSecureRef(file.url)) {
+                try {
+                    await removeSecureDoc(file.url);
+                } catch (removeErr) {
+                    console.error("DELETE /api/files: failed to remove secure object:", removeErr);
+                }
+            } else {
+                const supabase = getSupabase();
+                if (supabase) {
+                    const url = file.url;
+                    const bucketPrefix = `/storage/v1/object/public/${STORAGE_BUCKET}/`;
+                    const pathIdx = url.indexOf(bucketPrefix);
+                    if (pathIdx >= 0) {
+                        const storagePath = url.substring(pathIdx + bucketPrefix.length);
+                        await supabase.storage.from(STORAGE_BUCKET).remove([storagePath]);
+                    }
                 }
             }
             await prisma.projectFile.delete({ where: { id: fileId } });

--- a/src/app/api/files/signed-upload/route.ts
+++ b/src/app/api/files/signed-upload/route.ts
@@ -1,12 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getSupabase, STORAGE_BUCKET } from "@/lib/supabase";
+import { SECURE_BUCKET } from "@/lib/secure-storage";
 import { authenticateMobileOrSession, userCanAccessProject } from "@/lib/mobile-auth";
 import { hasPermission } from "@/lib/permissions";
 
 export const maxDuration = 30;
 
 type FileInfo = { name: string; size: number; mimeType: string };
+
+// Server-validated allowlist of private upload scopes — the client can only ask for one
+// of these named scopes, never an arbitrary bucket. "contract-original" is the only one
+// today: a contract PDF original uploaded via EntityContractsClient, which must land in
+// the private secure-docs bucket rather than the public project-files bucket.
+const PRIVATE_UPLOAD_SCOPES = new Set(["contract-original"]);
 
 // POST: generate signed upload URLs so the browser can upload directly to Supabase,
 // bypassing Vercel's 4.5 MB serverless payload limit. Hybrid auth — accepts NextAuth
@@ -23,12 +30,13 @@ export async function POST(req: NextRequest) {
         }
 
         const body = await req.json();
-        const { projectId, leadId, folderId, files, visibility } = body as {
+        const { projectId, leadId, folderId, files, visibility, scope } = body as {
             projectId?: string;
             leadId?: string;
             folderId?: string;
             files: FileInfo[];
             visibility?: string;
+            scope?: string;
         };
 
         if (!projectId && !leadId) {
@@ -36,6 +44,21 @@ export async function POST(req: NextRequest) {
         }
         if (!files?.length) {
             return NextResponse.json({ error: "files required" }, { status: 400 });
+        }
+
+        // A named, server-validated scope routes the upload to the private secure-docs
+        // bucket instead of the public one. Never take a bucket name from the client.
+        let targetBucket: string = STORAGE_BUCKET;
+        if (scope !== undefined) {
+            if (typeof scope !== "string" || !PRIVATE_UPLOAD_SCOPES.has(scope)) {
+                return NextResponse.json({ error: "Invalid scope" }, { status: 400 });
+            }
+            // Private scopes are for staff-only document flows (e.g. contract originals) —
+            // gate them the same way the DB record that will reference the upload is gated.
+            if (user.role !== "ADMIN" && user.role !== "MANAGER") {
+                return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+            }
+            targetBucket = SECURE_BUCKET;
         }
 
         if (visibility === "financial") {
@@ -82,22 +105,24 @@ export async function POST(req: NextRequest) {
                 const storagePath = `${prefix}/${Date.now()}_${uniq.slice(0, 8)}_${safeName}`;
 
                 const { data, error } = await supabase.storage
-                    .from(STORAGE_BUCKET)
+                    .from(targetBucket)
                     .createSignedUploadUrl(storagePath);
 
                 if (error || !data) {
                     throw new Error(`Failed to create signed URL for ${f.name}: ${error?.message}`);
                 }
 
-                const { data: urlData } = supabase.storage
-                    .from(STORAGE_BUCKET)
-                    .getPublicUrl(storagePath);
+                // The private bucket has no public URL — a caller must resolve a signed URL
+                // server-side via resolveDocUrl() instead. Only build one for the public bucket.
+                const publicUrl = targetBucket === STORAGE_BUCKET
+                    ? supabase.storage.from(targetBucket).getPublicUrl(storagePath).data.publicUrl
+                    : null;
 
                 return {
                     signedUrl: data.signedUrl,
                     token: data.token,
                     storagePath,
-                    publicUrl: urlData.publicUrl,
+                    publicUrl,
                     name: f.name,
                     size: f.size,
                     mimeType: f.mimeType,

--- a/src/app/api/portal/contracts/[id]/finalize/route.ts
+++ b/src/app/api/portal/contracts/[id]/finalize/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getSupabase, STORAGE_BUCKET } from "@/lib/supabase";
+import { getSupabase } from "@/lib/supabase";
 import { sendNotification } from "@/lib/email";
 import { resolveSessionClientId } from "@/lib/portal-auth";
 import { archiveExecutedContractPdf, sendExecutedContractEmails } from "@/lib/contract-finalize";
+import { uploadSecureDoc, removeSecureDoc, downloadDocBytes } from "@/lib/secure-storage";
 import { PDFDocument } from "pdf-lib";
 import { appendContractCountersignaturePage } from "@/lib/pdf";
 
@@ -122,9 +123,8 @@ export async function POST(
             let committed = false;
             let storagePathUploaded: string | null = null;
             try {
-                const { data: dl, error: dlErr } = await supabase.storage.from(STORAGE_BUCKET).download(contract.originalPdfPath);
-                if (dlErr || !dl) throw new Error("Could not load original PDF contract");
-                const originalBuffer = Buffer.from(await dl.arrayBuffer());
+                const originalBuffer = await downloadDocBytes(contract.originalPdfPath);
+                if (!originalBuffer) throw new Error("Could not load original PDF contract");
 
                 const settings = await prisma.companySettings.findUnique({ where: { id: "singleton" } });
                 const ip = contract.approvalIp || "0.0.0.0";
@@ -146,8 +146,11 @@ export async function POST(
                     clientOnlyPdf
                 );
                 record = archived.record;
-                storagePathUploaded = archived.storagePath;
-                
+                // Track the secure ref the archive step returned (not the raw storage path) —
+                // the executed PDF lives in SECURE_BUCKET, so cleanup must go through
+                // removeSecureDoc rather than a raw STORAGE_BUCKET remove().
+                storagePathUploaded = archived.publicUrl;
+
                 await prisma.contract.update({
                     where: { id: contract.id },
                     data: { status: "Finalized" },
@@ -192,7 +195,7 @@ export async function POST(
                 console.error("Finalize PDF Contract Error:", err);
                 if (!committed && storagePathUploaded) {
                     try {
-                        await supabase.storage.from(STORAGE_BUCKET).remove([storagePathUploaded]);
+                        await removeSecureDoc(storagePathUploaded);
                     } catch {}
                 }
                 return NextResponse.json({ error: err.message || "Failed to finalize PDF contract" }, { status: 500 });
@@ -225,10 +228,10 @@ export async function POST(
 
             const cPrefix = contract.projectId ? `projects/${contract.projectId}` : `leads/${contract.leadId}`;
             const intermediatePath = `${cPrefix}/intermediate/${Date.now()}_Signed_Contract_${contract.id}.pdf`;
-            const { error: cUpErr } = await supabase.storage
-                .from(STORAGE_BUCKET)
-                .upload(intermediatePath, cBuffer, { contentType: "application/pdf", upsert: false });
-            if (cUpErr) {
+            let secureRef: string;
+            try {
+                secureRef = await uploadSecureDoc(intermediatePath, cBuffer, "application/pdf");
+            } catch (cUpErr: any) {
                 return NextResponse.json({ error: `Storage upload failed: ${cUpErr.message}` }, { status: 500 });
             }
 
@@ -239,15 +242,15 @@ export async function POST(
             try {
                 claim = await prisma.contract.updateMany({
                     where: { id: contract.id, signedPdfPath: null },
-                    data: { signedPdfPath: intermediatePath },
+                    data: { signedPdfPath: secureRef },
                 });
             } catch (claimErr) {
                 // DB threw between upload and claim — remove the orphaned upload before bubbling up.
-                try { await supabase.storage.from(STORAGE_BUCKET).remove([intermediatePath]); } catch {}
+                try { await removeSecureDoc(secureRef); } catch {}
                 throw claimErr;
             }
             if (claim.count === 0) {
-                try { await supabase.storage.from(STORAGE_BUCKET).remove([intermediatePath]); } catch {}
+                try { await removeSecureDoc(secureRef); } catch {}
                 return NextResponse.json({ success: true, awaitingCountersign: true });
             }
 
@@ -317,7 +320,6 @@ export async function POST(
         let safeName = `Executed_Contract_${contract.id}.pdf`;
         let publicUrl = "";
         let committed = false;
-        let storagePathUploaded: string | null = null;
         try {
             let formData;
             try {
@@ -344,7 +346,6 @@ export async function POST(
             );
             record = archived.record;
             publicUrl = archived.publicUrl;
-            storagePathUploaded = archived.storagePath;
             safeName = archived.fileName;
             committed = true;
         } catch (pipelineErr: any) {
@@ -355,11 +356,12 @@ export async function POST(
                     where: { id, status: "Finalized" },
                     data: { status: "Signed" },
                 });
-                // Best-effort cleanup of any uploaded storage object so a retry
-                // doesn't leave orphans.
-                if (storagePathUploaded) {
+                // Best-effort cleanup of any uploaded storage object so a retry doesn't
+                // leave orphans. `publicUrl` is the secure ref archiveExecutedContractPdf
+                // returned — the executed PDF lives in SECURE_BUCKET, not STORAGE_BUCKET.
+                if (publicUrl) {
                     try {
-                        await supabase.storage.from(STORAGE_BUCKET).remove([storagePathUploaded]);
+                        await removeSecureDoc(publicUrl);
                     } catch {}
                 }
             }

--- a/src/app/api/portal/estimates/[id]/pdf-upload/route.ts
+++ b/src/app/api/portal/estimates/[id]/pdf-upload/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createHmac, timingSafeEqual } from "crypto";
 import { prisma } from "@/lib/prisma";
-import { getSupabase, STORAGE_BUCKET } from "@/lib/supabase";
+import { getSupabase } from "@/lib/supabase";
+import { uploadSecureDoc } from "@/lib/secure-storage";
 
 export const maxDuration = 60;
 
@@ -84,22 +85,15 @@ export async function POST(
         const safeName = `Estimate_${(estimate.code || id).replace(/[^a-zA-Z0-9._-]/g, "_")}.pdf`;
         const storagePath = `estimate-pdfs/${id}/${Date.now()}_${safeName}`;
 
-        const { error: uploadError } = await supabase.storage
-            .from(STORAGE_BUCKET)
-            .upload(storagePath, buffer, {
-                contentType: "application/pdf",
-                upsert: true,
-            });
-
-        if (uploadError) {
+        let secureRef: string;
+        try {
+            secureRef = await uploadSecureDoc(storagePath, buffer, "application/pdf");
+        } catch (uploadError: any) {
             console.error("Supabase upload error:", uploadError);
             return NextResponse.json({ error: `Storage upload failed: ${uploadError.message}` }, { status: 500 });
         }
 
-        const { data: urlData } = supabase.storage.from(STORAGE_BUCKET).getPublicUrl(storagePath);
-        const url = urlData?.publicUrl || storagePath;
-
-        return NextResponse.json({ success: true, url }, { status: 200 });
+        return NextResponse.json({ success: true, url: secureRef }, { status: 200 });
     } catch (err: any) {
         console.error("PDF upload error:", err);
         return NextResponse.json({ error: err.message || "Upload failed" }, { status: 500 });

--- a/src/app/api/portal/files/route.ts
+++ b/src/app/api/portal/files/route.ts
@@ -5,6 +5,7 @@ import { resolveSessionClientId } from "@/lib/portal-auth";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 import { getPortalVisibility } from "@/lib/actions";
+import { resolveDocUrl } from "@/lib/secure-storage";
 
 // GET: list shared files for a portal client (read-only)
 export async function GET(req: NextRequest) {
@@ -88,7 +89,7 @@ export async function GET(req: NextRequest) {
                 ? { OR: [{ visibility: "shared" }, { visibility: null }] }
                 : { visibility: "shared" }),
         };
-        const files = await prisma.projectFile.findMany({
+        const filesRaw = await prisma.projectFile.findMany({
             where: fileWhere,
             orderBy: { createdAt: "desc" },
             select: {
@@ -100,6 +101,9 @@ export async function GET(req: NextRequest) {
                 createdAt: true,
             },
         });
+        const files = await Promise.all(
+            filesRaw.map(async (f) => ({ ...f, url: await resolveDocUrl(f.url) }))
+        );
 
         return NextResponse.json({ folders, files });
     } catch (err: any) {

--- a/src/app/leads/[id]/contracts/page.tsx
+++ b/src/app/leads/[id]/contracts/page.tsx
@@ -2,7 +2,7 @@ import { getLead, getDocumentTemplates } from "@/lib/actions";
 import { notFound } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import EntityContractsClient from "@/components/EntityContractsClient";
-import { getSupabase } from "@/lib/supabase";
+import { resolveDocUrl } from "@/lib/secure-storage";
 
 export const dynamic = "force-dynamic";
 
@@ -33,7 +33,8 @@ export default async function LeadContractsPage({ params, searchParams }: {
     });
 
     // Executed-PDF lookup: widen to cover files saved under either the lead or the project.
-    const executedFiles = await prisma.projectFile.findMany({
+    // ProjectFile.url may hold either a legacy public URL or a secure ref — resolve per row.
+    const executedFilesRaw = await prisma.projectFile.findMany({
         where: {
             OR: [
                 { leadId: lead.id },
@@ -45,13 +46,11 @@ export default async function LeadContractsPage({ params, searchParams }: {
         orderBy: { createdAt: "desc" },
         select: { name: true, url: true },
     });
+    const executedFiles = await Promise.all(
+        executedFilesRaw.map(async (f) => ({ name: f.name, url: await resolveDocUrl(f.url) }))
+    );
 
-    const supabase = getSupabase();
-    const findOriginalPdfUrl = (originalPdfPath: string | null) => {
-        if (!originalPdfPath || !supabase) return null;
-        const { data } = supabase.storage.from("project-files").getPublicUrl(originalPdfPath);
-        return data?.publicUrl || null;
-    };
+    const findOriginalPdfUrl = (originalPdfPath: string | null) => resolveDocUrl(originalPdfPath);
 
     const findExecutedPdfUrl = (contractId: string, title: string) => {
         const exactName = `Executed_Contract_${contractId}.pdf`;
@@ -61,13 +60,16 @@ export default async function LeadContractsPage({ params, searchParams }: {
         return executedFiles.find(f => f.name.startsWith(safeName))?.url || null;
     };
 
-    const serialized = JSON.parse(JSON.stringify(
-        contracts.map(c => ({
-            ...c,
-            executedPdfUrl: findExecutedPdfUrl(c.id, c.title),
-            originalPdfUrl: findOriginalPdfUrl(c.originalPdfPath)
-        }))
-    ));
+    const resolvedContracts = await Promise.all(contracts.map(async (c) => ({
+        ...c,
+        signatureUrl: await resolveDocUrl(c.signatureUrl),
+        contractorSignatureUrl: await resolveDocUrl(c.contractorSignatureUrl),
+        companySignatureUrl: await resolveDocUrl(c.companySignatureUrl),
+        executedPdfUrl: findExecutedPdfUrl(c.id, c.title),
+        originalPdfUrl: await findOriginalPdfUrl(c.originalPdfPath),
+    })));
+
+    const serialized = JSON.parse(JSON.stringify(resolvedContracts));
 
     const linkedEntity = linkedProjectId
         ? { type: "project" as const, id: linkedProjectId, name: (lead.project as any).name }

--- a/src/app/leads/[id]/estimates/[estimateId]/page.tsx
+++ b/src/app/leads/[id]/estimates/[estimateId]/page.tsx
@@ -1,6 +1,7 @@
 import { getEstimate, getLead, getCompanySettings, getEstimateActivity } from "@/lib/actions";
 import { notFound } from "next/navigation";
 import EstimateEditor from "@/app/projects/[id]/estimates/[estimateId]/EstimateEditor";
+import { resolveDocUrl } from "@/lib/secure-storage";
 
 export const dynamic = "force-dynamic";
 
@@ -18,6 +19,12 @@ export default async function LeadEstimatePage({ params }: { params: Promise<{ i
     }
 
     const serializedEstimate = JSON.parse(JSON.stringify(estimate));
+    serializedEstimate.signatureUrl = await resolveDocUrl((estimate as any).signatureUrl);
+    if (Array.isArray(serializedEstimate.files)) {
+        serializedEstimate.files = await Promise.all(
+            serializedEstimate.files.map(async (f: any) => ({ ...f, url: await resolveDocUrl(f.url) }))
+        );
+    }
 
     let salesTaxes: { id?: string; name: string; rate: number; isDefault: boolean }[] = [];
     try {

--- a/src/app/leads/[id]/meetings/page.tsx
+++ b/src/app/leads/[id]/meetings/page.tsx
@@ -1,6 +1,7 @@
 import { getLead, getLeadMeetings } from "@/lib/actions";
 import LeadDetailsSidebar from "../LeadDetailsSidebar";
 import LeadMeetingsPanel from "./LeadMeetingsPanel";
+import { resolveDocUrl } from "@/lib/secure-storage";
 
 export default async function LeadMeetingsPage({ params }: { params: Promise<{ id: string }> }) {
     const resolvedParams = await params;
@@ -42,7 +43,7 @@ export default async function LeadMeetingsPage({ params }: { params: Promise<{ i
                 clientCity={(lead.client as any)?.city || null}
                 clientState={(lead.client as any)?.state || null}
                 clientZip={(lead.client as any)?.zipCode || null}
-                clientTaxExemptCertUrl={(lead.client as any)?.taxExemptCertUrl || null}
+                clientTaxExemptCertUrl={await resolveDocUrl((lead.client as any)?.taxExemptCertUrl)}
                 clientTaxExemptCertExpiresAt={(lead.client as any)?.taxExemptCertExpiresAt?.toISOString?.() || null}
                 clientTaxExemptCertNote={(lead.client as any)?.taxExemptCertNote || null}
                 initialMessage={lead.message || null}

--- a/src/app/leads/[id]/page.tsx
+++ b/src/app/leads/[id]/page.tsx
@@ -2,6 +2,7 @@ import { getLead } from "@/lib/actions";
 import ClientMessaging from "@/components/ClientMessaging";
 import LeadMessagingHeader from "./LeadMessagingHeader";
 import LeadDetailsSidebar from "./LeadDetailsSidebar";
+import { resolveDocUrl } from "@/lib/secure-storage";
 
 export default async function LeadDetailPage({ params }: { params: Promise<{ id: string }> }) {
     const resolvedParams = await params;
@@ -57,7 +58,7 @@ export default async function LeadDetailPage({ params }: { params: Promise<{ id:
                 clientCity={(lead.client as any)?.city || null}
                 clientState={(lead.client as any)?.state || null}
                 clientZip={(lead.client as any)?.zipCode || null}
-                clientTaxExemptCertUrl={(lead.client as any)?.taxExemptCertUrl || null}
+                clientTaxExemptCertUrl={await resolveDocUrl((lead.client as any)?.taxExemptCertUrl)}
                 clientTaxExemptCertExpiresAt={(lead.client as any)?.taxExemptCertExpiresAt?.toISOString?.() || null}
                 clientTaxExemptCertNote={(lead.client as any)?.taxExemptCertNote || null}
                 initialMessage={initialMessage}

--- a/src/app/leads/[id]/tasks/page.tsx
+++ b/src/app/leads/[id]/tasks/page.tsx
@@ -1,6 +1,7 @@
 import { getLead, getLeadTasks, getTeamMembers } from "@/lib/actions";
 import LeadDetailsSidebar from "../LeadDetailsSidebar";
 import LeadTasksPanel from "./LeadTasksPanel";
+import { resolveDocUrl } from "@/lib/secure-storage";
 
 export default async function LeadTasksPage({ params }: { params: Promise<{ id: string }> }) {
     const resolvedParams = await params;
@@ -42,7 +43,7 @@ export default async function LeadTasksPage({ params }: { params: Promise<{ id: 
                 clientCity={(lead.client as any)?.city || null}
                 clientState={(lead.client as any)?.state || null}
                 clientZip={(lead.client as any)?.zipCode || null}
-                clientTaxExemptCertUrl={(lead.client as any)?.taxExemptCertUrl || null}
+                clientTaxExemptCertUrl={await resolveDocUrl((lead.client as any)?.taxExemptCertUrl)}
                 clientTaxExemptCertExpiresAt={(lead.client as any)?.taxExemptCertExpiresAt?.toISOString?.() || null}
                 clientTaxExemptCertNote={(lead.client as any)?.taxExemptCertNote || null}
                 initialMessage={lead.message || null}

--- a/src/app/portal/change-orders/[id]/page.tsx
+++ b/src/app/portal/change-orders/[id]/page.tsx
@@ -2,6 +2,7 @@ import { getChangeOrderForPortal, getPublicCompanySettings, getPortalVisibility 
 import { notFound } from "next/navigation";
 import PortalChangeOrderClient from "./PortalChangeOrderClient";
 import Link from "next/link";
+import { resolveDocUrl } from "@/lib/secure-storage";
 
 export default async function PortalChangeOrderPage({ params }: { params: Promise<{ id: string }> }) {
     const resolvedParams = await params;
@@ -30,5 +31,11 @@ export default async function PortalChangeOrderPage({ params }: { params: Promis
         }
     }
 
-    return <PortalChangeOrderClient initialData={changeOrder} companySettings={settings} />;
+    const initialData = {
+        ...changeOrder,
+        clientSignatureUrl: await resolveDocUrl((changeOrder as any).clientSignatureUrl),
+        companySignatureUrl: await resolveDocUrl((changeOrder as any).companySignatureUrl),
+    };
+
+    return <PortalChangeOrderClient initialData={initialData} companySettings={settings} />;
 }

--- a/src/app/portal/contracts/[id]/page.tsx
+++ b/src/app/portal/contracts/[id]/page.tsx
@@ -2,7 +2,7 @@ import { getContractForPortal, getPublicCompanySettings, getPortalVisibility, ge
 import { notFound } from "next/navigation";
 import PortalContractClient from "./PortalContractClient";
 import Link from "next/link";
-import { getSupabase } from "@/lib/supabase";
+import { resolveDocUrl } from "@/lib/secure-storage";
 
 export const dynamic = "force-dynamic";
 
@@ -55,19 +55,16 @@ export default async function PortalContractPage({
     });
 
     const serializedContract = JSON.parse(JSON.stringify(contract));
-    if (contract.originalPdfPath) {
-        const supabase = getSupabase();
-        if (supabase) {
-            const { data } = supabase.storage.from("project-files").getPublicUrl(contract.originalPdfPath);
-            serializedContract.originalPdfUrl = data?.publicUrl || null;
-        }
-    }
+    serializedContract.originalPdfUrl = await resolveDocUrl(contract.originalPdfPath);
+    serializedContract.signatureUrl = await resolveDocUrl(contract.signatureUrl);
+    serializedContract.contractorSignatureUrl = await resolveDocUrl(contract.contractorSignatureUrl);
+    serializedContract.companySignatureUrl = await resolveDocUrl(contract.companySignatureUrl);
 
     return (
         <PortalContractClient
             initialContract={serializedContract}
             companySettings={settings}
-            archivedPdfUrl={archivedFile?.url || null}
+            archivedPdfUrl={await resolveDocUrl(archivedFile?.url)}
             accessToken={resolvedSearch.token || null}
         />
     );

--- a/src/app/portal/estimates/[id]/page.tsx
+++ b/src/app/portal/estimates/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from "next/navigation";
 import PortalEstimateClient from "./PortalEstimateClient";
 import Link from "next/link";
 import { prisma } from "@/lib/prisma";
+import { resolveDocUrl } from "@/lib/secure-storage";
 
 export default async function PortalEstimatePage({ params }: { params: Promise<{ id: string }> }) {
     const resolvedParams = await params;
@@ -60,5 +61,15 @@ export default async function PortalEstimatePage({ params }: { params: Promise<{
         }
     }
 
-    return <PortalEstimateClient initialEstimate={estimate} companySettings={settings} />;
+    const resolvedEstimate: any = {
+        ...estimate,
+        signatureUrl: await resolveDocUrl((estimate as any).signatureUrl),
+    };
+    if (Array.isArray((estimate as any).files)) {
+        resolvedEstimate.files = await Promise.all(
+            (estimate as any).files.map(async (f: any) => ({ ...f, url: await resolveDocUrl(f.url) }))
+        );
+    }
+
+    return <PortalEstimateClient initialEstimate={resolvedEstimate} companySettings={settings} />;
 }

--- a/src/app/projects/[id]/change-orders/[coId]/page.tsx
+++ b/src/app/projects/[id]/change-orders/[coId]/page.tsx
@@ -1,6 +1,7 @@
 import { getChangeOrder, getProject } from "@/lib/actions";
 import { notFound } from "next/navigation";
 import ChangeOrderEditor from "./ChangeOrderEditor";
+import { resolveDocUrl } from "@/lib/secure-storage";
 
 export const dynamic = "force-dynamic";
 
@@ -14,9 +15,15 @@ export default async function ChangeOrderPage({
     const co = await getChangeOrder(resolvedParams.coId);
 
     if (!project) return <div>Project not found</div>;
-    if (!co) { 
+    if (!co) {
         notFound();
     }
+
+    const initialData = {
+        ...co,
+        clientSignatureUrl: await resolveDocUrl((co as any).clientSignatureUrl),
+        companySignatureUrl: await resolveDocUrl((co as any).companySignatureUrl),
+    };
 
     return (
         <div className="flex h-[calc(100%+48px)] -m-6 overflow-hidden">
@@ -29,7 +36,7 @@ export default async function ChangeOrderPage({
                         clientEmail: project.client.email || undefined,
                         location: project.location || undefined
                     }}
-                    initialData={co}
+                    initialData={initialData}
                 />
             </div>
         </div>

--- a/src/app/projects/[id]/contracts/page.tsx
+++ b/src/app/projects/[id]/contracts/page.tsx
@@ -2,7 +2,7 @@ import { getProject, getDocumentTemplates } from "@/lib/actions";
 import { notFound } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import EntityContractsClient from "@/components/EntityContractsClient";
-import { getSupabase } from "@/lib/supabase";
+import { resolveDocUrl } from "@/lib/secure-storage";
 
 export const dynamic = "force-dynamic";
 
@@ -29,7 +29,8 @@ export default async function ProjectContractsPage({ params }: { params: Promise
     });
 
     // Executed-PDF lookup: widen to cover files saved under either the project or the lead.
-    const executedFiles = await prisma.projectFile.findMany({
+    // ProjectFile.url may hold either a legacy public URL or a secure ref — resolve per row.
+    const executedFilesRaw = await prisma.projectFile.findMany({
         where: {
             OR: [
                 { projectId: project.id },
@@ -41,13 +42,11 @@ export default async function ProjectContractsPage({ params }: { params: Promise
         orderBy: { createdAt: "desc" },
         select: { name: true, url: true },
     });
+    const executedFiles = await Promise.all(
+        executedFilesRaw.map(async (f) => ({ name: f.name, url: await resolveDocUrl(f.url) }))
+    );
 
-    const supabase = getSupabase();
-    const findOriginalPdfUrl = (originalPdfPath: string | null) => {
-        if (!originalPdfPath || !supabase) return null;
-        const { data } = supabase.storage.from("project-files").getPublicUrl(originalPdfPath);
-        return data?.publicUrl || null;
-    };
+    const findOriginalPdfUrl = (originalPdfPath: string | null) => resolveDocUrl(originalPdfPath);
 
     const findExecutedPdfUrl = (contractId: string, title: string) => {
         const exactName = `Executed_Contract_${contractId}.pdf`;
@@ -57,13 +56,16 @@ export default async function ProjectContractsPage({ params }: { params: Promise
         return executedFiles.find(f => f.name.startsWith(safeName))?.url || null;
     };
 
-    const serialized = JSON.parse(JSON.stringify(
-        contracts.map(c => ({
-            ...c,
-            executedPdfUrl: findExecutedPdfUrl(c.id, c.title),
-            originalPdfUrl: findOriginalPdfUrl(c.originalPdfPath)
-        }))
-    ));
+    const resolvedContracts = await Promise.all(contracts.map(async (c) => ({
+        ...c,
+        signatureUrl: await resolveDocUrl(c.signatureUrl),
+        contractorSignatureUrl: await resolveDocUrl(c.contractorSignatureUrl),
+        companySignatureUrl: await resolveDocUrl(c.companySignatureUrl),
+        executedPdfUrl: findExecutedPdfUrl(c.id, c.title),
+        originalPdfUrl: await findOriginalPdfUrl(c.originalPdfPath),
+    })));
+
+    const serialized = JSON.parse(JSON.stringify(resolvedContracts));
 
     const linkedEntity = linkedLeadId
         ? { type: "lead" as const, id: linkedLeadId, name: (project as any).lead?.name ?? "" }

--- a/src/app/projects/[id]/estimates/[estimateId]/page.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/page.tsx
@@ -1,6 +1,7 @@
 import { getEstimate, getProject, getCompanySettings, getEstimateActivity } from "@/lib/actions";
 import EstimateEditor from "./EstimateEditor";
 import { notFound } from "next/navigation";
+import { resolveDocUrl } from "@/lib/secure-storage";
 
 export const dynamic = "force-dynamic";
 
@@ -28,6 +29,14 @@ export default async function EstimatePage({
         salesTaxes = settings.salesTaxes ? JSON.parse(settings.salesTaxes) : [];
     } catch { /* ignore parse errors */ }
 
+    const serializedEstimate = JSON.parse(JSON.stringify(estimate));
+    serializedEstimate.signatureUrl = await resolveDocUrl((estimate as any).signatureUrl);
+    if (Array.isArray(serializedEstimate.files)) {
+        serializedEstimate.files = await Promise.all(
+            serializedEstimate.files.map(async (f: any) => ({ ...f, url: await resolveDocUrl(f.url) }))
+        );
+    }
+
     return (
         <div className="flex h-[calc(100%+48px)] -m-6 overflow-hidden">
             <div className="flex-1 bg-slate-50 overflow-hidden flex flex-col">
@@ -42,7 +51,7 @@ export default async function EstimatePage({
                         clientTaxExemptCertUrl: (project.client as any)?.taxExemptCertUrl || null,
                         clientTaxExemptCertExpiresAt: (project.client as any)?.taxExemptCertExpiresAt?.toISOString?.() || null
                     }}
-                    initialEstimate={JSON.parse(JSON.stringify(estimate))}
+                    initialEstimate={serializedEstimate}
                     salesTaxes={salesTaxes}
                     settings={settings}
                     activityEvents={activityEvents}

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 import ProjectHeader from "./ProjectHeader";
 import ProjectDashboardsWidget from "@/components/ProjectDashboardsWidget";
 import { formatCurrency } from "@/lib/utils";
+import { resolveDocUrl } from "@/lib/secure-storage";
 
 export const dynamic = "force-dynamic";
 
@@ -56,7 +57,10 @@ export default async function ProjectDashboardPage({ params }: { params: Promise
         orderBy: { createdAt: "desc" },
         take: 8,
         select: { id: true, name: true, url: true, mimeType: true, size: true, createdAt: true },
-    }).then(r => { console.timeEnd("[DASHBOARD] recentFiles"); return r; });
+    }).then(async (rows) => {
+        console.timeEnd("[DASHBOARD] recentFiles");
+        return Promise.all(rows.map(async (f) => ({ ...f, url: await resolveDocUrl(f.url) })));
+    });
 
     const [project, tasks, portalVisibility, recentActivity, recentFiles] = await Promise.all([
         projectPromise,
@@ -293,7 +297,7 @@ export default async function ProjectDashboardPage({ params }: { params: Promise
                                             >
                                                 {isImage ? (
                                                     <img
-                                                        src={file.url}
+                                                        src={file.url || ""}
                                                         alt={file.name}
                                                         loading="lazy"
                                                         width={80}

--- a/src/app/settings/contacts/page.tsx
+++ b/src/app/settings/contacts/page.tsx
@@ -2,12 +2,17 @@ export const dynamic = "force-dynamic";
 import { getSessionOrDev } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { getClients } from "@/lib/actions";
+import { resolveDocUrl } from "@/lib/secure-storage";
 import ContactsClient from "./ContactsClient";
 
 export default async function ContactsPage() {
     const session = await getSessionOrDev();
     if (!session?.user) return redirect("/login");
 
-    const clients = await getClients();
+    const clientsRaw = await getClients();
+    const clients = await Promise.all(clientsRaw.map(async (c: any) => ({
+        ...c,
+        taxExemptCertUrl: await resolveDocUrl(c.taxExemptCertUrl),
+    })));
     return <ContactsClient clients={clients} />;
 }

--- a/src/components/EntityContractsClient.tsx
+++ b/src/components/EntityContractsClient.tsx
@@ -246,6 +246,9 @@ export default function EntityContractsClient({
                     leadId: entity.type === "lead" ? entity.id : undefined,
                     visibility: "shared",
                     files: [{ name: file.name, size: file.size, mimeType: "application/pdf" }],
+                    // Contract originals carry legal/PII weight — route this upload to the
+                    // private secure-docs bucket instead of the public one.
+                    scope: "contract-original",
                 }),
             });
             const data = await res.json();
@@ -269,17 +272,14 @@ export default function EntityContractsClient({
                 throw new Error(msg);
             }
 
-            // Create the contract in DB referencing the storagePath (upload.storagePath)
+            // Create the contract in DB referencing the storagePath (upload.storagePath).
+            // Uploaded into the private bucket above, so store it as a secure ref — the
+            // server resolves a preview URL for us (the private bucket has no public one).
             const titleWithoutExt = file.name.replace(/\.[^/.]+$/, "");
-            const newContract = await createContractFromPdf(context, titleWithoutExt, upload.storagePath);
-            
-            const mappedContract = {
-                ...newContract,
-                originalPdfUrl: upload.publicUrl
-            };
+            const newContract = await createContractFromPdf(context, titleWithoutExt, upload.storagePath, true);
 
             toast.success("PDF contract imported successfully!", { id: uploadToast });
-            openEditor(mappedContract);
+            openEditor(newContract);
             router.refresh();
         } catch (err: any) {
             console.error("PDF upload error:", err);

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -26,6 +26,7 @@ import { normalizeE164 } from "./phone";
 import { getDefaultColorForTaskName } from "@/app/projects/[id]/schedule/schedule-utils";
 import { headers } from "next/headers";
 import { getSupabase, STORAGE_BUCKET } from "./supabase";
+import { uploadSecureDoc, removeSecureDoc, downloadDocBytes, isSecureRef, resolveDocUrl, toSecureRef } from "./secure-storage";
 import { archiveExecutedContractPdf, sendExecutedContractEmails } from "./contract-finalize";
 import { appendContractCountersignaturePage } from "./pdf";
 import { defaultTaxForNewEstimate } from "./wa-tax";
@@ -685,19 +686,10 @@ export async function saveClientTaxExemptCert(clientId: string, formData: FormDa
             throw new Error("Certificate must be a PDF or image");
         }
 
-        const { getSupabase, STORAGE_BUCKET } = await import("./supabase");
-        const supabase = getSupabase();
-        if (!supabase) throw new Error("Storage not configured");
-
         const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
         const storagePath = `tax-certs/${clientId}/${Date.now()}_${safeName}`;
         const buffer = Buffer.from(await file.arrayBuffer());
-        const { error: uploadError } = await supabase.storage
-            .from(STORAGE_BUCKET)
-            .upload(storagePath, buffer, { contentType: file.type || "application/octet-stream", upsert: false });
-        if (uploadError) throw new Error(`Upload failed: ${uploadError.message}`);
-        const { data: urlData } = supabase.storage.from(STORAGE_BUCKET).getPublicUrl(storagePath);
-        certUrl = urlData?.publicUrl || storagePath;
+        certUrl = await uploadSecureDoc(storagePath, buffer, file.type || "application/octet-stream");
     }
     if (!certUrl) throw new Error("Attach a certificate file");
 
@@ -725,7 +717,12 @@ export async function saveClientTaxExemptCert(clientId: string, formData: FormDa
     });
 
     await revalidateClientCertSurfaces(clientId);
-    return JSON.parse(JSON.stringify(updated));
+    // The caller pushes this straight into local component state, which the subsequent
+    // router.refresh() won't replace, so hand back a loadable URL rather than a `secure:` ref.
+    return JSON.parse(JSON.stringify({
+        ...updated,
+        taxExemptCertUrl: await resolveDocUrl(updated.taxExemptCertUrl),
+    }));
 }
 
 export async function removeClientTaxExemptCert(clientId: string) {
@@ -743,13 +740,17 @@ export async function removeClientTaxExemptCert(clientId: string) {
         data: { taxExemptCertUrl: null, taxExemptCertExpiresAt: null, taxExemptCertNote: null },
     });
 
-    // Best-effort: explicit "Remove" should not leave the file publicly reachable.
+    // Best-effort: explicit "Remove" should not leave the file reachable.
     if (count === 1) {
         try {
-            const { getSupabase, STORAGE_BUCKET } = await import("./supabase");
-            const supabase = getSupabase();
-            const path = taxCertStoragePathFromUrl(client.taxExemptCertUrl, STORAGE_BUCKET);
-            if (supabase && path) await supabase.storage.from(STORAGE_BUCKET).remove([path]);
+            if (isSecureRef(client.taxExemptCertUrl)) {
+                await removeSecureDoc(client.taxExemptCertUrl!);
+            } else {
+                const { getSupabase, STORAGE_BUCKET } = await import("./supabase");
+                const supabase = getSupabase();
+                const path = taxCertStoragePathFromUrl(client.taxExemptCertUrl, STORAGE_BUCKET);
+                if (supabase && path) await supabase.storage.from(STORAGE_BUCKET).remove([path]);
+            }
         } catch (e) {
             console.warn("[removeClientTaxExemptCert] storage cleanup failed:", e instanceof Error ? e.message : e);
         }
@@ -2420,14 +2421,11 @@ export async function approveEstimate(estimateId: string, signatureName: string,
     let pdfBuffer: Buffer | null = null;
     let attachments: any = undefined;
     try {
-        if (capturedPdfUrl && isAllowedCapturedPdfUrl(capturedPdfUrl)) {
-            const res = await fetch(capturedPdfUrl);
-            if (res.ok) {
-                const ab = await res.arrayBuffer();
-                pdfBuffer = Buffer.from(ab);
+        if (capturedPdfUrl) {
+            pdfBuffer = await downloadDocBytes(capturedPdfUrl);
+            if (!pdfBuffer) {
+                console.warn("[approveEstimate] Failed to read capturedPdfUrl:", capturedPdfUrl);
             }
-        } else if (capturedPdfUrl) {
-            console.warn("[approveEstimate] Rejected capturedPdfUrl (failed allowlist):", capturedPdfUrl);
         }
         if (!pdfBuffer) {
             const { generateEstimatePdf } = await import("./pdf");
@@ -2502,49 +2500,49 @@ export async function approveEstimate(estimateId: string, signatureName: string,
 
     // ─── 3. File the signed PDF into the project's "Signed Documents" folder ───
     if (pdfBuffer && estimate?.projectId) {
+        let filedSecureRef: string | null = null;
         try {
-            const { getSupabase, STORAGE_BUCKET } = await import("./supabase");
-            const supabase = getSupabase();
-
-            if (supabase) {
-                // Find or create a "Signed Documents" folder for this project
-                let folder = await prisma.fileFolder.findFirst({
-                    where: { projectId: estimate.projectId, name: "Signed Documents", parentId: null },
+            // Find or create a "Signed Documents" folder for this project
+            let folder = await prisma.fileFolder.findFirst({
+                where: { projectId: estimate.projectId, name: "Signed Documents", parentId: null },
+            });
+            if (!folder) {
+                folder = await prisma.fileFolder.create({
+                    data: { name: "Signed Documents", projectId: estimate.projectId },
                 });
-                if (!folder) {
-                    folder = await prisma.fileFolder.create({
-                        data: { name: "Signed Documents", projectId: estimate.projectId },
-                    });
-                }
+            }
 
-                // Upload to Supabase Storage
-                const storagePath = `projects/${estimate.projectId}/signed/${Date.now()}_${pdfFilename}`;
-                const { error: uploadError } = await supabase.storage
-                    .from(STORAGE_BUCKET)
-                    .upload(storagePath, pdfBuffer, {
-                        contentType: "application/pdf",
-                        upsert: false,
-                    });
+            // Upload to the private secure-docs bucket
+            const storagePath = `projects/${estimate.projectId}/signed/${Date.now()}_${pdfFilename}`;
+            filedSecureRef = await uploadSecureDoc(storagePath, pdfBuffer, "application/pdf");
 
-                if (!uploadError) {
-                    const { data: urlData } = supabase.storage.from(STORAGE_BUCKET).getPublicUrl(storagePath);
-                    const publicUrl = urlData?.publicUrl || storagePath;
+            await prisma.projectFile.create({
+                data: {
+                    name: pdfFilename,
+                    url: filedSecureRef,
+                    size: pdfBuffer.length,
+                    mimeType: "application/pdf",
+                    projectId: estimate.projectId,
+                    folderId: folder.id,
+                },
+            });
 
-                    await prisma.projectFile.create({
-                        data: {
-                            name: pdfFilename,
-                            url: publicUrl,
-                            size: pdfBuffer.length,
-                            mimeType: "application/pdf",
-                            projectId: estimate.projectId,
-                            folderId: folder.id,
-                        },
-                    });
-                } else {
-                    console.error("[approveEstimate] Supabase upload failed:", uploadError);
+            // The portal-captured PDF (if any) was only a transient capture used to build
+            // pdfBuffer above — now that a permanent copy is filed, remove the temporary
+            // object so it doesn't linger as an orphan duplicate in the private bucket.
+            if (capturedPdfUrl && isSecureRef(capturedPdfUrl)) {
+                try {
+                    await removeSecureDoc(capturedPdfUrl);
+                } catch (cleanupErr) {
+                    console.error("[approveEstimate] Failed to remove transient captured PDF:", cleanupErr);
                 }
             }
         } catch (fileErr) {
+            // The upload may have succeeded even though the DB write failed — remove the
+            // orphaned storage object so a retry doesn't leave a dangling signed PDF behind.
+            if (filedSecureRef) {
+                try { await removeSecureDoc(filedSecureRef); } catch {}
+            }
             // Non-critical — don't block the approval if filing fails
             console.error("[approveEstimate] Failed to file signed PDF:", fileErr);
         }
@@ -5104,13 +5102,11 @@ export async function sendEstimateToClient(estimateId: string, templateId?: stri
     let pdfAttached = false;
     try {
         let pdfBuffer: Buffer | undefined;
-        if (capturedPdfUrl && isAllowedCapturedPdfUrl(capturedPdfUrl)) {
-            // Use the pre-captured portal PDF (high-quality, matches what client sees)
-            const res = await fetch(capturedPdfUrl);
-            if (res.ok) {
-                const ab = await res.arrayBuffer();
-                pdfBuffer = Buffer.from(ab);
-            }
+        if (capturedPdfUrl && (isSecureRef(capturedPdfUrl) || isAllowedCapturedPdfUrl(capturedPdfUrl))) {
+            // Use the pre-captured portal PDF (high-quality, matches what client sees).
+            // Read via the service key so this still works now that the capture lands in the
+            // private bucket; the allowlist still gates legacy http(s) values.
+            pdfBuffer = (await downloadDocBytes(capturedPdfUrl)) ?? undefined;
         } else if (capturedPdfUrl) {
             console.warn("[sendEstimateToClient] Rejected capturedPdfUrl (failed allowlist):", capturedPdfUrl);
         }
@@ -5692,7 +5688,8 @@ export async function createContractBlank(
 export async function createContractFromPdf(
     context: { type: "project" | "lead"; id: string },
     title: string,
-    originalPdfPath: string
+    originalPdfPath: string,
+    isPrivate: boolean = false
 ) {
     const session = await getServerSession(authOptions);
     if (!session?.user?.email) throw new Error("Not authenticated");
@@ -5705,7 +5702,11 @@ export async function createContractFromPdf(
         data: {
             title,
             body: "", // Empty HTML body for PDF contracts
-            originalPdfPath,
+            // `originalPdfPath` is a raw storage path. When the upload targeted the private
+            // secure-docs bucket (see /api/files/signed-upload's "contract-original" scope),
+            // wrap it into a secure ref so every downstream reader (downloadDocBytes,
+            // resolveDocUrl) treats it correctly.
+            originalPdfPath: isPrivate ? toSecureRef(originalPdfPath) : originalPdfPath,
             requiresCountersign: coSettings?.requireContractCountersign ?? false,
             ...(context.type === "project" ? { projectId: context.id } : { leadId: context.id }),
             status: "Draft",
@@ -5715,7 +5716,13 @@ export async function createContractFromPdf(
     if (context.type === "project") revalidatePath(`/projects/${context.id}`);
     if (context.type === "lead") revalidatePath(`/leads/${context.id}`);
 
-    return contract;
+    // Resolve a browser-loadable URL server-side (mirrors the contracts page's own
+    // findOriginalPdfUrl) so the client can preview the just-uploaded PDF immediately
+    // without ever calling resolveDocUrl itself — the private bucket has no public URL,
+    // so the caller has no other way to get one.
+    const originalPdfUrl = await resolveDocUrl(contract.originalPdfPath);
+
+    return { ...contract, originalPdfUrl };
 }
 
 export async function updateContract(id: string, data: { title?: string; body?: string; status?: string; requiresCountersign?: boolean }) {
@@ -6058,9 +6065,8 @@ async function updateExecutedPdfIfFinalized(contractId: string, ip: string | nul
     if (!supabase) return;
 
     // 1. Download original PDF
-    const { data: dl, error: dlErr } = await supabase.storage.from(STORAGE_BUCKET).download(contract.originalPdfPath);
-    if (dlErr || !dl) throw new Error("Could not load original PDF contract");
-    const originalBuffer = Buffer.from(await dl.arrayBuffer());
+    const originalBuffer = await downloadDocBytes(contract.originalPdfPath);
+    if (!originalBuffer) throw new Error("Could not load original PDF contract");
 
     // 2. Generate updated PDF
     const settings = await prisma.companySettings.findUnique({ where: { id: "singleton" } });
@@ -6097,13 +6103,21 @@ async function updateExecutedPdfIfFinalized(contractId: string, ip: string | nul
 
     // 4. Delete the old file from Storage if it exists
     if (existingFile?.url) {
-        const match = existingFile.url.match(/\/project-files\/(.+)$/);
-        if (match) {
-            const oldStoragePath = decodeURIComponent(match[1]);
+        if (isSecureRef(existingFile.url)) {
             try {
-                await supabase.storage.from(STORAGE_BUCKET).remove([oldStoragePath]);
+                await removeSecureDoc(existingFile.url);
             } catch (removeErr) {
                 console.warn("[updateExecutedPdfIfFinalized] Could not remove old PDF from storage:", removeErr);
+            }
+        } else {
+            const match = existingFile.url.match(/\/project-files\/(.+)$/);
+            if (match) {
+                const oldStoragePath = decodeURIComponent(match[1]);
+                try {
+                    await supabase.storage.from(STORAGE_BUCKET).remove([oldStoragePath]);
+                } catch (removeErr) {
+                    console.warn("[updateExecutedPdfIfFinalized] Could not remove old PDF from storage:", removeErr);
+                }
             }
         }
         // Delete the old DB record
@@ -6332,10 +6346,18 @@ export async function approveContract(contractId: string, signatureName: string,
 }
 
 export async function getContractSigningHistory(contractId: string) {
-    return await prisma.contractSigningRecord.findMany({
+    const records = await prisma.contractSigningRecord.findMany({
         where: { contractId },
         orderBy: { signedAt: "desc" },
     });
+    // Called live from the Signing History modal, so resolve here: the client can't turn a
+    // private-bucket `secure:` ref into a loadable URL itself. Legacy values pass through.
+    return await Promise.all(
+        records.map(async (record) => ({
+            ...record,
+            signatureUrl: await resolveDocUrl(record.signatureUrl),
+        })),
+    );
 }
 
 /**
@@ -6444,9 +6466,12 @@ export async function countersignContractAsCompany(contractId: string, signerNam
         const supabase = getSupabase();
         if (!supabase) throw new Error("Storage not configured.");
 
-        const { data: dl, error: dlErr } = await supabase.storage.from(STORAGE_BUCKET).download(after.signedPdfPath);
-        if (dlErr || !dl) throw new Error("Could not load the signed contract PDF.");
-        const clientPdf = Buffer.from(await dl.arrayBuffer());
+        // signedPdfPath is polymorphic: a secure ref for a freshly-uploaded intermediate
+        // (countersign-required, non-PDF contracts), or a legacy bare path when it was set
+        // to the pre-existing originalPdfPath (PDF-contract countersign branch). downloadDocBytes
+        // handles both.
+        const clientPdf = await downloadDocBytes(after.signedPdfPath);
+        if (!clientPdf) throw new Error("Could not load the signed contract PDF.");
 
         const settings = await prisma.companySettings.findUnique({ where: { id: "singleton" } });
         executedBuffer = await appendContractCountersignaturePage(clientPdf, {
@@ -6469,8 +6494,20 @@ export async function countersignContractAsCompany(contractId: string, signerNam
         executedRecord = archived.record;
         archivedMeta = { publicUrl: archived.publicUrl, fileName: archived.fileName };
 
-        // Drop the now-superseded private intermediate (best-effort).
-        try { await supabase.storage.from(STORAGE_BUCKET).remove([after.signedPdfPath]); } catch {}
+        // Drop the now-superseded private intermediate (best-effort). For a PDF-contract
+        // countersign, signedPdfPath was set to the SAME value as originalPdfPath (see
+        // finalize/route.ts) — there is no distinct intermediate to remove in that case, and
+        // deleting it would delete the contract's original PDF. Only remove when signedPdfPath
+        // names a genuinely distinct, contract-owned object.
+        try {
+            if (after.signedPdfPath !== after.originalPdfPath) {
+                if (isSecureRef(after.signedPdfPath)) {
+                    await removeSecureDoc(after.signedPdfPath);
+                } else {
+                    await supabase.storage.from(STORAGE_BUCKET).remove([after.signedPdfPath]);
+                }
+            }
+        } catch {}
     } catch (e: any) {
         // Roll back the finalize claim so the admin can retry. companySignedAt stays set (the
         // company DID sign); the retry re-claims and re-archives.

--- a/src/lib/contract-finalize.ts
+++ b/src/lib/contract-finalize.ts
@@ -6,8 +6,8 @@
 // "archive the executed PDF" and "email the executed PDF" steps have exactly one
 // implementation each — never a second writer for the same lifecycle event.
 import { prisma } from "./prisma";
-import { getSupabase, STORAGE_BUCKET } from "./supabase";
 import { sendNotification } from "./email";
+import { uploadSecureDoc, removeSecureDoc } from "./secure-storage";
 
 const esc = (s: string) =>
   s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
@@ -20,28 +20,21 @@ export function executedContractFileName(contractId: string): string {
 type ContractRef = { id: string; title: string; projectId: string | null; leadId: string | null };
 
 /**
- * Upload an executed-contract PDF buffer to Storage and create the shared ProjectFile row.
- * The caller owns the contract status transition + rollback. Throws on failure so the
- * caller can roll back and best-effort remove the returned storagePath.
+ * Upload an executed-contract PDF buffer to the private secure-docs bucket and create the
+ * shared ProjectFile row. The caller owns the contract status transition + rollback. Throws
+ * on failure so the caller can roll back and best-effort remove the returned storagePath.
  */
 export async function archiveExecutedContractPdf(
   contract: ContractRef,
   buffer: Buffer
 ): Promise<{ record: any; publicUrl: string; storagePath: string; fileName: string }> {
-  const supabase = getSupabase();
-  if (!supabase) throw new Error("Storage not configured.");
-
   const fileName = executedContractFileName(contract.id);
   const prefix = contract.projectId ? `projects/${contract.projectId}` : `leads/${contract.leadId}`;
   const storagePath = `${prefix}/${Date.now()}_${fileName}`;
 
-  const { error: uploadError } = await supabase.storage
-    .from(STORAGE_BUCKET)
-    .upload(storagePath, buffer, { contentType: "application/pdf", upsert: false });
-  if (uploadError) throw new Error(`Storage upload failed: ${uploadError.message}`);
-
-  const { data: urlData } = supabase.storage.from(STORAGE_BUCKET).getPublicUrl(storagePath);
-  const publicUrl = urlData?.publicUrl || storagePath;
+  // `publicUrl` on the return value now carries a secure ref (secure:<path>), not a
+  // browser-loadable URL — signed URLs must be minted per-read via resolveDocUrl().
+  const publicUrl = await uploadSecureDoc(storagePath, buffer, "application/pdf");
 
   let record;
   try {
@@ -59,7 +52,7 @@ export async function archiveExecutedContractPdf(
   } catch (e) {
     // The upload succeeded but the DB row failed — remove the orphaned storage object so a
     // retry doesn't leave a dangling executed PDF in the bucket.
-    try { await supabase.storage.from(STORAGE_BUCKET).remove([storagePath]); } catch {}
+    try { await removeSecureDoc(publicUrl); } catch {}
     throw e;
   }
   return { record, publicUrl, storagePath, fileName };
@@ -89,7 +82,8 @@ export async function sendExecutedContractEmails(opts: {
     `<h2 style="font-size:18px;margin:0 0 8px;color:#16a34a;">&#10003; Document Executed</h2>`,
     `<p style="color:#666;margin:0 0 16px;">Hi ${esc(opts.clientName || "Client")},</p>`,
     `<p style="color:#666;margin:0 0 16px;line-height:1.5;">Thank you! <strong>${esc(opts.contractTitle)}</strong> has been fully signed and executed. A PDF copy is attached and archived for your records.</p>`,
-    `<div style="text-align:center;margin:0 0 16px;"><a href="${encodeURI(opts.publicUrl)}" target="_blank" style="display:inline-block;background:#222;color:#fff;text-decoration:none;padding:14px 32px;border-radius:8px;font-weight:600;font-size:15px;">Download PDF</a></div>`,
+    // No download link here — publicUrl is now a secure ref, and a signed URL would expire
+    // before the recipient clicks it. The PDF is already attached to this same email.
     '</div></body></html>',
   ].join('');
 

--- a/src/lib/pdf.ts
+++ b/src/lib/pdf.ts
@@ -3,14 +3,25 @@ import { prisma } from './prisma';
 import { toNum } from './prisma-helpers';
 import { buildLetterheadConfig, type LetterheadConfig } from './letterhead';
 import { isOwnSignatureStorageUrl } from './signature-storage';
+import { isSecureRef, downloadDocBytes } from './secure-storage';
 import { coTaxRate, coTaxLabel } from './co-tax';
 import { drawRichHtml, type RichTextCtx } from './pdf-richtext';
 
+/** pdf-lib only supports PNG/JPG; SignaturePad always emits PNG, so a failed PNG embed
+ *  falls through to a JPG attempt (no content-type header is available once bytes come
+ *  from downloadDocBytes rather than a fetch() Response). */
+async function embedImageBytes(doc: PDFDocument, bytes: Uint8Array): Promise<PDFImage> {
+    try {
+        return await doc.embedPng(bytes);
+    } catch {
+        return await doc.embedJpg(bytes);
+    }
+}
+
 /**
- * Embed a signature image from either a legacy inline data-URL or a migrated http(s)
- * Storage URL. Returns the embedded image, or null if it can't be loaded/decoded.
- * pdf-lib only supports PNG/JPG; SignaturePad always emits PNG, so other types fall
- * through to a PNG attempt and are caught.
+ * Embed a signature image from a legacy inline data-URL, a secure ref (private bucket),
+ * or a migrated http(s) Storage URL. Returns the embedded image, or null if it can't be
+ * loaded/decoded.
  */
 async function embedSignatureImage(doc: PDFDocument, value: string): Promise<PDFImage | null> {
     try {
@@ -19,25 +30,17 @@ async function embedSignatureImage(doc: PDFDocument, value: string): Promise<PDF
             const bytes = Buffer.from(dataUrlMatch[2], 'base64');
             return /^jpe?g$/i.test(dataUrlMatch[1]) ? await doc.embedJpg(bytes) : await doc.embedPng(bytes);
         }
+        if (isSecureRef(value)) {
+            const bytes = await downloadDocBytes(value);
+            return bytes ? await embedImageBytes(doc, bytes) : null;
+        }
         if (/^https?:\/\//i.test(value)) {
             // SSRF guard: only fetch URLs that point at our own Supabase Storage signatures
             // dir. A DB-stored signature column must never be able to aim the server at an
             // arbitrary host (e.g. cloud metadata). Anything else is treated as no image.
             if (!isOwnSignatureStorageUrl(value)) return null;
-            const controller = new AbortController();
-            const timeoutId = setTimeout(() => controller.abort(), 4000);
-            let res: Response;
-            try {
-                res = await fetch(value, { signal: controller.signal });
-            } finally {
-                clearTimeout(timeoutId);
-            }
-            if (!res.ok) return null;
-            const bytes = new Uint8Array(await res.arrayBuffer());
-            const contentType = (res.headers.get('content-type') || '').toLowerCase();
-            return contentType.includes('jpeg') || contentType.includes('jpg')
-                ? await doc.embedJpg(bytes)
-                : await doc.embedPng(bytes);
+            const bytes = await downloadDocBytes(value);
+            return bytes ? await embedImageBytes(doc, bytes) : null;
         }
         return null;
     } catch (err) {

--- a/src/lib/secure-storage.ts
+++ b/src/lib/secure-storage.ts
@@ -1,0 +1,266 @@
+import { getSupabase, STORAGE_BUCKET } from "./supabase";
+
+/**
+ * Private bucket for documents that carry legal or PII weight: e-signatures, executed
+ * contract PDFs, signed estimate PDFs, and client tax-exemption certificates.
+ *
+ * `project-files` stays PUBLIC and keeps serving everything else (job photos, letterhead,
+ * takeoffs, room exports, general project files). Supabase's public flag is per-bucket,
+ * so separating the sensitive documents is the only way to make them private without
+ * breaking every other read path.
+ *
+ * Stored DB values are bucket-qualified so a row is never ambiguous mid-migration:
+ *
+ *   secure:signatures/contracts/<id>/client/<ts>_<uuid>.png   → private bucket, signed URL
+ *   https://<ref>.supabase.co/storage/v1/object/public/...    → legacy public URL
+ *   projects/<id>/signed/<ts>_Signed_Estimate.pdf             → legacy bare path (public bucket)
+ *   data:image/png;base64,...                                 → legacy inline signature
+ *
+ * Every read path goes through resolveDocUrl() (browser) or downloadDocBytes() (server),
+ * both of which accept all four shapes. Nothing else should touch these buckets directly.
+ */
+export const SECURE_BUCKET = "secure-docs";
+export const SECURE_SCHEME = "secure:";
+
+/** Signed-URL lifetime for browser rendering. Long enough to load a page, short enough
+ *  that a leaked URL (referrer, shared screenshot, proxy log) expires quickly. */
+export const DEFAULT_SIGNED_URL_TTL_SECONDS = 600;
+
+export function toSecureRef(storagePath: string): string {
+    return `${SECURE_SCHEME}${storagePath}`;
+}
+
+export function isSecureRef(value: string | null | undefined): boolean {
+    return typeof value === "string" && value.startsWith(SECURE_SCHEME);
+}
+
+/** Storage path inside SECURE_BUCKET, or null when `value` is not a secure ref. */
+export function secureRefPath(value: string | null | undefined): string | null {
+    if (!isSecureRef(value)) return null;
+    const path = (value as string).slice(SECURE_SCHEME.length);
+    // Defence in depth: refuse traversal and absolute paths.
+    if (!path || path.startsWith("/") || path.includes("..")) return null;
+    return path;
+}
+
+function isDataUrl(value: string): boolean {
+    return value.startsWith("data:");
+}
+
+/**
+ * Parse one of OUR OWN Supabase storage object URLs into (bucket, path).
+ *
+ * This is the SSRF boundary for legacy absolute URLs read out of the database: a stored
+ * URL must never be able to point the server at an arbitrary host (cloud metadata, an
+ * internal service). Returns null for anything that is not an object URL in our own
+ * Supabase project, so callers can refuse rather than fetch.
+ */
+export function parseOwnStorageUrl(
+    value: string,
+): { bucket: string; path: string } | null {
+    try {
+        const parsed = new URL(value);
+        if (parsed.protocol !== "https:") return null;
+        if (
+            !parsed.hostname.endsWith(".supabase.co") &&
+            !parsed.hostname.endsWith(".supabase.in")
+        ) {
+            return null;
+        }
+        // Must be EXACTLY our own project host. A prefix check is not sufficient:
+        // `<ourref>.evil.supabase.co` satisfies both the suffix and prefix tests while
+        // belonging to someone else. With no SUPABASE_URL there is no storage client to
+        // download with anyway, so refuse rather than guess.
+        const supabaseUrl = process.env.SUPABASE_URL || "";
+        if (!supabaseUrl) return null;
+        let ourHost: string;
+        try {
+            ourHost = new URL(supabaseUrl).hostname.toLowerCase();
+        } catch {
+            return null;
+        }
+        if (parsed.hostname.toLowerCase() !== ourHost) return null;
+        const prefixes = ["/storage/v1/object/public/", "/storage/v1/object/sign/"];
+        const prefix = prefixes.find((p) => parsed.pathname.startsWith(p));
+        if (!prefix) return null;
+        const rest = parsed.pathname.slice(prefix.length);
+        const slash = rest.indexOf("/");
+        if (slash <= 0) return null;
+        const bucket = rest.slice(0, slash);
+        const path = decodeURIComponent(rest.slice(slash + 1));
+        if (!path || path.includes("..")) return null;
+        return { bucket, path };
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Turn a stored document reference into something a browser can load.
+ *
+ * - secure ref      → short-lived signed URL against the private bucket
+ * - data: URL       → returned unchanged (legacy inline signatures still render)
+ * - absolute URL    → returned unchanged (legacy public-bucket object, still served)
+ * - bare path       → resolved against the legacy public bucket
+ *
+ * Never throws; returns null when the reference cannot be resolved, so a missing
+ * signature renders as "no signature" rather than taking a page down.
+ */
+export async function resolveDocUrl(
+    stored: string | null | undefined,
+    ttlSeconds: number = DEFAULT_SIGNED_URL_TTL_SECONDS,
+): Promise<string | null> {
+    if (!stored) return null;
+
+    const securePath = secureRefPath(stored);
+    if (securePath) {
+        const supabase = getSupabase();
+        if (!supabase) return null;
+        try {
+            const { data, error } = await supabase.storage
+                .from(SECURE_BUCKET)
+                .createSignedUrl(securePath, ttlSeconds);
+            if (error) {
+                console.error("[secure-storage] signed URL failed", {
+                    operation: "createSignedUrl",
+                    message: error.message,
+                });
+                return null;
+            }
+            return data?.signedUrl ?? null;
+        } catch (error) {
+            console.error("[secure-storage] signed URL threw", {
+                operation: "createSignedUrl",
+                errorType: error instanceof Error ? error.name : typeof error,
+            });
+            return null;
+        }
+    }
+
+    if (isDataUrl(stored)) return stored;
+
+    if (/^https?:\/\//i.test(stored)) {
+        // Legacy public-bucket object. Still readable until the originals are purged.
+        return stored;
+    }
+
+    // Legacy bare storage path against the public bucket.
+    const supabase = getSupabase();
+    if (!supabase) return null;
+    try {
+        const { data } = supabase.storage.from(STORAGE_BUCKET).getPublicUrl(stored);
+        return data?.publicUrl ?? null;
+    } catch {
+        return null;
+    }
+}
+
+/** Resolve several references at once, preserving key order. */
+export async function resolveDocUrls<K extends string>(
+    entries: Record<K, string | null | undefined>,
+    ttlSeconds: number = DEFAULT_SIGNED_URL_TTL_SECONDS,
+): Promise<Record<K, string | null>> {
+    const keys = Object.keys(entries) as K[];
+    const resolved = await Promise.all(
+        keys.map((key) => resolveDocUrl(entries[key], ttlSeconds)),
+    );
+    return keys.reduce(
+        (acc, key, index) => {
+            acc[key] = resolved[index];
+            return acc;
+        },
+        {} as Record<K, string | null>,
+    );
+}
+
+/**
+ * Read a stored document's bytes server-side using the service key.
+ *
+ * Server-side consumers (PDF generation, Drive mirroring) must use this rather than
+ * fetch()ing a URL: it works against the private bucket, and it removes the SSRF surface
+ * entirely for migrated rows because no URL is ever dereferenced. Legacy absolute URLs
+ * are downloaded via the storage API after parseOwnStorageUrl() confirms they belong to
+ * us — an untrusted host is refused, not fetched.
+ */
+export async function downloadDocBytes(
+    stored: string | null | undefined,
+): Promise<Buffer | null> {
+    if (!stored) return null;
+
+    if (isDataUrl(stored)) {
+        const comma = stored.indexOf(",");
+        if (comma < 0) return null;
+        const meta = stored.slice(0, comma);
+        if (!meta.includes(";base64")) return null;
+        try {
+            const buffer = Buffer.from(stored.slice(comma + 1), "base64");
+            return buffer.length > 0 ? buffer : null;
+        } catch {
+            return null;
+        }
+    }
+
+    let bucket: string;
+    let path: string;
+
+    const securePath = secureRefPath(stored);
+    if (securePath) {
+        bucket = SECURE_BUCKET;
+        path = securePath;
+    } else if (/^https?:\/\//i.test(stored)) {
+        const parsed = parseOwnStorageUrl(stored);
+        if (!parsed) return null; // not ours — refuse
+        // An absolute URL is only ever a LEGACY public-bucket object. Private documents are
+        // always referenced by a `secure:` ref, so a stored URL naming any other bucket
+        // (notably SECURE_BUCKET) is not something we should dereference on its word.
+        if (parsed.bucket !== STORAGE_BUCKET) return null;
+        bucket = parsed.bucket;
+        path = parsed.path;
+    } else {
+        if (stored.startsWith("/") || stored.includes("..")) return null;
+        bucket = STORAGE_BUCKET;
+        path = stored;
+    }
+
+    const supabase = getSupabase();
+    if (!supabase) return null;
+    try {
+        const { data, error } = await supabase.storage.from(bucket).download(path);
+        if (error || !data) return null;
+        return Buffer.from(await data.arrayBuffer());
+    } catch (error) {
+        console.error("[secure-storage] download failed", {
+            operation: "download",
+            errorType: error instanceof Error ? error.name : typeof error,
+        });
+        return null;
+    }
+}
+
+/**
+ * Upload a sensitive document to the private bucket and return its stored reference.
+ * Throws on failure so callers can compensate (they own the surrounding transaction).
+ */
+export async function uploadSecureDoc(
+    storagePath: string,
+    body: Buffer,
+    contentType: string,
+): Promise<string> {
+    const supabase = getSupabase();
+    if (!supabase) throw new Error("Secure document storage is not configured.");
+    const { error } = await supabase.storage
+        .from(SECURE_BUCKET)
+        .upload(storagePath, body, { contentType, upsert: false });
+    if (error) throw new Error(`Storage upload failed: ${error.message}`);
+    return toSecureRef(storagePath);
+}
+
+/** Best-effort removal of a secure object, for compensating a failed DB write. */
+export async function removeSecureDoc(ref: string): Promise<void> {
+    const path = secureRefPath(ref);
+    if (!path) return;
+    const supabase = getSupabase();
+    if (!supabase) return;
+    const { error } = await supabase.storage.from(SECURE_BUCKET).remove([path]);
+    if (error) throw error;
+}

--- a/src/lib/signature-storage.ts
+++ b/src/lib/signature-storage.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "crypto";
 import { getSupabase, STORAGE_BUCKET } from "./supabase";
+import { SECURE_BUCKET, isSecureRef, toSecureRef } from "./secure-storage";
 
 // Accepts the data-URLs that SignaturePad / DocumentSignModal produce (canvas.toDataURL).
 const SIGNATURE_DATA_URL_RE = /^data:image\/(png|jpeg|webp);base64,([A-Za-z0-9+/=]+)$/;
@@ -18,7 +19,6 @@ export type SignatureStorageBucket = {
         body: Buffer,
         options: { contentType: string; upsert: false },
     ): Promise<{ error: unknown | null }>;
-    getPublicUrl(path: string): { data: { publicUrl?: string | null } };
     remove(paths: string[]): Promise<{ error: unknown | null }>;
 };
 
@@ -39,7 +39,7 @@ const noDiscard = async () => {};
 function defaultSignatureBucket(): SignatureStorageBucket | null {
     const supabase = getSupabase();
     return supabase
-        ? supabase.storage.from(STORAGE_BUCKET) as unknown as SignatureStorageBucket
+        ? supabase.storage.from(SECURE_BUCKET) as unknown as SignatureStorageBucket
         : null;
 }
 
@@ -94,6 +94,11 @@ export async function persistOwnedSignature(
     dependencies: Partial<SignaturePersistenceDependencies> = {},
 ): Promise<OwnedSignature> {
     if (!value) return { url: null, discard: noDiscard };
+
+    // Already migrated to the private bucket — pass through unchanged.
+    if (isSecureRef(value)) {
+        return { url: value, discard: noDiscard };
+    }
 
     // Already migrated / remote — only OUR storage URLs may pass through unchanged.
     if (/^https?:\/\//i.test(value)) {
@@ -182,25 +187,9 @@ export async function persistOwnedSignature(
         throw new Error("Couldn't save your signature — please try again.");
     }
 
-    let publicUrl: string | null | undefined;
-    try {
-        publicUrl = bucket.getPublicUrl(storagePath).data?.publicUrl;
-    } catch {
-        publicUrl = null;
-    }
-    if (!publicUrl) {
-        try {
-            await discard();
-        } catch (error) {
-            console.error("[signature-storage] cleanup failed", {
-                operation: "discard-unaddressable-signature",
-                errorType: cleanupErrorType(error),
-            });
-        }
-        throw new Error("Couldn't save your signature — please try again.");
-    }
-
-    return { url: publicUrl, discard };
+    // The address is derived locally from the storage path, so there's no "upload
+    // succeeded but we couldn't construct an address" failure mode to guard against here.
+    return { url: toSecureRef(storagePath), discard };
 }
 
 export async function persistSignature(


### PR DESCRIPTION
## Why

Both Supabase storage buckets were **public**. This is not theoretical — an unauthenticated `GET` (no `apikey`, no `Authorization`) against a real client contract e-signature returned **HTTP 200 with the image bytes**. Access control was URL secrecy only, and URLs leak through emails, the Drive mirror, portal HTML and browser history.

## Scope (deliberately narrowed)

Owner decision: most bucket content does not justify a migration. Only the documents carrying legal/PII weight move.

**Private now:** e-signatures (contracts + change orders), executed contract PDFs, signed estimate PDFs, intermediate signed contracts, client tax-exemption certificates.

**Staying public on purpose:** letterhead, task photos, takeoffs, room USDZ/renders, receipts, subcontractor COIs, ordinary project files, and all of `room-designer-assets` (code-seeded studio catalog).

Supabase's `public` flag is **per-bucket**, so the sensitive subset moves to a separate `secure-docs` bucket rather than flipping `project-files` — which keeps every other read path working untouched.

## No new client login

Signed URLs are minted **server-side** by pages that already authorised the viewer. Magic-link contract links and `/share/room/[token]` behave exactly as before: no account, no password. The diff contains **zero** changes to auth, middleware, permissions, or magic-link/token logic (independently verified).

Storage RLS was rejected as the mechanism: it evaluates the Supabase Auth JWT, and this app authenticates via NextAuth + Prisma, so a policy would have no end-user identity to key on.

## How

Stored values carry a `secure:` scheme prefix, so each row is self-describing. This matters because `ProjectFile` mixes sensitive and public rows in one table. Legacy shapes (absolute public URL, bare path, inline `data:` URL) all keep resolving, because the public originals are **not deleted** in this PR.

- `src/lib/secure-storage.ts` — resolver + service-key downloads, so server-side consumers (PDF generation) never dereference a stored URL at all
- `scripts/migrate-secure-docs.mjs` — copy + CAS backfill, size-verified, never deletes
- `scripts/purge-migrated-public-docs.mjs` — the destructive final step; dual-flag guarded, refuses to delete an original unless the secure copy exists, is non-zero and size-matches
- `docs/STORAGE-AUDIT.md` — findings, scope decision, production runbook

## Verified

- `npm run build` — 0 errors
- Bucket mechanism proven directly: anonymous read of `secure-docs` → **HTTP 400**; server-minted signed URL → **HTTP 200**
- Swept for remaining public-bucket uploads: only out-of-scope types remain (COIs, purchase orders, estimate attachments, photos, letterhead)

## Not verified — please note

**`e2e/money-pipeline.spec.ts` has not been run.** Two signature tests were removed: they asserted a failure mode that cannot occur now the object address is derived from the storage path instead of being constructed by the storage client. It cannot run locally (the harness rightly refuses a Supabase `DATABASE_URL`; Docker daemon unavailable). **CI is the gate here.**

## Review findings already addressed

A Codex review of the first pass caught, all fixed in this PR:

- Two writers still uploading in-scope docs to the **public** bucket (portal signed-estimate capture; new PDF contract originals) — the exposure would not have closed for new documents
- Three read paths downloading `originalPdfPath` from the public bucket, breaking on migrated rows
- An SSRF-adjacent hostname check accepting `<ourref>.evil.supabase.co` (now exact-match)
- An `exists()`-only check that would let a zero-byte secure copy authorise deleting a good public original

Plus a **latent pre-existing bug**: `countersignContractAsCompany` could delete a contract's *original* PDF, because `signedPdfPath` is sometimes assigned from `originalPdfPath`.

## Deploy order (does not close the exposure by itself)

Merging + deploying is safe on its own and changes nothing for existing documents. The exposure closes only at step 4.

1. Deploy (readers accept legacy shapes; new docs start landing privately)
2. `node scripts/migrate-secure-docs.mjs` — dry run, review counts
3. `node scripts/migrate-secure-docs.mjs --apply` — copies only
4. Verify on prod, then `purge-migrated-public-docs.mjs --apply --i-understand-this-deletes-public-originals`

Rollback before step 4 is a code revert; the public originals are still serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
