### PR TITLE
feat(security): sweep orphaned sensitive objects out of the public bucket

### DIFF
--- a/docs/STORAGE-AUDIT.md
+++ b/docs/STORAGE-AUDIT.md
@@ -82,6 +82,34 @@ Run in this order. Steps 1–3 are reversible; step 6 is not.
 
 Rollback before step 6 is a code revert — the public originals are still serving, so nothing is lost.
 
+7. **Sweep orphans** — `node scripts/sweep-orphaned-public-signatures.mjs --dest "<backup dir>" --apply`. The migration only moves objects a DB row points at, so it is blind to **orphans**: sensitive objects in storage that nothing references. These stay public forever otherwise. See below.
+
+## Executed 2026-07-27
+
+All steps ran against production. Result: **0 sensitive objects remain in the public bucket.**
+
+| Step | Outcome |
+|---|---|
+| Migration (`--apply`) | 32 rows → 26 unique objects copied, 0 failed, 0 corrupt |
+| Backup to Drive | 26 files / 9.3 MB + manifest, sha256-verified against live objects |
+| Purge of originals | 26 deleted, 0 refused, 0 failed |
+| Orphan sweep | **202 orphans** swept (14 signatures + 188 PDFs, 52.5 MB), 0 referenced, 0 failed |
+
+Backups live in Google Drive at `Claude/ProBuild-Storage-Backup-2026-07-27` (folder id `1AYDAB4toyYGv8s5nCoL0bPqhgg_bPe9j`), with `MANIFEST.json`, `MANIFEST-orphans.json` and `MANIFEST-orphans-signatures.json` recording table/column/row-id/path/size/sha256 per file. Restore maps 1:1 back to bucket paths.
+
+## Orphans: why the migration alone was not enough
+
+The migration is DB-driven, so it never sees objects that no row references. Sweeping found **202** such objects still world-readable after the purge:
+
+- **14 signature PNGs.** One contract had *five* near-identical 8,502-byte client signatures — the signing action uploads *before* its guarded DB write, so losing an idempotency race or hitting the already-signed retry leaves the upload behind. Re-signing also supersedes an earlier object.
+- **188 sensitive PDFs**, 52 MB. Mostly e2e test artifacts (`EST-MPTEST`, `Automated_Test_Lien_Release`), but including real-looking executed contracts whose `ProjectFile` rows had since been deleted.
+
+**The upstream orphan-generating bug still exists** (upload precedes the guarded write). It is no longer a *privacy* problem, because `persistSignature` now writes to the private bucket, so future orphans are wasted storage rather than exposed documents. A periodic sweep or cleanup-on-throw would close it properly.
+
+## Caveat: CDN cache lag
+
+Supabase serves public objects through Cloudflare with `cacheControl: max-age=3600`. **Deleting an object does not purge edge caches**, so a previously-fetched URL can keep returning the file for up to an hour. This was observed directly during verification: a deleted signature returned HTTP 200 from cache, then 400 once the cache was bypassed. Anyone who fetched a specific URL shortly before the purge may retain access briefly; there is no permanent exposure.
+
 ## Gotchas carried in from prior work
 
 - `isOwnSignatureStorageUrl()` in `src/lib/signature-storage.ts` is an **SSRF allowlist** gating the server-side signature fetch in `pdf.ts`. It is pinned to `project-files`; moving buckets requires updating it. Do not remove it.

--- a/scripts/backup-migrated-public-docs.mjs
+++ b/scripts/backup-migrated-public-docs.mjs
@@ -1,0 +1,285 @@
+// Safety backup for the secure-docs migration. Run this BEFORE
+// scripts/purge-migrated-public-docs.mjs deletes the public originals, so the purge becomes
+// reversible.
+//
+// For every in-scope DB column whose value is a `secure:<path>` ref (i.e. every row
+// scripts/purge-migrated-public-docs.mjs would act on), this downloads the ORIGINAL object at
+// that same path from the PUBLIC `project-files` bucket and writes it to
+// `<dest>/<storage-path>`, preserving the storage path structure exactly so a restore can map
+// 1:1 back to bucket paths. A MANIFEST.json is written alongside recording table/column/row
+// id/path/size/sha256 for every backed-up file, for an auditable restore.
+//
+// Same column scope as scripts/migrate-secure-docs.mjs and scripts/purge-migrated-public-docs.mjs:
+//   Contract.signatureUrl / contractorSignatureUrl / companySignatureUrl / signedPdfPath / originalPdfPath
+//   ContractSigningRecord.signatureUrl
+//   ChangeOrder.clientSignatureUrl / companySignatureUrl
+//   Client.taxExemptCertUrl
+//   ProjectFile.url (any row already holding a `secure:` ref — no extra path-pattern
+//     filtering needed, mirroring purge-migrated-public-docs.mjs's reasoning: only rows
+//     migrate-secure-docs.mjs touched, or new executed-contract PDFs uploaded straight to
+//     secure-docs via uploadSecureDoc(), can ever hold one)
+//
+// Values that are NOT `secure:` refs (inline `data:` URLs, un-migrated legacy values) are not
+// purge targets and are skipped without being counted as an error.
+//
+// Safety:
+//   - READ-ONLY with respect to Supabase and the database. Never writes to storage, never
+//     deletes anything, never UPDATEs any DB row. The only writes are local filesystem writes
+//     under --dest.
+//   - Idempotent re-runs: if a file already exists at the destination with a non-zero size
+//     matching the remote object's reported size, it's counted as already-backed-up and not
+//     re-downloaded (its sha256 is still recomputed from the local copy so the manifest stays
+//     complete).
+//   - A public original missing from `project-files` is logged clearly and counted as
+//     missing-original — this does not fail the run (two such rows are known to exist: a
+//     contract whose original PDF was destroyed by an older bug).
+//   - After every download the bytes written are verified non-zero and equal to the remote
+//     object's reported size; a mismatch is counted and loudly reported as failed (the file is
+//     left on disk as-is — a later re-run will detect the size mismatch and retry the
+//     download).
+//   - Any derived storage path containing ".." or starting with "/" is refused.
+//
+// Usage:
+//   node scripts/backup-migrated-public-docs.mjs --dest <dir>
+//
+// Requires (read from env or .env / .env.local):
+//   DATABASE_URL          Supabase transaction pooler URL (must include ?pgbouncer=true)
+//   SUPABASE_URL          Supabase project URL
+//   SUPABASE_SERVICE_KEY  Supabase service role key
+import { PrismaClient } from "@prisma/client";
+import { createClient } from "@supabase/supabase-js";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const PUBLIC_BUCKET = "project-files";
+const SECURE_SCHEME = "secure:";
+
+function parseDestArg(argv) {
+  const eq = argv.find((a) => a.startsWith("--dest="));
+  if (eq) return eq.slice("--dest=".length);
+  const idx = argv.indexOf("--dest");
+  if (idx !== -1 && argv[idx + 1]) return argv[idx + 1];
+  return undefined;
+}
+
+const DEST = parseDestArg(process.argv.slice(2));
+if (!DEST) {
+  console.error("Usage: node scripts/backup-migrated-public-docs.mjs --dest <dir>");
+  console.error("Refusing to run without a required --dest <dir> argument.");
+  process.exit(1);
+}
+
+function envFromFiles(key) {
+  if (process.env[key]) return process.env[key];
+  for (const f of [".env", ".env.local"]) {
+    if (!fs.existsSync(f)) continue;
+    const m = fs.readFileSync(f, "utf8").match(new RegExp(`^${key}\\s*=\\s*"?([^"\\n]+)"?`, "m"));
+    if (m) return m[1];
+  }
+  return undefined;
+}
+
+const DATABASE_URL = envFromFiles("DATABASE_URL");
+if (!DATABASE_URL) throw new Error("DATABASE_URL not found in env or .env files");
+if (!DATABASE_URL.includes("pgbouncer=true")) {
+  console.warn("⚠ DATABASE_URL has no pgbouncer=true — expected the Supabase transaction pooler. Continuing.");
+}
+
+const SUPABASE_URL = envFromFiles("SUPABASE_URL");
+const SUPABASE_SERVICE_KEY = envFromFiles("SUPABASE_SERVICE_KEY");
+if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+  throw new Error("SUPABASE_URL and SUPABASE_SERVICE_KEY are required (read access to project-files)");
+}
+
+const prisma = new PrismaClient({ datasources: { db: { url: DATABASE_URL } } });
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+
+// Same (table, column) scope purge-migrated-public-docs.mjs deletes from.
+const TARGETS = [
+  { table: "Contract", column: "signatureUrl" },
+  { table: "Contract", column: "contractorSignatureUrl" },
+  { table: "Contract", column: "companySignatureUrl" },
+  { table: "Contract", column: "signedPdfPath" },
+  { table: "Contract", column: "originalPdfPath" },
+  { table: "ContractSigningRecord", column: "signatureUrl" },
+  { table: "ChangeOrder", column: "clientSignatureUrl" },
+  { table: "ChangeOrder", column: "companySignatureUrl" },
+  { table: "Client", column: "taxExemptCertUrl" },
+  { table: "ProjectFile", column: "url" },
+];
+
+function firstLine(e) {
+  return (e?.message || e || "").toString().split("\n")[0];
+}
+
+function isSecureRef(value) {
+  return typeof value === "string" && value.startsWith(SECURE_SCHEME);
+}
+
+/** Storage path inside the bucket, or null when `value` isn't a secure ref or the derived
+ *  path is unsafe (mirrors secureRefPath() in scripts/purge-migrated-public-docs.mjs). */
+function secureRefPath(value) {
+  if (!isSecureRef(value)) return null;
+  const p = value.slice(SECURE_SCHEME.length);
+  if (!p || p.startsWith("/") || p.includes("..")) return null;
+  return p;
+}
+
+/**
+ * Fetch an object's size (in bytes) via the storage info() API (same approach as
+ * migrate-secure-docs.mjs / purge-migrated-public-docs.mjs). Returns null when the object
+ * doesn't exist or the metadata can't be fetched for any reason — callers must treat null as
+ * "can't verify", never as a size of 0.
+ */
+async function getObjectSize(bucket, objectPath) {
+  const { data, error } = await supabase.storage.from(bucket).info(objectPath);
+  if (error) {
+    console.warn(`    info() check failed for ${bucket}/${objectPath}: ${firstLine(error)}`);
+    return null;
+  }
+  return typeof data?.size === "number" ? data.size : null;
+}
+
+function sha256(buffer) {
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+function localFileSize(localPath) {
+  try {
+    return fs.statSync(localPath).size;
+  } catch {
+    return null;
+  }
+}
+
+function emptyStats() {
+  return {
+    scanned: 0,
+    backedUp: 0,
+    alreadyBackedUp: 0,
+    missingOriginal: 0,
+    failed: 0,
+    totalBytesWritten: 0,
+  };
+}
+
+/** Backs up one row's object. Mutates `stats` and pushes an entry to `manifestEntries` on
+ *  success (newly downloaded or already-backed-up). */
+async function backupOneRow({ table, column, id, objectPath, stats, manifestEntries }) {
+  const localPath = path.join(DEST, objectPath);
+
+  const sourceSize = await getObjectSize(PUBLIC_BUCKET, objectPath);
+  if (sourceSize === null) {
+    stats.missingOriginal++;
+    console.error(
+      `  ⚠ ${table}.${column} id=${id}: public original missing from ${PUBLIC_BUCKET} at "${objectPath}" — nothing to back up`
+    );
+    return;
+  }
+
+  const existingSize = localFileSize(localPath);
+  if (existingSize !== null && existingSize > 0 && existingSize === sourceSize) {
+    stats.alreadyBackedUp++;
+    const bytes = fs.readFileSync(localPath);
+    manifestEntries.push({ table, column, id, path: objectPath, size: bytes.length, sha256: sha256(bytes) });
+    console.log(`  · ${table}.${column} id=${id}: already backed up at "${objectPath}" (${existingSize}b) — skipping`);
+    return;
+  }
+
+  const { data: blob, error: downloadError } = await supabase.storage.from(PUBLIC_BUCKET).download(objectPath);
+  if (downloadError) {
+    stats.failed++;
+    console.error(`  ✗ ${table}.${column} id=${id}: download of ${PUBLIC_BUCKET}/${objectPath} failed — ${firstLine(downloadError)}`);
+    return;
+  }
+
+  const arrayBuffer = await blob.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+
+  fs.mkdirSync(path.dirname(localPath), { recursive: true });
+  fs.writeFileSync(localPath, buffer);
+
+  const writtenSize = localFileSize(localPath);
+  if (!writtenSize || writtenSize === 0 || writtenSize !== sourceSize) {
+    stats.failed++;
+    console.error(
+      `  ✗ ${table}.${column} id=${id}: MISMATCH after writing "${objectPath}" — wrote ${writtenSize ?? 0}b, ` +
+        `expected ${sourceSize}b. Left on disk for inspection; a re-run will retry.`
+    );
+    return;
+  }
+
+  stats.backedUp++;
+  stats.totalBytesWritten += writtenSize;
+  manifestEntries.push({ table, column, id, path: objectPath, size: writtenSize, sha256: sha256(buffer) });
+  console.log(`  ✓ ${table}.${column} id=${id}: backed up "${objectPath}" (${writtenSize}b)`);
+}
+
+async function processTarget(t, stats, manifestEntries) {
+  const label = `${t.table}.${t.column}`;
+  let rows;
+  try {
+    rows = await prisma.$queryRawUnsafe(`SELECT "id", "${t.column}" AS val FROM "${t.table}" WHERE "${t.column}" IS NOT NULL`);
+  } catch (e) {
+    console.log(`• ${label}: skipped (${firstLine(e)})`);
+    return;
+  }
+
+  for (const row of rows) {
+    const value = row.val;
+    if (!isSecureRef(value)) continue; // not a purge target — data: URL or un-migrated legacy value
+
+    stats.scanned++;
+    const objectPath = secureRefPath(value);
+    if (!objectPath) {
+      stats.failed++;
+      console.error(`  ✗ ${label} id=${row.id}: malformed secure ref "${value}" — refusing to touch`);
+      continue;
+    }
+
+    await backupOneRow({ table: t.table, column: t.column, id: row.id, objectPath, stats, manifestEntries });
+  }
+}
+
+(async () => {
+  console.log(`Backup destination: ${path.resolve(DEST)}\n`);
+  fs.mkdirSync(DEST, { recursive: true });
+
+  const stats = emptyStats();
+  const manifestEntries = [];
+
+  for (const t of TARGETS) {
+    await processTarget(t, stats, manifestEntries);
+  }
+
+  const manifestPath = path.join(DEST, "MANIFEST.json");
+  fs.writeFileSync(
+    manifestPath,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        sourceBucket: PUBLIC_BUCKET,
+        destDir: path.resolve(DEST),
+        files: manifestEntries,
+      },
+      null,
+      2
+    )
+  );
+
+  console.log(
+    `\nTotals: scanned=${stats.scanned} backed-up=${stats.backedUp} already-backed-up=${stats.alreadyBackedUp} ` +
+      `missing-original=${stats.missingOriginal} failed=${stats.failed} total-bytes-written=${stats.totalBytesWritten}`
+  );
+  console.log(`Manifest written to ${manifestPath} (${manifestEntries.length} files recorded)`);
+
+  if (stats.failed > 0) process.exitCode = 1;
+})()
+  .catch((e) => {
+    console.error("Backup failed:", e);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/restore-secure-docs-from-backup.mjs
+++ b/scripts/restore-secure-docs-from-backup.mjs
@@ -1,0 +1,405 @@
+// EMERGENCY UNDO for the secure-docs migration. Restores documents that
+// migrate-secure-docs.mjs moved into the PRIVATE `secure-docs` bucket (and that
+// purge-migrated-public-docs.mjs / sweep-orphaned-public-signatures.mjs then deleted from the
+// PUBLIC `project-files` bucket) back into the public bucket, from the on-disk backup that
+// backup-migrated-public-docs.mjs (and the orphan sweep) produced before those deletions.
+//
+// Run this ONLY if the private-bucket approach for sensitive documents has to be abandoned.
+// It re-publishes signatures, executed contract PDFs, signed estimate PDFs, and tax-exempt
+// certs to a PUBLIC bucket — that is the whole point, but it is a real security regression,
+// not a no-op, so --apply prints a loud banner saying so.
+//
+// BACKUP LAYOUT (input, produced by backup-migrated-public-docs.mjs / the orphan sweep):
+//   <source>/<storage-path>              the file itself, laid out at its original bucket path
+//   <source>/MANIFEST.json                { files: [{ table, column, id, path, size, sha256 }] }
+//   <source>/MANIFEST-orphans.json               { files: [{ path, size, sha256, orphan: true }] }
+//   <source>/MANIFEST-orphans-signatures.json    { files: [{ path, size, sha256, orphan: true }] }
+// All three manifest files are optional on disk (a given backup run may not have produced
+// every one) but at least one must be present, and be non-empty, or there is nothing to
+// restore. Missing manifest files are logged and skipped, not treated as an error.
+//
+// Phase 1 — re-upload (needs SUPABASE_URL + SUPABASE_SERVICE_KEY):
+//   For every entry in every manifest present (MANIFEST.json AND both orphan manifests —
+//   an orphan is still a real object that used to live in the public bucket), read the local
+//   backup file, verify its sha256 against the manifest (refuse and count sha-mismatch if it
+//   doesn't match — corrupt data is never uploaded), then upload it to `project-files` at the
+//   manifest `path`. An existing object at that path with the same non-zero size as the
+//   manifest is treated as already-restored (idempotent — counted as already-present, not
+//   re-uploaded).
+//
+// Phase 2 — revert DB refs (needs DATABASE_URL; only applies to MANIFEST.json entries):
+//   For each MANIFEST.json entry, build the legacy public URL
+//   `<SUPABASE_URL>/storage/v1/object/public/project-files/<path>` and, via a compare-and-swap
+//   UPDATE, set `table.column` for row `id` back to that URL — but ONLY if the column
+//   currently still holds `secure:<path>` exactly. A row that has since been re-signed, or
+//   whose column value has otherwise changed, is left untouched and counted as
+//   skipped-changed, so a restore can never clobber newer data. Orphan-manifest entries have
+//   no DB row by definition and are always skipped in this phase (skipped-orphan) — they were
+//   unreferenced when swept and still are.
+//
+// Never deletes anything, and never touches the `secure-docs` bucket at all — the private
+// copies are left in place after a restore, so the restore itself stays reversible.
+//
+// Table/column pairs eligible for phase 2 are restricted to the exact TARGETS scope from
+// migrate-secure-docs.mjs (plus ProjectFile.url, which that script migrates via a separate
+// row-selected path) — a hardcoded allowlist, not whatever a manifest file happens to say, so
+// a tampered or corrupted manifest can never smuggle arbitrary SQL identifiers into a raw
+// query.
+//
+// Usage:
+//   node scripts/restore-secure-docs-from-backup.mjs --source <dir>                      # dry run
+//   node scripts/restore-secure-docs-from-backup.mjs --source <dir> --apply              # write
+//   node scripts/restore-secure-docs-from-backup.mjs --source <dir> --phase upload       # re-upload only
+//   node scripts/restore-secure-docs-from-backup.mjs --source <dir> --phase db --apply   # DB revert only
+//
+// Requires (read from env or .env / .env.local):
+//   DATABASE_URL          Supabase transaction pooler URL (must include ?pgbouncer=true) — phase db/both
+//   SUPABASE_URL          Supabase project URL — phase upload/db/both (db needs it to build the public URL string)
+//   SUPABASE_SERVICE_KEY  Supabase service role key — phase upload/both
+import { PrismaClient } from "@prisma/client";
+import { createClient } from "@supabase/supabase-js";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const PUBLIC_BUCKET = "project-files";
+const SECURE_SCHEME = "secure:";
+
+// Exact column scope migrate-secure-docs.mjs migrates. Any MANIFEST.json entry naming a
+// (table, column) pair outside this list is refused rather than interpolated into SQL.
+const ALLOWED_COLUMNS = new Set([
+  "Contract.signatureUrl",
+  "Contract.contractorSignatureUrl",
+  "Contract.companySignatureUrl",
+  "Contract.signedPdfPath",
+  "Contract.originalPdfPath",
+  "ContractSigningRecord.signatureUrl",
+  "ChangeOrder.clientSignatureUrl",
+  "ChangeOrder.companySignatureUrl",
+  "Client.taxExemptCertUrl",
+  "ProjectFile.url",
+]);
+
+function parseArgs(argv) {
+  const out = { source: undefined, apply: false, phase: "both" };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--source") out.source = argv[++i];
+    else if (a.startsWith("--source=")) out.source = a.slice("--source=".length);
+    else if (a === "--apply") out.apply = true;
+    else if (a === "--phase") out.phase = argv[++i];
+    else if (a.startsWith("--phase=")) out.phase = a.slice("--phase=".length);
+  }
+  return out;
+}
+
+const ARGS = parseArgs(process.argv.slice(2));
+
+if (!ARGS.source) {
+  console.error("Usage: node scripts/restore-secure-docs-from-backup.mjs --source <dir> [--apply] [--phase upload|db|both]");
+  console.error("Refusing to run without a required --source <dir> argument.");
+  process.exit(1);
+}
+if (!["upload", "db", "both"].includes(ARGS.phase)) {
+  console.error(`Invalid --phase "${ARGS.phase}" — must be one of: upload, db, both.`);
+  process.exit(1);
+}
+
+const SOURCE = path.resolve(ARGS.source);
+const APPLY = ARGS.apply;
+const RUN_UPLOAD = ARGS.phase === "upload" || ARGS.phase === "both";
+const RUN_DB = ARGS.phase === "db" || ARGS.phase === "both";
+
+if (!fs.existsSync(SOURCE) || !fs.statSync(SOURCE).isDirectory()) {
+  console.error(`--source "${SOURCE}" does not exist or is not a directory.`);
+  process.exit(1);
+}
+
+function envFromFiles(key) {
+  if (process.env[key]) return process.env[key];
+  for (const f of [".env", ".env.local"]) {
+    if (!fs.existsSync(f)) continue;
+    const m = fs.readFileSync(f, "utf8").match(new RegExp(`^${key}\\s*=\\s*"?([^"\\n]+)"?`, "m"));
+    if (m) return m[1];
+  }
+  return undefined;
+}
+
+const SUPABASE_URL = envFromFiles("SUPABASE_URL");
+const SUPABASE_SERVICE_KEY = envFromFiles("SUPABASE_SERVICE_KEY");
+const DATABASE_URL = envFromFiles("DATABASE_URL");
+
+if (RUN_UPLOAD && (!SUPABASE_URL || !SUPABASE_SERVICE_KEY)) {
+  throw new Error("SUPABASE_URL and SUPABASE_SERVICE_KEY are required for the upload phase.");
+}
+if (RUN_DB && !SUPABASE_URL) {
+  throw new Error("SUPABASE_URL is required for the db phase (used to build the restored public URL).");
+}
+if (RUN_DB && !DATABASE_URL) {
+  throw new Error("DATABASE_URL is required for the db phase.");
+}
+if (RUN_DB && DATABASE_URL && !DATABASE_URL.includes("pgbouncer=true")) {
+  console.warn("⚠ DATABASE_URL has no pgbouncer=true — expected the Supabase transaction pooler. Continuing.");
+}
+
+// Only the upload phase makes storage API calls — the db phase only needs SUPABASE_URL as a
+// plain string to build the restored public URL, not a storage client.
+const supabase = RUN_UPLOAD ? createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY) : null;
+const prisma = RUN_DB ? new PrismaClient({ datasources: { db: { url: DATABASE_URL } } }) : null;
+
+function firstLine(e) {
+  return (e?.message || e || "").toString().split("\n")[0];
+}
+
+function isSafeStoragePath(p) {
+  return typeof p === "string" && p.length > 0 && !p.startsWith("/") && !p.includes("..");
+}
+
+function sha256Buffer(buffer) {
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+function guessContentType(objectPath) {
+  const ext = path.extname(objectPath).toLowerCase();
+  if (ext === ".pdf") return "application/pdf";
+  if (ext === ".png") return "image/png";
+  if (ext === ".jpg" || ext === ".jpeg") return "image/jpeg";
+  if (ext === ".webp") return "image/webp";
+  if (ext === ".svg") return "image/svg+xml";
+  return "application/octet-stream";
+}
+
+/** Load one manifest file if present. Returns [] (with a log line) if it doesn't exist or
+ *  fails to parse — a missing manifest is not an error, since not every backup run produces
+ *  every manifest. */
+function loadManifest(filename) {
+  const manifestPath = path.join(SOURCE, filename);
+  if (!fs.existsSync(manifestPath)) {
+    console.log(`  (${filename} not found — skipping)`);
+    return [];
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  } catch (e) {
+    console.error(`  ✗ ${filename}: failed to parse — ${firstLine(e)}`);
+    return [];
+  }
+  const files = Array.isArray(parsed?.files) ? parsed.files : [];
+  console.log(`  ${filename}: ${files.length} entries`);
+  return files.map((f) => ({ ...f, sourceManifest: filename }));
+}
+
+function getObjectSize(bucket, objectPath) {
+  return supabase.storage
+    .from(bucket)
+    .info(objectPath)
+    .then(({ data, error }) => {
+      if (error) return null;
+      return typeof data?.size === "number" ? data.size : null;
+    });
+}
+
+function emptyStats() {
+  return {
+    scanned: 0,
+    uploaded: 0,
+    alreadyPresent: 0,
+    shaMismatch: 0,
+    dbReverted: 0,
+    skippedChanged: 0,
+    skippedOrphan: 0,
+    failed: 0,
+    totalBytesUploaded: 0,
+  };
+}
+
+/** Phase 1: verify the local backup file against its manifest sha256, then upload it back to
+ *  the public bucket at the manifest path. Idempotent — an existing object of the same
+ *  non-zero size is treated as already-restored and left alone. */
+async function restoreOneFile(entry, stats) {
+  const label = entry.table ? `${entry.table}.${entry.column} id=${entry.id}` : "(orphan)";
+  const objectPath = entry.path;
+
+  if (!isSafeStoragePath(objectPath)) {
+    stats.failed++;
+    console.error(`  ✗ ${label}: unsafe manifest path "${objectPath}" — refusing to touch`);
+    return;
+  }
+
+  const localPath = path.join(SOURCE, objectPath);
+  let buffer;
+  try {
+    buffer = fs.readFileSync(localPath);
+  } catch (e) {
+    stats.failed++;
+    console.error(`  ✗ ${label}: local backup file missing at "${localPath}" — ${firstLine(e)}`);
+    return;
+  }
+
+  const actualSha = sha256Buffer(buffer);
+  if (entry.sha256 && actualSha !== entry.sha256) {
+    stats.shaMismatch++;
+    console.error(
+      `  ✗ ${label}: sha256 mismatch for "${objectPath}" (backup=${actualSha}, manifest=${entry.sha256}) — refusing to upload corrupt data`
+    );
+    return;
+  }
+
+  const existingSize = await getObjectSize(PUBLIC_BUCKET, objectPath);
+  if (existingSize !== null && existingSize > 0 && existingSize === buffer.length) {
+    stats.alreadyPresent++;
+    console.log(`  · ${label}: "${objectPath}" already present in ${PUBLIC_BUCKET} (${existingSize}b) — skipping`);
+    return;
+  }
+
+  if (!APPLY) {
+    stats.uploaded++; // "would upload" in dry run
+    console.log(`  (dry run) would upload "${objectPath}" (${buffer.length}b) to ${PUBLIC_BUCKET}`);
+    return;
+  }
+
+  const { error } = await supabase.storage
+    .from(PUBLIC_BUCKET)
+    .upload(objectPath, buffer, { contentType: guessContentType(objectPath), upsert: true });
+  if (error) {
+    stats.failed++;
+    console.error(`  ✗ ${label}: upload of "${objectPath}" to ${PUBLIC_BUCKET} failed — ${firstLine(error)}`);
+    return;
+  }
+  stats.uploaded++;
+  stats.totalBytesUploaded += buffer.length;
+  console.log(`  ✓ ${label}: uploaded "${objectPath}" (${buffer.length}b) to ${PUBLIC_BUCKET}`);
+}
+
+/** Phase 2: CAS-revert one MANIFEST.json entry's DB column back to the legacy public URL,
+ *  only if it still holds exactly `secure:<path>`. Orphan entries (no table/column/id) are
+ *  always skipped here. */
+async function revertOneDbRef(entry, stats) {
+  if (!entry.table || !entry.column || entry.id === undefined || entry.id === null) {
+    stats.skippedOrphan++;
+    console.log(`  ↷ orphan entry "${entry.path}": no DB row — skipped`);
+    return;
+  }
+
+  const label = `${entry.table}.${entry.column} id=${entry.id}`;
+  const key = `${entry.table}.${entry.column}`;
+  if (!ALLOWED_COLUMNS.has(key)) {
+    stats.failed++;
+    console.error(`  ✗ ${label}: "${key}" is outside the known secure-docs column scope — refusing to touch DB`);
+    return;
+  }
+
+  if (!isSafeStoragePath(entry.path)) {
+    stats.failed++;
+    console.error(`  ✗ ${label}: unsafe manifest path "${entry.path}" — refusing to touch DB`);
+    return;
+  }
+
+  const secureValue = `${SECURE_SCHEME}${entry.path}`;
+  const publicUrl = `${SUPABASE_URL.replace(/\/$/, "")}/storage/v1/object/public/${PUBLIC_BUCKET}/${entry.path}`;
+
+  const rows = await prisma.$queryRawUnsafe(
+    `SELECT "${entry.column}" AS val FROM "${entry.table}" WHERE "id" = $1`,
+    entry.id
+  );
+  const current = rows[0]?.val;
+  if (current !== secureValue) {
+    stats.skippedChanged++;
+    console.log(
+      `  ↷ ${label}: column is "${current === undefined ? "(row not found)" : truncate(current)}", not "${secureValue}" — left unchanged`
+    );
+    return;
+  }
+
+  if (!APPLY) {
+    stats.dbReverted++; // "would revert" in dry run
+    console.log(`  (dry run) would set ${label} → ${publicUrl}`);
+    return;
+  }
+
+  const affected = await prisma.$executeRawUnsafe(
+    `UPDATE "${entry.table}" SET "${entry.column}" = $1 WHERE "id" = $2 AND "${entry.column}" = $3`,
+    publicUrl,
+    entry.id,
+    secureValue
+  );
+  if (affected === 0) {
+    stats.skippedChanged++;
+    console.warn(`  ↷ ${label}: row changed since read — left unchanged (public object is already restored, safe to re-run)`);
+  } else {
+    stats.dbReverted++;
+    console.log(`  ✓ ${label}: reverted → ${publicUrl}`);
+  }
+}
+
+function truncate(v, n = 120) {
+  const s = (v ?? "").toString();
+  return s.length > n ? `${s.slice(0, n)}…` : s;
+}
+
+(async () => {
+  console.log(`Restore source: ${SOURCE}`);
+  console.log(`Mode: ${APPLY ? "APPLY (writing)" : "DRY RUN (pass --apply to write)"} — phase: ${ARGS.phase}\n`);
+
+  if (APPLY && RUN_UPLOAD) {
+    console.log(
+      "########################################################################\n" +
+        "# WARNING: --apply is re-publishing sensitive documents (e-signatures, #\n" +
+        "# executed contracts, signed estimate PDFs, tax-exempt certs) to the   #\n" +
+        "# PUBLIC bucket 'project-files'. This is the emergency undo path — the #\n" +
+        "# documents will be world-readable again once uploaded.               #\n" +
+        "########################################################################\n"
+    );
+  }
+
+  console.log("Loading manifests:");
+  const manifestEntries = loadManifest("MANIFEST.json");
+  const orphanEntries = loadManifest("MANIFEST-orphans.json");
+  const orphanSignatureEntries = loadManifest("MANIFEST-orphans-signatures.json");
+  const allEntries = [...manifestEntries, ...orphanEntries, ...orphanSignatureEntries];
+
+  if (allEntries.length === 0) {
+    console.error("\nNo manifest entries found under --source — nothing to restore.");
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`\nTotal entries loaded: ${allEntries.length}\n`);
+
+  const stats = emptyStats();
+  stats.scanned = allEntries.length;
+
+  if (RUN_UPLOAD) {
+    console.log("Phase 1 — re-upload to project-files:");
+    for (const entry of allEntries) {
+      await restoreOneFile(entry, stats);
+    }
+    console.log("");
+  }
+
+  if (RUN_DB) {
+    console.log("Phase 2 — revert DB refs (MANIFEST.json entries only):");
+    for (const entry of manifestEntries) {
+      await revertOneDbRef(entry, stats);
+    }
+    // Orphans never had a DB row to begin with — always skipped in this phase.
+    stats.skippedOrphan += orphanEntries.length + orphanSignatureEntries.length;
+    console.log("");
+  }
+
+  console.log(
+    `Totals: scanned=${stats.scanned} uploaded=${stats.uploaded} already-present=${stats.alreadyPresent} ` +
+      `sha-mismatch=${stats.shaMismatch} db-reverted=${stats.dbReverted} skipped-changed=${stats.skippedChanged} ` +
+      `skipped-orphan=${stats.skippedOrphan} failed=${stats.failed} total-bytes-uploaded=${stats.totalBytesUploaded}` +
+      (APPLY ? "" : " (dry run)")
+  );
+
+  if (stats.failed > 0 || stats.shaMismatch > 0) process.exitCode = 1;
+})()
+  .catch((e) => {
+    console.error("Restore failed:", e);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    if (prisma) await prisma.$disconnect();
+  });

--- a/scripts/sweep-orphaned-public-signatures.mjs
+++ b/scripts/sweep-orphaned-public-signatures.mjs
@@ -1,0 +1,179 @@
+/**
+ * Sweep orphaned signature objects out of the PUBLIC bucket.
+ *
+ * The document migration (migrate-secure-docs.mjs) moves objects that a DB row points at.
+ * It cannot see ORPHANS: signature objects left in storage that no row references. These
+ * arise when a signing action uploads before its guarded DB write and then loses an
+ * idempotency race or hits the already-signed retry, and when a re-sign supersedes an
+ * earlier object. Orphans are still real client signatures, and in a public bucket they
+ * stay world-readable forever.
+ *
+ * This backs each orphan up, verifies the copy byte-for-byte, then deletes the public
+ * original. It REFUSES to touch any object referenced by any DB column.
+ *
+ * Dry run by default:
+ *   node scripts/sweep-orphaned-public-signatures.mjs --dest "<backup dir>"
+ *   node scripts/sweep-orphaned-public-signatures.mjs --dest "<backup dir>" --apply
+ */
+import { PrismaClient } from "@prisma/client";
+import { createClient } from "@supabase/supabase-js";
+import { readFileSync, mkdirSync, writeFileSync, existsSync, statSync } from "fs";
+import { createHash } from "crypto";
+import { dirname, join, resolve } from "path";
+
+for (const f of [".env.local", ".env"]) {
+    try {
+        for (const line of readFileSync(f, "utf8").split(/\r?\n/)) {
+            const m = /^([A-Z0-9_]+)=(.*)$/.exec(line.trim());
+            if (m && !process.env[m[1]]) process.env[m[1]] = m[2].replace(/^"|"$/g, "");
+        }
+    } catch { /* optional */ }
+}
+
+const APPLY = process.argv.includes("--apply");
+const destIdx = process.argv.indexOf("--dest");
+const DEST = destIdx > -1 ? process.argv[destIdx + 1] : null;
+if (!DEST) {
+    console.error("Refusing to run: --dest <dir> is required (orphans are backed up before deletion).");
+    process.exit(1);
+}
+
+const PUBLIC_BUCKET = "project-files";
+const prisma = new PrismaClient();
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+
+async function walk(prefix, out) {
+    let offset = 0;
+    for (;;) {
+        const { data, error } = await supabase.storage
+            .from(PUBLIC_BUCKET)
+            .list(prefix, { limit: 100, offset, sortBy: { column: "name", order: "asc" } });
+        if (error) throw new Error(`list ${prefix}: ${error.message}`);
+        if (!data || data.length === 0) return;
+        for (const e of data) {
+            const full = prefix ? `${prefix}/${e.name}` : e.name;
+            if (e.id === null) await walk(full, out);
+            else out.push({ path: full, size: e.metadata?.size ?? 0 });
+        }
+        if (data.length < 100) return;
+        offset += data.length;
+    }
+}
+
+const REF_COLUMNS = [
+    ["Contract", "signatureUrl"], ["Contract", "contractorSignatureUrl"],
+    ["Contract", "companySignatureUrl"], ["Contract", "signedPdfPath"],
+    ["Contract", "originalPdfPath"], ["ContractSigningRecord", "signatureUrl"],
+    ["ChangeOrder", "clientSignatureUrl"], ["ChangeOrder", "companySignatureUrl"],
+    ["Client", "taxExemptCertUrl"], ["ProjectFile", "url"], ["Estimate", "signatureUrl"],
+];
+
+console.log(APPLY
+    ? "Sweep mode: APPLY (orphans will be backed up, verified, then DELETED from the public bucket)\n"
+    : "Sweep mode: DRY RUN (pass --apply to back up and delete)\n");
+
+const refValues = [];
+for (const [table, column] of REF_COLUMNS) {
+    try {
+        const rows = await prisma.$queryRawUnsafe(
+            `SELECT "${column}" AS v FROM "${table}" WHERE "${column}" IS NOT NULL`
+        );
+        for (const r of rows) if (r.v) refValues.push(String(r.v));
+    } catch (e) {
+        console.log(`  (skipped ${table}.${column}: ${e.message.split("\n")[0]})`);
+    }
+}
+console.log(`Reference values loaded: ${refValues.length} across ${REF_COLUMNS.length} columns.`);
+
+// Sensitive PDFs (executed contracts, signed estimates, intermediate signed contracts)
+// live interleaved with ordinary PUBLIC project files, so they are matched by rule rather
+// than by prefix — the same rule the migration used. Ordinary project files never match.
+const isSensitivePdf = (p) =>
+    p.includes("_Executed_Contract_") ||
+    /^(projects|leads)\/[^/]+\/signed\//.test(p) ||
+    (p.includes("/intermediate/") && p.toLowerCase().endsWith(".pdf"));
+
+const objects = [];
+await walk("signatures", objects);            // whole prefix is sensitive by definition
+const pdfCandidates = [];
+for (const root of ["projects", "leads"]) await walk(root, pdfCandidates);
+objects.push(...pdfCandidates.filter((o) => isSensitivePdf(o.path)));
+console.log(`Sensitive objects in the PUBLIC bucket: ${objects.length}\n`);
+
+const stats = { scanned: 0, swept: 0, refusedReferenced: 0, failed: 0, bytes: 0 };
+const manifest = [];
+
+for (const obj of objects) {
+    stats.scanned++;
+    if (obj.path.includes("..") || obj.path.startsWith("/")) {
+        console.log(`  ! refusing suspicious path ${obj.path}`);
+        stats.failed++;
+        continue;
+    }
+    // Full-path match, plus a deliberately stricter basename match so that a stored value
+    // differing only by URL-encoding can never let a still-referenced object be deleted.
+    // Erring toward "referenced" only ever leaves a file in place; the reverse loses data.
+    const basename = obj.path.slice(obj.path.lastIndexOf("/") + 1);
+    if (refValues.some((v) => v.includes(obj.path) || v.includes(basename))) {
+        console.log(`  = REFERENCED, left alone: ${obj.path}`);
+        stats.refusedReferenced++;
+        continue;
+    }
+
+    const { data, error } = await supabase.storage.from(PUBLIC_BUCKET).download(obj.path);
+    if (error || !data) {
+        console.log(`  ! download failed, NOT deleting: ${obj.path} (${error?.message ?? "no data"})`);
+        stats.failed++;
+        continue;
+    }
+    const bytes = Buffer.from(await data.arrayBuffer());
+    if (bytes.length === 0) {
+        console.log(`  ! zero bytes downloaded, NOT deleting: ${obj.path}`);
+        stats.failed++;
+        continue;
+    }
+
+    const target = join(resolve(DEST), obj.path.replace(/\//g, "\\"));
+    if (APPLY) {
+        mkdirSync(dirname(target), { recursive: true });
+        writeFileSync(target, bytes);
+        const written = statSync(target).size;
+        if (written !== bytes.length) {
+            console.log(`  ! backup size mismatch, NOT deleting: ${obj.path}`);
+            stats.failed++;
+            continue;
+        }
+    }
+    const sha = createHash("sha256").update(bytes).digest("hex");
+    manifest.push({ path: obj.path, size: bytes.length, sha256: sha, orphan: true });
+
+    if (!APPLY) {
+        console.log(`  (dry run) would back up + delete ${obj.path} (${bytes.length}b)`);
+        continue;
+    }
+
+    const del = await supabase.storage.from(PUBLIC_BUCKET).remove([obj.path]);
+    if (del.error) {
+        console.log(`  ! delete failed (backup kept): ${obj.path} (${del.error.message})`);
+        stats.failed++;
+        continue;
+    }
+    console.log(`  ✓ swept ${obj.path} (${bytes.length}b)`);
+    stats.swept++;
+    stats.bytes += bytes.length;
+}
+
+if (APPLY && manifest.length > 0) {
+    const mPath = join(resolve(DEST), "MANIFEST-orphans.json");
+    writeFileSync(mPath, JSON.stringify({
+        generatedAt: new Date().toISOString(),
+        sourceBucket: PUBLIC_BUCKET,
+        note: "Orphaned signature objects: present in storage, referenced by no DB row. Backed up then deleted from the public bucket.",
+        files: manifest,
+    }, null, 2));
+    console.log(`\nManifest written to ${mPath} (${manifest.length} files)`);
+}
+
+console.log(`\nTotals: scanned=${stats.scanned} swept=${stats.swept} referenced-left-alone=${stats.refusedReferenced} failed=${stats.failed} bytes=${stats.bytes}${APPLY ? "" : " (dry run)"}`);
+if (stats.failed > 0) process.exitCode = 1;
+await prisma.$disconnect();

--- a/src/app/leads/[id]/contracts/page.tsx
+++ b/src/app/leads/[id]/contracts/page.tsx
@@ -28,7 +28,10 @@ export default async function LeadContractsPage({ params, searchParams }: {
                 ...(linkedProjectId ? [{ projectId: linkedProjectId }] : []),
             ],
         },
-        include: { signingRecords: true },
+        // Only the record COUNT is rendered here; the Signing History modal loads full
+        // records (with resolved signature URLs) on demand. Selecting just the id keeps raw
+        // `secure:` signature paths out of the serialized page payload.
+        include: { signingRecords: { select: { id: true } } },
         orderBy: { createdAt: "desc" },
     });
 

--- a/src/app/projects/[id]/contracts/page.tsx
+++ b/src/app/projects/[id]/contracts/page.tsx
@@ -24,7 +24,10 @@ export default async function ProjectContractsPage({ params }: { params: Promise
                 ...(linkedLeadId ? [{ leadId: linkedLeadId }] : []),
             ],
         },
-        include: { signingRecords: true },
+        // Only the record COUNT is rendered here; the Signing History modal loads full
+        // records (with resolved signature URLs) on demand. Selecting just the id keeps raw
+        // `secure:` signature paths out of the serialized page payload.
+        include: { signingRecords: { select: { id: true } } },
         orderBy: { createdAt: "desc" },
     });
 


### PR DESCRIPTION
Follow-up to #249. Adds the tooling that was actually needed to finish closing the exposure, plus the record of the production run.

## The gap #249 left

The migration is **DB-driven**, so it only moves objects a row points at. It is blind to **orphans** — sensitive objects sitting in storage that nothing references. After migrating and purging, **202 were still world-readable**:

- **14 signature PNGs.** One contract had *five* near-identical 8,502-byte client signatures.
- **188 executed-contract / signed-estimate PDFs**, 52 MB. Mostly e2e test artifacts (`EST-MPTEST`, `Automated_Test_Lien_Release`), but including real-looking executed contracts whose `ProjectFile` rows had since been deleted.

**Root cause:** signing actions upload *before* their guarded DB write, so losing an idempotency race or hitting the already-signed retry leaves the upload behind; re-signing likewise supersedes an earlier object.

That upstream bug is unchanged here, but it is **no longer a privacy issue** — `persistSignature` now writes to the private bucket, so future orphans are wasted storage rather than exposed client documents. A cleanup-on-throw or scheduled sweep would close it properly.

## What's added

- **`scripts/sweep-orphaned-public-signatures.mjs`** — finds sensitive objects still in the public bucket, refuses anything a DB row references (matching on full path **and** basename, deliberately erring toward "leave it in place" since the opposite loses data), backs each up with a sha256 manifest, verifies the copy, then deletes the public original. Dry run by default.
- **`scripts/backup-migrated-public-docs.mjs`** — the pre-purge safety backup that makes deletion reversible. Covers exactly the purge script's target list, so backup scope provably equals deletion scope.
- **`docs/STORAGE-AUDIT.md`** — the production run, backup location, and caveats.

## Production run (2026-07-27)

| Step | Outcome |
|---|---|
| Migration | 32 rows → 26 objects, 0 failed |
| Backup to Drive | 26 files / 9.3 MB, sha256-verified against live objects |
| Purge | 26 deleted, 0 refused |
| Orphan sweep | 202 swept (52.5 MB), 0 referenced, 0 failed |

**Verified: 0 sensitive objects remain in the public bucket.** The five documents used as the original proof — a client signature PNG, two executed contracts, two signed estimates — all returned HTTP 200 to an unauthenticated request before this work and all return HTTP 400 now.

Backups are in Google Drive (`Claude/ProBuild-Storage-Backup-2026-07-27`), owner + one writer, no link sharing, with manifests mapping 1:1 back to bucket paths.

## Caveat worth knowing

Supabase fronts public objects with Cloudflare at `max-age=3600`, and **deleting an object does not purge edge caches**. Observed directly: a deleted signature returned 200 from cache, then 400 once bypassed. Someone who fetched a specific URL just before the purge may retain access for up to an hour. No permanent exposure.

## Still unverified

The **app UI has not been clicked through** on prod. Storage, signed URLs and the DB are verified, but nobody has confirmed a signature renders in the portal. Backups + manifests make any problem recoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
