### PR TITLE
feat(portal): product library + clipper, client selection proposals, project favorites, two-way design files

### DIFF
--- a/docs/specs/product-library-portal-selections.md
+++ b/docs/specs/product-library-portal-selections.md
@@ -1,0 +1,148 @@
+# Spec: Product Library, Clipper, Client Selection Proposals, Two-Way Design Files
+
+Origin: Janet Hoppe portal feedback (2026-07-25) + Justin's direction (2026-07-27).
+Branch: `claude/probuild-portal-feedback-831d45`
+
+## Problem
+
+1. Clients cannot suggest selection items — the selections tab is one-way (PM stages boards, client picks). Janet: "I should at least be able to add items in the dashboard that are suspended until you approve them."
+2. There is no reusable product catalog. Every SelectionOption is retyped per board. Houzz Pro has a "Product Clipper" that captures products from any retail site into a library; we want the same engine.
+3. Clients on $100k+ jobs bring their own designer and need to exchange design files both ways. Portal Files is currently team-publish-only.
+
+## Decisions (locked with Justin)
+
+- Product library is **company-wide**; every clip is reusable across projects.
+- Each project gets a **client-visible Favorites list** (library items pinned to the project). Approved client suggestions land there automatically.
+- Client proposal flow: client suggests → Pending (clearly badged "waiting for approval") → PM approves (optionally sets price, picks board/category) or declines with note. Nothing counts as an official selection until PM approval.
+- v1 capture front door is a **bookmarklet** for the team; Chrome extension is a later phase (NOT in this branch).
+- AI paste-a-link parsing: structured data first (JSON-LD schema.org/Product, OpenGraph), Gemini fallback.
+
+## Non-goals
+
+- No Chrome extension in this branch.
+- No client-visible pricing on proposals until PM approves.
+- No changes to the existing SelectionBoard pick/submit flow (`submitClientSelections`) or any money path.
+- No schedule changes (Richard handles high-level schedule as data).
+
+---
+
+## Schema (all additive — ship with `scripts/apply-product-library.mjs`, idempotent per repo convention)
+
+```prisma
+model ProductLibraryItem {
+  id          String   @id @default(cuid())
+  name        String
+  description String?
+  imageUrl    String?
+  price       Decimal? @db.Decimal(12, 2) // list price captured at clip time
+  vendor      String?
+  vendorUrl   String?  // source/product URL
+  category    String?  // free text v1 (e.g. "Plumbing Fixtures")
+  source      String   @default("clip") // "clip" | "manual" | "client_proposal"
+  clippedById String?
+  clippedBy   User?    @relation(fields: [clippedById], references: [id])
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  favorites   ProjectProductFavorite[]
+  @@index([category])
+  @@index([createdAt])
+}
+
+model ProjectProductFavorite {
+  id            String   @id @default(cuid())
+  projectId     String
+  project       Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  productId     String
+  product       ProductLibraryItem @relation(fields: [productId], references: [id], onDelete: Cascade)
+  addedById     String?  // team member User, null when added via approved client proposal
+  addedBy       User?    @relation(fields: [addedById], references: [id])
+  addedByClient Boolean  @default(false)
+  note          String?
+  createdAt     DateTime @default(now())
+  @@unique([projectId, productId])
+  @@index([projectId])
+}
+
+model SelectionProposal {
+  id           String   @id @default(cuid())
+  projectId    String
+  project      Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  name         String
+  description  String?
+  imageUrl     String?
+  price        Decimal? @db.Decimal(12, 2) // parsed list price; NOT shown to client until approved
+  vendorUrl    String?
+  clientNote   String?
+  status       String   @default("Pending") // "Pending" | "Approved" | "Declined"
+  pmNote       String?  // decline reason / approval comment, client-visible
+  productId    String?  // ProductLibraryItem created on approval
+  boardId      String?  // optional: SelectionBoard the PM approved it into
+  categoryId   String?  // optional: SelectionCategory it became an option in
+  decidedById  String?
+  decidedBy    User?    @relation(fields: [decidedById], references: [id])
+  decidedAt    DateTime?
+  createdAt    DateTime @default(now())
+  @@index([projectId, status])
+}
+```
+
+`ProjectFile` gains: `uploadedByClient Boolean @default(false)`.
+No change to `FileFolder` (existing `visibility: "shared"` tier is the client-visible mechanism).
+
+Relation back-fields added on `User` and `Project` as required by Prisma.
+
+## Phase 1 — parser + backend (executor 1)
+
+**`src/lib/product-parse.ts`** — `parseProductUrl(url: string): Promise<ParsedProduct>`:
+1. Validate URL: http/https only; resolve host and reject private/link-local IPs (follow the SSRF-guard pattern in `src/lib/signature-storage.ts` / `src/lib/pdf.ts`). 10s timeout, ~2MB response cap, realistic browser User-Agent.
+2. Extract in order: JSON-LD `schema.org/Product` (name, image, offers.price, brand) → OpenGraph/meta tags (`og:title`, `og:image`, `product:price:amount`) → Gemini fallback (existing Gemini usage pattern is in `src/lib/actions.ts`; strip HTML to text, cap tokens, ask for strict JSON {name, price, imageUrl, vendor, description}).
+3. Return `{name, description?, price?, imageUrl?, vendor?, vendorUrl}` — never throw for parse failures; return `{vendorUrl, name: null}` so UIs degrade to manual entry.
+
+**API routes:**
+- `POST /api/products/parse` — team-only (session + role check like neighboring team APIs). Body `{url}` → ParsedProduct.
+- `POST /api/portal/projects/[id]/proposals/parse` — portal-client auth (copy the auth/ownership guard from an existing portal API route for the same project scoping). Same body/response, but **strip `price` from the response** (price is PM-side info until approval; still persisted on the proposal server-side).
+
+**Server actions (in `src/lib/actions.ts` per repo convention):**
+- `createProductLibraryItem(data)` / `updateProductLibraryItem(id, data)` / `deleteProductLibraryItem(id)` — team roles per `src/lib/permissions.ts` conventions.
+- `getProductLibrary({search?, category?})` — newest first.
+- `addProjectFavorite(projectId, productId, note?)` / `removeProjectFavorite(projectId, productId)` — team.
+- `getProjectFavorites(projectId)` — team + portal variants (portal variant checks client owns project, like `getSelectionBoardsForPortal` at actions.ts:9405).
+- `submitSelectionProposal(projectId, {url?, name, description?, imageUrl?, clientNote?})` — PORTAL action: parses url server-side if provided (price persisted, not returned), creates SelectionProposal Pending, emails the team like `submitClientSelections` (actions.ts:9384-9399) does, writes activity log entry.
+- `getSelectionProposalsForPortal(projectId)` — client's own proposals, all statuses, price omitted unless Approved.
+- `getSelectionProposals(projectId)` — team view.
+- `decideSelectionProposal(proposalId, {action: "approve"|"decline", pmNote?, price?, boardId?, categoryId?, addToFavorites?: boolean})` — team only. Approve: creates ProductLibraryItem (source "client_proposal"), links productId, defaults `addToFavorites: true` → creates ProjectProductFavorite with `addedByClient: true`; if boardId+categoryId given, also creates a SelectionOption in that category (do NOT touch board status). Decline: status + pmNote. Both: set decidedBy/decidedAt, notify client by email (reuse the portal email helper used for selections), activity log. Guard with a status CAS (`updateMany WHERE status='Pending'`) so double-decisions no-op.
+
+**Client file upload backend:**
+- Portal upload action/route: accepts file for project → Supabase storage (follow existing team file-upload path), creates ProjectFile with `uploadedByClient: true`, `visibility: "shared"`, into a "Design Files" FileFolder (find-or-create, visibility "shared") — plus optional folderId if the client uploads into another shared folder. Enforce: client can only target folders whose effective visibility is "shared", size cap consistent with existing upload limits, mime allowlist (images, pdf, dwg/dxf, common office docs, zip).
+- On upload: email the team (same recipient logic as selection submissions) + activity log.
+
+## Phase 2 — internal UI + bookmarklet (executor 2)
+
+- **`/company/product-library`** — List layout per DESIGN_SYSTEM.md: search + category filter, grid of product cards (image, name, vendor, price), "Recently clipped" default sort. Add/edit modal (manual entry with a "Parse from URL" field that calls `/api/products/parse` and prefills). Card action: "Add to project…" (project picker → `addProjectFavorite`).
+- **`/clip` page** — team-auth page reading `?url=` param: auto-parses on load, shows editable prefilled form, Save to Library + optional "also favorite to project" picker. This is the bookmarklet target.
+- **Bookmarklet**: on the product-library page, a "Get the Clipper" card with a draggable link `javascript:window.open('<origin>/clip?url='+encodeURIComponent(location.href),'probuild-clip','width=480,height=720')` and one-line instructions. Origin from `NEXT_PUBLIC_APP_URL`.
+- **Project selections tab (team side)**: "Client suggestions" section listing SelectionProposals with status; approve dialog (price input, optional board/category picker from the project's boards, favorites toggle), decline dialog (note). Favorites section: list + add-from-library.
+- Hover-reveal buttons must include the `[@media(hover:none)]` pattern from CLAUDE.md.
+
+## Phase 3 — portal UI (executor 3)
+
+- **Selections tab** (`src/app/portal/projects/[id]/selections/`): keep existing boards UI untouched. Add:
+  - "Suggest an item" button → modal: paste-a-link field (calls portal parse route, prefills name/image — no price shown) + manual fields (name required, note, photo URL) → `submitSelectionProposal`.
+  - "Your suggestions" list: Pending (amber "Waiting for PM review" badge), Approved (green, shows pmNote + price now visible), Declined (neutral, shows pmNote). Empty state invites first suggestion.
+- **Favorites section** ("Project Favorites") on the selections tab (or overview if cleaner): grid of ProjectProductFavorite cards (image, name, vendor, link) — read-only for client in v1 apart from suggestions flowing in.
+- **Files tab**: "Upload a file" affordance for clients (respecting `showFiles` visibility): drag/drop or picker → portal upload route → lands in shared "Design Files" folder; uploaded-by-client files badge as "From you". Show shared folders/files as today.
+- Gate everything on existing `getPortalVisibility` flags (`showSelections`, `showFiles`); no new toggles in v1.
+
+## Verification
+
+- `npm run build` — 0 errors.
+- Checker: schema applied cleanly via script dry-run inspection (script NOT run against prod in this branch; runs at deploy per CLAUDE.md), actions enforce auth scoping (portal actions cannot read other projects' proposals/favorites; parse route strips price), decideSelectionProposal is idempotent under double-submit, client upload cannot target team-only folders.
+- Codex review after implementation (external URL fetching / SSRF, auth boundaries, new portal write paths).
+- e2e money pipeline untouched — confirm no diffs in money-path files.
+
+## Out of scope / later
+
+- Chrome extension (same API; unlisted Web Store listing).
+- Client clipping directly (extension with portal login).
+- Structured categories/tags taxonomy for the library.
+- Portal freshness audit routine (separate scheduled-agent task).

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,9 @@ model User {
   dispatchPublications DispatchPublication[] @relation("DispatchPublisher")
   createdTaskMaterials TaskMaterial[] @relation("TaskMaterialCreator")
   taskMaterialStatusChanges TaskMaterial[] @relation("TaskMaterialStatusChanger")
+  clippedProducts    ProductLibraryItem[]
+  addedFavorites     ProjectProductFavorite[]
+  decidedProposals   SelectionProposal[]
 }
 
 model Client {
@@ -260,6 +263,8 @@ model Project {
   bidPackages         BidPackage[]
   teamMessages        TeamMessage[]
   activityLogs        ActivityLog[]
+  productFavorites    ProjectProductFavorite[]
+  selectionProposals  SelectionProposal[]
 
   @@index([viewedAt])
   @@index([clientId])
@@ -1071,6 +1076,7 @@ model ProjectFile {
   folder       FileFolder? @relation(fields: [folderId], references: [id], onDelete: SetNull)
   uploadedById String?
   uploadedBy   User?       @relation(fields: [uploadedById], references: [id])
+  uploadedByClient Boolean @default(false)
   createdAt    DateTime    @default(now())
 
   @@index([projectId])
@@ -1532,6 +1538,75 @@ model SelectionOption {
   selected    Boolean           @default(false)
   order       Int               @default(0)
   createdAt   DateTime          @default(now())
+}
+
+
+// Company-wide reusable product catalog, populated via the team "clipper" (paste a
+// vendor URL, parsed server-side) or manual entry. Approved client SelectionProposals
+// also mint a row here (source: "client_proposal"). See docs/specs/product-library-portal-selections.md.
+model ProductLibraryItem {
+  id          String   @id @default(cuid())
+  name        String
+  description String?
+  imageUrl    String?
+  price       Decimal? @db.Decimal(12, 2) // list price captured at clip time
+  vendor      String?
+  vendorUrl   String?  // source/product URL
+  category    String?  // free text v1 (e.g. "Plumbing Fixtures")
+  source      String   @default("clip") // "clip" | "manual" | "client_proposal"
+  clippedById String?
+  clippedBy   User?    @relation(fields: [clippedById], references: [id])
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  favorites   ProjectProductFavorite[]
+
+  @@index([category])
+  @@index([createdAt])
+}
+
+// A ProductLibraryItem pinned to one project — the client-visible "Project Favorites"
+// list. Rows created by an approved client SelectionProposal carry addedByClient: true
+// and a null addedById (no team member picked it).
+model ProjectProductFavorite {
+  id            String   @id @default(cuid())
+  projectId     String
+  project       Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  productId     String
+  product       ProductLibraryItem @relation(fields: [productId], references: [id], onDelete: Cascade)
+  addedById     String?  // team member User, null when added via approved client proposal
+  addedBy       User?    @relation(fields: [addedById], references: [id])
+  addedByClient Boolean  @default(false)
+  note          String?
+  createdAt     DateTime @default(now())
+
+  @@unique([projectId, productId])
+  @@index([projectId])
+}
+
+// A client-suggested selection item, submitted from the portal. Pending until a PM
+// approves (mints a ProductLibraryItem + optional favorite/board option) or declines.
+// Price is never shown to the client until the proposal is Approved.
+model SelectionProposal {
+  id           String   @id @default(cuid())
+  projectId    String
+  project      Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  name         String
+  description  String?
+  imageUrl     String?
+  price        Decimal? @db.Decimal(12, 2) // parsed list price; NOT shown to client until approved
+  vendorUrl    String?
+  clientNote   String?
+  status       String   @default("Pending") // "Pending" | "Approved" | "Declined"
+  pmNote       String?  // decline reason / approval comment, client-visible
+  productId    String?  // ProductLibraryItem created on approval
+  boardId      String?  // optional: SelectionBoard the PM approved it into
+  categoryId   String?  // optional: SelectionCategory it became an option in
+  decidedById  String?
+  decidedBy    User?    @relation(fields: [decidedById], references: [id])
+  decidedAt    DateTime?
+  createdAt    DateTime @default(now())
+
+  @@index([projectId, status])
 }
 
 model MoodBoard {

--- a/scripts/apply-product-library.mjs
+++ b/scripts/apply-product-library.mjs
@@ -1,0 +1,184 @@
+// One-off additive migration for the Product Library / Clipper / Client Selection
+// Proposals spec (docs/specs/product-library-portal-selections.md).
+// Safe to re-run while the previous build is live.
+//
+// Run only through the release orchestrator:
+//   node scripts/apply-product-library.mjs
+//
+// Do not run this during implementation handoff. The new Prisma client selects
+// these columns/tables immediately, so schema must be applied before deploy.
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+function resolveDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const file of [".env", ".env.local"]) {
+    if (!fs.existsSync(file)) continue;
+    const match = fs.readFileSync(file, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+    if (match) return match[1];
+  }
+  throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const prisma = new PrismaClient({
+  datasources: { db: { url: resolveDatabaseUrl() } },
+});
+
+const statements = [
+  // ── ProjectFile.uploadedByClient ─────────────────────────────────────────
+  `ALTER TABLE "ProjectFile"
+     ADD COLUMN IF NOT EXISTS "uploadedByClient" BOOLEAN NOT NULL DEFAULT false`,
+
+  // ── ProductLibraryItem ───────────────────────────────────────────────────
+  `CREATE TABLE IF NOT EXISTS "ProductLibraryItem" (
+     "id" TEXT NOT NULL,
+     "name" TEXT NOT NULL,
+     "description" TEXT,
+     "imageUrl" TEXT,
+     "price" DECIMAL(12,2),
+     "vendor" TEXT,
+     "vendorUrl" TEXT,
+     "category" TEXT,
+     "source" TEXT NOT NULL DEFAULT 'clip',
+     "clippedById" TEXT,
+     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+     "updatedAt" TIMESTAMP(3) NOT NULL,
+     CONSTRAINT "ProductLibraryItem_pkey" PRIMARY KEY ("id")
+   )`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'ProductLibraryItem_clippedById_fkey'
+         AND conrelid = '"ProductLibraryItem"'::regclass
+     ) THEN
+       ALTER TABLE "ProductLibraryItem"
+         ADD CONSTRAINT "ProductLibraryItem_clippedById_fkey"
+         FOREIGN KEY ("clippedById") REFERENCES "User"("id")
+         ON DELETE SET NULL ON UPDATE CASCADE;
+     END IF;
+   END $$`,
+  `CREATE INDEX IF NOT EXISTS "ProductLibraryItem_category_idx" ON "ProductLibraryItem" ("category")`,
+  `CREATE INDEX IF NOT EXISTS "ProductLibraryItem_createdAt_idx" ON "ProductLibraryItem" ("createdAt")`,
+
+  // ── ProjectProductFavorite ───────────────────────────────────────────────
+  `CREATE TABLE IF NOT EXISTS "ProjectProductFavorite" (
+     "id" TEXT NOT NULL,
+     "projectId" TEXT NOT NULL,
+     "productId" TEXT NOT NULL,
+     "addedById" TEXT,
+     "addedByClient" BOOLEAN NOT NULL DEFAULT false,
+     "note" TEXT,
+     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+     CONSTRAINT "ProjectProductFavorite_pkey" PRIMARY KEY ("id")
+   )`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'ProjectProductFavorite_projectId_fkey'
+         AND conrelid = '"ProjectProductFavorite"'::regclass
+     ) THEN
+       ALTER TABLE "ProjectProductFavorite"
+         ADD CONSTRAINT "ProjectProductFavorite_projectId_fkey"
+         FOREIGN KEY ("projectId") REFERENCES "Project"("id")
+         ON DELETE CASCADE ON UPDATE CASCADE;
+     END IF;
+   END $$`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'ProjectProductFavorite_productId_fkey'
+         AND conrelid = '"ProjectProductFavorite"'::regclass
+     ) THEN
+       ALTER TABLE "ProjectProductFavorite"
+         ADD CONSTRAINT "ProjectProductFavorite_productId_fkey"
+         FOREIGN KEY ("productId") REFERENCES "ProductLibraryItem"("id")
+         ON DELETE CASCADE ON UPDATE CASCADE;
+     END IF;
+   END $$`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'ProjectProductFavorite_addedById_fkey'
+         AND conrelid = '"ProjectProductFavorite"'::regclass
+     ) THEN
+       ALTER TABLE "ProjectProductFavorite"
+         ADD CONSTRAINT "ProjectProductFavorite_addedById_fkey"
+         FOREIGN KEY ("addedById") REFERENCES "User"("id")
+         ON DELETE SET NULL ON UPDATE CASCADE;
+     END IF;
+   END $$`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'ProjectProductFavorite_projectId_productId_key'
+         AND conrelid = '"ProjectProductFavorite"'::regclass
+     ) THEN
+       ALTER TABLE "ProjectProductFavorite"
+         ADD CONSTRAINT "ProjectProductFavorite_projectId_productId_key"
+         UNIQUE ("projectId", "productId");
+     END IF;
+   END $$`,
+  `CREATE INDEX IF NOT EXISTS "ProjectProductFavorite_projectId_idx" ON "ProjectProductFavorite" ("projectId")`,
+
+  // ── SelectionProposal ────────────────────────────────────────────────────
+  `CREATE TABLE IF NOT EXISTS "SelectionProposal" (
+     "id" TEXT NOT NULL,
+     "projectId" TEXT NOT NULL,
+     "name" TEXT NOT NULL,
+     "description" TEXT,
+     "imageUrl" TEXT,
+     "price" DECIMAL(12,2),
+     "vendorUrl" TEXT,
+     "clientNote" TEXT,
+     "status" TEXT NOT NULL DEFAULT 'Pending',
+     "pmNote" TEXT,
+     "productId" TEXT,
+     "boardId" TEXT,
+     "categoryId" TEXT,
+     "decidedById" TEXT,
+     "decidedAt" TIMESTAMP(3),
+     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+     CONSTRAINT "SelectionProposal_pkey" PRIMARY KEY ("id")
+   )`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'SelectionProposal_projectId_fkey'
+         AND conrelid = '"SelectionProposal"'::regclass
+     ) THEN
+       ALTER TABLE "SelectionProposal"
+         ADD CONSTRAINT "SelectionProposal_projectId_fkey"
+         FOREIGN KEY ("projectId") REFERENCES "Project"("id")
+         ON DELETE CASCADE ON UPDATE CASCADE;
+     END IF;
+   END $$`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'SelectionProposal_decidedById_fkey'
+         AND conrelid = '"SelectionProposal"'::regclass
+     ) THEN
+       ALTER TABLE "SelectionProposal"
+         ADD CONSTRAINT "SelectionProposal_decidedById_fkey"
+         FOREIGN KEY ("decidedById") REFERENCES "User"("id")
+         ON DELETE SET NULL ON UPDATE CASCADE;
+     END IF;
+   END $$`,
+  `CREATE INDEX IF NOT EXISTS "SelectionProposal_projectId_status_idx" ON "SelectionProposal" ("projectId", "status")`,
+
+  // These tables are server-only. RLS with no policies denies direct
+  // anon/authenticated Data API access; server-side Prisma uses the owner role.
+  `ALTER TABLE "ProductLibraryItem" ENABLE ROW LEVEL SECURITY`,
+  `ALTER TABLE "ProjectProductFavorite" ENABLE ROW LEVEL SECURITY`,
+  `ALTER TABLE "SelectionProposal" ENABLE ROW LEVEL SECURITY`,
+];
+
+try {
+  for (const sql of statements) {
+    await prisma.$executeRawUnsafe(sql);
+    console.log("applied:", sql.split("\n")[0]);
+  }
+  console.log("Product library schema applied successfully.");
+} finally {
+  await prisma.$disconnect();
+}

--- a/src/app/api/portal/files/route.ts
+++ b/src/app/api/portal/files/route.ts
@@ -108,6 +108,7 @@ export async function GET(req: NextRequest) {
                 size: true,
                 mimeType: true,
                 createdAt: true,
+                uploadedByClient: true,
             },
         });
 

--- a/src/app/api/portal/files/route.ts
+++ b/src/app/api/portal/files/route.ts
@@ -4,7 +4,17 @@ import { isAncestorChainShared } from "@/lib/file-auth";
 import { resolveSessionClientId } from "@/lib/portal-auth";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
-import { getPortalVisibility } from "@/lib/actions";
+import { getPortalVisibility, logActivity } from "@/lib/actions";
+import { getSupabase, STORAGE_BUCKET } from "@/lib/supabase";
+import { PORTAL_UPLOAD_EXTENSIONS } from "@/lib/project-files";
+import { sendNotification } from "@/lib/email";
+
+export const maxDuration = 30;
+
+// Matches the MAX_SINGLE_FILE_BYTES precedent used for email attachments in
+// actions.ts — the closest existing "one file" size cap in this codebase.
+const PORTAL_UPLOAD_MAX_BYTES = 8 * 1024 * 1024;
+const DESIGN_FILES_FOLDER_NAME = "Design Files";
 
 // GET: list shared files for a portal client (read-only)
 export async function GET(req: NextRequest) {
@@ -105,5 +115,171 @@ export async function GET(req: NextRequest) {
     } catch (err: any) {
         console.error("GET /api/portal/files error:", err);
         return NextResponse.json({ error: err.message || "Failed to list files" }, { status: 500 });
+    }
+}
+
+// POST: client uploads a file from the portal Files tab. Lands in the project's
+// "Design Files" shared folder by default (find-or-create), or into another
+// folder the client explicitly targets — but ONLY if that folder's full ancestor
+// chain is "shared" visibility (a client can never write into a team/financial
+// folder by guessing a folderId).
+export async function POST(req: NextRequest) {
+    try {
+        const { searchParams } = new URL(req.url);
+        const projectIdQuery = searchParams.get("projectId");
+
+        const supabase = getSupabase();
+        if (!supabase) {
+            return NextResponse.json({ error: "Storage not configured" }, { status: 500 });
+        }
+
+        let formData;
+        try {
+            formData = await req.formData();
+        } catch (parseErr: any) {
+            return NextResponse.json({ error: `File too large or invalid: ${parseErr.message}` }, { status: 413 });
+        }
+
+        const projectId = (formData.get("projectId") as string | null) || projectIdQuery;
+        const folderId = formData.get("folderId") as string | null;
+        const file = formData.get("file") as File | null;
+
+        if (!projectId) {
+            return NextResponse.json({ error: "projectId required" }, { status: 400 });
+        }
+        if (!file) {
+            return NextResponse.json({ error: "file required" }, { status: 400 });
+        }
+
+        const visibility = await getPortalVisibility(projectId);
+        if (!visibility.isPortalEnabled || !visibility.showFiles) {
+            return NextResponse.json({ error: "Not found" }, { status: 404 });
+        }
+
+        const staffSession = await getServerSession(authOptions);
+        const isStaff = ["ADMIN", "MANAGER"].includes((staffSession?.user as any)?.role);
+
+        let client: { id: string; name: string; email: string | null } | null = null;
+        if (!isStaff) {
+            const sessionClientId = await resolveSessionClientId();
+            if (!sessionClientId) {
+                return NextResponse.json({ error: "Not found" }, { status: 404 });
+            }
+            const project = await prisma.project.findFirst({
+                where: { id: projectId, clientId: sessionClientId },
+                select: { client: { select: { id: true, name: true, email: true } } },
+            });
+            if (!project) {
+                return NextResponse.json({ error: "Not found" }, { status: 404 });
+            }
+            client = project.client;
+        } else {
+            const project = await prisma.project.findUnique({
+                where: { id: projectId },
+                select: { client: { select: { id: true, name: true, email: true } } },
+            });
+            client = project?.client ?? null;
+        }
+
+        const ext = file.name.includes(".") ? `.${file.name.split(".").pop()!.toLowerCase()}` : "";
+        if (!PORTAL_UPLOAD_EXTENSIONS.has(ext)) {
+            return NextResponse.json({ error: `File type not allowed: ${ext || "(no extension)"}.` }, { status: 400 });
+        }
+        if (file.size > PORTAL_UPLOAD_MAX_BYTES) {
+            return NextResponse.json({ error: "File is too large (8 MB max)." }, { status: 413 });
+        }
+
+        // Resolve the target folder: client-specified folderId must be shared
+        // (full ancestor chain), otherwise default to the "Design Files" folder
+        // (find-or-create at the project root, visibility "shared").
+        let targetFolderId: string;
+        if (folderId) {
+            const allShared = await isAncestorChainShared(folderId, projectId);
+            if (!allShared) {
+                return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+            }
+            targetFolderId = folderId;
+        } else {
+            let folder = await prisma.fileFolder.findFirst({
+                where: { projectId, name: DESIGN_FILES_FOLDER_NAME, parentId: null, visibility: "shared" },
+            });
+            if (!folder) {
+                folder = await prisma.fileFolder.create({
+                    data: { projectId, name: DESIGN_FILES_FOLDER_NAME, visibility: "shared" },
+                });
+            }
+            targetFolderId = folder.id;
+        }
+
+        const bytes = await file.arrayBuffer();
+        const buffer = Buffer.from(bytes);
+
+        const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
+        const storagePath = `projects/${projectId}/portal-uploads/${Date.now()}_${safeName}`;
+
+        const { error: uploadError } = await supabase.storage
+            .from(STORAGE_BUCKET)
+            .upload(storagePath, buffer, {
+                contentType: file.type || "application/octet-stream",
+                upsert: false,
+            });
+        if (uploadError) {
+            console.error("Supabase upload error:", uploadError);
+            return NextResponse.json({ error: `Storage upload failed: ${uploadError.message}` }, { status: 500 });
+        }
+
+        const { data: urlData } = supabase.storage.from(STORAGE_BUCKET).getPublicUrl(storagePath);
+        const publicUrl = urlData?.publicUrl || storagePath;
+
+        const record = await prisma.projectFile.create({
+            data: {
+                name: file.name,
+                url: publicUrl,
+                size: buffer.length,
+                mimeType: file.type || "application/octet-stream",
+                visibility: "shared",
+                projectId,
+                folderId: targetFolderId,
+                uploadedByClient: true,
+            },
+        });
+
+        // Notify the team + activity log — same "client did something" pattern
+        // as submitSelectionProposal.
+        try {
+            const project = await prisma.project.findUnique({ where: { id: projectId }, select: { name: true } });
+            const settings = await prisma.companySettings.findUnique({
+                where: { id: "singleton" },
+                select: { notificationEmail: true },
+            });
+            if (settings?.notificationEmail) {
+                await sendNotification(
+                    settings.notificationEmail,
+                    `📎 Client uploaded a file — ${project?.name || "Project"}`,
+                    `<div style="font-family: sans-serif; color: #333;">
+                        <h3>New Design File From Client</h3>
+                        <p><strong>${client?.name || "Client"}</strong> uploaded <strong>${file.name}</strong> to project <strong>${project?.name || ""}</strong>.</p>
+                        <p>It's in the "${DESIGN_FILES_FOLDER_NAME}" folder on the project's Files tab.</p>
+                    </div>`
+                );
+            }
+        } catch (notifyErr) {
+            console.error("[portal files POST] notify failed:", notifyErr);
+        }
+
+        await logActivity({
+            projectId,
+            actorType: "CLIENT",
+            actorName: client?.name || "Client",
+            action: "uploaded_file",
+            entityType: "ProjectFile",
+            entityId: record.id,
+            entityName: file.name,
+        });
+
+        return NextResponse.json({ file: record }, { status: 201 });
+    } catch (err: any) {
+        console.error("POST /api/portal/files error:", err);
+        return NextResponse.json({ error: err.message || "Upload failed" }, { status: 500 });
     }
 }

--- a/src/app/api/portal/files/route.ts
+++ b/src/app/api/portal/files/route.ts
@@ -134,6 +134,17 @@ export async function POST(req: NextRequest) {
             return NextResponse.json({ error: "Storage not configured" }, { status: 500 });
         }
 
+        // Reject oversized uploads BEFORE buffering the body into memory via
+        // formData() — an absent or missing Content-Length is treated as
+        // oversized too (a chunked/unsized request could otherwise stream past
+        // the cap before formData() ever returns). The per-file size check
+        // below (after parsing) is the real enforcement; this is just to avoid
+        // buffering an unbounded body in the first place.
+        const contentLength = req.headers.get("content-length");
+        if (!contentLength || Number(contentLength) > PORTAL_UPLOAD_MAX_BYTES) {
+            return NextResponse.json({ error: "File is too large (8 MB max)." }, { status: 413 });
+        }
+
         let formData;
         try {
             formData = await req.formData();

--- a/src/app/api/portal/projects/[id]/proposals/parse/route.ts
+++ b/src/app/api/portal/projects/[id]/proposals/parse/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { resolveSessionClientId } from "@/lib/portal-auth";
+import { parseProductUrl } from "@/lib/product-parse";
+
+export const maxDuration = 30;
+
+// POST: portal-client product URL parse, used to prefill the "suggest an item"
+// form. Price is stripped from the response — it's PM-side info until the
+// proposal is approved. (submitSelectionProposal re-parses server-side and
+// persists price on the SelectionProposal row; this route never persists.)
+export async function POST(req: NextRequest, props: { params: Promise<{ id: string }> }) {
+    try {
+        const { id: projectId } = await props.params;
+
+        const staffSession = await getServerSession(authOptions);
+        const isStaff = ["ADMIN", "MANAGER"].includes((staffSession?.user as any)?.role);
+
+        if (!isStaff) {
+            const sessionClientId = await resolveSessionClientId();
+            if (!sessionClientId) {
+                return NextResponse.json({ error: "Not found" }, { status: 404 });
+            }
+            const project = await prisma.project.findFirst({
+                where: { id: projectId, clientId: sessionClientId },
+                select: { id: true },
+            });
+            if (!project) {
+                return NextResponse.json({ error: "Not found" }, { status: 404 });
+            }
+        }
+
+        const body = await req.json().catch(() => null);
+        const url = typeof body?.url === "string" ? body.url.trim() : "";
+        if (!url) {
+            return NextResponse.json({ error: "url required" }, { status: 400 });
+        }
+
+        const parsed = await parseProductUrl(url);
+        const { price, ...withoutPrice } = parsed;
+        return NextResponse.json(withoutPrice);
+    } catch (err: any) {
+        console.error("POST /api/portal/projects/[id]/proposals/parse error:", err);
+        return NextResponse.json({ error: err.message || "Parse failed" }, { status: 500 });
+    }
+}

--- a/src/app/api/portal/projects/[id]/proposals/parse/route.ts
+++ b/src/app/api/portal/projects/[id]/proposals/parse/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { resolveSessionClientId } from "@/lib/portal-auth";
 import { parseProductUrl } from "@/lib/product-parse";
+import { getPortalVisibility } from "@/lib/actions";
 
 export const maxDuration = 30;
 
@@ -14,6 +15,15 @@ export const maxDuration = 30;
 export async function POST(req: NextRequest, props: { params: Promise<{ id: string }> }) {
     try {
         const { id: projectId } = await props.params;
+
+        // Same order as the portal selections page and /api/portal/files:
+        // visibility gate first, applied uniformly (no staff bypass) — this
+        // route only exists to prefill the "suggest an item" form, which is
+        // itself gated on showSelections.
+        const visibility = await getPortalVisibility(projectId);
+        if (!visibility.isPortalEnabled || !visibility.showSelections) {
+            return NextResponse.json({ error: "Not found" }, { status: 404 });
+        }
 
         const staffSession = await getServerSession(authOptions);
         const isStaff = ["ADMIN", "MANAGER"].includes((staffSession?.user as any)?.role);

--- a/src/app/api/products/parse/route.ts
+++ b/src/app/api/products/parse/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { parseProductUrl } from "@/lib/product-parse";
+import { ROLES } from "@/lib/permissions";
 
 export const maxDuration = 30;
 
@@ -15,7 +16,10 @@ export async function POST(req: NextRequest) {
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
         }
         const user = await prisma.user.findUnique({ where: { email: session.user.email.toLowerCase() } });
-        if (!user || user.status === "DISABLED") {
+        // Gate on a real staff role, not just "a User row exists" — mirrors
+        // /api/users' role-allowlist pattern. ROLES is the canonical
+        // ADMIN/MANAGER/FIELD_CREW/FINANCE list from src/lib/permissions.ts.
+        if (!user || user.status === "DISABLED" || !ROLES.includes(user.role)) {
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
         }
 

--- a/src/app/api/products/parse/route.ts
+++ b/src/app/api/products/parse/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { parseProductUrl } from "@/lib/product-parse";
+
+export const maxDuration = 30;
+
+// POST: team-only product URL parse for the clipper / product library. Full
+// ParsedProduct (including price) — team members are allowed to see list price.
+export async function POST(req: NextRequest) {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.email) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+        const user = await prisma.user.findUnique({ where: { email: session.user.email.toLowerCase() } });
+        if (!user || user.status === "DISABLED") {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const body = await req.json().catch(() => null);
+        const url = typeof body?.url === "string" ? body.url.trim() : "";
+        if (!url) {
+            return NextResponse.json({ error: "url required" }, { status: 400 });
+        }
+
+        const parsed = await parseProductUrl(url);
+        return NextResponse.json(parsed);
+    } catch (err: any) {
+        console.error("POST /api/products/parse error:", err);
+        return NextResponse.json({ error: err.message || "Parse failed" }, { status: 500 });
+    }
+}

--- a/src/app/clip/ClipClient.tsx
+++ b/src/app/clip/ClipClient.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { createProductLibraryItem, addProjectFavorite } from "@/lib/actions";
+import { ImageOff, Check, RefreshCw } from "lucide-react";
+
+interface ProjectOption {
+    id: string;
+    name: string;
+}
+
+const EMPTY_FORM = {
+    name: "",
+    description: "",
+    imageUrl: "",
+    price: "",
+    vendor: "",
+    category: "",
+};
+
+export default function ClipClient({ initialUrl, allProjects }: { initialUrl: string; allProjects: ProjectOption[] }) {
+    const [url, setUrl] = useState(initialUrl);
+    const [form, setForm] = useState(EMPTY_FORM);
+    const [parsing, setParsing] = useState(false);
+    const [parsed, setParsed] = useState(false);
+    const [saving, setSaving] = useState(false);
+    const [savedProduct, setSavedProduct] = useState<{ id: string; toProject?: string } | null>(null);
+    const [showProjectPicker, setShowProjectPicker] = useState(false);
+    const [pickedProjectId, setPickedProjectId] = useState("");
+
+    useEffect(() => {
+        if (initialUrl) {
+            void parseUrl(initialUrl);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [initialUrl]);
+
+    async function parseUrl(targetUrl: string) {
+        const trimmed = targetUrl.trim();
+        if (!trimmed) return;
+        setParsing(true);
+        try {
+            const res = await fetch("/api/products/parse", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ url: trimmed }),
+            });
+            const data = await res.json();
+            if (!res.ok) throw new Error(data?.error || "Parse failed");
+            setForm((f) => ({
+                ...f,
+                name: data.name || f.name,
+                description: data.description ?? f.description,
+                imageUrl: data.imageUrl ?? f.imageUrl,
+                price: data.price != null ? String(data.price) : f.price,
+                vendor: data.vendor ?? f.vendor,
+            }));
+            setParsed(true);
+            if (!data.name) {
+                toast.info("Couldn't auto-detect this page — fill in details manually.");
+            }
+        } catch (e: any) {
+            toast.error(e.message || "Couldn't parse that page");
+        } finally {
+            setParsing(false);
+        }
+    }
+
+    function resetForAnother() {
+        setUrl("");
+        setForm(EMPTY_FORM);
+        setParsed(false);
+        setSavedProduct(null);
+        setShowProjectPicker(false);
+        setPickedProjectId("");
+    }
+
+    async function saveToLibrary(): Promise<{ id: string } | null> {
+        if (!form.name.trim()) {
+            toast.error("Name is required");
+            return null;
+        }
+        try {
+            const created = await createProductLibraryItem({
+                name: form.name.trim(),
+                description: form.description || undefined,
+                imageUrl: form.imageUrl || undefined,
+                price: form.price ? parseFloat(form.price) : undefined,
+                vendor: form.vendor || undefined,
+                vendorUrl: url || undefined,
+                category: form.category || undefined,
+                source: "clip",
+            });
+            return { id: created.id };
+        } catch (e: any) {
+            toast.error(e.message || "Failed to save product");
+            return null;
+        }
+    }
+
+    async function handleSaveOnly() {
+        setSaving(true);
+        try {
+            const created = await saveToLibrary();
+            if (created) {
+                setSavedProduct({ id: created.id });
+                toast.success("Saved to product library");
+            }
+        } finally {
+            setSaving(false);
+        }
+    }
+
+    async function handleSaveAndAddToProject() {
+        if (!pickedProjectId) return;
+        setSaving(true);
+        try {
+            const created = await saveToLibrary();
+            if (created) {
+                const projectName = allProjects.find((p) => p.id === pickedProjectId)?.name || "project";
+                await addProjectFavorite(pickedProjectId, created.id);
+                setSavedProduct({ id: created.id, toProject: projectName });
+                toast.success(`Saved and added to ${projectName}`);
+            }
+        } catch (e: any) {
+            toast.error(e.message || "Failed to add to project");
+        } finally {
+            setSaving(false);
+        }
+    }
+
+    if (savedProduct) {
+        return (
+            <div className="min-h-screen bg-hui-background flex items-center justify-center p-6">
+                <div className="hui-card w-full max-w-sm p-6 text-center">
+                    <div className="w-14 h-14 bg-green-100 rounded-2xl flex items-center justify-center mx-auto mb-4">
+                        <Check className="w-7 h-7 text-green-600" />
+                    </div>
+                    <h1 className="text-base font-bold text-hui-textMain">Clipped!</h1>
+                    <p className="text-sm text-hui-textMuted mt-1">
+                        {savedProduct.toProject
+                            ? `Saved to the library and added to ${savedProduct.toProject}'s favorites.`
+                            : "Saved to the product library."}
+                    </p>
+                    <div className="flex flex-col gap-2 mt-6">
+                        <button onClick={resetForAnother} className="hui-btn hui-btn-secondary w-full">
+                            Clip another
+                        </button>
+                        <button onClick={() => window.close()} className="hui-btn hui-btn-green w-full">
+                            Close window
+                        </button>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="min-h-screen bg-hui-background p-4">
+            <div className="max-w-sm mx-auto">
+                <h1 className="text-base font-bold text-hui-textMain mb-1">ProBuild Clip</h1>
+                <p className="text-xs text-hui-textMuted mb-4">Capture this product into the shared library.</p>
+
+                <div className="hui-card p-4 space-y-3">
+                    <div className="flex gap-2">
+                        <input
+                            type="url"
+                            value={url}
+                            onChange={(e) => setUrl(e.target.value)}
+                            placeholder="https://vendor.com/product/..."
+                            className="hui-input flex-1 text-sm"
+                            onKeyDown={(e) => e.key === "Enter" && (e.preventDefault(), parseUrl(url))}
+                        />
+                        <button
+                            onClick={() => parseUrl(url)}
+                            disabled={parsing || !url.trim()}
+                            title="Re-parse"
+                            aria-label="Re-parse"
+                            className="hui-btn hui-btn-secondary px-3 disabled:opacity-50"
+                        >
+                            <RefreshCw className={`w-4 h-4 ${parsing ? "animate-spin" : ""}`} />
+                        </button>
+                    </div>
+
+                    {parsing && (
+                        <p className="text-xs text-hui-textMuted">Reading the page...</p>
+                    )}
+
+                    <div className="h-28 bg-slate-50 border border-hui-border rounded-lg flex items-center justify-center overflow-hidden">
+                        {form.imageUrl ? (
+                            <img
+                                src={form.imageUrl}
+                                alt="Preview"
+                                className="h-full object-contain"
+                                onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
+                            />
+                        ) : (
+                            <ImageOff className="w-6 h-6 text-slate-300" />
+                        )}
+                    </div>
+
+                    <div>
+                        <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Name *</label>
+                        <input
+                            type="text"
+                            value={form.name}
+                            onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+                            className="hui-input w-full mt-1 text-sm"
+                            placeholder="Product name"
+                        />
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-2">
+                        <div>
+                            <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Price</label>
+                            <input
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                value={form.price}
+                                onChange={(e) => setForm((f) => ({ ...f, price: e.target.value }))}
+                                className="hui-input w-full mt-1 text-sm"
+                                placeholder="0.00"
+                            />
+                        </div>
+                        <div>
+                            <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Vendor</label>
+                            <input
+                                type="text"
+                                value={form.vendor}
+                                onChange={(e) => setForm((f) => ({ ...f, vendor: e.target.value }))}
+                                className="hui-input w-full mt-1 text-sm"
+                                placeholder="e.g. Ferguson"
+                            />
+                        </div>
+                    </div>
+
+                    <div>
+                        <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Category</label>
+                        <input
+                            type="text"
+                            value={form.category}
+                            onChange={(e) => setForm((f) => ({ ...f, category: e.target.value }))}
+                            className="hui-input w-full mt-1 text-sm"
+                            placeholder="e.g. Plumbing Fixtures"
+                        />
+                    </div>
+
+                    <div>
+                        <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Description</label>
+                        <textarea
+                            value={form.description}
+                            onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+                            className="hui-input w-full mt-1 text-sm"
+                            rows={2}
+                        />
+                    </div>
+
+                    {showProjectPicker && (
+                        <div className="border-t border-hui-border pt-3">
+                            <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Project</label>
+                            <select
+                                value={pickedProjectId}
+                                onChange={(e) => setPickedProjectId(e.target.value)}
+                                className="hui-input w-full mt-1 text-sm"
+                            >
+                                <option value="">— Pick a project —</option>
+                                {allProjects.map((p) => (
+                                    <option key={p.id} value={p.id}>{p.name}</option>
+                                ))}
+                            </select>
+                        </div>
+                    )}
+
+                    <div className="flex flex-col gap-2 pt-1">
+                        {!showProjectPicker ? (
+                            <>
+                                <button
+                                    onClick={handleSaveOnly}
+                                    disabled={saving || !form.name.trim()}
+                                    className="hui-btn hui-btn-green w-full disabled:opacity-50"
+                                >
+                                    {saving ? "Saving..." : "Save to Library"}
+                                </button>
+                                <button
+                                    onClick={() => setShowProjectPicker(true)}
+                                    disabled={!form.name.trim() || allProjects.length === 0}
+                                    className="hui-btn hui-btn-secondary w-full disabled:opacity-50"
+                                >
+                                    Save + Add to Project
+                                </button>
+                            </>
+                        ) : (
+                            <>
+                                <button
+                                    onClick={handleSaveAndAddToProject}
+                                    disabled={saving || !pickedProjectId}
+                                    className="hui-btn hui-btn-green w-full disabled:opacity-50"
+                                >
+                                    {saving ? "Saving..." : "Save + Add"}
+                                </button>
+                                <button
+                                    onClick={() => setShowProjectPicker(false)}
+                                    className="hui-btn hui-btn-secondary w-full"
+                                >
+                                    Back
+                                </button>
+                            </>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/app/clip/ClipClient.tsx
+++ b/src/app/clip/ClipClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { createProductLibraryItem, addProjectFavorite } from "@/lib/actions";
+import { isHttpUrl } from "@/lib/url-safety";
 import { ImageOff, Check, RefreshCw } from "lucide-react";
 
 interface ProjectOption {
@@ -188,7 +189,7 @@ export default function ClipClient({ initialUrl, allProjects }: { initialUrl: st
                     )}
 
                     <div className="h-28 bg-slate-50 border border-hui-border rounded-lg flex items-center justify-center overflow-hidden">
-                        {form.imageUrl ? (
+                        {isHttpUrl(form.imageUrl) ? (
                             <img
                                 src={form.imageUrl}
                                 alt="Preview"

--- a/src/app/clip/page.tsx
+++ b/src/app/clip/page.tsx
@@ -1,0 +1,28 @@
+export const dynamic = "force-dynamic";
+import { getSessionOrDev } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import { getProjects } from "@/lib/actions";
+import ClipClient from "./ClipClient";
+
+// The bookmarklet capture popup — team-authed. Rendered bare (AppLayout treats
+// /clip as a public route so it skips the sidebar/header), but auth is still
+// enforced right here exactly like every other team page: no session -> normal
+// login redirect, CLIENT role -> portal.
+export default async function ClipPage(props: { searchParams: Promise<{ url?: string }> }) {
+    const { url } = await props.searchParams;
+
+    const session = await getSessionOrDev();
+    if (!session?.user) redirect("/login");
+    const role = (session.user as any)?.role;
+    if (role === "CLIENT") redirect("/portal");
+
+    let allProjects: { id: string; name: string }[] = [];
+    try {
+        const allProjs = await getProjects();
+        allProjects = allProjs
+            .filter((p: any) => p.status !== "Archived")
+            .map((p: any) => ({ id: p.id, name: p.name }));
+    } catch {}
+
+    return <ClipClient initialUrl={url || ""} allProjects={allProjects} />;
+}

--- a/src/app/company/layout.tsx
+++ b/src/app/company/layout.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Users, Building, FileText, Anchor, Shield } from "lucide-react";
+import { Users, Building, FileText, Anchor, Shield, ShoppingBag } from "lucide-react";
 import ErrorBoundary from "@/components/ErrorBoundary";
 
 export default function CompanyLayout({ children }: { children: React.ReactNode }) {
@@ -26,6 +26,7 @@ export default function CompanyLayout({ children }: { children: React.ReactNode 
                 { name: "Cost Codes & Phases", href: "/company/cost-codes", icon: FileText },
                 { name: "My Items", href: "/company/my-items", icon: FileText },
                 { name: "Catalogs", href: "/company/catalogs", icon: FileText },
+                { name: "Product Library", href: "/company/product-library", icon: ShoppingBag },
             ]
         }
     ];

--- a/src/app/company/product-library/ProductLibraryClient.tsx
+++ b/src/app/company/product-library/ProductLibraryClient.tsx
@@ -8,6 +8,7 @@ import {
     deleteProductLibraryItem,
     addProjectFavorite,
 } from "@/lib/actions";
+import { isHttpUrl } from "@/lib/url-safety";
 import {
     Plus,
     Search,
@@ -332,7 +333,7 @@ export default function ProductLibraryClient({ initialProducts, allProjects, app
                             <div key={product.id} className="hui-card overflow-hidden group relative flex flex-col">
                                 {/* Image */}
                                 <div className="h-36 bg-gradient-to-br from-slate-100 to-slate-200 flex items-center justify-center overflow-hidden">
-                                    {product.imageUrl ? (
+                                    {isHttpUrl(product.imageUrl) ? (
                                         <img
                                             src={product.imageUrl}
                                             alt={product.name}
@@ -383,7 +384,7 @@ export default function ProductLibraryClient({ initialProducts, allProjects, app
                                     )}
                                     <div className="flex-1" />
                                     <div className="flex items-center gap-2 mt-2">
-                                        {product.vendorUrl && (
+                                        {isHttpUrl(product.vendorUrl) && (
                                             <a
                                                 href={product.vendorUrl}
                                                 target="_blank"
@@ -532,7 +533,7 @@ export default function ProductLibraryClient({ initialProducts, allProjects, app
                                         placeholder="https://vendor.com/product/..."
                                     />
                                 </div>
-                                {form.imageUrl && (
+                                {isHttpUrl(form.imageUrl) && (
                                     <div className="h-28 bg-slate-50 border border-hui-border rounded-lg flex items-center justify-center overflow-hidden">
                                         <img src={form.imageUrl} alt="Preview" className="h-full object-contain" onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }} />
                                     </div>

--- a/src/app/company/product-library/ProductLibraryClient.tsx
+++ b/src/app/company/product-library/ProductLibraryClient.tsx
@@ -1,0 +1,612 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { toast } from "sonner";
+import {
+    createProductLibraryItem,
+    updateProductLibraryItem,
+    deleteProductLibraryItem,
+    addProjectFavorite,
+} from "@/lib/actions";
+import {
+    Plus,
+    Search,
+    Edit2,
+    Trash2,
+    ExternalLink,
+    ImageOff,
+    X,
+    Link2,
+    FolderPlus,
+    Clipboard,
+} from "lucide-react";
+
+interface Product {
+    id: string;
+    name: string;
+    description: string | null;
+    imageUrl: string | null;
+    price: number | string | null;
+    vendor: string | null;
+    vendorUrl: string | null;
+    category: string | null;
+    source: string;
+    createdAt: string;
+}
+
+interface ProjectOption {
+    id: string;
+    name: string;
+}
+
+interface Props {
+    initialProducts: Product[];
+    allProjects: ProjectOption[];
+    appUrl: string;
+}
+
+const EMPTY_FORM = {
+    name: "",
+    description: "",
+    imageUrl: "",
+    price: "",
+    vendor: "",
+    vendorUrl: "",
+    category: "",
+};
+
+function formatPrice(value: number | string | null | undefined): string | null {
+    if (value === null || value === undefined || value === "") return null;
+    const num = Number(value);
+    if (isNaN(num)) return null;
+    return num.toLocaleString("en-US", { style: "currency", currency: "USD" });
+}
+
+function EmptyState({ icon, title, description, action, onAction }: {
+    icon: React.ReactNode; title: string; description: string; action?: string; onAction?: () => void;
+}) {
+    return (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+            <div className="w-16 h-16 bg-slate-100 rounded-2xl flex items-center justify-center mb-4">{icon}</div>
+            <h3 className="text-base font-semibold text-hui-textMain">{title}</h3>
+            <p className="text-sm text-hui-textMuted mt-1 max-w-md">{description}</p>
+            {action && onAction && (
+                <button onClick={onAction} className="hui-btn hui-btn-green mt-4">{action}</button>
+            )}
+        </div>
+    );
+}
+
+export default function ProductLibraryClient({ initialProducts, allProjects, appUrl }: Props) {
+    const [products, setProducts] = useState<Product[]>(initialProducts);
+    const [search, setSearch] = useState("");
+    const [categoryFilter, setCategoryFilter] = useState("");
+    const [isPending, startTransition] = useTransition();
+
+    // Add/Edit modal
+    const [showForm, setShowForm] = useState(false);
+    const [editingId, setEditingId] = useState<string | null>(null);
+    const [form, setForm] = useState(EMPTY_FORM);
+    const [parseUrl, setParseUrl] = useState("");
+    const [parsing, setParsing] = useState(false);
+    const [saving, setSaving] = useState(false);
+
+    // Add-to-project modal
+    const [addToProjectFor, setAddToProjectFor] = useState<Product | null>(null);
+    const [pickedProjectId, setPickedProjectId] = useState("");
+    const [favoriteNote, setFavoriteNote] = useState("");
+    const [addingFavorite, setAddingFavorite] = useState(false);
+
+    const categories = useMemo(() => {
+        const set = new Set<string>();
+        products.forEach((p) => { if (p.category) set.add(p.category); });
+        return Array.from(set).sort();
+    }, [products]);
+
+    const filtered = useMemo(() => {
+        const q = search.trim().toLowerCase();
+        return products.filter((p) => {
+            if (categoryFilter && p.category !== categoryFilter) return false;
+            if (!q) return true;
+            return (
+                p.name.toLowerCase().includes(q) ||
+                (p.vendor || "").toLowerCase().includes(q) ||
+                (p.category || "").toLowerCase().includes(q)
+            );
+        });
+    }, [products, search, categoryFilter]);
+
+    function openAdd() {
+        setEditingId(null);
+        setForm(EMPTY_FORM);
+        setParseUrl("");
+        setShowForm(true);
+    }
+
+    function openEdit(product: Product) {
+        setEditingId(product.id);
+        setForm({
+            name: product.name,
+            description: product.description || "",
+            imageUrl: product.imageUrl || "",
+            price: product.price != null ? String(product.price) : "",
+            vendor: product.vendor || "",
+            vendorUrl: product.vendorUrl || "",
+            category: product.category || "",
+        });
+        setParseUrl(product.vendorUrl || "");
+        setShowForm(true);
+    }
+
+    function closeForm() {
+        setShowForm(false);
+        setEditingId(null);
+        setForm(EMPTY_FORM);
+        setParseUrl("");
+    }
+
+    async function handleParse() {
+        const url = parseUrl.trim();
+        if (!url) return;
+        setParsing(true);
+        try {
+            const res = await fetch("/api/products/parse", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ url }),
+            });
+            const data = await res.json();
+            if (!res.ok) throw new Error(data?.error || "Parse failed");
+            setForm((f) => ({
+                ...f,
+                name: data.name || f.name,
+                description: data.description ?? f.description,
+                imageUrl: data.imageUrl ?? f.imageUrl,
+                price: data.price != null ? String(data.price) : f.price,
+                vendor: data.vendor ?? f.vendor,
+                vendorUrl: data.vendorUrl || url,
+            }));
+            if (!data.name) {
+                toast.info("Couldn't auto-detect product details — fill in the fields manually.");
+            } else {
+                toast.success("Product details pulled in — review and save.");
+            }
+        } catch (e: any) {
+            toast.error(e.message || "Failed to parse URL");
+        } finally {
+            setParsing(false);
+        }
+    }
+
+    async function handleSave() {
+        if (!form.name.trim()) return;
+        setSaving(true);
+        try {
+            const payload = {
+                name: form.name.trim(),
+                description: form.description || undefined,
+                imageUrl: form.imageUrl || undefined,
+                price: form.price ? parseFloat(form.price) : undefined,
+                vendor: form.vendor || undefined,
+                vendorUrl: form.vendorUrl || undefined,
+                category: form.category || undefined,
+            };
+            if (editingId) {
+                const updated = await updateProductLibraryItem(editingId, payload);
+                setProducts((prev) => prev.map((p) => (p.id === editingId ? ({ ...p, ...updated } as unknown as Product) : p)));
+                toast.success("Product updated");
+            } else {
+                const created = await createProductLibraryItem({ ...payload, source: "manual" });
+                setProducts((prev) => [created as unknown as Product, ...prev]);
+                toast.success("Product added to library");
+            }
+            closeForm();
+        } catch (e: any) {
+            toast.error(e.message || "Failed to save product");
+        } finally {
+            setSaving(false);
+        }
+    }
+
+    function handleDelete(product: Product) {
+        if (!confirm(`Delete "${product.name}" from the product library? This cannot be undone.`)) return;
+        startTransition(async () => {
+            try {
+                await deleteProductLibraryItem(product.id);
+                setProducts((prev) => prev.filter((p) => p.id !== product.id));
+                toast.success("Product deleted");
+            } catch (e: any) {
+                toast.error(e.message || "Failed to delete product");
+            }
+        });
+    }
+
+    function openAddToProject(product: Product) {
+        setAddToProjectFor(product);
+        setPickedProjectId("");
+        setFavoriteNote("");
+    }
+
+    async function handleAddToProject() {
+        if (!addToProjectFor || !pickedProjectId) return;
+        setAddingFavorite(true);
+        try {
+            await addProjectFavorite(pickedProjectId, addToProjectFor.id, favoriteNote || undefined);
+            const projectName = allProjects.find((p) => p.id === pickedProjectId)?.name || "project";
+            toast.success(`Added to ${projectName}'s favorites`);
+            setAddToProjectFor(null);
+        } catch (e: any) {
+            toast.error(e.message || "Failed to add to project");
+        } finally {
+            setAddingFavorite(false);
+        }
+    }
+
+    const bookmarkletHref =
+        "javascript:(function(){window.open('" + appUrl + "/clip?url='+encodeURIComponent(location.href),'probuild-clip','width=480,height=720');})();";
+
+    return (
+        <div className="max-w-6xl mx-auto py-8 px-6">
+            {/* Header */}
+            <div className="flex items-center justify-between mb-6">
+                <div>
+                    <h1 className="text-xl font-bold text-hui-textMain">Product Library</h1>
+                    <p className="text-sm text-hui-textMuted mt-1">
+                        {products.length} product{products.length !== 1 ? "s" : ""} · reusable across every project
+                    </p>
+                </div>
+                <button onClick={openAdd} className="hui-btn hui-btn-green flex items-center gap-2">
+                    <Plus className="w-4 h-4" />
+                    Add Product
+                </button>
+            </div>
+
+            {/* Bookmarklet card */}
+            <div className="hui-card p-5 mb-6 flex items-center justify-between gap-6 flex-wrap">
+                <div className="flex items-center gap-4">
+                    <div className="w-11 h-11 bg-hui-primary/10 rounded-xl flex items-center justify-center shrink-0">
+                        <Clipboard className="w-5 h-5 text-hui-primary" />
+                    </div>
+                    <div>
+                        <h2 className="text-base font-semibold text-hui-textMain">Get the Clipper</h2>
+                        <p className="text-sm text-hui-textMuted mt-0.5">
+                            Drag this to your bookmarks bar. On any product page, click it to clip straight to the library.
+                        </p>
+                    </div>
+                </div>
+                <a
+                    href={bookmarkletHref}
+                    onClick={(e) => e.preventDefault()}
+                    className="hui-btn hui-btn-secondary flex items-center gap-2 cursor-grab active:cursor-grabbing shrink-0"
+                    title="Drag me to your bookmarks bar"
+                >
+                    <Link2 className="w-4 h-4" />
+                    ProBuild Clip
+                </a>
+            </div>
+
+            {/* Search + category filter */}
+            <div className="flex items-center gap-3 mb-4 flex-wrap">
+                <div className="relative flex-1 min-w-[220px]">
+                    <Search className="w-4 h-4 text-hui-textMuted absolute left-3 top-1/2 -translate-y-1/2" />
+                    <input
+                        type="text"
+                        placeholder="Search products, vendors, categories..."
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                        className="hui-input w-full pl-9"
+                    />
+                </div>
+                <select
+                    value={categoryFilter}
+                    onChange={(e) => setCategoryFilter(e.target.value)}
+                    className="hui-input w-56"
+                >
+                    <option value="">All categories</option>
+                    {categories.map((c) => (
+                        <option key={c} value={c}>{c}</option>
+                    ))}
+                </select>
+            </div>
+
+            {/* Grid */}
+            {filtered.length === 0 ? (
+                <div className="hui-card">
+                    <EmptyState
+                        icon={<Clipboard className="w-7 h-7 text-slate-400" />}
+                        title={products.length === 0 ? "No products clipped yet" : "No products match your filters"}
+                        description={
+                            products.length === 0
+                                ? "Paste a product URL to clip it into the library, or drag the Clipper bookmarklet above to your bookmarks bar."
+                                : "Try a different search term or category."
+                        }
+                        action={products.length === 0 ? "Add Product" : undefined}
+                        onAction={products.length === 0 ? openAdd : undefined}
+                    />
+                </div>
+            ) : (
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                    {filtered.map((product) => {
+                        const price = formatPrice(product.price);
+                        return (
+                            <div key={product.id} className="hui-card overflow-hidden group relative flex flex-col">
+                                {/* Image */}
+                                <div className="h-36 bg-gradient-to-br from-slate-100 to-slate-200 flex items-center justify-center overflow-hidden">
+                                    {product.imageUrl ? (
+                                        <img
+                                            src={product.imageUrl}
+                                            alt={product.name}
+                                            className="w-full h-full object-cover"
+                                            onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
+                                        />
+                                    ) : (
+                                        <ImageOff className="w-8 h-8 text-slate-300" />
+                                    )}
+                                </div>
+
+                                {/* Edit / delete — hover reveal, always visible on no-hover devices */}
+                                <div className="absolute top-2 right-2 flex gap-1 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto transition">
+                                    <button
+                                        onClick={() => openEdit(product)}
+                                        title="Edit"
+                                        aria-label="Edit product"
+                                        className="w-7 h-7 rounded-lg bg-white/90 backdrop-blur shadow flex items-center justify-center text-slate-500 hover:text-hui-primary transition"
+                                    >
+                                        <Edit2 className="w-3.5 h-3.5" />
+                                    </button>
+                                    <button
+                                        onClick={() => handleDelete(product)}
+                                        disabled={isPending}
+                                        title="Delete"
+                                        aria-label="Delete product"
+                                        className="w-7 h-7 rounded-lg bg-white/90 backdrop-blur shadow flex items-center justify-center text-slate-500 hover:text-red-600 transition"
+                                    >
+                                        <Trash2 className="w-3.5 h-3.5" />
+                                    </button>
+                                </div>
+
+                                {/* Info */}
+                                <div className="p-3 flex-1 flex flex-col">
+                                    <div className="flex items-start justify-between gap-2 mb-1">
+                                        <h3 className="text-sm font-semibold text-hui-textMain line-clamp-2">{product.name}</h3>
+                                        {price && (
+                                            <span className="text-sm font-bold text-hui-primary whitespace-nowrap">{price}</span>
+                                        )}
+                                    </div>
+                                    {product.vendor && (
+                                        <p className="text-xs text-hui-textMuted mb-1">{product.vendor}</p>
+                                    )}
+                                    {product.category && (
+                                        <span className="inline-block w-fit text-[10px] font-semibold uppercase tracking-wider text-hui-textMuted bg-slate-100 rounded-full px-2 py-0.5 mb-2">
+                                            {product.category}
+                                        </span>
+                                    )}
+                                    <div className="flex-1" />
+                                    <div className="flex items-center gap-2 mt-2">
+                                        {product.vendorUrl && (
+                                            <a
+                                                href={product.vendorUrl}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className="text-xs text-blue-600 hover:underline flex items-center gap-1"
+                                            >
+                                                <ExternalLink className="w-3 h-3" />
+                                                Source
+                                            </a>
+                                        )}
+                                        <div className="flex-1" />
+                                        <button
+                                            onClick={() => openAddToProject(product)}
+                                            className="text-xs font-medium text-hui-primary hover:text-hui-primaryHover flex items-center gap-1 transition"
+                                        >
+                                            <FolderPlus className="w-3.5 h-3.5" />
+                                            Add to project…
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+
+            {/* Add / Edit modal */}
+            {showForm && (
+                <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4" onClick={closeForm}>
+                    <div
+                        className="bg-white rounded-xl shadow-2xl max-w-lg w-full max-h-[90vh] overflow-y-auto"
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        <div className="px-6 py-4 border-b border-hui-border flex items-center justify-between">
+                            <h3 className="text-lg font-bold text-hui-textMain">
+                                {editingId ? "Edit Product" : "Add Product"}
+                            </h3>
+                            <button onClick={closeForm} aria-label="Close" className="text-hui-textMuted hover:text-hui-textMain">
+                                <X className="w-5 h-5" />
+                            </button>
+                        </div>
+
+                        <div className="p-6 space-y-4">
+                            {/* Parse from URL */}
+                            <div>
+                                <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Paste Product URL</label>
+                                <div className="flex gap-2 mt-1">
+                                    <input
+                                        type="url"
+                                        placeholder="https://vendor.com/product/..."
+                                        value={parseUrl}
+                                        onChange={(e) => setParseUrl(e.target.value)}
+                                        className="hui-input flex-1"
+                                        onKeyDown={(e) => e.key === "Enter" && (e.preventDefault(), handleParse())}
+                                    />
+                                    <button
+                                        onClick={handleParse}
+                                        disabled={parsing || !parseUrl.trim()}
+                                        className="hui-btn hui-btn-secondary whitespace-nowrap disabled:opacity-50"
+                                    >
+                                        {parsing ? "Parsing..." : "Parse"}
+                                    </button>
+                                </div>
+                                <p className="text-xs text-hui-textMuted mt-1">
+                                    Pulls in name, image, price, and vendor when available. Everything below stays editable.
+                                </p>
+                            </div>
+
+                            <div className="border-t border-hui-border pt-4 space-y-4">
+                                <div>
+                                    <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Name *</label>
+                                    <input
+                                        type="text"
+                                        value={form.name}
+                                        onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+                                        className="hui-input w-full mt-1"
+                                        placeholder="Product name"
+                                    />
+                                </div>
+                                <div>
+                                    <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Description</label>
+                                    <textarea
+                                        value={form.description}
+                                        onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+                                        className="hui-input w-full mt-1"
+                                        rows={2}
+                                    />
+                                </div>
+                                <div className="grid grid-cols-2 gap-4">
+                                    <div>
+                                        <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Price</label>
+                                        <input
+                                            type="number"
+                                            step="0.01"
+                                            min="0"
+                                            value={form.price}
+                                            onChange={(e) => setForm((f) => ({ ...f, price: e.target.value }))}
+                                            className="hui-input w-full mt-1"
+                                            placeholder="0.00"
+                                        />
+                                    </div>
+                                    <div>
+                                        <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Vendor</label>
+                                        <input
+                                            type="text"
+                                            value={form.vendor}
+                                            onChange={(e) => setForm((f) => ({ ...f, vendor: e.target.value }))}
+                                            className="hui-input w-full mt-1"
+                                            placeholder="e.g. Ferguson"
+                                        />
+                                    </div>
+                                </div>
+                                <div className="grid grid-cols-2 gap-4">
+                                    <div>
+                                        <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Category</label>
+                                        <input
+                                            type="text"
+                                            list="product-library-categories"
+                                            value={form.category}
+                                            onChange={(e) => setForm((f) => ({ ...f, category: e.target.value }))}
+                                            className="hui-input w-full mt-1"
+                                            placeholder="e.g. Plumbing Fixtures"
+                                        />
+                                        <datalist id="product-library-categories">
+                                            {categories.map((c) => <option key={c} value={c} />)}
+                                        </datalist>
+                                    </div>
+                                    <div>
+                                        <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Image URL</label>
+                                        <input
+                                            type="url"
+                                            value={form.imageUrl}
+                                            onChange={(e) => setForm((f) => ({ ...f, imageUrl: e.target.value }))}
+                                            className="hui-input w-full mt-1"
+                                            placeholder="https://..."
+                                        />
+                                    </div>
+                                </div>
+                                <div>
+                                    <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Source Link</label>
+                                    <input
+                                        type="url"
+                                        value={form.vendorUrl}
+                                        onChange={(e) => setForm((f) => ({ ...f, vendorUrl: e.target.value }))}
+                                        className="hui-input w-full mt-1"
+                                        placeholder="https://vendor.com/product/..."
+                                    />
+                                </div>
+                                {form.imageUrl && (
+                                    <div className="h-28 bg-slate-50 border border-hui-border rounded-lg flex items-center justify-center overflow-hidden">
+                                        <img src={form.imageUrl} alt="Preview" className="h-full object-contain" onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }} />
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+
+                        <div className="px-6 py-4 border-t border-hui-border flex justify-end gap-3 bg-slate-50">
+                            <button onClick={closeForm} className="hui-btn hui-btn-secondary">Cancel</button>
+                            <button
+                                onClick={handleSave}
+                                disabled={saving || !form.name.trim()}
+                                className="hui-btn hui-btn-green disabled:opacity-50"
+                            >
+                                {saving ? "Saving..." : editingId ? "Save Changes" : "Add to Library"}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Add to project modal */}
+            {addToProjectFor && (
+                <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4" onClick={() => setAddToProjectFor(null)}>
+                    <div className="bg-white rounded-xl shadow-2xl max-w-md w-full" onClick={(e) => e.stopPropagation()}>
+                        <div className="px-6 py-4 border-b border-hui-border">
+                            <h3 className="text-lg font-bold text-hui-textMain">Add to project favorites</h3>
+                            <p className="text-xs text-hui-textMuted mt-0.5">{addToProjectFor.name}</p>
+                        </div>
+                        <div className="p-6 space-y-4">
+                            {allProjects.length === 0 ? (
+                                <p className="text-sm text-hui-textMuted">No active projects found.</p>
+                            ) : (
+                                <>
+                                    <div>
+                                        <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Project</label>
+                                        <select
+                                            value={pickedProjectId}
+                                            onChange={(e) => setPickedProjectId(e.target.value)}
+                                            className="hui-input w-full mt-1"
+                                            autoFocus
+                                        >
+                                            <option value="">— Pick a project —</option>
+                                            {allProjects.map((p) => (
+                                                <option key={p.id} value={p.id}>{p.name}</option>
+                                            ))}
+                                        </select>
+                                    </div>
+                                    <div>
+                                        <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Note (optional)</label>
+                                        <textarea
+                                            value={favoriteNote}
+                                            onChange={(e) => setFavoriteNote(e.target.value)}
+                                            className="hui-input w-full mt-1"
+                                            rows={2}
+                                            placeholder="Why this fits the project..."
+                                        />
+                                    </div>
+                                </>
+                            )}
+                        </div>
+                        <div className="px-6 py-4 border-t border-hui-border flex justify-end gap-3 bg-slate-50">
+                            <button onClick={() => setAddToProjectFor(null)} className="hui-btn hui-btn-secondary">Cancel</button>
+                            <button
+                                onClick={handleAddToProject}
+                                disabled={addingFavorite || !pickedProjectId}
+                                className="hui-btn hui-btn-green disabled:opacity-50"
+                            >
+                                {addingFavorite ? "Adding..." : "Add to Favorites"}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/app/company/product-library/page.tsx
+++ b/src/app/company/product-library/page.tsx
@@ -1,0 +1,31 @@
+export const dynamic = "force-dynamic";
+import { getSessionOrDev } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import { getProductLibrary, getProjects } from "@/lib/actions";
+import ProductLibraryClient from "./ProductLibraryClient";
+
+export default async function ProductLibraryPage() {
+    const session = await getSessionOrDev();
+    if (!session?.user) redirect("/login");
+    const role = (session.user as any)?.role;
+    if (role === "CLIENT") redirect("/portal");
+
+    const [products, allProjectsRaw] = await Promise.all([
+        getProductLibrary(),
+        getProjects(),
+    ]);
+
+    const allProjects = allProjectsRaw
+        .filter((p: any) => p.status !== "Archived")
+        .map((p: any) => ({ id: p.id, name: p.name }));
+
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+
+    return (
+        <ProductLibraryClient
+            initialProducts={JSON.parse(JSON.stringify(products))}
+            allProjects={allProjects}
+            appUrl={appUrl}
+        />
+    );
+}

--- a/src/app/portal/projects/[id]/selections/PortalProjectFavorites.tsx
+++ b/src/app/portal/projects/[id]/selections/PortalProjectFavorites.tsx
@@ -4,6 +4,8 @@
 // intentionally never shown here (see docs/specs/product-library-portal-selections.md
 // Phase 3, item 2) — favorites are ideas being explored, not priced selections.
 
+import { isHttpUrl } from "@/lib/url-safety";
+
 interface FavoriteProduct {
     id: string;
     name: string;
@@ -40,7 +42,7 @@ export default function PortalProjectFavorites({ favorites }: { favorites: Favor
                             className="rounded-xl border-2 border-slate-200 overflow-hidden hover:shadow-sm transition-all duration-200"
                         >
                             <div className="h-48 bg-slate-100 flex items-center justify-center overflow-hidden">
-                                {fav.product.imageUrl ? (
+                                {isHttpUrl(fav.product.imageUrl) ? (
                                     <img
                                         src={fav.product.imageUrl}
                                         alt={fav.product.name}
@@ -61,7 +63,7 @@ export default function PortalProjectFavorites({ favorites }: { favorites: Favor
                                 {fav.note && (
                                     <p className="text-sm text-slate-500 mb-3 line-clamp-3">{fav.note}</p>
                                 )}
-                                {fav.product.vendorUrl && (
+                                {isHttpUrl(fav.product.vendorUrl) && (
                                     <a
                                         href={fav.product.vendorUrl}
                                         target="_blank"

--- a/src/app/portal/projects/[id]/selections/PortalProjectFavorites.tsx
+++ b/src/app/portal/projects/[id]/selections/PortalProjectFavorites.tsx
@@ -1,0 +1,82 @@
+// Read-only "Project Favorites" grid — items your team has pinned from the
+// product library, plus anything that landed here automatically from an
+// approved client suggestion (see PortalSuggestionsSection). Price is
+// intentionally never shown here (see docs/specs/product-library-portal-selections.md
+// Phase 3, item 2) — favorites are ideas being explored, not priced selections.
+
+interface FavoriteProduct {
+    id: string;
+    name: string;
+    imageUrl: string | null;
+    vendor: string | null;
+    vendorUrl: string | null;
+}
+
+interface Favorite {
+    id: string;
+    note: string | null;
+    product: FavoriteProduct;
+}
+
+export default function PortalProjectFavorites({ favorites }: { favorites: Favorite[] }) {
+    return (
+        <div>
+            <div className="mb-4">
+                <h2 className="text-xl font-bold text-hui-textMain">Project Favorites</h2>
+                <p className="text-sm text-hui-textMuted">Things your team has been finding for your project.</p>
+            </div>
+
+            {favorites.length === 0 ? (
+                <div className="hui-card p-10 text-center">
+                    <p className="text-sm text-hui-textMuted">
+                        Your team will pin ideas here as they find them.
+                    </p>
+                </div>
+            ) : (
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {favorites.map(fav => (
+                        <div
+                            key={fav.id}
+                            className="rounded-xl border-2 border-slate-200 overflow-hidden hover:shadow-sm transition-all duration-200"
+                        >
+                            <div className="h-48 bg-slate-100 flex items-center justify-center overflow-hidden">
+                                {fav.product.imageUrl ? (
+                                    <img
+                                        src={fav.product.imageUrl}
+                                        alt={fav.product.name}
+                                        className="w-full h-full object-cover"
+                                    />
+                                ) : (
+                                    <svg className="w-12 h-12 text-slate-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                                    </svg>
+                                )}
+                            </div>
+
+                            <div className="p-4 bg-white">
+                                <h4 className="font-bold text-slate-800 leading-tight mb-1">{fav.product.name}</h4>
+                                {fav.product.vendor && (
+                                    <p className="text-xs text-slate-500 mb-2">{fav.product.vendor}</p>
+                                )}
+                                {fav.note && (
+                                    <p className="text-sm text-slate-500 mb-3 line-clamp-3">{fav.note}</p>
+                                )}
+                                {fav.product.vendorUrl && (
+                                    <a
+                                        href={fav.product.vendorUrl}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="text-xs font-semibold text-blue-600 hover:text-blue-800 inline-flex items-center gap-1"
+                                    >
+                                        View Product
+                                        <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+                                    </a>
+                                )}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/app/portal/projects/[id]/selections/PortalSuggestionsSection.tsx
+++ b/src/app/portal/projects/[id]/selections/PortalSuggestionsSection.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { submitSelectionProposal } from "@/lib/actions";
+
+interface Proposal {
+    id: string;
+    name: string;
+    description: string | null;
+    imageUrl: string | null;
+    price: number | null;
+    vendorUrl: string | null;
+    clientNote: string | null;
+    status: string;
+    pmNote: string | null;
+    createdAt: string;
+}
+
+function statusBadge(status: string) {
+    if (status === "Approved") {
+        return { label: "Approved", className: "bg-emerald-50 text-emerald-700" };
+    }
+    if (status === "Declined") {
+        return { label: "Not this time", className: "bg-slate-100 text-slate-600" };
+    }
+    return { label: "Waiting for review", className: "bg-amber-50 text-amber-700" };
+}
+
+function SuggestItemModal({
+    projectId,
+    open,
+    onClose,
+    onSubmitted,
+}: {
+    projectId: string;
+    open: boolean;
+    onClose: () => void;
+    onSubmitted: () => void;
+}) {
+    const [url, setUrl] = useState("");
+    const [name, setName] = useState("");
+    const [imageUrl, setImageUrl] = useState("");
+    const [clientNote, setClientNote] = useState("");
+    const [parsedDescription, setParsedDescription] = useState<string | undefined>(undefined);
+    const [parsing, setParsing] = useState(false);
+    const [submitting, setSubmitting] = useState(false);
+
+    function reset() {
+        setUrl("");
+        setName("");
+        setImageUrl("");
+        setClientNote("");
+        setParsedDescription(undefined);
+    }
+
+    async function handleParse() {
+        const trimmed = url.trim();
+        if (!trimmed) return;
+        setParsing(true);
+        try {
+            const res = await fetch(`/api/portal/projects/${projectId}/proposals/parse`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ url: trimmed }),
+            });
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) throw new Error(data.error || "Couldn't read that link");
+            if (data.name) setName(data.name);
+            if (data.imageUrl) setImageUrl(data.imageUrl);
+            if (data.description) setParsedDescription(data.description);
+            toast.success("Filled in what we could find — feel free to edit it.");
+        } catch (e: any) {
+            toast.error(e.message || "Couldn't read that link. You can still fill this in by hand.");
+        } finally {
+            setParsing(false);
+        }
+    }
+
+    async function handleSubmit() {
+        if (!name.trim()) {
+            toast.error("Give it a name so we know what you're pointing at.");
+            return;
+        }
+        setSubmitting(true);
+        try {
+            await submitSelectionProposal(projectId, {
+                url: url.trim() || undefined,
+                name: name.trim(),
+                description: parsedDescription,
+                imageUrl: imageUrl.trim() || undefined,
+                clientNote: clientNote.trim() || undefined,
+            });
+            toast.success("Sent to your project manager for review.");
+            reset();
+            onClose();
+            onSubmitted();
+        } catch (e: any) {
+            toast.error(e.message || "Couldn't send that suggestion. Please try again.");
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    if (!open) return null;
+
+    return (
+        <div
+            className="fixed inset-0 bg-slate-900/50 flex items-center justify-center z-50 p-4"
+            onClick={() => { if (!submitting) { reset(); onClose(); } }}
+        >
+            <div
+                className="bg-white rounded-xl shadow-xl w-full max-w-md border border-hui-border max-h-[90vh] overflow-y-auto"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <div className="px-6 py-4 border-b border-hui-border flex justify-between items-center">
+                    <div>
+                        <h2 className="text-base font-bold text-hui-textMain">Suggest an item</h2>
+                        <p className="text-xs text-hui-textMuted mt-0.5">Found something you love? Send it our way.</p>
+                    </div>
+                    <button
+                        onClick={() => { if (!submitting) { reset(); onClose(); } }}
+                        aria-label="Close"
+                        className="text-hui-textMuted hover:text-hui-textMain ml-4 shrink-0"
+                    >
+                        <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
+                    </button>
+                </div>
+
+                <div className="p-6 space-y-5">
+                    <div>
+                        <label className="block text-sm font-medium text-hui-textMain mb-1">Paste a product link</label>
+                        <div className="flex gap-2">
+                            <input
+                                type="url"
+                                className="hui-input"
+                                placeholder="https://..."
+                                value={url}
+                                onChange={(e) => setUrl(e.target.value)}
+                                disabled={submitting}
+                            />
+                            <button
+                                type="button"
+                                onClick={handleParse}
+                                disabled={!url.trim() || parsing || submitting}
+                                className="hui-btn hui-btn-secondary shrink-0 disabled:opacity-50"
+                            >
+                                {parsing ? "Parsing…" : "Parse"}
+                            </button>
+                        </div>
+                        <p className="text-xs text-hui-textMuted mt-1">We'll try to pull the name and photo. Price stays with your project manager for now.</p>
+                    </div>
+
+                    <div>
+                        <label className="block text-sm font-medium text-hui-textMain mb-1">Item name</label>
+                        <input
+                            type="text"
+                            className="hui-input"
+                            placeholder="e.g. Brushed brass cabinet pulls"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            disabled={submitting}
+                        />
+                    </div>
+
+                    <div>
+                        <label className="block text-sm font-medium text-hui-textMain mb-1">
+                            Photo URL <span className="text-hui-textMuted font-normal">(optional)</span>
+                        </label>
+                        <input
+                            type="url"
+                            className="hui-input"
+                            placeholder="https://..."
+                            value={imageUrl}
+                            onChange={(e) => setImageUrl(e.target.value)}
+                            disabled={submitting}
+                        />
+                    </div>
+
+                    <div>
+                        <label className="block text-sm font-medium text-hui-textMain mb-1">
+                            Note to your project manager <span className="text-hui-textMuted font-normal">(optional)</span>
+                        </label>
+                        <textarea
+                            className="hui-input"
+                            rows={3}
+                            placeholder="Why you like it, where it'd go, anything else..."
+                            value={clientNote}
+                            onChange={(e) => setClientNote(e.target.value)}
+                            disabled={submitting}
+                        />
+                    </div>
+                </div>
+
+                <div className="px-6 py-4 border-t border-hui-border flex justify-end gap-3 bg-slate-50 rounded-b-xl">
+                    <button
+                        onClick={() => { if (!submitting) { reset(); onClose(); } }}
+                        className="hui-btn hui-btn-secondary"
+                        disabled={submitting}
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        onClick={handleSubmit}
+                        disabled={submitting || !name.trim()}
+                        className="hui-btn hui-btn-green disabled:opacity-50"
+                    >
+                        {submitting ? "Sending…" : "Send suggestion"}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default function PortalSuggestionsSection({
+    projectId,
+    initialProposals,
+}: {
+    projectId: string;
+    initialProposals: Proposal[];
+}) {
+    const router = useRouter();
+    const [modalOpen, setModalOpen] = useState(false);
+
+    return (
+        <div className="hui-card p-6">
+            <div className="flex items-center justify-between mb-4 flex-wrap gap-3">
+                <div>
+                    <h2 className="text-xl font-bold text-hui-textMain">Your suggestions</h2>
+                    <p className="text-sm text-hui-textMuted">Items you've sent us, and where they stand.</p>
+                </div>
+                <button onClick={() => setModalOpen(true)} className="hui-btn hui-btn-green">
+                    Suggest an item
+                </button>
+            </div>
+
+            {initialProposals.length === 0 ? (
+                <div className="py-10 text-center">
+                    <p className="text-sm text-hui-textMuted">
+                        Found something you love? Send it to us and we&apos;ll price it out.
+                    </p>
+                </div>
+            ) : (
+                <div className="space-y-3">
+                    {initialProposals.map(p => {
+                        const badge = statusBadge(p.status);
+                        return (
+                            <div key={p.id} className="flex gap-4 border border-slate-200 rounded-lg p-4">
+                                <div className="w-16 h-16 rounded-lg bg-slate-100 flex items-center justify-center overflow-hidden shrink-0">
+                                    {p.imageUrl ? (
+                                        <img src={p.imageUrl} alt={p.name} className="w-full h-full object-cover" />
+                                    ) : (
+                                        <svg className="w-6 h-6 text-slate-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                                        </svg>
+                                    )}
+                                </div>
+                                <div className="flex-1 min-w-0">
+                                    <div className="flex items-start justify-between gap-3 flex-wrap">
+                                        <h4 className="font-bold text-slate-800 leading-tight">{p.name}</h4>
+                                        <span className={`shrink-0 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${badge.className}`}>
+                                            {badge.label}
+                                        </span>
+                                    </div>
+                                    {p.status === "Approved" && p.price != null && (
+                                        <p className="text-sm font-semibold text-slate-700 mt-1">${p.price.toLocaleString()}</p>
+                                    )}
+                                    {p.clientNote && (
+                                        <p className="text-xs text-hui-textMuted mt-1">You noted: {p.clientNote}</p>
+                                    )}
+                                    {p.pmNote && (
+                                        <p className="text-sm text-slate-600 mt-1.5 bg-slate-50 rounded-md px-2.5 py-1.5">
+                                            {p.status === "Declined" ? "From your project manager: " : "Note: "}{p.pmNote}
+                                        </p>
+                                    )}
+                                    {p.vendorUrl && (
+                                        <a
+                                            href={p.vendorUrl}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="text-xs font-semibold text-blue-600 hover:text-blue-800 inline-flex items-center gap-1 mt-2"
+                                        >
+                                            View link
+                                            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+                                        </a>
+                                    )}
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+
+            <SuggestItemModal
+                projectId={projectId}
+                open={modalOpen}
+                onClose={() => setModalOpen(false)}
+                onSubmitted={() => router.refresh()}
+            />
+        </div>
+    );
+}

--- a/src/app/portal/projects/[id]/selections/PortalSuggestionsSection.tsx
+++ b/src/app/portal/projects/[id]/selections/PortalSuggestionsSection.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { submitSelectionProposal } from "@/lib/actions";
+import { isHttpUrl } from "@/lib/url-safety";
 
 interface Proposal {
     id: string;
@@ -249,7 +250,7 @@ export default function PortalSuggestionsSection({
                         return (
                             <div key={p.id} className="flex gap-4 border border-slate-200 rounded-lg p-4">
                                 <div className="w-16 h-16 rounded-lg bg-slate-100 flex items-center justify-center overflow-hidden shrink-0">
-                                    {p.imageUrl ? (
+                                    {isHttpUrl(p.imageUrl) ? (
                                         <img src={p.imageUrl} alt={p.name} className="w-full h-full object-cover" />
                                     ) : (
                                         <svg className="w-6 h-6 text-slate-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -275,7 +276,7 @@ export default function PortalSuggestionsSection({
                                             {p.status === "Declined" ? "From your project manager: " : "Note: "}{p.pmNote}
                                         </p>
                                     )}
-                                    {p.vendorUrl && (
+                                    {isHttpUrl(p.vendorUrl) && (
                                         <a
                                             href={p.vendorUrl}
                                             target="_blank"

--- a/src/app/portal/projects/[id]/selections/page.tsx
+++ b/src/app/portal/projects/[id]/selections/page.tsx
@@ -2,9 +2,16 @@ import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
-import { getSelectionBoardsForPortal, getPortalVisibility } from "@/lib/actions";
+import {
+    getSelectionBoardsForPortal,
+    getPortalVisibility,
+    getSelectionProposalsForPortal,
+    getProjectFavoritesForPortal,
+} from "@/lib/actions";
 import Link from "next/link";
 import PortalSelectionsClient from "./PortalSelectionsClient";
+import PortalProjectFavorites from "./PortalProjectFavorites";
+import PortalSuggestionsSection from "./PortalSuggestionsSection";
 
 export default async function PortalSelectionsPage(props: { params: Promise<{ id: string }> }) {
     const { id } = await props.params;
@@ -31,7 +38,18 @@ export default async function PortalSelectionsPage(props: { params: Promise<{ id
         );
     }
 
-    const boards = await getSelectionBoardsForPortal(id);
+    const [boards, proposals, favorites] = await Promise.all([
+        getSelectionBoardsForPortal(id),
+        getSelectionProposalsForPortal(id),
+        getProjectFavoritesForPortal(id),
+    ]);
+
+    // Only show the read-only Favorites section when there's something to look
+    // at, or when the tab already has other content (boards/proposals) so an
+    // empty Favorites card isn't the only thing on an otherwise-empty page —
+    // the "Your suggestions" section below always renders and covers that case
+    // with its own invite-to-suggest empty state.
+    const showFavorites = favorites.length > 0 || boards.length > 0 || proposals.length > 0;
 
     return (
         <div className="max-w-5xl mx-auto py-8 px-4">
@@ -62,6 +80,16 @@ export default async function PortalSelectionsPage(props: { params: Promise<{ id
             ) : (
                 <PortalSelectionsClient boards={JSON.parse(JSON.stringify(boards))} />
             )}
+
+            <div className="mt-12 space-y-12">
+                {showFavorites && (
+                    <PortalProjectFavorites favorites={JSON.parse(JSON.stringify(favorites))} />
+                )}
+                <PortalSuggestionsSection
+                    projectId={id}
+                    initialProposals={JSON.parse(JSON.stringify(proposals))}
+                />
+            </div>
         </div>
     );
 }

--- a/src/app/projects/[id]/selections/ClientSuggestions.tsx
+++ b/src/app/projects/[id]/selections/ClientSuggestions.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { decideSelectionProposal } from "@/lib/actions";
+import { isHttpUrl } from "@/lib/url-safety";
 import { ImageOff, ExternalLink, Lightbulb } from "lucide-react";
 
 interface Proposal {
@@ -49,6 +50,15 @@ export default function ClientSuggestions({
 }) {
     const router = useRouter();
     const [proposals, setProposals] = useState<Proposal[]>(initialProposals);
+
+    // initialProposals is only the INITIAL value for useState — React never
+    // re-derives state from a changed prop on its own. Without this, a
+    // decided proposal keeps rendering as Pending (with live Approve/Decline
+    // buttons) after router.refresh() re-fetches the server component below,
+    // because local state was never told the prop changed.
+    useEffect(() => {
+        setProposals(initialProposals);
+    }, [initialProposals]);
 
     // Approve dialog state
     const [approveFor, setApproveFor] = useState<Proposal | null>(null);
@@ -102,6 +112,10 @@ export default function ClientSuggestions({
                 toast.error("This suggestion was already decided.");
             } else {
                 toast.success("Suggestion approved");
+                // Optimistic: flip status locally so the Approve/Decline buttons
+                // disappear immediately, rather than waiting on the
+                // router.refresh() round-trip below to bring fresh server data.
+                setProposals((prev) => prev.map((p) => (p.id === approveFor.id ? { ...p, status: "Approved" } : p)));
             }
             setApproveFor(null);
             router.refresh();
@@ -124,6 +138,7 @@ export default function ClientSuggestions({
                 toast.error("This suggestion was already decided.");
             } else {
                 toast.success("Suggestion declined");
+                setProposals((prev) => prev.map((p) => (p.id === declineFor.id ? { ...p, status: "Declined" } : p)));
             }
             setDeclineFor(null);
             router.refresh();
@@ -155,7 +170,7 @@ export default function ClientSuggestions({
                     {[...pending, ...decided].map((p) => (
                         <div key={p.id} className="flex gap-4 p-4">
                             <div className="w-16 h-16 rounded-lg bg-slate-100 flex items-center justify-center overflow-hidden shrink-0">
-                                {p.imageUrl ? (
+                                {isHttpUrl(p.imageUrl) ? (
                                     <img src={p.imageUrl} alt={p.name} className="w-full h-full object-cover" />
                                 ) : (
                                     <ImageOff className="w-5 h-5 text-slate-300" />
@@ -168,7 +183,7 @@ export default function ClientSuggestions({
                                         {p.clientNote && (
                                             <p className="text-xs text-hui-textMuted mt-0.5">&quot;{p.clientNote}&quot;</p>
                                         )}
-                                        {p.vendorUrl && (
+                                        {isHttpUrl(p.vendorUrl) && (
                                             <a
                                                 href={p.vendorUrl}
                                                 target="_blank"

--- a/src/app/projects/[id]/selections/ClientSuggestions.tsx
+++ b/src/app/projects/[id]/selections/ClientSuggestions.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { decideSelectionProposal } from "@/lib/actions";
+import { ImageOff, ExternalLink, Lightbulb } from "lucide-react";
+
+interface Proposal {
+    id: string;
+    name: string;
+    description: string | null;
+    imageUrl: string | null;
+    price: number | string | null;
+    vendorUrl: string | null;
+    clientNote: string | null;
+    status: string;
+    pmNote: string | null;
+    decidedBy: { id: string; name: string | null; email: string } | null;
+    decidedAt: string | null;
+    createdAt: string;
+}
+
+interface Category {
+    id: string;
+    name: string;
+}
+
+interface Board {
+    id: string;
+    title: string;
+    categories: Category[];
+}
+
+function statusBadge(status: string) {
+    if (status === "Pending") return "bg-amber-100 text-amber-700";
+    if (status === "Approved") return "bg-green-100 text-green-700";
+    return "bg-slate-100 text-slate-600";
+}
+
+export default function ClientSuggestions({
+    projectId,
+    initialProposals,
+    boards,
+}: {
+    projectId: string;
+    initialProposals: Proposal[];
+    boards: Board[];
+}) {
+    const router = useRouter();
+    const [proposals, setProposals] = useState<Proposal[]>(initialProposals);
+
+    // Approve dialog state
+    const [approveFor, setApproveFor] = useState<Proposal | null>(null);
+    const [approvePrice, setApprovePrice] = useState("");
+    const [approveBoardId, setApproveBoardId] = useState("");
+    const [approveCategoryId, setApproveCategoryId] = useState("");
+    const [approveAddToFavorites, setApproveAddToFavorites] = useState(true);
+    const [approveNote, setApproveNote] = useState("");
+    const [approving, setApproving] = useState(false);
+
+    // Decline dialog state
+    const [declineFor, setDeclineFor] = useState<Proposal | null>(null);
+    const [declineNote, setDeclineNote] = useState("");
+    const [declining, setDeclining] = useState(false);
+
+    const pending = proposals.filter((p) => p.status === "Pending");
+    const decided = proposals.filter((p) => p.status !== "Pending");
+
+    const selectedBoard = useMemo(
+        () => boards.find((b) => b.id === approveBoardId) || null,
+        [boards, approveBoardId]
+    );
+
+    function openApprove(proposal: Proposal) {
+        setApproveFor(proposal);
+        setApprovePrice(proposal.price != null ? String(proposal.price) : "");
+        setApproveBoardId("");
+        setApproveCategoryId("");
+        setApproveAddToFavorites(true);
+        setApproveNote("");
+    }
+
+    function openDecline(proposal: Proposal) {
+        setDeclineFor(proposal);
+        setDeclineNote("");
+    }
+
+    async function handleApprove() {
+        if (!approveFor) return;
+        setApproving(true);
+        try {
+            const result = await decideSelectionProposal(approveFor.id, {
+                action: "approve",
+                pmNote: approveNote || undefined,
+                price: approvePrice ? parseFloat(approvePrice) : undefined,
+                boardId: approveBoardId || undefined,
+                categoryId: approveBoardId ? (approveCategoryId || undefined) : undefined,
+                addToFavorites: approveAddToFavorites,
+            });
+            if (!result.success) {
+                toast.error("This suggestion was already decided.");
+            } else {
+                toast.success("Suggestion approved");
+            }
+            setApproveFor(null);
+            router.refresh();
+        } catch (e: any) {
+            toast.error(e.message || "Failed to approve");
+        } finally {
+            setApproving(false);
+        }
+    }
+
+    async function handleDecline() {
+        if (!declineFor || !declineNote.trim()) return;
+        setDeclining(true);
+        try {
+            const result = await decideSelectionProposal(declineFor.id, {
+                action: "decline",
+                pmNote: declineNote.trim(),
+            });
+            if (!result.success) {
+                toast.error("This suggestion was already decided.");
+            } else {
+                toast.success("Suggestion declined");
+            }
+            setDeclineFor(null);
+            router.refresh();
+        } catch (e: any) {
+            toast.error(e.message || "Failed to decline");
+        } finally {
+            setDeclining(false);
+        }
+    }
+
+    return (
+        <div>
+            <div className="mb-4">
+                <h2 className="text-base font-semibold text-hui-textMain">Client Suggestions</h2>
+                <p className="text-sm text-hui-textMuted mt-1">
+                    Items the client suggested from their portal. Nothing here counts as an official selection until you approve it.
+                </p>
+            </div>
+
+            {proposals.length === 0 ? (
+                <div className="hui-card p-8 text-center">
+                    <div className="w-12 h-12 bg-slate-100 rounded-2xl flex items-center justify-center mx-auto mb-3">
+                        <Lightbulb className="w-6 h-6 text-slate-400" />
+                    </div>
+                    <p className="text-sm text-hui-textMuted">No client suggestions yet.</p>
+                </div>
+            ) : (
+                <div className="hui-card divide-y divide-slate-100">
+                    {[...pending, ...decided].map((p) => (
+                        <div key={p.id} className="flex gap-4 p-4">
+                            <div className="w-16 h-16 rounded-lg bg-slate-100 flex items-center justify-center overflow-hidden shrink-0">
+                                {p.imageUrl ? (
+                                    <img src={p.imageUrl} alt={p.name} className="w-full h-full object-cover" />
+                                ) : (
+                                    <ImageOff className="w-5 h-5 text-slate-300" />
+                                )}
+                            </div>
+                            <div className="flex-1 min-w-0">
+                                <div className="flex items-start justify-between gap-3">
+                                    <div>
+                                        <p className="text-sm font-semibold text-hui-textMain">{p.name}</p>
+                                        {p.clientNote && (
+                                            <p className="text-xs text-hui-textMuted mt-0.5">&quot;{p.clientNote}&quot;</p>
+                                        )}
+                                        {p.vendorUrl && (
+                                            <a
+                                                href={p.vendorUrl}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className="text-xs text-blue-600 hover:underline flex items-center gap-1 mt-1"
+                                            >
+                                                <ExternalLink className="w-3 h-3" />
+                                                View link
+                                            </a>
+                                        )}
+                                    </div>
+                                    <span className={`text-xs font-semibold px-2 py-0.5 rounded-full shrink-0 ${statusBadge(p.status)}`}>
+                                        {p.status === "Pending" ? "Waiting for review" : p.status}
+                                    </span>
+                                </div>
+
+                                {p.status === "Pending" ? (
+                                    <div className="flex gap-2 mt-3">
+                                        <button onClick={() => openApprove(p)} className="hui-btn hui-btn-green text-xs py-1.5 px-3">
+                                            Approve
+                                        </button>
+                                        <button onClick={() => openDecline(p)} className="hui-btn hui-btn-secondary text-xs py-1.5 px-3">
+                                            Decline
+                                        </button>
+                                    </div>
+                                ) : (
+                                    <div className="mt-2 text-xs text-hui-textMuted space-y-0.5">
+                                        {p.status === "Approved" && p.price != null && (
+                                            <p>Price: <span className="font-semibold text-hui-textMain">${Number(p.price).toLocaleString()}</span></p>
+                                        )}
+                                        {p.pmNote && <p>Note: &quot;{p.pmNote}&quot;</p>}
+                                        {p.decidedBy && <p>Decided by {p.decidedBy.name || p.decidedBy.email}</p>}
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {/* Approve dialog */}
+            {approveFor && (
+                <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4" onClick={() => setApproveFor(null)}>
+                    <div className="bg-white rounded-xl shadow-2xl max-w-md w-full" onClick={(e) => e.stopPropagation()}>
+                        <div className="px-6 py-4 border-b border-hui-border">
+                            <h3 className="text-lg font-bold text-hui-textMain">Approve suggestion</h3>
+                            <p className="text-xs text-hui-textMuted mt-0.5">{approveFor.name}</p>
+                        </div>
+                        <div className="p-6 space-y-4">
+                            <div>
+                                <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Price</label>
+                                <input
+                                    type="number"
+                                    step="0.01"
+                                    min="0"
+                                    value={approvePrice}
+                                    onChange={(e) => setApprovePrice(e.target.value)}
+                                    className="hui-input w-full mt-1"
+                                    placeholder="0.00"
+                                />
+                            </div>
+                            <div className="grid grid-cols-2 gap-3">
+                                <div>
+                                    <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Add to board (optional)</label>
+                                    <select
+                                        value={approveBoardId}
+                                        onChange={(e) => { setApproveBoardId(e.target.value); setApproveCategoryId(""); }}
+                                        className="hui-input w-full mt-1"
+                                    >
+                                        <option value="">— None —</option>
+                                        {boards.map((b) => (
+                                            <option key={b.id} value={b.id}>{b.title}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                                <div>
+                                    <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Category</label>
+                                    <select
+                                        value={approveCategoryId}
+                                        onChange={(e) => setApproveCategoryId(e.target.value)}
+                                        className="hui-input w-full mt-1 disabled:opacity-50"
+                                        disabled={!selectedBoard || selectedBoard.categories.length === 0}
+                                    >
+                                        <option value="">— None —</option>
+                                        {selectedBoard?.categories.map((c) => (
+                                            <option key={c.id} value={c.id}>{c.name}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                            </div>
+                            <label className="flex items-center gap-2 text-sm text-hui-textMain">
+                                <input
+                                    type="checkbox"
+                                    checked={approveAddToFavorites}
+                                    onChange={(e) => setApproveAddToFavorites(e.target.checked)}
+                                    className="w-4 h-4"
+                                />
+                                Add to project favorites
+                            </label>
+                            <div>
+                                <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Note to client (optional)</label>
+                                <textarea
+                                    value={approveNote}
+                                    onChange={(e) => setApproveNote(e.target.value)}
+                                    className="hui-input w-full mt-1"
+                                    rows={2}
+                                />
+                            </div>
+                        </div>
+                        <div className="px-6 py-4 border-t border-hui-border flex justify-end gap-3 bg-slate-50 rounded-b-xl">
+                            <button onClick={() => setApproveFor(null)} className="hui-btn hui-btn-secondary" disabled={approving}>Cancel</button>
+                            <button onClick={handleApprove} disabled={approving} className="hui-btn hui-btn-green disabled:opacity-50">
+                                {approving ? "Approving..." : "Approve"}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Decline dialog */}
+            {declineFor && (
+                <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4" onClick={() => setDeclineFor(null)}>
+                    <div className="bg-white rounded-xl shadow-2xl max-w-md w-full" onClick={(e) => e.stopPropagation()}>
+                        <div className="px-6 py-4 border-b border-hui-border">
+                            <h3 className="text-lg font-bold text-hui-textMain">Decline suggestion</h3>
+                            <p className="text-xs text-hui-textMuted mt-0.5">{declineFor.name}</p>
+                        </div>
+                        <div className="p-6">
+                            <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Reason (required, shown to client)</label>
+                            <textarea
+                                value={declineNote}
+                                onChange={(e) => setDeclineNote(e.target.value)}
+                                className="hui-input w-full mt-1"
+                                rows={3}
+                                autoFocus
+                                placeholder="Let the client know why this didn't work..."
+                            />
+                        </div>
+                        <div className="px-6 py-4 border-t border-hui-border flex justify-end gap-3 bg-slate-50 rounded-b-xl">
+                            <button onClick={() => setDeclineFor(null)} className="hui-btn hui-btn-secondary" disabled={declining}>Cancel</button>
+                            <button
+                                onClick={handleDecline}
+                                disabled={declining || !declineNote.trim()}
+                                className="hui-btn hui-btn-primary disabled:opacity-50"
+                            >
+                                {declining ? "Declining..." : "Decline"}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/app/projects/[id]/selections/ProjectFavoritesSection.tsx
+++ b/src/app/projects/[id]/selections/ProjectFavoritesSection.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { getProductLibrary, addProjectFavorite, removeProjectFavorite } from "@/lib/actions";
+import { ImageOff, ExternalLink, Star, Plus, X, Search } from "lucide-react";
+
+interface Product {
+    id: string;
+    name: string;
+    imageUrl: string | null;
+    price: number | string | null;
+    vendor: string | null;
+    vendorUrl: string | null;
+    category: string | null;
+}
+
+interface Favorite {
+    id: string;
+    productId: string;
+    addedByClient: boolean;
+    note: string | null;
+    product: Product;
+}
+
+function formatPrice(value: number | string | null | undefined): string | null {
+    if (value === null || value === undefined || value === "") return null;
+    const num = Number(value);
+    if (isNaN(num)) return null;
+    return num.toLocaleString("en-US", { style: "currency", currency: "USD" });
+}
+
+export default function ProjectFavoritesSection({
+    projectId,
+    initialFavorites,
+}: {
+    projectId: string;
+    initialFavorites: Favorite[];
+}) {
+    const [favorites, setFavorites] = useState<Favorite[]>(initialFavorites);
+    const [removingId, setRemovingId] = useState<string | null>(null);
+
+    // Add-from-library modal
+    const [showAdd, setShowAdd] = useState(false);
+    const [search, setSearch] = useState("");
+    const [results, setResults] = useState<Product[]>([]);
+    const [searching, setSearching] = useState(false);
+    const [addingId, setAddingId] = useState<string | null>(null);
+
+    const favoritedProductIds = new Set(favorites.map((f) => f.productId));
+
+    useEffect(() => {
+        if (!showAdd) return;
+        setSearching(true);
+        const handle = setTimeout(() => {
+            getProductLibrary(search.trim() ? { search: search.trim() } : undefined)
+                .then((items) => setResults(items as unknown as Product[]))
+                .catch(() => toast.error("Failed to load product library"))
+                .finally(() => setSearching(false));
+        }, 250);
+        return () => clearTimeout(handle);
+    }, [showAdd, search]);
+
+    async function handleRemove(favorite: Favorite) {
+        if (!confirm(`Remove "${favorite.product.name}" from this project's favorites?`)) return;
+        setRemovingId(favorite.id);
+        try {
+            await removeProjectFavorite(projectId, favorite.productId);
+            setFavorites((prev) => prev.filter((f) => f.id !== favorite.id));
+            toast.success("Removed from favorites");
+        } catch (e: any) {
+            toast.error(e.message || "Failed to remove");
+        } finally {
+            setRemovingId(null);
+        }
+    }
+
+    async function handleAdd(product: Product) {
+        setAddingId(product.id);
+        try {
+            const favorite = await addProjectFavorite(projectId, product.id);
+            setFavorites((prev) => [
+                { id: favorite.id, productId: product.id, addedByClient: false, note: favorite.note ?? null, product },
+                ...prev,
+            ]);
+            toast.success(`Added "${product.name}"`);
+        } catch (e: any) {
+            toast.error(e.message || "Failed to add");
+        } finally {
+            setAddingId(null);
+        }
+    }
+
+    return (
+        <div>
+            <div className="flex items-center justify-between mb-4">
+                <div>
+                    <h2 className="text-base font-semibold text-hui-textMain">Project Favorites</h2>
+                    <p className="text-sm text-hui-textMuted mt-1">Client-visible picks pinned to this project.</p>
+                </div>
+                <button onClick={() => setShowAdd(true)} className="hui-btn hui-btn-secondary text-sm flex items-center gap-1.5">
+                    <Plus className="w-4 h-4" />
+                    Add from Library
+                </button>
+            </div>
+
+            {favorites.length === 0 ? (
+                <div className="hui-card p-8 text-center">
+                    <div className="w-12 h-12 bg-slate-100 rounded-2xl flex items-center justify-center mx-auto mb-3">
+                        <Star className="w-6 h-6 text-slate-400" />
+                    </div>
+                    <p className="text-sm text-hui-textMuted">No favorites yet. Add one from the product library.</p>
+                </div>
+            ) : (
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                    {favorites.map((f) => {
+                        const price = formatPrice(f.product.price);
+                        return (
+                            <div key={f.id} className="hui-card overflow-hidden group relative flex flex-col">
+                                <div className="h-32 bg-gradient-to-br from-slate-100 to-slate-200 flex items-center justify-center overflow-hidden">
+                                    {f.product.imageUrl ? (
+                                        <img src={f.product.imageUrl} alt={f.product.name} className="w-full h-full object-cover" />
+                                    ) : (
+                                        <ImageOff className="w-7 h-7 text-slate-300" />
+                                    )}
+                                </div>
+                                <button
+                                    onClick={() => handleRemove(f)}
+                                    disabled={removingId === f.id}
+                                    title="Remove from favorites"
+                                    aria-label="Remove from favorites"
+                                    className="absolute top-2 right-2 w-7 h-7 rounded-lg bg-white/90 backdrop-blur shadow flex items-center justify-center text-slate-500 hover:text-red-600 transition opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto"
+                                >
+                                    <X className="w-3.5 h-3.5" />
+                                </button>
+                                <div className="p-3 flex-1 flex flex-col">
+                                    <div className="flex items-start justify-between gap-2">
+                                        <h3 className="text-sm font-semibold text-hui-textMain line-clamp-2">{f.product.name}</h3>
+                                        {price && <span className="text-sm font-bold text-hui-primary whitespace-nowrap">{price}</span>}
+                                    </div>
+                                    {f.product.vendor && <p className="text-xs text-hui-textMuted mt-0.5">{f.product.vendor}</p>}
+                                    {f.addedByClient && (
+                                        <span className="inline-block w-fit text-[10px] font-semibold uppercase tracking-wider text-green-700 bg-green-100 rounded-full px-2 py-0.5 mt-2">
+                                            From client suggestion
+                                        </span>
+                                    )}
+                                    <div className="flex-1" />
+                                    {f.product.vendorUrl && (
+                                        <a
+                                            href={f.product.vendorUrl}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="text-xs text-blue-600 hover:underline flex items-center gap-1 mt-2"
+                                        >
+                                            <ExternalLink className="w-3 h-3" />
+                                            Source
+                                        </a>
+                                    )}
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+
+            {/* Add from library modal */}
+            {showAdd && (
+                <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4" onClick={() => setShowAdd(false)}>
+                    <div
+                        className="bg-white rounded-xl shadow-2xl max-w-lg w-full max-h-[80vh] flex flex-col"
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        <div className="px-6 py-4 border-b border-hui-border flex items-center justify-between">
+                            <h3 className="text-lg font-bold text-hui-textMain">Add from Product Library</h3>
+                            <button onClick={() => setShowAdd(false)} aria-label="Close" className="text-hui-textMuted hover:text-hui-textMain">
+                                <X className="w-5 h-5" />
+                            </button>
+                        </div>
+                        <div className="p-4 border-b border-hui-border">
+                            <div className="relative">
+                                <Search className="w-4 h-4 text-hui-textMuted absolute left-3 top-1/2 -translate-y-1/2" />
+                                <input
+                                    type="text"
+                                    placeholder="Search products, vendors, categories..."
+                                    value={search}
+                                    onChange={(e) => setSearch(e.target.value)}
+                                    className="hui-input w-full pl-9"
+                                    autoFocus
+                                />
+                            </div>
+                        </div>
+                        <div className="overflow-y-auto flex-1 divide-y divide-slate-100">
+                            {searching ? (
+                                <p className="text-sm text-hui-textMuted text-center py-8">Searching...</p>
+                            ) : results.length === 0 ? (
+                                <p className="text-sm text-hui-textMuted text-center py-8">No products found.</p>
+                            ) : (
+                                results.map((product) => {
+                                    const already = favoritedProductIds.has(product.id);
+                                    const price = formatPrice(product.price);
+                                    return (
+                                        <div key={product.id} className="flex items-center gap-3 p-3">
+                                            <div className="w-12 h-12 rounded-lg bg-slate-100 flex items-center justify-center overflow-hidden shrink-0">
+                                                {product.imageUrl ? (
+                                                    <img src={product.imageUrl} alt={product.name} className="w-full h-full object-cover" />
+                                                ) : (
+                                                    <ImageOff className="w-4 h-4 text-slate-300" />
+                                                )}
+                                            </div>
+                                            <div className="flex-1 min-w-0">
+                                                <p className="text-sm font-medium text-hui-textMain truncate">{product.name}</p>
+                                                <p className="text-xs text-hui-textMuted">
+                                                    {product.vendor || "—"}{price ? ` · ${price}` : ""}
+                                                </p>
+                                            </div>
+                                            <button
+                                                onClick={() => handleAdd(product)}
+                                                disabled={already || addingId === product.id}
+                                                className="hui-btn hui-btn-secondary text-xs px-3 py-1.5 disabled:opacity-50 shrink-0"
+                                            >
+                                                {already ? "Added" : addingId === product.id ? "Adding..." : "Add"}
+                                            </button>
+                                        </div>
+                                    );
+                                })
+                            )}
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/app/projects/[id]/selections/ProjectFavoritesSection.tsx
+++ b/src/app/projects/[id]/selections/ProjectFavoritesSection.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { getProductLibrary, addProjectFavorite, removeProjectFavorite } from "@/lib/actions";
+import { isHttpUrl } from "@/lib/url-safety";
 import { ImageOff, ExternalLink, Star, Plus, X, Search } from "lucide-react";
 
 interface Product {
@@ -118,7 +119,7 @@ export default function ProjectFavoritesSection({
                         return (
                             <div key={f.id} className="hui-card overflow-hidden group relative flex flex-col">
                                 <div className="h-32 bg-gradient-to-br from-slate-100 to-slate-200 flex items-center justify-center overflow-hidden">
-                                    {f.product.imageUrl ? (
+                                    {isHttpUrl(f.product.imageUrl) ? (
                                         <img src={f.product.imageUrl} alt={f.product.name} className="w-full h-full object-cover" />
                                     ) : (
                                         <ImageOff className="w-7 h-7 text-slate-300" />
@@ -145,7 +146,7 @@ export default function ProjectFavoritesSection({
                                         </span>
                                     )}
                                     <div className="flex-1" />
-                                    {f.product.vendorUrl && (
+                                    {isHttpUrl(f.product.vendorUrl) && (
                                         <a
                                             href={f.product.vendorUrl}
                                             target="_blank"
@@ -201,7 +202,7 @@ export default function ProjectFavoritesSection({
                                     return (
                                         <div key={product.id} className="flex items-center gap-3 p-3">
                                             <div className="w-12 h-12 rounded-lg bg-slate-100 flex items-center justify-center overflow-hidden shrink-0">
-                                                {product.imageUrl ? (
+                                                {isHttpUrl(product.imageUrl) ? (
                                                     <img src={product.imageUrl} alt={product.name} className="w-full h-full object-cover" />
                                                 ) : (
                                                     <ImageOff className="w-4 h-4 text-slate-300" />

--- a/src/app/projects/[id]/selections/page.tsx
+++ b/src/app/projects/[id]/selections/page.tsx
@@ -1,9 +1,34 @@
-import { getSelectionBoards } from "@/lib/actions";
+import { getSelectionBoards, getSelectionProposals, getProjectFavorites } from "@/lib/actions";
 import SelectionsClient from "./SelectionsClient";
+import ClientSuggestions from "./ClientSuggestions";
+import ProjectFavoritesSection from "./ProjectFavoritesSection";
 
 export default async function SelectionsPage(props: { params: Promise<{ id: string }> }) {
     const { id } = await props.params;
-    const boards = await getSelectionBoards(id);
+    const [boards, proposals, favorites] = await Promise.all([
+        getSelectionBoards(id),
+        getSelectionProposals(id),
+        getProjectFavorites(id),
+    ]);
 
-    return <SelectionsClient projectId={id} initialBoards={JSON.parse(JSON.stringify(boards))} />;
+    const boardsJson = JSON.parse(JSON.stringify(boards));
+
+    return (
+        <>
+            <SelectionsClient projectId={id} initialBoards={boardsJson} />
+            <div className="max-w-5xl mx-auto mt-10">
+                <ClientSuggestions
+                    projectId={id}
+                    initialProposals={JSON.parse(JSON.stringify(proposals))}
+                    boards={boardsJson}
+                />
+            </div>
+            <div className="max-w-5xl mx-auto mt-10">
+                <ProjectFavoritesSection
+                    projectId={id}
+                    initialFavorites={JSON.parse(JSON.stringify(favorites))}
+                />
+            </div>
+        </>
+    );
 }

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -28,9 +28,13 @@ export default function AppLayout({ children, logoUrl }: { children: React.React
     const status = isDevMock ? 'authenticated' : sessionStatus;
     const role = (session?.user as any)?.role;
 
+    // /clip is the bookmarklet capture popup — team-authed but rendered bare
+    // (no sidebar/header) since it opens in a 480x720 window.push chrome-less
+    // popup. Auth itself is still enforced by the page's own server-side
+    // getSessionOrDev() + redirect("/login"), same as every other team page.
     useEffect(() => {
         if (status === 'authenticated') {
-            const isPublicRoute = pathname?.startsWith('/portal') || pathname?.startsWith('/sub-portal') || pathname?.startsWith('/share') || pathname === '/login';
+            const isPublicRoute = pathname?.startsWith('/portal') || pathname?.startsWith('/sub-portal') || pathname?.startsWith('/share') || pathname === '/login' || pathname === '/clip';
 
             // If an authenticated user suddenly has no role, they were likely deleted.
             // Force sign out to clear the stale session so they can try again.
@@ -44,14 +48,14 @@ export default function AppLayout({ children, logoUrl }: { children: React.React
             }
         }
         if (status === 'unauthenticated' && process.env.NODE_ENV !== 'development') { // Bypass only if NOT in development
-            const isPublicRoute = pathname?.startsWith('/portal') || pathname?.startsWith('/sub-portal') || pathname?.startsWith('/share') || pathname === '/login';
+            const isPublicRoute = pathname?.startsWith('/portal') || pathname?.startsWith('/sub-portal') || pathname?.startsWith('/share') || pathname === '/login' || pathname === '/clip';
             if (!isPublicRoute) {
                 router.replace('/login');
             }
         }
     }, [status, role, pathname, router, session]);
 
-    const isPublicRoute = pathname?.startsWith('/portal') || pathname?.startsWith('/sub-portal') || pathname?.startsWith('/share') || pathname === '/login';
+    const isPublicRoute = pathname?.startsWith('/portal') || pathname?.startsWith('/sub-portal') || pathname?.startsWith('/share') || pathname === '/login' || pathname === '/clip';
 
     if (status === 'authenticated' && !role && !isPublicRoute) {
         return <div className="min-h-screen bg-hui-background flex items-center justify-center text-slate-500">Signing out...</div>;

--- a/src/components/PortalFileBrowser.tsx
+++ b/src/components/PortalFileBrowser.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
+import { toast } from "sonner";
 
 type FileRecord = {
     id: string;
@@ -9,6 +10,7 @@ type FileRecord = {
     size: number;
     mimeType: string;
     createdAt: string;
+    uploadedByClient: boolean;
 };
 
 type FolderRecord = {
@@ -46,6 +48,9 @@ export default function PortalFileBrowser({ projectId }: { projectId: string }) 
     const [viewMode, setViewMode] = useState<"grid" | "list">("list");
     const [previewFile, setPreviewFile] = useState<FileRecord | null>(null);
     const [loaded, setLoaded] = useState(false);
+    const [uploading, setUploading] = useState(false);
+    const [dragOver, setDragOver] = useState(false);
+    const fileInputRef = useRef<HTMLInputElement>(null);
 
     const fetchFiles = useCallback(async (folderId: string | null = currentFolder) => {
         const params = new URLSearchParams({ projectId });
@@ -77,6 +82,39 @@ export default function PortalFileBrowser({ projectId }: { projectId: string }) 
         fetchFiles(folderId);
     }
 
+    async function uploadFiles(fileList: FileList | File[]) {
+        const toUpload = Array.from(fileList);
+        if (toUpload.length === 0) return;
+        setUploading(true);
+        let successCount = 0;
+        for (const file of toUpload) {
+            const formData = new FormData();
+            formData.append("projectId", projectId);
+            if (currentFolder) formData.append("folderId", currentFolder);
+            formData.append("file", file);
+            try {
+                const res = await fetch("/api/portal/files", { method: "POST", body: formData });
+                const data = await res.json().catch(() => ({}));
+                if (!res.ok) throw new Error(data.error || "Upload failed");
+                successCount++;
+            } catch (e: any) {
+                toast.error(`${file.name}: ${e.message || "Upload failed"}`);
+            }
+        }
+        setUploading(false);
+        if (fileInputRef.current) fileInputRef.current.value = "";
+        if (successCount > 0) {
+            toast.success(successCount === 1 ? "File uploaded" : `${successCount} files uploaded`);
+            fetchFiles(currentFolder);
+        }
+    }
+
+    function handleDrop(e: React.DragEvent) {
+        e.preventDefault();
+        setDragOver(false);
+        if (e.dataTransfer.files?.length) uploadFiles(e.dataTransfer.files);
+    }
+
     const isEmpty = folders.length === 0 && files.length === 0;
 
     return (
@@ -92,13 +130,29 @@ export default function PortalFileBrowser({ projectId }: { projectId: string }) 
                         <p className="text-sm text-hui-textMuted">{files.length} file{files.length !== 1 ? "s" : ""}</p>
                     </div>
                 </div>
-                <div className="flex items-center gap-1 bg-slate-100 p-1 rounded-lg">
-                    <button onClick={() => setViewMode("grid")} aria-label="Grid view" title="Grid view" className={`p-1.5 rounded-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${viewMode === "grid" ? "bg-white shadow-sm" : "text-slate-400 hover:text-slate-600"}`}>
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+                <div className="flex items-center gap-3">
+                    <div className="flex items-center gap-1 bg-slate-100 p-1 rounded-lg">
+                        <button onClick={() => setViewMode("grid")} aria-label="Grid view" title="Grid view" className={`p-1.5 rounded-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${viewMode === "grid" ? "bg-white shadow-sm" : "text-slate-400 hover:text-slate-600"}`}>
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+                        </button>
+                        <button onClick={() => setViewMode("list")} aria-label="List view" title="List view" className={`p-1.5 rounded-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${viewMode === "list" ? "bg-white shadow-sm" : "text-slate-400 hover:text-slate-600"}`}>
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/></svg>
+                        </button>
+                    </div>
+                    <button
+                        onClick={() => fileInputRef.current?.click()}
+                        disabled={uploading}
+                        className="hui-btn hui-btn-green disabled:opacity-50"
+                    >
+                        {uploading ? "Uploading…" : "Upload a file"}
                     </button>
-                    <button onClick={() => setViewMode("list")} aria-label="List view" title="List view" className={`p-1.5 rounded-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${viewMode === "list" ? "bg-white shadow-sm" : "text-slate-400 hover:text-slate-600"}`}>
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/></svg>
-                    </button>
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        multiple
+                        className="hidden"
+                        onChange={(e) => { if (e.target.files?.length) uploadFiles(e.target.files); }}
+                    />
                 </div>
             </div>
 
@@ -116,6 +170,29 @@ export default function PortalFileBrowser({ projectId }: { projectId: string }) 
                         </button>
                     </div>
                 ))}
+            </div>
+
+            {/* Upload dropzone */}
+            <div
+                onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+                onDragLeave={() => setDragOver(false)}
+                onDrop={handleDrop}
+                className={`mb-6 rounded-xl border-2 border-dashed px-4 py-5 text-center transition ${dragOver ? "border-blue-400 bg-blue-50/50" : "border-slate-200 bg-slate-50/50"}`}
+            >
+                <p className="text-sm font-medium text-hui-textMain">
+                    Drag files here, or{" "}
+                    <button
+                        type="button"
+                        onClick={() => fileInputRef.current?.click()}
+                        disabled={uploading}
+                        className="text-blue-600 hover:text-blue-800 font-semibold underline underline-offset-2 disabled:opacity-50"
+                    >
+                        browse
+                    </button>
+                </p>
+                <p className="text-xs text-hui-textMuted mt-1">
+                    Drawings, PDFs, and photos from your designer land in the shared Design Files folder.
+                </p>
             </div>
 
             {/* Empty State */}
@@ -171,7 +248,12 @@ export default function PortalFileBrowser({ projectId }: { projectId: string }) 
                                         )}
                                     </div>
                                     <div className="p-3">
-                                        <a href={file.url} target="_blank" rel="noreferrer" className="text-xs font-semibold text-hui-textMain hover:text-blue-600 truncate block transition">{file.name}</a>
+                                        <div className="flex items-center gap-1.5">
+                                            <a href={file.url} target="_blank" rel="noreferrer" className="text-xs font-semibold text-hui-textMain hover:text-blue-600 truncate block transition">{file.name}</a>
+                                            {file.uploadedByClient && (
+                                                <span className="shrink-0 text-[9px] font-bold uppercase tracking-wide text-emerald-700 bg-emerald-50 px-1.5 py-0.5 rounded-full">From you</span>
+                                            )}
+                                        </div>
                                         <div className="flex items-center justify-between mt-1">
                                             <span className="text-[10px] text-slate-400">{formatBytes(file.size)}</span>
                                             <span className="text-[10px] text-slate-400">{new Date(file.createdAt).toLocaleDateString()}</span>
@@ -192,7 +274,12 @@ export default function PortalFileBrowser({ projectId }: { projectId: string }) 
                                         )}
                                     </div>
                                     <div className="flex-1 min-w-0">
-                                        <a href={file.url} target="_blank" rel="noreferrer" className="text-sm font-medium text-hui-textMain hover:text-blue-600 truncate block transition">{file.name}</a>
+                                        <div className="flex items-center gap-1.5">
+                                            <a href={file.url} target="_blank" rel="noreferrer" className="text-sm font-medium text-hui-textMain hover:text-blue-600 truncate block transition">{file.name}</a>
+                                            {file.uploadedByClient && (
+                                                <span className="shrink-0 text-[9px] font-bold uppercase tracking-wide text-emerald-700 bg-emerald-50 px-1.5 py-0.5 rounded-full">From you</span>
+                                            )}
+                                        </div>
                                         <p className="text-[10px] text-slate-400">{formatBytes(file.size)}</p>
                                     </div>
                                     <span className="text-[10px] text-slate-400 shrink-0">{new Date(file.createdAt).toLocaleDateString()}</span>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -9752,9 +9752,18 @@ export async function decideSelectionProposal(proposalId: string, input: {
         // Never touches SelectionBoard.status — approving a suggestion must not
         // silently flip a board back to an earlier lifecycle state.
         if (input.boardId && input.categoryId) {
-            const category = await prisma.selectionCategory.findFirst({
-                where: { id: input.categoryId, boardId: input.boardId },
+            // Verify the board itself belongs to this proposal's project — without
+            // this, a staff user scoped to project A could pass a boardId from
+            // project B and write a SelectionOption into another project's board.
+            const board = await prisma.selectionBoard.findFirst({
+                where: { id: input.boardId, projectId: proposal.projectId },
+                select: { id: true },
             });
+            const category = board
+                ? await prisma.selectionCategory.findFirst({
+                    where: { id: input.categoryId, boardId: input.boardId },
+                })
+                : null;
             if (category) {
                 const maxOrder = await prisma.selectionOption.aggregate({
                     where: { categoryId: input.categoryId },

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -12,6 +12,7 @@ import { formatCurrency } from "./utils";
 import { createHash, createHmac, timingSafeEqual } from "crypto";
 import { resolveSessionClientId } from "./portal-auth";
 import { persistSignature } from "./signature-storage";
+import { parseProductUrl } from "./product-parse";
 import { canUseDevAuthFallback, getCurrentUserWithPermissions, hasPermission, canAccessProject } from "./permissions";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { enqueueMilestonePaid, drainPaymentNotifications } from "./payment-outbox";
@@ -9420,6 +9421,401 @@ export async function getSelectionBoardsForPortal(projectId: string) {
     });
 }
 
+// =============================================
+// Product Library, Clipper, Client Selection Proposals
+// (docs/specs/product-library-portal-selections.md)
+// =============================================
+
+/**
+ * Ownership assertion for the portal-facing product-library actions below.
+ * Mirrors the staff-bypass + resolveSessionClientId + project-ownership check
+ * used inline by /api/portal/files and the portal selections/files pages —
+ * pulled into one helper since several new portal actions need it.
+ */
+async function assertPortalProjectOwnership(projectId: string): Promise<{ isStaff: boolean; clientId: string | null }> {
+    const session = await getSessionOrDev();
+    const role = (session?.user as { role?: string } | undefined)?.role;
+    const isStaff = role === "ADMIN" || role === "MANAGER";
+    if (isStaff) return { isStaff: true, clientId: null };
+
+    const clientId = await resolveSessionClientId();
+    if (!clientId) throw new Error("Unauthorized");
+    const project = await prisma.project.findFirst({ where: { id: projectId, clientId }, select: { id: true } });
+    if (!project) throw new Error("Unauthorized");
+    return { isStaff: false, clientId };
+}
+
+// ── Product Library CRUD (team) ─────────────────────────────────────────────
+
+export async function createProductLibraryItem(data: {
+    name: string;
+    description?: string;
+    imageUrl?: string;
+    price?: number;
+    vendor?: string;
+    vendorUrl?: string;
+    category?: string;
+    source?: "clip" | "manual";
+}) {
+    const user = await assertActiveStaff();
+    const name = data.name?.trim();
+    if (!name) throw new Error("Name is required");
+
+    const item = await prisma.productLibraryItem.create({
+        data: {
+            name,
+            description: data.description?.trim() || null,
+            imageUrl: data.imageUrl || null,
+            price: data.price ?? null,
+            vendor: data.vendor?.trim() || null,
+            vendorUrl: data.vendorUrl || null,
+            category: data.category?.trim() || null,
+            source: data.source || "manual",
+            clippedById: user.id,
+        },
+    });
+    revalidatePath("/company/product-library");
+    return item;
+}
+
+export async function updateProductLibraryItem(id: string, data: {
+    name?: string;
+    description?: string;
+    imageUrl?: string;
+    price?: number;
+    vendor?: string;
+    vendorUrl?: string;
+    category?: string;
+}) {
+    await assertActiveStaff();
+    const item = await prisma.productLibraryItem.update({
+        where: { id },
+        data: {
+            ...(data.name !== undefined && { name: data.name.trim() }),
+            ...(data.description !== undefined && { description: data.description?.trim() || null }),
+            ...(data.imageUrl !== undefined && { imageUrl: data.imageUrl || null }),
+            ...(data.price !== undefined && { price: data.price }),
+            ...(data.vendor !== undefined && { vendor: data.vendor?.trim() || null }),
+            ...(data.vendorUrl !== undefined && { vendorUrl: data.vendorUrl || null }),
+            ...(data.category !== undefined && { category: data.category?.trim() || null }),
+        },
+    });
+    revalidatePath("/company/product-library");
+    return item;
+}
+
+export async function deleteProductLibraryItem(id: string) {
+    await assertActiveStaff();
+    await prisma.productLibraryItem.delete({ where: { id } });
+    revalidatePath("/company/product-library");
+    return { success: true };
+}
+
+export async function getProductLibrary(filter?: { search?: string; category?: string }) {
+    await assertActiveStaff();
+    const where: any = {};
+    if (filter?.category) where.category = filter.category;
+    if (filter?.search?.trim()) {
+        const q = filter.search.trim();
+        where.OR = [
+            { name: { contains: q, mode: "insensitive" } },
+            { vendor: { contains: q, mode: "insensitive" } },
+            { category: { contains: q, mode: "insensitive" } },
+        ];
+    }
+    return prisma.productLibraryItem.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+    });
+}
+
+// ── Project Favorites (team + portal read) ──────────────────────────────────
+
+export async function addProjectFavorite(projectId: string, productId: string, note?: string) {
+    const user = await assertActiveStaff();
+    if (!canAccessProject(user, projectId)) throw new Error("Forbidden");
+    const favorite = await prisma.projectProductFavorite.upsert({
+        where: { projectId_productId: { projectId, productId } },
+        update: { note: note?.trim() || null },
+        create: { projectId, productId, note: note?.trim() || null, addedById: user.id, addedByClient: false },
+    });
+    revalidatePath(`/projects/${projectId}/selections`);
+    return favorite;
+}
+
+export async function removeProjectFavorite(projectId: string, productId: string) {
+    const user = await assertActiveStaff();
+    if (!canAccessProject(user, projectId)) throw new Error("Forbidden");
+    await prisma.projectProductFavorite.deleteMany({ where: { projectId, productId } });
+    revalidatePath(`/projects/${projectId}/selections`);
+    return { success: true };
+}
+
+export async function getProjectFavorites(projectId: string) {
+    const user = await assertActiveStaff();
+    if (!canAccessProject(user, projectId)) throw new Error("Forbidden");
+    return prisma.projectProductFavorite.findMany({
+        where: { projectId },
+        orderBy: { createdAt: "desc" },
+        include: { product: true },
+    });
+}
+
+export async function getProjectFavoritesForPortal(projectId: string) {
+    await assertPortalProjectOwnership(projectId);
+    return prisma.projectProductFavorite.findMany({
+        where: { projectId },
+        orderBy: { createdAt: "desc" },
+        include: { product: true },
+    });
+}
+
+// ── Client Selection Proposals ("Client suggestions") ───────────────────────
+
+export async function submitSelectionProposal(projectId: string, data: {
+    url?: string;
+    name: string;
+    description?: string;
+    imageUrl?: string;
+    clientNote?: string;
+}) {
+    await assertPortalProjectOwnership(projectId);
+
+    const manualName = data.name?.trim();
+    const url = data.url?.trim();
+    if (!manualName && !url) throw new Error("A name or a product link is required");
+
+    // Parse server-side so price is captured even though it's never returned
+    // to the client here. Never throws — degrades to {vendorUrl, name: null}.
+    let parsed: Awaited<ReturnType<typeof parseProductUrl>> | null = null;
+    if (url) {
+        parsed = await parseProductUrl(url);
+    }
+
+    const name = (manualName || parsed?.name || "Suggested item").slice(0, 200);
+
+    const proposal = await prisma.selectionProposal.create({
+        data: {
+            projectId,
+            name,
+            description: data.description?.trim() || parsed?.description || null,
+            imageUrl: data.imageUrl || parsed?.imageUrl || null,
+            price: parsed?.price ?? null,
+            vendorUrl: url || parsed?.vendorUrl || null,
+            clientNote: data.clientNote?.trim() || null,
+            status: "Pending",
+        },
+    });
+
+    const project = await prisma.project.findUnique({ where: { id: projectId }, include: { client: true } });
+
+    // Notify the team — same recipient/pattern as submitClientSelections.
+    const settings = await getCachedCompanySettings();
+    if (settings.notificationEmail && project) {
+        await sendNotification(
+            settings.notificationEmail,
+            `💡 New Client Suggestion — ${project.name}`,
+            `<div style="font-family: sans-serif; color: #333;">
+                <h3>New Selection Suggestion</h3>
+                <p><strong>${project.client?.name || "Client"}</strong> suggested an item for project <strong>${project.name}</strong>:</p>
+                <ul>
+                    <li><strong>${name}</strong></li>
+                    ${proposal.vendorUrl ? `<li><a href="${proposal.vendorUrl}">${proposal.vendorUrl}</a></li>` : ""}
+                    ${proposal.clientNote ? `<li>Note: ${proposal.clientNote}</li>` : ""}
+                </ul>
+                <p>Review it on the project's Selections tab.</p>
+            </div>`
+        );
+    }
+
+    await logActivity({
+        projectId,
+        actorType: "CLIENT",
+        actorName: project?.client?.name || "Client",
+        action: "suggested_selection_item",
+        entityType: "SelectionProposal",
+        entityId: proposal.id,
+        entityName: name,
+    });
+
+    revalidatePath(`/portal/projects/${projectId}/selections`);
+    revalidatePath(`/projects/${projectId}/selections`);
+
+    // Price is PM-side info until approval — never return it to the client.
+    const { price, ...proposalWithoutPrice } = proposal;
+    return proposalWithoutPrice;
+}
+
+export async function getSelectionProposalsForPortal(projectId: string) {
+    await assertPortalProjectOwnership(projectId);
+    const proposals = await prisma.selectionProposal.findMany({
+        where: { projectId },
+        orderBy: { createdAt: "desc" },
+    });
+    // Price stays hidden until a proposal is Approved.
+    return proposals.map((p) => (p.status === "Approved" ? p : { ...p, price: null }));
+}
+
+export async function getSelectionProposals(projectId: string) {
+    const user = await assertActiveStaff();
+    if (!canAccessProject(user, projectId)) throw new Error("Forbidden");
+    return prisma.selectionProposal.findMany({
+        where: { projectId },
+        orderBy: { createdAt: "desc" },
+        include: { decidedBy: { select: { id: true, name: true, email: true } } },
+    });
+}
+
+export async function decideSelectionProposal(proposalId: string, input: {
+    action: "approve" | "decline";
+    pmNote?: string;
+    price?: number;
+    boardId?: string;
+    categoryId?: string;
+    addToFavorites?: boolean;
+}) {
+    const user = await assertActiveStaff();
+    if (input.action !== "approve" && input.action !== "decline") throw new Error("Invalid action");
+
+    const proposal = await prisma.selectionProposal.findUnique({
+        where: { id: proposalId },
+        include: { project: { include: { client: true } } },
+    });
+    if (!proposal) throw new Error("Proposal not found");
+    if (!canAccessProject(user, proposal.projectId)) throw new Error("Forbidden");
+
+    const newStatus = input.action === "approve" ? "Approved" : "Declined";
+    const decidedAt = new Date();
+    const pmNote = input.pmNote?.trim() || null;
+
+    // Status CAS: only a Pending proposal transitions. A duplicate decide call
+    // (double-click, retried request) matches zero rows and no-ops instead of
+    // re-deciding or minting a second ProductLibraryItem/favorite/option.
+    const claim = await prisma.selectionProposal.updateMany({
+        where: { id: proposalId, status: "Pending" },
+        data: {
+            status: newStatus,
+            pmNote,
+            decidedById: user.id,
+            decidedAt,
+            ...(input.action === "approve" ? {
+                price: input.price ?? proposal.price ?? null,
+                boardId: input.boardId || null,
+                categoryId: input.categoryId || null,
+            } : {}),
+        },
+    });
+    if (claim.count === 0) {
+        return { success: false, alreadyDecided: true };
+    }
+
+    let productId: string | null = null;
+    let favoriteCreated = false;
+    let optionCreated = false;
+
+    if (input.action === "approve") {
+        const product = await prisma.productLibraryItem.create({
+            data: {
+                name: proposal.name,
+                description: proposal.description,
+                imageUrl: proposal.imageUrl,
+                price: input.price ?? proposal.price ?? null,
+                vendorUrl: proposal.vendorUrl,
+                source: "client_proposal",
+                clippedById: user.id,
+            },
+        });
+        productId = product.id;
+
+        await prisma.selectionProposal.update({
+            where: { id: proposalId },
+            data: { productId: product.id },
+        });
+
+        // Default true per spec — approving a suggestion pins it to the
+        // project's client-visible Favorites list unless explicitly opted out.
+        if (input.addToFavorites !== false) {
+            await prisma.projectProductFavorite.upsert({
+                where: { projectId_productId: { projectId: proposal.projectId, productId: product.id } },
+                update: {},
+                create: {
+                    projectId: proposal.projectId,
+                    productId: product.id,
+                    addedById: null,
+                    addedByClient: true,
+                },
+            });
+            favoriteCreated = true;
+        }
+
+        // Optional: also drop it into a board category as a pickable option.
+        // Never touches SelectionBoard.status — approving a suggestion must not
+        // silently flip a board back to an earlier lifecycle state.
+        if (input.boardId && input.categoryId) {
+            const category = await prisma.selectionCategory.findFirst({
+                where: { id: input.categoryId, boardId: input.boardId },
+            });
+            if (category) {
+                const maxOrder = await prisma.selectionOption.aggregate({
+                    where: { categoryId: input.categoryId },
+                    _max: { order: true },
+                });
+                await prisma.selectionOption.create({
+                    data: {
+                        categoryId: input.categoryId,
+                        name: proposal.name,
+                        description: proposal.description,
+                        imageUrl: proposal.imageUrl,
+                        price: input.price ?? proposal.price ?? null,
+                        vendorUrl: proposal.vendorUrl,
+                        order: (maxOrder._max.order ?? -1) + 1,
+                    },
+                });
+                optionCreated = true;
+            }
+        }
+    }
+
+    // Notify the client of the decision — same portal-link email pattern as
+    // sendSelectionBoardToClient.
+    const clientEmail = proposal.project.client?.email;
+    if (clientEmail) {
+        const settings = await getCachedCompanySettings();
+        const { buildClientPortalUrl } = await import("./client-portal-auth");
+        const portalUrl = await buildClientPortalUrl(proposal.project.clientId, clientEmail, `/portal/projects/${proposal.projectId}/selections`);
+        const cc = buildCc(clientEmail, (proposal.project.client as any)?.additionalEmail);
+        const isApproved = input.action === "approve";
+        await sendNotification(
+            clientEmail,
+            isApproved ? `✅ Your suggestion was approved — ${proposal.project.name}` : `Update on your suggestion — ${proposal.project.name}`,
+            `<div style="font-family: sans-serif; color: #333;">
+                <h2>${isApproved ? "Your Suggestion Was Approved" : "Update on Your Suggestion"}</h2>
+                <p>Hi ${proposal.project.client?.name || "there"},</p>
+                <p>Your suggested item "<strong>${proposal.name}</strong>" for <strong>${proposal.project.name}</strong> ${isApproved ? "has been approved and added to your project." : "was not approved this time."}</p>
+                ${pmNote ? `<p style="color:#555;">Note from your project manager: "${pmNote}"</p>` : ""}
+                <p><a href="${portalUrl}" style="display:inline-block;padding:12px 24px;background:#4c9a2a;color:#fff;text-decoration:none;border-radius:6px;font-weight:bold;">View Selections</a></p>
+                <p style="color:#666;font-size:13px;">— ${settings.companyName || "Your Project Team"}</p>
+            </div>`,
+            undefined,
+            { cc, copyToInternal: true }
+        );
+    }
+
+    await logActivity({
+        projectId: proposal.projectId,
+        actorType: "TEAM",
+        actorName: user.name || user.email,
+        action: input.action === "approve" ? "approved_selection_suggestion" : "declined_selection_suggestion",
+        entityType: "SelectionProposal",
+        entityId: proposal.id,
+        entityName: proposal.name,
+    });
+
+    revalidatePath(`/projects/${proposal.projectId}/selections`);
+    revalidatePath(`/portal/projects/${proposal.projectId}/selections`);
+
+    return { success: true, status: newStatus, productId, favoriteCreated, optionCreated };
+}
 
 // =============================================
 // Daily Logs CRUD

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -13,6 +13,7 @@ import { createHash, createHmac, timingSafeEqual } from "crypto";
 import { resolveSessionClientId } from "./portal-auth";
 import { persistSignature } from "./signature-storage";
 import { parseProductUrl } from "./product-parse";
+import { isHttpUrl } from "./url-safety";
 import { canUseDevAuthFallback, getCurrentUserWithPermissions, hasPermission, canAccessProject } from "./permissions";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { enqueueMilestonePaid, drainPaymentNotifications } from "./payment-outbox";
@@ -9427,12 +9428,20 @@ export async function getSelectionBoardsForPortal(projectId: string) {
 // =============================================
 
 /**
- * Ownership assertion for the portal-facing product-library actions below.
- * Mirrors the staff-bypass + resolveSessionClientId + project-ownership check
- * used inline by /api/portal/files and the portal selections/files pages —
- * pulled into one helper since several new portal actions need it.
+ * Ownership + visibility assertion for the portal-facing product-library
+ * actions below (all gated on the Selections tab: proposals and favorites).
+ * Mirrors the exact check order the portal selections page.tsx and
+ * /api/portal/files route use — visibility gate first, applied uniformly to
+ * staff AND client (no staff bypass here, matching how this feature area's
+ * own pages/routes read PortalVisibility; that's a different convention from
+ * assertPortalProjectAccessCore's staff-bypass, which is scoped to the
+ * schedule/daily-logs areas) — then staff-bypass + resolveSessionClientId +
+ * project-ownership for the client path.
  */
 async function assertPortalProjectOwnership(projectId: string): Promise<{ isStaff: boolean; clientId: string | null }> {
+    const visibility = await getPortalVisibility(projectId);
+    if (!visibility.isPortalEnabled || !visibility.showSelections) throw new Error("Unauthorized");
+
     const session = await getSessionOrDev();
     const role = (session?.user as { role?: string } | undefined)?.role;
     const isStaff = role === "ADMIN" || role === "MANAGER";
@@ -9443,6 +9452,17 @@ async function assertPortalProjectOwnership(projectId: string): Promise<{ isStaf
     const project = await prisma.project.findFirst({ where: { id: projectId, clientId }, select: { id: true } });
     if (!project) throw new Error("Unauthorized");
     return { isStaff: false, clientId };
+}
+
+/** Persist boundary for any stored vendorUrl/imageUrl: only a plain http(s)
+ * URL is ever written — a scraped page, Gemini's output, or a client-typed
+ * "Photo URL" field could otherwise smuggle a javascript:/data: URL into the
+ * DB, which would execute if a render site ever put it straight into href/img
+ * src. Render sites additionally guard with the same isHttpUrl() check
+ * (belt-and-suspenders — see ClientSuggestions.tsx etc.), but nothing unsafe
+ * should reach the database in the first place. */
+function safeUrlOrNull(url: string | null | undefined): string | null {
+    return isHttpUrl(url) ? url : null;
 }
 
 // ── Product Library CRUD (team) ─────────────────────────────────────────────
@@ -9465,10 +9485,10 @@ export async function createProductLibraryItem(data: {
         data: {
             name,
             description: data.description?.trim() || null,
-            imageUrl: data.imageUrl || null,
+            imageUrl: safeUrlOrNull(data.imageUrl),
             price: data.price ?? null,
             vendor: data.vendor?.trim() || null,
-            vendorUrl: data.vendorUrl || null,
+            vendorUrl: safeUrlOrNull(data.vendorUrl),
             category: data.category?.trim() || null,
             source: data.source || "manual",
             clippedById: user.id,
@@ -9493,10 +9513,10 @@ export async function updateProductLibraryItem(id: string, data: {
         data: {
             ...(data.name !== undefined && { name: data.name.trim() }),
             ...(data.description !== undefined && { description: data.description?.trim() || null }),
-            ...(data.imageUrl !== undefined && { imageUrl: data.imageUrl || null }),
+            ...(data.imageUrl !== undefined && { imageUrl: safeUrlOrNull(data.imageUrl) }),
             ...(data.price !== undefined && { price: data.price }),
             ...(data.vendor !== undefined && { vendor: data.vendor?.trim() || null }),
-            ...(data.vendorUrl !== undefined && { vendorUrl: data.vendorUrl || null }),
+            ...(data.vendorUrl !== undefined && { vendorUrl: safeUrlOrNull(data.vendorUrl) }),
             ...(data.category !== undefined && { category: data.category?.trim() || null }),
         },
     });
@@ -9599,9 +9619,9 @@ export async function submitSelectionProposal(projectId: string, data: {
             projectId,
             name,
             description: data.description?.trim() || parsed?.description || null,
-            imageUrl: data.imageUrl || parsed?.imageUrl || null,
+            imageUrl: safeUrlOrNull(data.imageUrl) || safeUrlOrNull(parsed?.imageUrl),
             price: parsed?.price ?? null,
-            vendorUrl: url || parsed?.vendorUrl || null,
+            vendorUrl: safeUrlOrNull(url) || safeUrlOrNull(parsed?.vendorUrl),
             clientNote: data.clientNote?.trim() || null,
             status: "Pending",
         },
@@ -9687,47 +9707,82 @@ export async function decideSelectionProposal(proposalId: string, input: {
     const newStatus = input.action === "approve" ? "Approved" : "Declined";
     const decidedAt = new Date();
     const pmNote = input.pmNote?.trim() || null;
+    // Re-validated at every persist boundary — proposal.imageUrl/vendorUrl were
+    // already sanitized when the proposal was created (submitSelectionProposal),
+    // but this is the second place they get copied into a new row, so it's
+    // checked again rather than trusted.
+    const safeImageUrl = safeUrlOrNull(proposal.imageUrl);
+    const safeVendorUrl = safeUrlOrNull(proposal.vendorUrl);
 
-    // Status CAS: only a Pending proposal transitions. A duplicate decide call
-    // (double-click, retried request) matches zero rows and no-ops instead of
-    // re-deciding or minting a second ProductLibraryItem/favorite/option.
-    const claim = await prisma.selectionProposal.updateMany({
-        where: { id: proposalId, status: "Pending" },
-        data: {
-            status: newStatus,
-            pmNote,
-            decidedById: user.id,
-            decidedAt,
-            ...(input.action === "approve" ? {
-                price: input.price ?? proposal.price ?? null,
-                boardId: input.boardId || null,
-                categoryId: input.categoryId || null,
-            } : {}),
-        },
-    });
-    if (claim.count === 0) {
-        return { success: false, alreadyDecided: true };
+    // Validate board/category ownership BEFORE the transaction (not inside it —
+    // no point opening a transaction just to discover the board doesn't belong
+    // to this project). A staff user scoped to project A could otherwise pass a
+    // boardId from project B and write a SelectionOption into another
+    // project's board.
+    let validCategoryId: string | null = null;
+    if (input.action === "approve" && input.boardId && input.categoryId) {
+        const board = await prisma.selectionBoard.findFirst({
+            where: { id: input.boardId, projectId: proposal.projectId },
+            select: { id: true },
+        });
+        if (board) {
+            const category = await prisma.selectionCategory.findFirst({
+                where: { id: input.categoryId, boardId: input.boardId },
+                select: { id: true },
+            });
+            if (category) validCategoryId = category.id;
+        }
     }
 
     let productId: string | null = null;
     let favoriteCreated = false;
     let optionCreated = false;
+    let alreadyDecided = false;
 
-    if (input.action === "approve") {
-        const product = await prisma.productLibraryItem.create({
+    // CAS claim + every dependent write (ProductLibraryItem, favorite,
+    // SelectionOption, the proposal's own productId backfill) run inside one
+    // transaction so a mid-sequence failure can't leave a half-approved
+    // proposal (e.g. status flipped to Approved but no ProductLibraryItem).
+    await prisma.$transaction(async (tx) => {
+        // Status CAS: only a Pending proposal transitions. A duplicate decide
+        // call (double-click, retried request) matches zero rows and no-ops
+        // instead of re-deciding or minting a second ProductLibraryItem/
+        // favorite/option.
+        const claim = await tx.selectionProposal.updateMany({
+            where: { id: proposalId, status: "Pending" },
+            data: {
+                status: newStatus,
+                pmNote,
+                decidedById: user.id,
+                decidedAt,
+                ...(input.action === "approve" ? {
+                    price: input.price ?? proposal.price ?? null,
+                    boardId: input.boardId || null,
+                    categoryId: validCategoryId,
+                } : {}),
+            },
+        });
+        if (claim.count === 0) {
+            alreadyDecided = true;
+            return;
+        }
+
+        if (input.action !== "approve") return;
+
+        const product = await tx.productLibraryItem.create({
             data: {
                 name: proposal.name,
                 description: proposal.description,
-                imageUrl: proposal.imageUrl,
+                imageUrl: safeImageUrl,
                 price: input.price ?? proposal.price ?? null,
-                vendorUrl: proposal.vendorUrl,
+                vendorUrl: safeVendorUrl,
                 source: "client_proposal",
                 clippedById: user.id,
             },
         });
         productId = product.id;
 
-        await prisma.selectionProposal.update({
+        await tx.selectionProposal.update({
             where: { id: proposalId },
             data: { productId: product.id },
         });
@@ -9735,7 +9790,7 @@ export async function decideSelectionProposal(proposalId: string, input: {
         // Default true per spec — approving a suggestion pins it to the
         // project's client-visible Favorites list unless explicitly opted out.
         if (input.addToFavorites !== false) {
-            await prisma.projectProductFavorite.upsert({
+            await tx.projectProductFavorite.upsert({
                 where: { projectId_productId: { projectId: proposal.projectId, productId: product.id } },
                 update: {},
                 create: {
@@ -9748,66 +9803,65 @@ export async function decideSelectionProposal(proposalId: string, input: {
             favoriteCreated = true;
         }
 
-        // Optional: also drop it into a board category as a pickable option.
-        // Never touches SelectionBoard.status — approving a suggestion must not
-        // silently flip a board back to an earlier lifecycle state.
-        if (input.boardId && input.categoryId) {
-            // Verify the board itself belongs to this proposal's project — without
-            // this, a staff user scoped to project A could pass a boardId from
-            // project B and write a SelectionOption into another project's board.
-            const board = await prisma.selectionBoard.findFirst({
-                where: { id: input.boardId, projectId: proposal.projectId },
-                select: { id: true },
+        // Optional: also drop it into a board category as a pickable option
+        // (validCategoryId is only set above once board+category ownership is
+        // confirmed). Never touches SelectionBoard.status — approving a
+        // suggestion must not silently flip a board back to an earlier
+        // lifecycle state.
+        if (validCategoryId) {
+            const maxOrder = await tx.selectionOption.aggregate({
+                where: { categoryId: validCategoryId },
+                _max: { order: true },
             });
-            const category = board
-                ? await prisma.selectionCategory.findFirst({
-                    where: { id: input.categoryId, boardId: input.boardId },
-                })
-                : null;
-            if (category) {
-                const maxOrder = await prisma.selectionOption.aggregate({
-                    where: { categoryId: input.categoryId },
-                    _max: { order: true },
-                });
-                await prisma.selectionOption.create({
-                    data: {
-                        categoryId: input.categoryId,
-                        name: proposal.name,
-                        description: proposal.description,
-                        imageUrl: proposal.imageUrl,
-                        price: input.price ?? proposal.price ?? null,
-                        vendorUrl: proposal.vendorUrl,
-                        order: (maxOrder._max.order ?? -1) + 1,
-                    },
-                });
-                optionCreated = true;
-            }
+            await tx.selectionOption.create({
+                data: {
+                    categoryId: validCategoryId,
+                    name: proposal.name,
+                    description: proposal.description,
+                    imageUrl: safeImageUrl,
+                    price: input.price ?? proposal.price ?? null,
+                    vendorUrl: safeVendorUrl,
+                    order: (maxOrder._max.order ?? -1) + 1,
+                },
+            });
+            optionCreated = true;
         }
+    });
+
+    if (alreadyDecided) {
+        return { success: false, alreadyDecided: true };
     }
 
-    // Notify the client of the decision — same portal-link email pattern as
-    // sendSelectionBoardToClient.
-    const clientEmail = proposal.project.client?.email;
-    if (clientEmail) {
-        const settings = await getCachedCompanySettings();
-        const { buildClientPortalUrl } = await import("./client-portal-auth");
-        const portalUrl = await buildClientPortalUrl(proposal.project.clientId, clientEmail, `/portal/projects/${proposal.projectId}/selections`);
-        const cc = buildCc(clientEmail, (proposal.project.client as any)?.additionalEmail);
-        const isApproved = input.action === "approve";
-        await sendNotification(
-            clientEmail,
-            isApproved ? `✅ Your suggestion was approved — ${proposal.project.name}` : `Update on your suggestion — ${proposal.project.name}`,
-            `<div style="font-family: sans-serif; color: #333;">
-                <h2>${isApproved ? "Your Suggestion Was Approved" : "Update on Your Suggestion"}</h2>
-                <p>Hi ${proposal.project.client?.name || "there"},</p>
-                <p>Your suggested item "<strong>${proposal.name}</strong>" for <strong>${proposal.project.name}</strong> ${isApproved ? "has been approved and added to your project." : "was not approved this time."}</p>
-                ${pmNote ? `<p style="color:#555;">Note from your project manager: "${pmNote}"</p>` : ""}
-                <p><a href="${portalUrl}" style="display:inline-block;padding:12px 24px;background:#4c9a2a;color:#fff;text-decoration:none;border-radius:6px;font-weight:bold;">View Selections</a></p>
-                <p style="color:#666;font-size:13px;">— ${settings.companyName || "Your Project Team"}</p>
-            </div>`,
-            undefined,
-            { cc, copyToInternal: true }
-        );
+    // Notifications + activity log run AFTER the transaction commits, and a
+    // failure here must not throw the whole action into a failed state — the
+    // decision is already durably recorded. Same pattern submitClientSelections
+    // and the other portal notifiers use (sendNotification never throws on its
+    // own, but building the portal link can, so the whole block is wrapped).
+    try {
+        const clientEmail = proposal.project.client?.email;
+        if (clientEmail) {
+            const settings = await getCachedCompanySettings();
+            const { buildClientPortalUrl } = await import("./client-portal-auth");
+            const portalUrl = await buildClientPortalUrl(proposal.project.clientId, clientEmail, `/portal/projects/${proposal.projectId}/selections`);
+            const cc = buildCc(clientEmail, (proposal.project.client as any)?.additionalEmail);
+            const isApproved = input.action === "approve";
+            await sendNotification(
+                clientEmail,
+                isApproved ? `✅ Your suggestion was approved — ${proposal.project.name}` : `Update on your suggestion — ${proposal.project.name}`,
+                `<div style="font-family: sans-serif; color: #333;">
+                    <h2>${isApproved ? "Your Suggestion Was Approved" : "Update on Your Suggestion"}</h2>
+                    <p>Hi ${proposal.project.client?.name || "there"},</p>
+                    <p>Your suggested item "<strong>${proposal.name}</strong>" for <strong>${proposal.project.name}</strong> ${isApproved ? "has been approved and added to your project." : "was not approved this time."}</p>
+                    ${pmNote ? `<p style="color:#555;">Note from your project manager: "${pmNote}"</p>` : ""}
+                    <p><a href="${portalUrl}" style="display:inline-block;padding:12px 24px;background:#4c9a2a;color:#fff;text-decoration:none;border-radius:6px;font-weight:bold;">View Selections</a></p>
+                    <p style="color:#666;font-size:13px;">— ${settings.companyName || "Your Project Team"}</p>
+                </div>`,
+                undefined,
+                { cc, copyToInternal: true }
+            );
+        }
+    } catch (err) {
+        console.error("[decideSelectionProposal] client notification failed:", err);
     }
 
     await logActivity({

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -9714,40 +9714,27 @@ export async function decideSelectionProposal(proposalId: string, input: {
     const safeImageUrl = safeUrlOrNull(proposal.imageUrl);
     const safeVendorUrl = safeUrlOrNull(proposal.vendorUrl);
 
-    // Validate board/category ownership BEFORE the transaction (not inside it —
-    // no point opening a transaction just to discover the board doesn't belong
-    // to this project). A staff user scoped to project A could otherwise pass a
-    // boardId from project B and write a SelectionOption into another
-    // project's board.
-    let validCategoryId: string | null = null;
-    if (input.action === "approve" && input.boardId && input.categoryId) {
-        const board = await prisma.selectionBoard.findFirst({
-            where: { id: input.boardId, projectId: proposal.projectId },
-            select: { id: true },
-        });
-        if (board) {
-            const category = await prisma.selectionCategory.findFirst({
-                where: { id: input.categoryId, boardId: input.boardId },
-                select: { id: true },
-            });
-            if (category) validCategoryId = category.id;
-        }
-    }
-
     let productId: string | null = null;
     let favoriteCreated = false;
     let optionCreated = false;
     let alreadyDecided = false;
 
-    // CAS claim + every dependent write (ProductLibraryItem, favorite,
-    // SelectionOption, the proposal's own productId backfill) run inside one
-    // transaction so a mid-sequence failure can't leave a half-approved
-    // proposal (e.g. status flipped to Approved but no ProductLibraryItem).
+    // CAS claim + board/category validation + every dependent write
+    // (ProductLibraryItem, favorite, SelectionOption, the proposal's own
+    // productId/boardId/categoryId backfill) run inside one transaction, so:
+    //   - a mid-sequence failure can't leave a half-approved proposal (e.g.
+    //     status flipped to Approved but no ProductLibraryItem), and
+    //   - the board/category ownership check reads the SAME transactional
+    //     snapshot the writes commit against — validating outside the
+    //     transaction would leave a TOCTOU window where the board/category
+    //     could be deleted or reassigned between the check and the write.
     await prisma.$transaction(async (tx) => {
         // Status CAS: only a Pending proposal transitions. A duplicate decide
         // call (double-click, retried request) matches zero rows and no-ops
         // instead of re-deciding or minting a second ProductLibraryItem/
-        // favorite/option.
+        // favorite/option. boardId/categoryId are intentionally NOT set here —
+        // they're only known-valid once the check below runs, inside this same
+        // transaction, and are written in the follow-up update further down.
         const claim = await tx.selectionProposal.updateMany({
             where: { id: proposalId, status: "Pending" },
             data: {
@@ -9757,8 +9744,6 @@ export async function decideSelectionProposal(proposalId: string, input: {
                 decidedAt,
                 ...(input.action === "approve" ? {
                     price: input.price ?? proposal.price ?? null,
-                    boardId: input.boardId || null,
-                    categoryId: validCategoryId,
                 } : {}),
             },
         });
@@ -9768,6 +9753,37 @@ export async function decideSelectionProposal(proposalId: string, input: {
         }
 
         if (input.action !== "approve") return;
+
+        // Validate board/category ownership INSIDE the transaction (after the
+        // claim, same isolated snapshot the writes below use). A staff user
+        // scoped to project A could otherwise pass a boardId from project B
+        // and write a SelectionOption into another project's board. Only ever
+        // persist boardId/categoryId on the proposal when BOTH were supplied
+        // AND validated — never the raw, unvalidated input.boardId. If the
+        // caller explicitly asked to link a board+category and that link
+        // doesn't check out, abort the whole decision (throwing here rolls
+        // back the CAS claim above too, so the proposal stays Pending) rather
+        // than silently approving without the link.
+        let validBoardId: string | null = null;
+        let validCategoryId: string | null = null;
+        if (input.boardId && input.categoryId) {
+            const board = await tx.selectionBoard.findFirst({
+                where: { id: input.boardId, projectId: proposal.projectId },
+                select: { id: true },
+            });
+            if (!board) {
+                throw new Error("That board doesn't belong to this project — refresh and try again.");
+            }
+            const category = await tx.selectionCategory.findFirst({
+                where: { id: input.categoryId, boardId: input.boardId },
+                select: { id: true },
+            });
+            if (!category) {
+                throw new Error("That category doesn't belong to the selected board — refresh and try again.");
+            }
+            validBoardId = board.id;
+            validCategoryId = category.id;
+        }
 
         const product = await tx.productLibraryItem.create({
             data: {
@@ -9784,7 +9800,7 @@ export async function decideSelectionProposal(proposalId: string, input: {
 
         await tx.selectionProposal.update({
             where: { id: proposalId },
-            data: { productId: product.id },
+            data: { productId: product.id, boardId: validBoardId, categoryId: validCategoryId },
         });
 
         // Default true per spec — approving a suggestion pins it to the

--- a/src/lib/product-parse.ts
+++ b/src/lib/product-parse.ts
@@ -1,5 +1,8 @@
 import dns from "node:dns";
 import net from "node:net";
+import http from "node:http";
+import https from "node:https";
+import { isHttpUrl } from "./url-safety";
 
 // ─── Product Clipper: url -> {name, price, imageUrl, vendor, description} ───
 //
@@ -18,20 +21,179 @@ export type ParsedProduct = {
 };
 
 const FETCH_TIMEOUT_MS = 10_000;
-const MAX_RESPONSE_BYTES = 2 * 1024 * 1024; // ~2MB cap
+const MAX_RESPONSE_BYTES = 2 * 1024 * 1024; // ~2MB cap, cumulative across the whole redirect chain
+const MAX_REDIRECTS = 5;
+const ALLOWED_PORTS = new Set([80, 443]);
 const BROWSER_USER_AGENT =
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
+// =============================================================================
+// SSRF guard: IP range denylist + connect-time DNS validation
+// =============================================================================
+//
+// Two layers, both required:
+//   1. isSafeExternalUrl() — cheap SYNTACTIC pre-check (protocol, port, and the
+//      one case it must resolve itself: a literal IP host, e.g. http://169.254.169.254/,
+//      since Node's net.connect skips its `lookup` option entirely when the host
+//      is already an IP literal — a custom lookup would simply never run for it).
+//   2. The `lookup` option passed to http.request/https.request in fetchOneHop()
+//      below — for hostname-based URLs, this is what actually gets called during
+//      the real connect, and it validates every resolved address before handing
+//      ONE of them back to Node to connect to. Because the validated address is
+//      the exact address connected to (no second DNS resolution happens after),
+//      this closes the DNS-rebinding window a check-then-fetch design would have
+//      (resolve+validate at check time, then fetch() re-resolves at connect time
+//      — an attacker's DNS server can answer differently the second time).
+
+function ipv4ToInt(ip: string): number | null {
+    const parts = ip.split(".").map(Number);
+    if (parts.length !== 4 || parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)) return null;
+    return ((parts[0] * 16777216) + (parts[1] * 65536) + (parts[2] * 256) + parts[3]) >>> 0;
+}
+
+function inCidrInt(ipInt: number, base: string, prefixLen: number): boolean {
+    const baseInt = ipv4ToInt(base);
+    if (baseInt === null) return false;
+    const mask = prefixLen === 0 ? 0 : (0xFFFFFFFF << (32 - prefixLen)) >>> 0;
+    return ((ipInt >>> 0) & mask) === (baseInt & mask);
+}
+
+// Every non-global IPv4 range: RFC1918 privates, loopback, link-local, CGNAT,
+// the IANA special-purpose blocks (this-network, IETF protocol assignments,
+// TEST-NET-1/2/3, 6to4 relay anycast, benchmarking), multicast, reserved, and
+// the limited broadcast address.
+const IPV4_BLOCKED_RANGES: Array<[string, number]> = [
+    ["0.0.0.0", 8],
+    ["10.0.0.0", 8],
+    ["100.64.0.0", 10],
+    ["127.0.0.0", 8],
+    ["169.254.0.0", 16],
+    ["172.16.0.0", 12],
+    ["192.0.0.0", 24],
+    ["192.0.2.0", 24],
+    ["192.88.99.0", 24],
+    ["192.168.0.0", 16],
+    ["198.18.0.0", 15],
+    ["198.51.100.0", 24],
+    ["203.0.113.0", 24],
+    ["224.0.0.0", 4],
+    ["240.0.0.0", 4],
+    ["255.255.255.255", 32],
+];
+
+function isBlockedIPv4Int(ipInt: number): boolean {
+    return IPV4_BLOCKED_RANGES.some(([base, len]) => inCidrInt(ipInt, base, len));
+}
+
+function isBlockedIPv4(ip: string): boolean {
+    const ipInt = ipv4ToInt(ip);
+    if (ipInt === null) return true; // fail closed
+    return isBlockedIPv4Int(ipInt);
+}
+
 /**
- * SSRF guard for the product clipper. Only public http/https URLs are allowed —
- * this rejects loopback, link-local, private (RFC1918/RFC4193), and other
- * reserved ranges so a pasted "product URL" can never be used to reach internal
- * infrastructure (e.g. cloud metadata at 169.254.169.254). Modeled on the
- * isOwnSignatureStorageUrl allowlist pattern in signature-storage.ts, but this
- * guard is a denylist because — unlike signatures — the whole point of the
- * clipper is fetching arbitrary third-party vendor sites.
+ * Expand any valid IPv6 literal (including "::" compression and an embedded
+ * trailing IPv4 like "::ffff:127.0.0.1") into a 128-bit integer for numeric
+ * prefix comparisons. Returns null for anything that doesn't parse.
  */
-export async function isSafeExternalUrl(url: string): Promise<boolean> {
+function ipv6ToBigInt(ip: string): bigint | null {
+    if (!net.isIPv6(ip)) return null;
+    let head = ip;
+    let tail = "";
+    let hasDoubleColon = false;
+    if (ip.includes("::")) {
+        hasDoubleColon = true;
+        const idx = ip.indexOf("::");
+        head = ip.slice(0, idx);
+        tail = ip.slice(idx + 2);
+    }
+    const expand = (s: string) => (s ? s.split(":") : []);
+    let headParts = expand(head);
+    let tailParts = expand(tail);
+
+    function v4Embedded(parts: string[]): string[] {
+        if (parts.length === 0) return parts;
+        const last = parts[parts.length - 1];
+        if (last.includes(".")) {
+            const octets = last.split(".").map(Number);
+            if (octets.length === 4 && octets.every((o) => Number.isInteger(o) && o >= 0 && o <= 255)) {
+                const hi = ((octets[0] << 8) | octets[1]).toString(16);
+                const lo = ((octets[2] << 8) | octets[3]).toString(16);
+                return [...parts.slice(0, -1), hi, lo];
+            }
+        }
+        return parts;
+    }
+    headParts = v4Embedded(headParts);
+    tailParts = v4Embedded(tailParts);
+
+    let allParts: string[];
+    if (hasDoubleColon) {
+        const missing = 8 - (headParts.length + tailParts.length);
+        if (missing < 0) return null;
+        allParts = [...headParts, ...Array(missing).fill("0"), ...tailParts];
+    } else {
+        allParts = headParts;
+    }
+    if (allParts.length !== 8) return null;
+
+    let result = BigInt(0);
+    for (const part of allParts) {
+        if (part === "") return null;
+        const val = parseInt(part, 16);
+        if (!Number.isInteger(val) || val < 0 || val > 0xFFFF) return null;
+        result = (result << BigInt(16)) | BigInt(val);
+    }
+    return result;
+}
+
+function ipv6InCidr(ipBig: bigint, base: string, prefixLen: number): boolean {
+    const baseBig = ipv6ToBigInt(base);
+    if (baseBig === null) return false;
+    const shift = BigInt(128 - prefixLen);
+    const mask = prefixLen === 0 ? BigInt(0) : ((BigInt(1) << BigInt(prefixLen)) - BigInt(1)) << shift;
+    return (ipBig & mask) === (baseBig & mask);
+}
+
+// fc00::/7 (unique local), fe80::/10 (link-local), fec0::/10 (deprecated
+// site-local), ff00::/8 (multicast), 2001:db8::/32 (documentation). :: and ::1
+// are checked as exact values below; ::ffff:0:0/96 and 64:ff9b::/96 decode
+// their embedded IPv4 and re-run the IPv4 check.
+const IPV6_BLOCKED_RANGES: Array<[string, number]> = [
+    ["fc00::", 7],
+    ["fe80::", 10],
+    ["fec0::", 10],
+    ["ff00::", 8],
+    ["2001:db8::", 32],
+];
+
+function isBlockedIPv6(ip: string): boolean {
+    const big = ipv6ToBigInt(ip);
+    if (big === null) return true; // fail closed
+    if (big === BigInt(0)) return true; // ::
+    if (big === BigInt(1)) return true; // ::1
+    if (ipv6InCidr(big, "::ffff:0:0", 96) || ipv6InCidr(big, "64:ff9b::", 96)) {
+        // IPv4-mapped (::ffff:a.b.c.d) or NAT64 (64:ff9b::a.b.c.d) — the real
+        // target is the embedded IPv4 address, so validate that instead.
+        return isBlockedIPv4Int(Number(big & BigInt(0xFFFFFFFF)));
+    }
+    return IPV6_BLOCKED_RANGES.some(([base, len]) => ipv6InCidr(big, base, len));
+}
+
+function isBlockedIp(ip: string): boolean {
+    const family = net.isIP(ip);
+    if (family === 4) return isBlockedIPv4(ip);
+    if (family === 6) return isBlockedIPv6(ip);
+    return true; // not a valid IP literal — fail closed
+}
+
+/**
+ * Syntactic SSRF pre-check: http/https only, port 80/443 only, and — because
+ * Node's connection layer skips the custom `lookup` entirely for literal IP
+ * hosts — validates a literal-IP host directly. Hostname-based URLs are NOT
+ * resolved here; that happens once, at actual connect time, in fetchOneHop().
+ */
+export function isSafeExternalUrl(url: string): boolean {
     let parsed: URL;
     try {
         parsed = new URL(url);
@@ -41,132 +203,164 @@ export async function isSafeExternalUrl(url: string): Promise<boolean> {
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
     if (!parsed.hostname) return false;
 
-    // Reject bare IP literals AND resolved DNS results that land in a private
-    // range — resolve the hostname ourselves rather than trusting fetch() to
-    // reject internal targets after the fact.
-    let addresses: string[];
-    if (net.isIP(parsed.hostname)) {
-        addresses = [parsed.hostname];
-    } else {
-        try {
-            const results = await dns.promises.lookup(parsed.hostname, { all: true, verbatim: true });
-            addresses = results.map((r) => r.address);
-        } catch {
-            return false; // unresolvable host — fail closed
-        }
-    }
-    if (addresses.length === 0) return false;
-    return addresses.every((addr) => !isPrivateOrReservedIp(addr));
-}
+    const port = parsed.port ? Number(parsed.port) : (parsed.protocol === "https:" ? 443 : 80);
+    if (!ALLOWED_PORTS.has(port)) return false;
 
-function isPrivateOrReservedIp(ip: string): boolean {
-    if (net.isIPv4(ip)) {
-        const parts = ip.split(".").map(Number);
-        if (parts.length !== 4 || parts.some((p) => Number.isNaN(p))) return true;
-        const [a, b] = parts;
-        if (a === 10) return true; // 10.0.0.0/8
-        if (a === 127) return true; // loopback
-        if (a === 0) return true; // "this" network
-        if (a === 169 && b === 254) return true; // link-local
-        if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
-        if (a === 192 && b === 168) return true; // 192.168.0.0/16
-        if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT 100.64.0.0/10
-        if (a >= 224) return true; // multicast + reserved (224.0.0.0/4, 240.0.0.0/4)
-        return false;
-    }
-    if (net.isIPv6(ip)) {
-        const lower = ip.toLowerCase();
-        if (lower === "::1") return true; // loopback
-        if (lower === "::") return true; // unspecified
-        if (lower.startsWith("::ffff:")) {
-            // IPv4-mapped IPv6 — check the embedded v4 address.
-            const v4 = lower.split(":").pop() || "";
-            if (net.isIPv4(v4)) return isPrivateOrReservedIp(v4);
-        }
-        if (lower.startsWith("fc") || lower.startsWith("fd")) return true; // fc00::/7 (unique local)
-        if (lower.startsWith("fe8") || lower.startsWith("fe9") || lower.startsWith("fea") || lower.startsWith("feb")) return true; // fe80::/10 link-local
-        return false;
-    }
-    // Unknown format — fail closed.
+    if (net.isIP(parsed.hostname) !== 0 && isBlockedIp(parsed.hostname)) return false;
+
     return true;
 }
 
-// Redirect hops to follow before giving up. Each hop is re-validated against
-// isSafeExternalUrl — see the SSRF note on guardedFetchText below.
-const MAX_REDIRECTS = 5;
+// =============================================================================
+// Transport: node:http/https with a validating `lookup`, manual redirects
+// =============================================================================
 
-/**
- * Fetch a URL with a hard timeout and response-size cap, following redirects
- * MANUALLY (never `redirect: "follow"`). A vendor site could otherwise 302 to
- * an internal target (169.254.169.254, localhost, an RFC1918 address) and a
- * plain fetch would follow it unvalidated — that's a real SSRF even though
- * the original URL passed isSafeExternalUrl(). Every hop's URL — the initial
- * one and every Location target — is re-validated before it's fetched, which
- * also narrows (though doesn't eliminate) the DNS-rebinding window between
- * the check and the connect for each individual hop.
- *
- * Returns null on any failure (timeout, unsafe redirect target, too many
- * redirects, non-2xx, oversized body, network error) — never throws.
- */
-async function guardedFetchText(url: string): Promise<string | null> {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-    try {
-        let currentUrl = url;
-        let total = 0;
-        const chunks: Uint8Array[] = [];
+type NodeLookupCallback = (err: NodeJS.ErrnoException | null, address: string, family: number) => void;
 
-        for (let redirects = 0; ; redirects++) {
-            // Re-validate right before connecting on every hop, not just the
-            // caller-supplied starting URL.
-            if (!(await isSafeExternalUrl(currentUrl))) return null;
+/** dns.lookup-compatible function that rejects any resolved address in the
+ * blocked ranges, and otherwise hands Node the exact address it validated —
+ * that address is what Node actually connects to, so there's no window
+ * between "validated" and "connected to" for a rebinding DNS server to exploit. */
+function validatingLookup(hostname: string, options: unknown, callback: NodeLookupCallback): void {
+    const cb: NodeLookupCallback = typeof options === "function" ? (options as NodeLookupCallback) : callback;
+    dns.lookup(hostname, { all: true, verbatim: true }, (err, addresses) => {
+        if (err) { cb(err, "", 4); return; }
+        const list = addresses as dns.LookupAddress[];
+        if (!list.length) { cb(new Error("DNS lookup returned no addresses"), "", 4); return; }
+        const blocked = list.find((a) => isBlockedIp(a.address));
+        if (blocked) { cb(new Error(`Resolved address ${blocked.address} is not allowed`), "", 4); return; }
+        const chosen = list[0];
+        cb(null, chosen.address, chosen.family);
+    });
+}
 
-            const res = await fetch(currentUrl, {
-                signal: controller.signal,
-                redirect: "manual",
+type HopResult =
+    | { kind: "redirect"; location: string }
+    | { kind: "body"; text: string }
+    | { kind: "fail" };
+
+function fetchOneHop(url: string, deadline: number): Promise<HopResult> {
+    return new Promise((resolve) => {
+        let parsed: URL;
+        try {
+            parsed = new URL(url);
+        } catch {
+            resolve({ kind: "fail" });
+            return;
+        }
+
+        const timeLeft = deadline - Date.now();
+        if (timeLeft <= 0) { resolve({ kind: "fail" }); return; }
+
+        const transport = parsed.protocol === "https:" ? https : http;
+        const port = parsed.port ? Number(parsed.port) : (parsed.protocol === "https:" ? 443 : 80);
+
+        let settled = false;
+        const settle = (result: HopResult) => {
+            if (settled) return;
+            settled = true;
+            resolve(result);
+        };
+
+        const req = transport.request(
+            {
+                hostname: parsed.hostname,
+                port,
+                path: `${parsed.pathname}${parsed.search}`,
+                method: "GET",
+                // Validated at actual connect time — see validatingLookup() above.
+                lookup: validatingLookup as unknown as typeof dns.lookup,
                 headers: {
                     "User-Agent": BROWSER_USER_AGENT,
                     Accept: "text/html,application/xhtml+xml",
                 },
-            });
+                timeout: timeLeft,
+            },
+            (res) => {
+                const status = res.statusCode || 0;
+                const location = res.headers.location;
 
-            const location = res.headers.get("location");
-            if (res.status >= 300 && res.status < 400 && location) {
-                if (redirects >= MAX_REDIRECTS) return null;
-                try {
-                    currentUrl = new URL(location, currentUrl).toString();
-                } catch {
-                    return null;
+                if (status >= 300 && status < 400 && location) {
+                    // Drain nothing — destroy immediately so a huge redirect body
+                    // can never be used to bypass the response-size cap.
+                    res.destroy();
+                    settle({ kind: "redirect", location });
+                    return;
                 }
-                continue; // loop re-validates currentUrl before following it
-            }
 
-            if (!res.ok || !res.body) return null;
+                if (status < 200 || status >= 300) {
+                    res.destroy();
+                    settle({ kind: "fail" });
+                    return;
+                }
 
-            const contentLengthHeader = res.headers.get("content-length");
-            if (contentLengthHeader && total + Number(contentLengthHeader) > MAX_RESPONSE_BYTES) return null;
+                const contentLengthHeader = res.headers["content-length"];
+                if (contentLengthHeader && Number(contentLengthHeader) > MAX_RESPONSE_BYTES) {
+                    res.destroy();
+                    settle({ kind: "fail" });
+                    return;
+                }
 
-            const reader = res.body.getReader();
-            while (true) {
-                const { done, value } = await reader.read();
-                if (done) break;
-                if (value) {
-                    total += value.byteLength;
+                const chunks: Buffer[] = [];
+                let total = 0;
+                res.on("data", (chunk: Buffer) => {
+                    total += chunk.length;
                     if (total > MAX_RESPONSE_BYTES) {
-                        await reader.cancel().catch(() => {});
-                        return null;
+                        res.destroy();
+                        settle({ kind: "fail" });
+                        return;
                     }
-                    chunks.push(value);
-                }
+                    chunks.push(chunk);
+                });
+                res.on("end", () => settle({ kind: "body", text: Buffer.concat(chunks).toString("utf8") }));
+                res.on("error", () => settle({ kind: "fail" }));
+            },
+        );
+
+        req.on("timeout", () => req.destroy(new Error("timeout")));
+        req.on("error", () => settle({ kind: "fail" }));
+        req.end();
+    });
+}
+
+/**
+ * Fetch a URL with a hard timeout (shared across the whole redirect chain) and
+ * a cumulative response-size cap, following redirects MANUALLY. Every hop's
+ * URL — the initial one and every Location target, resolved against the
+ * current URL — is re-validated via isSafeExternalUrl() before it's requested,
+ * and the actual connect for hostname-based hops is validated by
+ * validatingLookup() above (see the SSRF guard section for why both layers
+ * exist). Capped at MAX_REDIRECTS hops.
+ *
+ * Returns null on any failure (timeout, unsafe target, too many redirects,
+ * non-2xx, oversized body, network error) — never throws.
+ */
+async function guardedFetchText(url: string): Promise<string | null> {
+    const deadline = Date.now() + FETCH_TIMEOUT_MS;
+    let currentUrl = url;
+
+    for (let redirects = 0; ; redirects++) {
+        if (!isSafeExternalUrl(currentUrl)) return null;
+        if (Date.now() >= deadline) return null;
+
+        const result = await fetchOneHop(currentUrl, deadline);
+        if (result.kind === "fail") return null;
+        if (result.kind === "redirect") {
+            if (redirects >= MAX_REDIRECTS) return null;
+            try {
+                currentUrl = new URL(result.location, currentUrl).toString();
+            } catch {
+                return null;
             }
-            return Buffer.concat(chunks.map((c) => Buffer.from(c))).toString("utf8");
+            continue;
         }
-    } catch {
-        return null;
-    } finally {
-        clearTimeout(timeoutId);
+        return result.text;
     }
 }
+
+// =============================================================================
+// Extraction: JSON-LD -> OpenGraph -> Gemini, all normalized by one function
+// =============================================================================
 
 function toNumberOrUndefined(value: unknown): number | undefined {
     if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -195,11 +389,62 @@ function firstString(value: unknown): string | undefined {
     return undefined;
 }
 
+// Unclamped, unvalidated extraction result — normalizeParsedProduct() below is
+// the single place that enforces length limits, price bounds, image-URL safety,
+// and currency handling for every extraction path.
+type RawExtract = {
+    name?: string;
+    description?: string;
+    imageUrl?: string;
+    price?: number;
+    priceCurrency?: string;
+    vendor?: string;
+};
+
+const MAX_NAME_LEN = 200;
+const MAX_VENDOR_LEN = 100;
+const MAX_DESCRIPTION_LEN = 2000;
+const MAX_PRICE = 9_999_999.99;
+
+/**
+ * Single normalization point for every extraction path (JSON-LD, OpenGraph,
+ * Gemini). Clamps string lengths, rejects a non-finite/out-of-range price,
+ * drops an imageUrl that isn't a plain http(s) URL (never persist/return a
+ * javascript:/data: URL pulled from a scraped page), and — if the page quoted
+ * a non-USD price — nulls the price and folds the original amount/currency
+ * into the description instead (no schema change for a currency field).
+ * Returns null if there's no usable name.
+ */
+function normalizeParsedProduct(raw: RawExtract): Omit<ParsedProduct, "vendorUrl"> | null {
+    const name = raw.name?.trim().slice(0, MAX_NAME_LEN);
+    if (!name) return null;
+
+    let description = raw.description?.trim().slice(0, MAX_DESCRIPTION_LEN) || undefined;
+    const vendor = raw.vendor?.trim().slice(0, MAX_VENDOR_LEN) || undefined;
+    const imageUrl = raw.imageUrl && isHttpUrl(raw.imageUrl) ? raw.imageUrl : undefined;
+
+    const rawPrice =
+        typeof raw.price === "number" && Number.isFinite(raw.price) && raw.price > 0 && raw.price <= MAX_PRICE
+            ? raw.price
+            : undefined;
+
+    let price: number | undefined = rawPrice;
+    const currency = raw.priceCurrency?.trim().toUpperCase();
+    if (rawPrice !== undefined && currency && currency !== "USD") {
+        price = undefined;
+        const note = `Listed price: ${rawPrice} ${currency}`;
+        description = description ? `${description}\n${note}` : note;
+        description = description.slice(0, MAX_DESCRIPTION_LEN);
+    }
+
+    return { name, description, imageUrl, price, vendor };
+}
+
 /**
  * Extract a schema.org/Product from any JSON-LD <script> blocks on the page.
  * Handles both a bare Product object and an @graph array containing one.
  */
-function parseJsonLdProduct(html: string): Partial<ParsedProduct> | null {
+function parseJsonLdProduct(html: string): RawExtract | null {
     const scriptRe = /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
     let match: RegExpExecArray | null;
     while ((match = scriptRe.exec(html))) {
@@ -226,6 +471,7 @@ function parseJsonLdProduct(html: string): Partial<ParsedProduct> | null {
                     description: firstString(node.description),
                     imageUrl: firstString(node.image),
                     price,
+                    priceCurrency: firstString(offer?.priceCurrency),
                     vendor: firstString(node.brand) || firstString(offer?.seller),
                 };
             }
@@ -247,10 +493,11 @@ function extractMetaContent(html: string, attr: "property" | "name", key: string
     return match?.[1]?.trim() || undefined;
 }
 
-function parseOpenGraph(html: string): Partial<ParsedProduct> | null {
+function parseOpenGraph(html: string): RawExtract | null {
     const title = extractMetaContent(html, "property", "og:title");
     const image = extractMetaContent(html, "property", "og:image");
     const priceAmount = extractMetaContent(html, "property", "product:price:amount");
+    const priceCurrency = extractMetaContent(html, "property", "product:price:currency");
     const siteName = extractMetaContent(html, "property", "og:site_name");
     const description = extractMetaContent(html, "property", "og:description");
 
@@ -265,6 +512,7 @@ function parseOpenGraph(html: string): Partial<ParsedProduct> | null {
         description,
         imageUrl: image,
         price: toNumberOrUndefined(priceAmount),
+        priceCurrency,
         vendor: siteName,
     };
 }
@@ -284,7 +532,7 @@ function stripHtmlToText(html: string, maxChars: number): string {
  * Uses the same generativelanguage.googleapis.com REST call pattern as the
  * rest of src/lib/actions.ts (aiGeneratePunchlist, aiGenerateSchedule).
  */
-async function parseWithGemini(html: string, url: string): Promise<Partial<ParsedProduct> | null> {
+async function parseWithGemini(html: string, url: string): Promise<RawExtract | null> {
     const apiKey = process.env.GEMINI_API_KEY;
     if (!apiKey) return null;
 
@@ -298,11 +546,12 @@ PAGE TEXT (stripped of HTML):
 ${pageText}
 
 Return ONLY strict JSON with this exact shape, no other text:
-{"name": string|null, "price": number|null, "imageUrl": string|null, "vendor": string|null, "description": string|null}
+{"name": string|null, "price": number|null, "currency": string|null, "imageUrl": string|null, "vendor": string|null, "description": string|null}
 
 Rules:
 - "name" is the product's title/name. If you cannot identify a specific product, use null.
 - "price" is the numeric list price with no currency symbol (e.g. 129.99). Use null if not found.
+- "currency" is the ISO 4217 currency code (e.g. "USD", "EUR", "GBP") the price is listed in. Assume "USD" for a bare $ sign. Use null if you can't tell.
 - "imageUrl" is the product's main image URL if visible in the text, otherwise null.
 - "vendor" is the store/brand name, otherwise null.
 - "description" is a one-sentence product description, otherwise null.`;
@@ -335,6 +584,7 @@ Rules:
             description: typeof parsed.description === "string" ? parsed.description : undefined,
             imageUrl: typeof parsed.imageUrl === "string" ? parsed.imageUrl : undefined,
             price: toNumberOrUndefined(parsed.price),
+            priceCurrency: typeof parsed.currency === "string" ? parsed.currency : undefined,
             vendor: typeof parsed.vendor === "string" ? parsed.vendor : undefined,
         };
     } catch {
@@ -350,26 +600,19 @@ Rules:
 export async function parseProductUrl(url: string): Promise<ParsedProduct> {
     const fallback: ParsedProduct = { vendorUrl: url, name: null };
 
-    const safe = await isSafeExternalUrl(url);
-    if (!safe) return fallback;
+    if (!isSafeExternalUrl(url)) return fallback;
 
     const html = await guardedFetchText(url);
     if (!html) return fallback;
 
-    const jsonLd = parseJsonLdProduct(html);
-    if (jsonLd?.name) {
-        return { vendorUrl: url, name: jsonLd.name, description: jsonLd.description, price: jsonLd.price, imageUrl: jsonLd.imageUrl, vendor: jsonLd.vendor };
-    }
+    const jsonLd = normalizeParsedProduct(parseJsonLdProduct(html) || {});
+    if (jsonLd) return { vendorUrl: url, ...jsonLd };
 
-    const og = parseOpenGraph(html);
-    if (og?.name) {
-        return { vendorUrl: url, name: og.name, description: og.description, price: og.price, imageUrl: og.imageUrl, vendor: og.vendor };
-    }
+    const og = normalizeParsedProduct(parseOpenGraph(html) || {});
+    if (og) return { vendorUrl: url, ...og };
 
-    const gemini = await parseWithGemini(html, url);
-    if (gemini?.name) {
-        return { vendorUrl: url, name: gemini.name, description: gemini.description, price: gemini.price, imageUrl: gemini.imageUrl, vendor: gemini.vendor };
-    }
+    const gemini = normalizeParsedProduct((await parseWithGemini(html, url)) || {});
+    if (gemini) return { vendorUrl: url, ...gemini };
 
     return fallback;
 }

--- a/src/lib/product-parse.ts
+++ b/src/lib/product-parse.ts
@@ -91,44 +91,76 @@ function isPrivateOrReservedIp(ip: string): boolean {
     return true;
 }
 
+// Redirect hops to follow before giving up. Each hop is re-validated against
+// isSafeExternalUrl — see the SSRF note on guardedFetchText below.
+const MAX_REDIRECTS = 5;
+
 /**
- * Fetch a URL with a hard timeout and response-size cap. Caller must have
- * already validated the URL via isSafeExternalUrl(). Returns null on any
- * failure (timeout, non-2xx, oversized body, network error) — never throws.
+ * Fetch a URL with a hard timeout and response-size cap, following redirects
+ * MANUALLY (never `redirect: "follow"`). A vendor site could otherwise 302 to
+ * an internal target (169.254.169.254, localhost, an RFC1918 address) and a
+ * plain fetch would follow it unvalidated — that's a real SSRF even though
+ * the original URL passed isSafeExternalUrl(). Every hop's URL — the initial
+ * one and every Location target — is re-validated before it's fetched, which
+ * also narrows (though doesn't eliminate) the DNS-rebinding window between
+ * the check and the connect for each individual hop.
+ *
+ * Returns null on any failure (timeout, unsafe redirect target, too many
+ * redirects, non-2xx, oversized body, network error) — never throws.
  */
 async function guardedFetchText(url: string): Promise<string | null> {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
     try {
-        const res = await fetch(url, {
-            signal: controller.signal,
-            redirect: "follow",
-            headers: {
-                "User-Agent": BROWSER_USER_AGENT,
-                Accept: "text/html,application/xhtml+xml",
-            },
-        });
-        if (!res.ok || !res.body) return null;
-
-        const contentLengthHeader = res.headers.get("content-length");
-        if (contentLengthHeader && Number(contentLengthHeader) > MAX_RESPONSE_BYTES) return null;
-
-        const reader = res.body.getReader();
-        const chunks: Uint8Array[] = [];
+        let currentUrl = url;
         let total = 0;
-        while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            if (value) {
-                total += value.byteLength;
-                if (total > MAX_RESPONSE_BYTES) {
-                    await reader.cancel().catch(() => {});
+        const chunks: Uint8Array[] = [];
+
+        for (let redirects = 0; ; redirects++) {
+            // Re-validate right before connecting on every hop, not just the
+            // caller-supplied starting URL.
+            if (!(await isSafeExternalUrl(currentUrl))) return null;
+
+            const res = await fetch(currentUrl, {
+                signal: controller.signal,
+                redirect: "manual",
+                headers: {
+                    "User-Agent": BROWSER_USER_AGENT,
+                    Accept: "text/html,application/xhtml+xml",
+                },
+            });
+
+            const location = res.headers.get("location");
+            if (res.status >= 300 && res.status < 400 && location) {
+                if (redirects >= MAX_REDIRECTS) return null;
+                try {
+                    currentUrl = new URL(location, currentUrl).toString();
+                } catch {
                     return null;
                 }
-                chunks.push(value);
+                continue; // loop re-validates currentUrl before following it
             }
+
+            if (!res.ok || !res.body) return null;
+
+            const contentLengthHeader = res.headers.get("content-length");
+            if (contentLengthHeader && total + Number(contentLengthHeader) > MAX_RESPONSE_BYTES) return null;
+
+            const reader = res.body.getReader();
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                if (value) {
+                    total += value.byteLength;
+                    if (total > MAX_RESPONSE_BYTES) {
+                        await reader.cancel().catch(() => {});
+                        return null;
+                    }
+                    chunks.push(value);
+                }
+            }
+            return Buffer.concat(chunks.map((c) => Buffer.from(c))).toString("utf8");
         }
-        return Buffer.concat(chunks.map((c) => Buffer.from(c))).toString("utf8");
     } catch {
         return null;
     } finally {

--- a/src/lib/product-parse.ts
+++ b/src/lib/product-parse.ts
@@ -1,0 +1,343 @@
+import dns from "node:dns";
+import net from "node:net";
+
+// ─── Product Clipper: url -> {name, price, imageUrl, vendor, description} ───
+//
+// Capture chain: JSON-LD (schema.org/Product) -> OpenGraph/meta tags -> Gemini
+// fallback (arbitrary vendor page, worst case). Never throws — a parse failure
+// always degrades to {vendorUrl, name: null} so the caller UI can fall back to
+// manual entry. See docs/specs/product-library-portal-selections.md Phase 1.
+
+export type ParsedProduct = {
+    vendorUrl: string;
+    name: string | null;
+    description?: string;
+    price?: number;
+    imageUrl?: string;
+    vendor?: string;
+};
+
+const FETCH_TIMEOUT_MS = 10_000;
+const MAX_RESPONSE_BYTES = 2 * 1024 * 1024; // ~2MB cap
+const BROWSER_USER_AGENT =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+
+/**
+ * SSRF guard for the product clipper. Only public http/https URLs are allowed —
+ * this rejects loopback, link-local, private (RFC1918/RFC4193), and other
+ * reserved ranges so a pasted "product URL" can never be used to reach internal
+ * infrastructure (e.g. cloud metadata at 169.254.169.254). Modeled on the
+ * isOwnSignatureStorageUrl allowlist pattern in signature-storage.ts, but this
+ * guard is a denylist because — unlike signatures — the whole point of the
+ * clipper is fetching arbitrary third-party vendor sites.
+ */
+export async function isSafeExternalUrl(url: string): Promise<boolean> {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return false;
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+    if (!parsed.hostname) return false;
+
+    // Reject bare IP literals AND resolved DNS results that land in a private
+    // range — resolve the hostname ourselves rather than trusting fetch() to
+    // reject internal targets after the fact.
+    let addresses: string[];
+    if (net.isIP(parsed.hostname)) {
+        addresses = [parsed.hostname];
+    } else {
+        try {
+            const results = await dns.promises.lookup(parsed.hostname, { all: true, verbatim: true });
+            addresses = results.map((r) => r.address);
+        } catch {
+            return false; // unresolvable host — fail closed
+        }
+    }
+    if (addresses.length === 0) return false;
+    return addresses.every((addr) => !isPrivateOrReservedIp(addr));
+}
+
+function isPrivateOrReservedIp(ip: string): boolean {
+    if (net.isIPv4(ip)) {
+        const parts = ip.split(".").map(Number);
+        if (parts.length !== 4 || parts.some((p) => Number.isNaN(p))) return true;
+        const [a, b] = parts;
+        if (a === 10) return true; // 10.0.0.0/8
+        if (a === 127) return true; // loopback
+        if (a === 0) return true; // "this" network
+        if (a === 169 && b === 254) return true; // link-local
+        if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+        if (a === 192 && b === 168) return true; // 192.168.0.0/16
+        if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT 100.64.0.0/10
+        if (a >= 224) return true; // multicast + reserved (224.0.0.0/4, 240.0.0.0/4)
+        return false;
+    }
+    if (net.isIPv6(ip)) {
+        const lower = ip.toLowerCase();
+        if (lower === "::1") return true; // loopback
+        if (lower === "::") return true; // unspecified
+        if (lower.startsWith("::ffff:")) {
+            // IPv4-mapped IPv6 — check the embedded v4 address.
+            const v4 = lower.split(":").pop() || "";
+            if (net.isIPv4(v4)) return isPrivateOrReservedIp(v4);
+        }
+        if (lower.startsWith("fc") || lower.startsWith("fd")) return true; // fc00::/7 (unique local)
+        if (lower.startsWith("fe8") || lower.startsWith("fe9") || lower.startsWith("fea") || lower.startsWith("feb")) return true; // fe80::/10 link-local
+        return false;
+    }
+    // Unknown format — fail closed.
+    return true;
+}
+
+/**
+ * Fetch a URL with a hard timeout and response-size cap. Caller must have
+ * already validated the URL via isSafeExternalUrl(). Returns null on any
+ * failure (timeout, non-2xx, oversized body, network error) — never throws.
+ */
+async function guardedFetchText(url: string): Promise<string | null> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+        const res = await fetch(url, {
+            signal: controller.signal,
+            redirect: "follow",
+            headers: {
+                "User-Agent": BROWSER_USER_AGENT,
+                Accept: "text/html,application/xhtml+xml",
+            },
+        });
+        if (!res.ok || !res.body) return null;
+
+        const contentLengthHeader = res.headers.get("content-length");
+        if (contentLengthHeader && Number(contentLengthHeader) > MAX_RESPONSE_BYTES) return null;
+
+        const reader = res.body.getReader();
+        const chunks: Uint8Array[] = [];
+        let total = 0;
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (value) {
+                total += value.byteLength;
+                if (total > MAX_RESPONSE_BYTES) {
+                    await reader.cancel().catch(() => {});
+                    return null;
+                }
+                chunks.push(value);
+            }
+        }
+        return Buffer.concat(chunks.map((c) => Buffer.from(c))).toString("utf8");
+    } catch {
+        return null;
+    } finally {
+        clearTimeout(timeoutId);
+    }
+}
+
+function toNumberOrUndefined(value: unknown): number | undefined {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string") {
+        const cleaned = value.replace(/[^0-9.]/g, "");
+        const num = parseFloat(cleaned);
+        if (!Number.isNaN(num)) return num;
+    }
+    return undefined;
+}
+
+function firstString(value: unknown): string | undefined {
+    if (typeof value === "string" && value.trim()) return value.trim();
+    if (Array.isArray(value)) {
+        for (const v of value) {
+            const s = firstString(v);
+            if (s) return s;
+        }
+    }
+    if (value && typeof value === "object" && "name" in (value as any)) {
+        return firstString((value as any).name);
+    }
+    if (value && typeof value === "object" && "url" in (value as any)) {
+        return firstString((value as any).url);
+    }
+    return undefined;
+}
+
+/**
+ * Extract a schema.org/Product from any JSON-LD <script> blocks on the page.
+ * Handles both a bare Product object and an @graph array containing one.
+ */
+function parseJsonLdProduct(html: string): Partial<ParsedProduct> | null {
+    const scriptRe = /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+    let match: RegExpExecArray | null;
+    while ((match = scriptRe.exec(html))) {
+        let data: any;
+        try {
+            data = JSON.parse(match[1].trim());
+        } catch {
+            continue;
+        }
+        const candidates: any[] = Array.isArray(data) ? data : [data];
+        for (const candidate of candidates) {
+            const nodes: any[] = candidate?.["@graph"] ? candidate["@graph"] : [candidate];
+            for (const node of nodes) {
+                const types = Array.isArray(node?.["@type"]) ? node["@type"] : [node?.["@type"]];
+                if (!types.some((t: unknown) => typeof t === "string" && t.toLowerCase() === "product")) continue;
+
+                const offer = Array.isArray(node.offers) ? node.offers[0] : node.offers;
+                const price = toNumberOrUndefined(offer?.price ?? offer?.lowPrice);
+                const name = firstString(node.name);
+                if (!name) continue;
+
+                return {
+                    name,
+                    description: firstString(node.description),
+                    imageUrl: firstString(node.image),
+                    price,
+                    vendor: firstString(node.brand) || firstString(offer?.seller),
+                };
+            }
+        }
+    }
+    return null;
+}
+
+function extractMetaContent(html: string, attr: "property" | "name", key: string): string | undefined {
+    const re = new RegExp(
+        `<meta[^>]+${attr}=["']${key}["'][^>]*content=["']([^"']*)["']`,
+        "i",
+    );
+    const reversed = new RegExp(
+        `<meta[^>]+content=["']([^"']*)["'][^>]*${attr}=["']${key}["']`,
+        "i",
+    );
+    const match = html.match(re) || html.match(reversed);
+    return match?.[1]?.trim() || undefined;
+}
+
+function parseOpenGraph(html: string): Partial<ParsedProduct> | null {
+    const title = extractMetaContent(html, "property", "og:title");
+    const image = extractMetaContent(html, "property", "og:image");
+    const priceAmount = extractMetaContent(html, "property", "product:price:amount");
+    const siteName = extractMetaContent(html, "property", "og:site_name");
+    const description = extractMetaContent(html, "property", "og:description");
+
+    if (!title && !image) return null;
+
+    const titleTagMatch = html.match(/<title[^>]*>([^<]*)<\/title>/i);
+    const name = title || titleTagMatch?.[1]?.trim();
+    if (!name) return null;
+
+    return {
+        name,
+        description,
+        imageUrl: image,
+        price: toNumberOrUndefined(priceAmount),
+        vendor: siteName,
+    };
+}
+
+function stripHtmlToText(html: string, maxChars: number): string {
+    const withoutScripts = html
+        .replace(/<script[\s\S]*?<\/script>/gi, " ")
+        .replace(/<style[\s\S]*?<\/style>/gi, " ")
+        .replace(/<[^>]+>/g, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+    return withoutScripts.slice(0, maxChars);
+}
+
+/**
+ * Gemini fallback: give the model stripped page text and ask for strict JSON.
+ * Uses the same generativelanguage.googleapis.com REST call pattern as the
+ * rest of src/lib/actions.ts (aiGeneratePunchlist, aiGenerateSchedule).
+ */
+async function parseWithGemini(html: string, url: string): Promise<Partial<ParsedProduct> | null> {
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) return null;
+
+    const pageText = stripHtmlToText(html, 8000);
+    if (!pageText) return null;
+
+    const prompt = `You are extracting product info from a retail/vendor web page for a remodeling contractor's product library.
+
+PAGE URL: ${url}
+PAGE TEXT (stripped of HTML):
+${pageText}
+
+Return ONLY strict JSON with this exact shape, no other text:
+{"name": string|null, "price": number|null, "imageUrl": string|null, "vendor": string|null, "description": string|null}
+
+Rules:
+- "name" is the product's title/name. If you cannot identify a specific product, use null.
+- "price" is the numeric list price with no currency symbol (e.g. 129.99). Use null if not found.
+- "imageUrl" is the product's main image URL if visible in the text, otherwise null.
+- "vendor" is the store/brand name, otherwise null.
+- "description" is a one-sentence product description, otherwise null.`;
+
+    try {
+        const res = await fetch(
+            `https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${apiKey}`,
+            {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    contents: [{ parts: [{ text: prompt }] }],
+                    generationConfig: { temperature: 0.2, responseMimeType: "application/json" },
+                }),
+                signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+            },
+        );
+        if (!res.ok) return null;
+        const data = await res.json();
+        const rawText = data?.candidates?.[0]?.content?.parts?.[0]?.text;
+        if (!rawText) return null;
+
+        const parsed = JSON.parse(rawText);
+        if (!parsed || typeof parsed !== "object") return null;
+        const name = typeof parsed.name === "string" && parsed.name.trim() ? parsed.name.trim() : null;
+        if (!name) return null;
+
+        return {
+            name,
+            description: typeof parsed.description === "string" ? parsed.description : undefined,
+            imageUrl: typeof parsed.imageUrl === "string" ? parsed.imageUrl : undefined,
+            price: toNumberOrUndefined(parsed.price),
+            vendor: typeof parsed.vendor === "string" ? parsed.vendor : undefined,
+        };
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Parse a pasted product URL into structured data for the clipper / client
+ * suggestion flows. Never throws — any failure at any stage degrades to
+ * {vendorUrl, name: null} so the caller can fall back to manual entry.
+ */
+export async function parseProductUrl(url: string): Promise<ParsedProduct> {
+    const fallback: ParsedProduct = { vendorUrl: url, name: null };
+
+    const safe = await isSafeExternalUrl(url);
+    if (!safe) return fallback;
+
+    const html = await guardedFetchText(url);
+    if (!html) return fallback;
+
+    const jsonLd = parseJsonLdProduct(html);
+    if (jsonLd?.name) {
+        return { vendorUrl: url, name: jsonLd.name, description: jsonLd.description, price: jsonLd.price, imageUrl: jsonLd.imageUrl, vendor: jsonLd.vendor };
+    }
+
+    const og = parseOpenGraph(html);
+    if (og?.name) {
+        return { vendorUrl: url, name: og.name, description: og.description, price: og.price, imageUrl: og.imageUrl, vendor: og.vendor };
+    }
+
+    const gemini = await parseWithGemini(html, url);
+    if (gemini?.name) {
+        return { vendorUrl: url, name: gemini.name, description: gemini.description, price: gemini.price, imageUrl: gemini.imageUrl, vendor: gemini.vendor };
+    }
+
+    return fallback;
+}

--- a/src/lib/product-parse.ts
+++ b/src/lib/product-parse.ts
@@ -24,6 +24,9 @@ const FETCH_TIMEOUT_MS = 10_000;
 const MAX_RESPONSE_BYTES = 2 * 1024 * 1024; // ~2MB cap, cumulative across the whole redirect chain
 const MAX_REDIRECTS = 5;
 const ALLOWED_PORTS = new Set([80, 443]);
+// Any URL we'd fetch, follow, or hand back to a caller (vendorUrl, imageUrl) —
+// an absurdly long string is never a legitimate product/image link.
+const MAX_URL_LEN = 2000;
 const BROWSER_USER_AGENT =
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
@@ -168,13 +171,20 @@ const IPV6_BLOCKED_RANGES: Array<[string, number]> = [
 ];
 
 function isBlockedIPv6(ip: string): boolean {
+    // Fail closed: ANY IPv6 string that doesn't parse to a definite 128-bit
+    // value is treated as blocked, never as "allowed" — this function has no
+    // implicit-allow fallthrough for an unrecognized/unparseable form.
     const big = ipv6ToBigInt(ip);
-    if (big === null) return true; // fail closed
+    if (big === null) return true;
     if (big === BigInt(0)) return true; // ::
     if (big === BigInt(1)) return true; // ::1
-    if (ipv6InCidr(big, "::ffff:0:0", 96) || ipv6InCidr(big, "64:ff9b::", 96)) {
-        // IPv4-mapped (::ffff:a.b.c.d) or NAT64 (64:ff9b::a.b.c.d) — the real
-        // target is the embedded IPv4 address, so validate that instead.
+    if (
+        ipv6InCidr(big, "::ffff:0:0", 96) ||   // IPv4-mapped: ::ffff:a.b.c.d
+        ipv6InCidr(big, "64:ff9b::", 96) ||    // NAT64: 64:ff9b::a.b.c.d
+        ipv6InCidr(big, "::", 96)              // IPv4-compatible (deprecated): ::a.b.c.d
+    ) {
+        // The real target is the embedded IPv4 address in all three forms —
+        // decode it and validate that instead of the IPv6 wrapper.
         return isBlockedIPv4Int(Number(big & BigInt(0xFFFFFFFF)));
     }
     return IPV6_BLOCKED_RANGES.some(([base, len]) => ipv6InCidr(big, base, len));
@@ -194,6 +204,13 @@ function isBlockedIp(ip: string): boolean {
  * resolved here; that happens once, at actual connect time, in fetchOneHop().
  */
 export function isSafeExternalUrl(url: string): boolean {
+    // Length gate first — this is what keeps an absurdly long vendorUrl out of
+    // the returned ParsedProduct too: every caller (parseProductUrl's initial
+    // check, and guardedFetchText's per-hop re-check) already treats a false
+    // result here as "unsafe", so vendorUrl never ends up backed by a URL
+    // longer than this without ever reaching a fetch attempt.
+    if (url.length > MAX_URL_LEN) return false;
+
     let parsed: URL;
     try {
         parsed = new URL(url);
@@ -215,22 +232,59 @@ export function isSafeExternalUrl(url: string): boolean {
 // Transport: node:http/https with a validating `lookup`, manual redirects
 // =============================================================================
 
-type NodeLookupCallback = (err: NodeJS.ErrnoException | null, address: string, family: number) => void;
+/**
+ * dns.lookup-compatible function that rejects any resolved address in the
+ * blocked ranges, and otherwise hands Node the exact address(es) it
+ * validated — that's what Node actually connects to, so there's no window
+ * between "validated" and "connected to" for a rebinding DNS server to
+ * exploit.
+ *
+ * Node's `lookup` option has TWO callback shapes depending on the caller's
+ * `options.all`:
+ *   - options.all is NOT true (the historical default): callback(err, address, family) — one address.
+ *   - options.all === true: callback(err, addresses) — an array of {address, family}.
+ * Node 20+ / Next 16 enable Happy Eyeballs (`autoSelectFamily`, on by
+ * default) for http(s).request, which calls `lookup` with `{ all: true }` to
+ * get every address so it can race them per RFC 8305. An earlier version of
+ * this function always replied with the single-address shape, which broke
+ * that contract silently. This version inspects `options.all` and replies in
+ * the shape the caller asked for, in both the success and error paths.
+ * `autoSelectFamily: false` is also set on the request below as a second,
+ * independent layer — but this function is correct either way.
+ */
+function validatingLookup(
+    hostname: string,
+    optionsOrCallback: dns.LookupAllOptions | dns.LookupOneOptions | ((...args: any[]) => void),
+    maybeCallback?: (...args: any[]) => void,
+): void {
+    const hasExplicitOptions = typeof optionsOrCallback !== "function";
+    const options = hasExplicitOptions ? (optionsOrCallback as dns.LookupAllOptions | dns.LookupOneOptions) : undefined;
+    const callback = (hasExplicitOptions ? maybeCallback : optionsOrCallback) as (...args: any[]) => void;
+    const wantsAll = !!(options && (options as dns.LookupAllOptions).all === true);
 
-/** dns.lookup-compatible function that rejects any resolved address in the
- * blocked ranges, and otherwise hands Node the exact address it validated —
- * that address is what Node actually connects to, so there's no window
- * between "validated" and "connected to" for a rebinding DNS server to exploit. */
-function validatingLookup(hostname: string, options: unknown, callback: NodeLookupCallback): void {
-    const cb: NodeLookupCallback = typeof options === "function" ? (options as NodeLookupCallback) : callback;
     dns.lookup(hostname, { all: true, verbatim: true }, (err, addresses) => {
-        if (err) { cb(err, "", 4); return; }
+        if (err) {
+            wantsAll ? callback(err, []) : callback(err, "", 4);
+            return;
+        }
         const list = addresses as dns.LookupAddress[];
-        if (!list.length) { cb(new Error("DNS lookup returned no addresses"), "", 4); return; }
+        if (!list.length) {
+            const noAddrErr = new Error("DNS lookup returned no addresses");
+            wantsAll ? callback(noAddrErr, []) : callback(noAddrErr, "", 4);
+            return;
+        }
         const blocked = list.find((a) => isBlockedIp(a.address));
-        if (blocked) { cb(new Error(`Resolved address ${blocked.address} is not allowed`), "", 4); return; }
-        const chosen = list[0];
-        cb(null, chosen.address, chosen.family);
+        if (blocked) {
+            const blockedErr = new Error(`Resolved address ${blocked.address} is not allowed`);
+            wantsAll ? callback(blockedErr, []) : callback(blockedErr, "", 4);
+            return;
+        }
+        if (wantsAll) {
+            callback(null, list);
+        } else {
+            const chosen = list[0];
+            callback(null, chosen.address, chosen.family);
+        }
     });
 }
 
@@ -239,7 +293,7 @@ type HopResult =
     | { kind: "body"; text: string }
     | { kind: "fail" };
 
-function fetchOneHop(url: string, deadline: number): Promise<HopResult> {
+function fetchOneHop(url: string, deadline: number, hardDeadlineSignal: AbortSignal): Promise<HopResult> {
     return new Promise((resolve) => {
         let parsed: URL;
         try {
@@ -250,7 +304,7 @@ function fetchOneHop(url: string, deadline: number): Promise<HopResult> {
         }
 
         const timeLeft = deadline - Date.now();
-        if (timeLeft <= 0) { resolve({ kind: "fail" }); return; }
+        if (timeLeft <= 0 || hardDeadlineSignal.aborted) { resolve({ kind: "fail" }); return; }
 
         const transport = parsed.protocol === "https:" ? https : http;
         const port = parsed.port ? Number(parsed.port) : (parsed.protocol === "https:" ? 443 : 80);
@@ -262,20 +316,34 @@ function fetchOneHop(url: string, deadline: number): Promise<HopResult> {
             resolve(result);
         };
 
-        const req = transport.request(
-            {
-                hostname: parsed.hostname,
-                port,
-                path: `${parsed.pathname}${parsed.search}`,
-                method: "GET",
-                // Validated at actual connect time — see validatingLookup() above.
-                lookup: validatingLookup as unknown as typeof dns.lookup,
-                headers: {
-                    "User-Agent": BROWSER_USER_AGENT,
-                    Accept: "text/html,application/xhtml+xml",
-                },
-                timeout: timeLeft,
+        // `autoSelectFamily` (Happy Eyeballs opt-out) and `signal` (hard
+        // wall-clock abort — see guardedFetchText) are both valid Node
+        // http(s).request options at runtime, but the @types/node version
+        // pinned in this repo predates them, hence the `as any`.
+        const requestOptions: any = {
+            hostname: parsed.hostname,
+            port,
+            path: `${parsed.pathname}${parsed.search}`,
+            method: "GET",
+            // Validated at actual connect time — see validatingLookup() above.
+            lookup: validatingLookup as unknown as typeof dns.lookup,
+            // Defense-in-depth alongside validatingLookup()'s {all:true}
+            // support: disabling Happy Eyeballs means Node won't call
+            // `lookup` with {all:true} in the first place on this request.
+            autoSelectFamily: false,
+            headers: {
+                "User-Agent": BROWSER_USER_AGENT,
+                Accept: "text/html,application/xhtml+xml",
             },
+            // Inactivity timeout — resets on every byte received, so alone it
+            // can't stop a trickling server. The hard wall-clock cap is
+            // `signal` below (shared across every hop by the caller).
+            timeout: timeLeft,
+            signal: hardDeadlineSignal,
+        };
+
+        const req = transport.request(
+            requestOptions,
             (res) => {
                 const status = res.statusCode || 0;
                 const location = res.headers.location;
@@ -332,29 +400,48 @@ function fetchOneHop(url: string, deadline: number): Promise<HopResult> {
  * validatingLookup() above (see the SSRF guard section for why both layers
  * exist). Capped at MAX_REDIRECTS hops.
  *
+ * The deadline is enforced TWO ways: fetchOneHop's per-request `timeout` is
+ * an INACTIVITY timeout (Node resets it on every byte received, so alone it
+ * can't stop a trickling server that dribbles one byte just often enough to
+ * never go quiet). The `hardDeadline` AbortController below is the real
+ * wall-clock cap — one timer, started once here, shared across every hop via
+ * the same AbortSignal, that destroys whatever request/response is currently
+ * in-flight the moment FETCH_TIMEOUT_MS elapses, no matter how much activity
+ * it's seeing.
+ *
  * Returns null on any failure (timeout, unsafe target, too many redirects,
  * non-2xx, oversized body, network error) — never throws.
  */
 async function guardedFetchText(url: string): Promise<string | null> {
     const deadline = Date.now() + FETCH_TIMEOUT_MS;
-    let currentUrl = url;
+    const hardDeadline = new AbortController();
+    const hardDeadlineTimer = setTimeout(
+        () => hardDeadline.abort(new Error("guardedFetchText hard deadline exceeded")),
+        FETCH_TIMEOUT_MS,
+    );
 
-    for (let redirects = 0; ; redirects++) {
-        if (!isSafeExternalUrl(currentUrl)) return null;
-        if (Date.now() >= deadline) return null;
+    try {
+        let currentUrl = url;
 
-        const result = await fetchOneHop(currentUrl, deadline);
-        if (result.kind === "fail") return null;
-        if (result.kind === "redirect") {
-            if (redirects >= MAX_REDIRECTS) return null;
-            try {
-                currentUrl = new URL(result.location, currentUrl).toString();
-            } catch {
-                return null;
+        for (let redirects = 0; ; redirects++) {
+            if (!isSafeExternalUrl(currentUrl)) return null;
+            if (Date.now() >= deadline || hardDeadline.signal.aborted) return null;
+
+            const result = await fetchOneHop(currentUrl, deadline, hardDeadline.signal);
+            if (result.kind === "fail") return null;
+            if (result.kind === "redirect") {
+                if (redirects >= MAX_REDIRECTS) return null;
+                try {
+                    currentUrl = new URL(result.location, currentUrl).toString();
+                } catch {
+                    return null;
+                }
+                continue;
             }
-            continue;
+            return result.text;
         }
-        return result.text;
+    } finally {
+        clearTimeout(hardDeadlineTimer);
     }
 }
 
@@ -409,11 +496,11 @@ const MAX_PRICE = 9_999_999.99;
 /**
  * Single normalization point for every extraction path (JSON-LD, OpenGraph,
  * Gemini). Clamps string lengths, rejects a non-finite/out-of-range price,
- * drops an imageUrl that isn't a plain http(s) URL (never persist/return a
- * javascript:/data: URL pulled from a scraped page), and — if the page quoted
- * a non-USD price — nulls the price and folds the original amount/currency
- * into the description instead (no schema change for a currency field).
- * Returns null if there's no usable name.
+ * drops an imageUrl that isn't a plain http(s) URL OR is over MAX_URL_LEN
+ * (never persist/return a javascript:/data:/absurdly-long URL pulled from a
+ * scraped page), and — if the page quoted a non-USD price — nulls the price
+ * and folds the original amount/currency into the description instead (no
+ * schema change for a currency field). Returns null if there's no usable name.
  */
 function normalizeParsedProduct(raw: RawExtract): Omit<ParsedProduct, "vendorUrl"> | null {
     const name = raw.name?.trim().slice(0, MAX_NAME_LEN);
@@ -421,7 +508,8 @@ function normalizeParsedProduct(raw: RawExtract): Omit<ParsedProduct, "vendorUrl
 
     let description = raw.description?.trim().slice(0, MAX_DESCRIPTION_LEN) || undefined;
     const vendor = raw.vendor?.trim().slice(0, MAX_VENDOR_LEN) || undefined;
-    const imageUrl = raw.imageUrl && isHttpUrl(raw.imageUrl) ? raw.imageUrl : undefined;
+    const imageUrl =
+        raw.imageUrl && raw.imageUrl.length <= MAX_URL_LEN && isHttpUrl(raw.imageUrl) ? raw.imageUrl : undefined;
 
     const rawPrice =
         typeof raw.price === "number" && Number.isFinite(raw.price) && raw.price > 0 && raw.price <= MAX_PRICE
@@ -598,7 +686,14 @@ Rules:
  * {vendorUrl, name: null} so the caller can fall back to manual entry.
  */
 export async function parseProductUrl(url: string): Promise<ParsedProduct> {
-    const fallback: ParsedProduct = { vendorUrl: url, name: null };
+    // vendorUrl is a required field on ParsedProduct (not optional — every
+    // caller expects it echoed back even on total failure, e.g. to show the
+    // link the user pasted), so an over-length url can't be "nulled" the way
+    // imageUrl is above. Instead it's capped to an empty string, which every
+    // render site and persist-layer check (isHttpUrl) already treats as "no
+    // link" — an over-length URL never survives into vendorUrl either way.
+    const safeVendorUrl = url.length <= MAX_URL_LEN ? url : "";
+    const fallback: ParsedProduct = { vendorUrl: safeVendorUrl, name: null };
 
     if (!isSafeExternalUrl(url)) return fallback;
 
@@ -606,13 +701,13 @@ export async function parseProductUrl(url: string): Promise<ParsedProduct> {
     if (!html) return fallback;
 
     const jsonLd = normalizeParsedProduct(parseJsonLdProduct(html) || {});
-    if (jsonLd) return { vendorUrl: url, ...jsonLd };
+    if (jsonLd) return { vendorUrl: safeVendorUrl, ...jsonLd };
 
     const og = normalizeParsedProduct(parseOpenGraph(html) || {});
-    if (og) return { vendorUrl: url, ...og };
+    if (og) return { vendorUrl: safeVendorUrl, ...og };
 
     const gemini = normalizeParsedProduct((await parseWithGemini(html, url)) || {});
-    if (gemini) return { vendorUrl: url, ...gemini };
+    if (gemini) return { vendorUrl: safeVendorUrl, ...gemini };
 
     return fallback;
 }

--- a/src/lib/project-files.ts
+++ b/src/lib/project-files.ts
@@ -10,6 +10,15 @@ export const ALLOWED_FILE_EXTENSIONS = new Set([
     ".txt", ".rtf", ".dwg", ".dxf",
 ]);
 
+// Client-portal file uploads (two-way Design Files exchange). Narrower purpose
+// than the team allowlist above — images, PDFs, CAD, common office docs, and
+// zip archives (designers often send a zipped folder of files) — but adds
+// .zip, which the team allowlist doesn't need.
+export const PORTAL_UPLOAD_EXTENSIONS = new Set([
+    ...ALLOWED_FILE_EXTENSIONS,
+    ".zip",
+]);
+
 const MIME_BY_EXTENSION: Record<string, string> = {
     ".pdf": "application/pdf",
     ".doc": "application/msword",

--- a/src/lib/url-safety.ts
+++ b/src/lib/url-safety.ts
@@ -1,0 +1,18 @@
+// Shared URL-safety helper for rendering stored, user-supplied URLs (product
+// vendorUrl/imageUrl, client-suggestion links, etc.) into href/img src. This is
+// NOT the SSRF guard (that's isSafeExternalUrl in product-parse.ts, server-only,
+// does DNS/IP validation) — this is a cheap, universally-importable check that a
+// stored string is a plain http(s) URL and not `javascript:`, `data:`, `vbscript:`,
+// or similar, before it's ever handed to the DOM. Has no server-only imports so
+// both server components/actions and "use client" components can import it.
+export function isHttpUrl(value: unknown): value is string {
+    if (typeof value !== "string") return false;
+    const trimmed = value.trim();
+    if (!trimmed) return false;
+    try {
+        const parsed = new URL(trimmed);
+        return parsed.protocol === "http:" || parsed.protocol === "https:";
+    } catch {
+        return false;
+    }
+}


### PR DESCRIPTION
Origin: Janet Hoppe's portal feedback (2026-07-25). Spec: `docs/specs/product-library-portal-selections.md`.

## What's in here

**Company-wide Product Library** (`/company/product-library`) — reusable product catalog. Add manually or paste a product URL: JSON-LD → OpenGraph → Gemini fallback parsing. "Add to project…" pins items to a project's client-visible favorites.

**Clipper bookmarklet** (`/clip`) — Houzz-style capture. Drag the bookmarklet from the library page; on any retail product page it opens a popup with the product pre-parsed, one click to save to the library and optionally a project. (Chrome extension deliberately deferred — same API when we want it.)

**Client selection proposals** — portal clients get "Suggest an item" on the Selections tab (paste-a-link parsing, price never shown pre-approval). Proposals land Pending; team reviews on the project Selections tab with approve (price + optional board/category placement + auto-favorite) or decline (note). Approval mints a library item. Existing board pick/submit flow untouched.

**Project Favorites** — client-visible pinboard per project; approved suggestions flow in automatically.

**Two-way design files** — portal clients can upload (drag/drop) into a shared "Design Files" folder; team gets notified; client uploads badge "From you". Shared-folder targeting enforced by ancestor-chain visibility check.

## Schema

3 new models (`ProductLibraryItem`, `ProjectProductFavorite`, `SelectionProposal`) + `ProjectFile.uploadedByClient`. **Run `node scripts/apply-product-library.mjs` against prod BEFORE deploying** (additive + idempotent, per the usual pre-deploy checklist).

## Review trail

- Checker round 1: caught SSRF redirect-follow bypass + cross-project boardId write → fixed.
- Codex round 1: 3 blockers, 8 real issues (DNS rebinding, incomplete IP denylist, stored `javascript:` URLs, non-transactional approval, portal visibility gaps, etc.) → all addressed.
- Codex round 2: confirmed 7/11, flagged residuals (IPv4-compatible IPv6 forms, TOCTOU on board validation, lookup-contract break, inactivity-only timeout) → all fixed in `7a4e049`.
- Checker final pass: all five residual fixes verified with executed test cases (e.g. `::127.0.0.1` blocks, `::8.8.8.8` passes); build 0 errors.
- Defended, not fixed: portal uploads validate by extension allowlist + 8MB cap (matches the existing team upload path); no magic-byte sniffing added. Flagging for an explicit call.

No money-path files touched (`payment-notifications.ts`, mirror logic, `e2e/money-pipeline.spec.ts` all clean in the diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)