### PR TITLE
feat(billing): progress billing core (schema + money logic + tests)

### DIFF
--- a/PROGRESS_BILLING_REPORT.md
+++ b/PROGRESS_BILLING_REPORT.md
@@ -1,0 +1,115 @@
+# Progress Billing Core — Implementation Report
+
+Branch: `feat/progress-billing-core` (created off `origin/main` @ `5f8812b`, fetched fresh). Not pushed. No UI in this pass, per the task.
+
+## 1. Schema — additive only
+
+`prisma/schema.prisma`:
+- New model `ProgressBilling` (invoiceId FK → Invoice `onDelete: Cascade`, code, description, status, subtotal/taxExempt/taxRate/taxAmount/total, qb* fields, sentAt/paidAt, `lines` relation). Indexes on `invoiceId`, `status`.
+- New model `ProgressBillingLine` (billingId FK → ProgressBilling `onDelete: Cascade`, optional scheduleId/changeOrderId, description, amount, order). Indexes on `billingId`, `scheduleId`.
+- `Estimate.taxInclusiveMilestones Boolean @default(true)` — one new column, nullable-safe default preserves legacy rows' meaning.
+- `Invoice.progressBillings ProgressBilling[]` back-relation (no column, just the Prisma relation field).
+
+No existing column, table, or relation was dropped, renamed, or made non-additive. Verified by re-reading the full diff after commit (see `git diff HEAD~3 HEAD~2 -- prisma/schema.prisma` — the diff also shows a lot of *unchanged* lines flagged as modified; that's a pre-existing CRLF/LF mix in the file being normalized by git's line-ending handling on commit, not a content change — confirmed with `git show <rev>:prisma/schema.prisma` on both sides, byte-identical after normalization).
+
+`scripts/apply-progress-billing-schema.mjs` — follows the repo's established `$executeRawUnsafe` pattern (see `scripts/apply-task-materials-schema.mjs` for the model this mirrors): `CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`, guarded `DO $$ ... IF NOT EXISTS (SELECT 1 FROM pg_constraint ...) THEN ADD CONSTRAINT`. Idempotent — safe to run twice. **Not run against prod** by this work (per the task's hard constraint against touching production/Supabase). It must be run before deploy, per `CLAUDE.md`'s pre-deploy checklist, whenever this branch ships.
+
+Deviation: I did **not** add `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` for the two new tables. About a third of the repo's `apply-*.mjs` scripts do this (`TaskMaterial`, dispatch/portal-tracker/mcp-confirmation tables); the majority, including every script touching Invoice/PaymentSchedule-adjacent tables, do not. Since `ProgressBilling`/`ProgressBillingLine` are a direct extension of `Invoice`/`PaymentSchedule` (which have no RLS enabled), I matched that precedent rather than the minority pattern. Flagging this as a judgment call in case the team's convention is actually "always RLS on new tables" and I picked the wrong sibling to match.
+
+## 2. Core logic — `src/lib/progress-billing.ts` (new file)
+
+Session-free cores, no auth checks, `withTxRetry` + `lockMoneyParents` in canonical Estimate→Invoice order for every transaction, cent-rounding via `Math.round(x*100)/100` everywhere. No network calls inside any transaction.
+
+- **`createProgressBillingCore(invoiceId, input)`** — validates lines (existence/ownership/Pending/no-qbInvoiceId/no-in-flight-Stripe for milestone lines; project+Approved for change-order lines), rejects over-billing, auto-splits a milestone billed for less than its full amount (reduces the original row, creates a new remainder row, never deletes, mirrors the split onto the linked `EstimatePaymentSchedule` when `sourceScheduleId` is set, points the new invoice-side remainder's `sourceScheduleId` at the new estimate-side row), computes tax for `preTax` and `targetTotal` modes, asserts `subtotal+taxAmount===total` and `sum(lines)===subtotal` to the cent before commit, and persists the billing + lines.
+- **`updateProgressBillingCore`** / **`deleteProgressBillingCore`** — Draft-only, no-`qbInvoiceId` guards.
+- **`stageProgressBillingToQuickBooksCore`** — resolves customer/item via the now-exported `resolveCustomerAndItem` (`quickbooks-payments.ts`), creates one QBO invoice, links it back with a conditional claim (id + Draft + no-qbInvoiceId + content snapshot of subtotal/total/description), compensates by deleting the orphaned QBO invoice on a claim miss. **Sends no email** — verified by grep: this file contains no call to `sendNotification`, `notifyMilestonePaid`, `drainPaymentNotifications`, or any Gmail/Resend send path, and `createQBMilestoneInvoice` (unlike the milestone rail's own flow) is called with a `billEmail` but ProBuild never triggers QBO's own invoice-email send — same as `pushMilestoneToQuickBooks`, which stages without sending.
+
+### Deviations / judgment calls (flagged per the task, not silently decided)
+
+1. **`updateProgressBillingCore` scope.** The spec said "Draft-only ... else throw" but didn't fully specify what fields are editable. Re-running AUTO-SPLIT against a changed line set is a genuine design fork (does a shrinking line un-split a milestone? does a growing line need a fresh over-billing check against whatever the milestone now looks like, possibly after a *different* billing already split it?) that I judged out of scope for a "no judgment calls, mechanical execution" pass. I implemented `updateProgressBillingCore` to edit **only `description` and `taxExempt`** (recomputing tax off the existing, unchanged subtotal). To change which milestones/amounts/change-orders make up a billing, the caller deletes the Draft (safe, tested — see below) and creates a new one. This is a real, working implementation, not a stub — but it is narrower than "input: CreateProgressBillingInput" might have implied. **If line-composition editing is actually required, this needs a follow-up decision**, not a guess from me.
+2. **Split uses the raw (pre-tax-mode) line amount, not the final persisted line amount, in `targetTotal` mode.** The over-billing check and AUTO-SPLIT both run on the amount the caller typed per line; the tax-math step (which only rescales in `targetTotal` mode) runs afterward and can shift the *persisted* `ProgressBillingLine.amount` away from the raw amount that was actually carved out of the milestone. In `preTax` mode these are always identical (no rescale happens), so this only matters for `targetTotal` + a partial-bill line combined — a combination no test in this pass exercises. I chose this ordering because it's what the task's procedural description literally specifies (validate → auto-split → *then* tax math), and it has a defensible reading (the split reflects what the user picked against the milestone; the tax-mode rescale is about hitting a specific client-facing total, not about renegotiating what the milestone gave up). But it is a real inconsistency worth a product decision before this ships a UI: if a user partially bills a milestone under `targetTotal` mode, the dollars removed from the milestone and the dollars that show up on the persisted billing line can differ by the rescale factor (typically well under a dollar, but not always). Flagged, not fixed.
+3. **Duplicate-`scheduleId` guard added.** The spec doesn't mention this; I added a rejection when the same milestone is referenced by two lines in one request, since the validation-then-split two-pass design would otherwise let both lines validate against the milestone's original (pre-split) amount and then double-split it. Low-risk defensive addition, not requested but not surgical-scope-violating either (it's inside the new file only).
+4. **`finalAmounts[last] <= 0` guard added** in `targetTotal` rescale — not in the spec's literal assertion list, added because a negative/zero persisted money line is a real bug class, not because a test requires it.
+5. **RLS** — see schema section above.
+
+## 3. QuickBooks settle-path extension — `src/lib/quickbooks-payments.ts`
+
+- `resolveCustomerAndItem` is now `export`ed (was file-private) so `progress-billing.ts` can reuse it, per the task's explicit instruction to use "the same helper `pushMilestoneToQuickBooks` uses."
+- Factored `markMilestonePaidFromQB`'s claim/recompute/mirror body into a new **caller-locked** helper `settleMilestonePaidInTx(t, paymentScheduleId, invoiceId, payment)` that does no locking of its own (the caller must already hold `lockMoneyParents`). `markMilestonePaidFromQB` now: locks → calls the helper → enqueues the paid notification (unchanged external behavior/signature). This is the single existing writer for the milestone-paid lifecycle; the new progress-billing settle path calls the **same** helper and does **not** call `enqueueMilestonePaid` — a `TODO(progress-billing)` comment marks exactly where that would go, per the hard constraint against sending/enqueueing notifications this pass.
+- `syncQuickBooksPayments` gained a second loop, after the existing milestone loop (left fully intact): fetches `ProgressBilling` rows with `qbInvoiceId != null` and `status in (Staged, Sent)`, probes each via `probeQBInvoice`, and on a fully-settled invoice (`total > 0 && balance <= 0`) runs one `withTxRetry`+`lockMoneyParents` transaction per billing that claims the `ProgressBilling` row (`updateMany` guarded on `status in (Staged,Sent)` and `qbPaymentId: null`) and then calls `settleMilestonePaidInTx` for every line that carries a `scheduleId` (custom/change-order lines are skipped — no milestone to settle). One lock covers every line of a billing because `createProgressBillingCore` only ever references milestones on the billing's own invoice.
+- `QBPaymentSyncResult` gained a new field, `progressBillingsSettled: number` (did not repurpose `settled`, which still counts individual milestones from the original per-milestone rail).
+- Verified no existing caller of `syncQuickBooksPayments` breaks: grepped all 6 callers in `src/`, none destructure/assert an exact result shape; `npm run build` compiles all of them cleanly against the extended interface.
+
+## 4. Tests — `e2e/progress-billing.spec.ts`
+
+Modeled on `e2e/milestone-rebalance.spec.ts` (`PFX = "pb-e2e"`, serial describes, direct core imports, `afterAll` cleanup by prefix — `ProgressBilling`/`ProgressBillingLine` cleaned via `invoiceId: startsWith` since their ids are auto-generated cuids, not prefixed; cascade delete on `Invoice` would also catch them as a backstop). 11 test cases, matching every item on the task's cover list:
+
+1. over-billing rejected, DB unchanged
+2. full bill: no split, one line, milestone stays Pending, invoice totals unchanged
+3. partial bill: auto-split (original reduced, `(remaining)` row created, sums to original, estimate mirror split the same way with the new invoice row pointing at the new estimate row, invoice totals unchanged, nothing deleted)
+4. `preTax` math at 8.8%
+5. `targetTotal` math: 33000 @ 8.8% → subtotal 30330.88, tax 2669.12, total 33000.00 exactly, lines sum to subtotal (uses two FULL-bill lines deliberately, to isolate the tax/rescale math from the auto-split mechanic — see deviation #2 above for why mixing them is a known open question)
+6. `taxExempt: true` overrides a non-zero invoice tax rate
+7. legacy `qbInvoiceId` milestone rejected with the Break-QB-Link message
+8. draft-only guards on both update and delete (once `status`/`qbInvoiceId` simulate "Staged")
+9. update recomputes tax off description/taxExempt only
+10. delete leaves an already-applied split intact
+11. `stageProgressBillingToQuickBooksCore` rejects with "QuickBooks is not connected" (no Integration row in the test DB) before any write, billing stays Draft with no `qbInvoiceId`
+
+**Not covered** (gap, noted rather than silently skipped): a change-order line (`changeOrderId` path) has no dedicated test — not on the task's explicit cover list, and I stayed in scope rather than adding uncalled-for surface area.
+
+### What I actually ran vs. did not run
+
+- `npm run build` (PowerShell) — **passed, 0 errors.** Tail:
+  ```
+  ✓ Compiled successfully in 27.2s
+    Collecting page data using 1 worker ...
+    Generating static pages using 1 worker (0/96) ...
+    ...
+  ✓ Generating static pages using 1 worker (96/96) in 926ms
+  Route (app)
+  ...
+  ```
+  Full route listing omitted here for length; re-run with `npm run build` to reproduce. Confirmed exit code 0 via a second run piping to `$LASTEXITCODE`.
+- `npx playwright test --list e2e/progress-billing.spec.ts` — **ran successfully**, listed all 13 tests (11 new + the shared `data.setup`/`auth.setup` fixtures), confirming the file parses and every `test()` is discovered:
+  ```
+  [chromium] › progress-billing.spec.ts:60:9 › createProgressBillingCore › rejects over-billing a milestone; DB unchanged
+  [chromium] › progress-billing.spec.ts:85:9 › ... bills a milestone in FULL ...
+  [chromium] › progress-billing.spec.ts:119:9 › ... PARTIAL bill auto-splits ...
+  [chromium] › progress-billing.spec.ts:190:9 › ... preTax ... = total
+  [chromium] › progress-billing.spec.ts:213:9 › ... targetTotal ... 33000 ...
+  [chromium] › progress-billing.spec.ts:256:9 › ... taxExempt: true ...
+  [chromium] › progress-billing.spec.ts:281:9 › ... rejects a milestone carrying a legacy qbInvoiceId ...
+  [chromium] › progress-billing.spec.ts:327:9 › ... draft-only guard ...
+  [chromium] › progress-billing.spec.ts:345:9 › ... updates description/taxExempt ...
+  [chromium] › progress-billing.spec.ts:370:9 › ... delete leaves an already-applied split intact
+  [chromium] › progress-billing.spec.ts:412:9 › ... rejects with QuickBooks-not-connected ...
+  Total: 13 tests in 3 files
+  ```
+- **`npx playwright test` (actual execution) — did NOT run. I could not stand up a throwaway Postgres in this environment.** Docker CLI is present (`docker version` succeeds) but the daemon was not running (`npipe:////./pipe/dockerDesktopLinuxEngine` connection refused). I launched Docker Desktop and polled `docker info` for roughly 9 minutes total across two waits; the daemon never came up in that window. I did not find another local Postgres to point at. **Do not treat the passing build/list output above as evidence the test logic is correct at runtime — it is only evidence the code compiles and the test file is well-formed.** The money-math assertions (split arithmetic, the two tax-mode formulas, the estimate-mirror pointer) are hand-verified by me against the spec's formulas (shown inline in the report and in code comments) but not machine-verified by an actual run. This is the single biggest risk in this deliverable — I'd want a real run before merging.
+- `e2e/money-pipeline.spec.ts` and `e2e/milestone-rebalance.spec.ts` — not run for the same Docker reason. I did verify by inspection that neither spec calls `syncQuickBooksPayments` or asserts an exact shape of `QBPaymentSyncResult`, so the additive interface change should not affect them, and `npm run build` type-checks every file that imports from `quickbooks-payments.ts` cleanly. But "should not affect" is inference, not a run.
+
+## 5. Known gaps / risks
+
+- **targetTotal + partial-split interaction** (deviation #2 above) — the split amount and the persisted billing-line amount can diverge by the rescale factor. No test exercises this combination. Needs a product decision, not a guess.
+- **`updateProgressBillingCore`'s narrow scope** (deviation #1) — if the real requirement is "edit which lines make up a Draft billing," this needs new design, not just new code.
+- **E2E suite unexecuted** — see above. The `--list` output and my manual formula verification are the only evidence right now.
+- **RLS on the two new tables** — matched the Invoice/PaymentSchedule precedent (off); flag if that's the wrong call.
+- **Change-order line path is implemented but untested** in this pass.
+- **`stageProgressBillingToQuickBooksCore` was never invoked against a live QuickBooks sandbox** (no such environment here, and doing so would violate the "nothing against production/Supabase" constraint even if a sandbox existed for this task) — its correctness against a real QBO response shape is inferred from mirroring `pushMilestoneToQuickBooks`'s already-proven pattern, not independently verified.
+
+## 6. Commits on this branch (not pushed)
+
+```
+714b925 test(billing): add e2e regression net for progress billing core
+9741735 feat(billing): add progress billing core logic (create/update/delete/stage)
+8f5ba1c feat(billing): add progress billing schema (ProgressBilling, ProgressBillingLine)
+```
+
+## 7. Files touched
+
+- `prisma/schema.prisma` — additive (see §1)
+- `scripts/apply-progress-billing-schema.mjs` — new
+- `src/lib/progress-billing.ts` — new
+- `src/lib/quickbooks-payments.ts` — extended (export + refactor + new settle loop, see §3)
+- `e2e/progress-billing.spec.ts` — new

--- a/PROGRESS_BILLING_REPORT.md
+++ b/PROGRESS_BILLING_REPORT.md
@@ -113,3 +113,100 @@ Modeled on `e2e/milestone-rebalance.spec.ts` (`PFX = "pb-e2e"`, serial describes
 - `src/lib/progress-billing.ts` — new
 - `src/lib/quickbooks-payments.ts` — extended (export + refactor + new settle loop, see §3)
 - `e2e/progress-billing.spec.ts` — new
+
+---
+
+# Round 2 — Codex review fixes (PR #252, branch `feat/progress-billing-core`)
+
+Codex BLOCKED PR #252 on round 1's implementation above. This section covers the fixes to items A–G of the round-2 brief, plus a mid-task course change from the orchestrator that removed change-order lines from progress billing entirely (see §2.5).
+
+## 1. A — replaced the amount-mode contract
+
+Deleted `amountMode` / `targetTotal` from `CreateProgressBillingInput`. New contract:
+
+- `lines[].amount` is always in the milestone's OWN units: **GROSS** for legacy vintage (`Estimate.taxInclusiveMilestones === true`, or no estimate at all), **PRE-TAX** for new vintage.
+- Optional `grossTotal?: number` — when supplied, the client pays exactly this; rejected if it differs from what the lines say they add up to (`expectedGross`) by more than 2 cents ("they must match").
+- `total = grossTotal ?? expectedGross`; `subtotal`/`taxAmount` are always derived by reversing tax out of `total` (never by adding tax on top of a "pre-tax" input), which is what fixes the round-1 bug: a $108 legacy (tax-inclusive) milestone billed as "$100 preTax" used to carve only $100 of gross value out of a $108 milestone while the client was actually charged $108 — leaving a phantom $8 "still owed" on a milestone that was, in reality, fully paid. Under the new contract the caller enters the milestone's own gross amount directly, so the carve and the charge always agree.
+- `ProgressBillingLine.amount` (persisted) is always pre-tax: each line's proportional share of `subtotal`, remainder on the last line, **every** line checked for `<= 0` (not just the last) — throws `"...rescaled amount is $0.00 or less..."`.
+- Split amount (what's carved from the milestone) is a *separate* proportional allocation: of `total` for legacy, identical to the persisted amount for new-vintage. `sum(splitAmounts)` is asserted to equal `total` (legacy) / `subtotal` (new vintage) to the cent before commit.
+
+## 2. B — consumption guard (double-billing / CO cap)
+
+Before splitting, every `scheduleId` line now computes `committed` = sum of `ProgressBillingLine.amount` from every OTHER non-Void `ProgressBilling` that references the same `scheduleId`, converted into the milestone's own units (grossed up per **that line's own billing's** `taxRate`/`taxExempt`, not the current billing's), and rejects when `splitAmount > milestone.amount - committed + 0.005`, naming the amount already billed and the billing code(s) it's on.
+
+This closes two real holes:
+- **A milestone billed in FULL never triggers AUTO-SPLIT** (its `PaymentSchedule.amount` never changes), so a second billing referencing the same still-Pending row used to be allowed to bill it again for up to that same (unchanged) amount. Now `committed` equals the full amount and `available` is 0.
+- **A milestone's post-split ORIGINAL row keeps exactly what was billed into it** as its new `amount` — so a second billing re-referencing that same (reduced) row for anything up to that reduced amount used to pass the old "does this exceed the row's current amount" check. `committed` closes this too.
+
+`§4` documents why I deliberately did **not** use the task brief's literal "$700 against the same milestone" example for the partial-split test — it already throws under the pre-fix code for an unrelated reason (plain over-bill against the row's reduced amount), so it wouldn't demonstrate this guard.
+
+The change-order half of item B (cap against `ChangeOrder.totalAmount`) was built in an earlier pass of this task and then **removed** per the orchestrator's course change — see §2.5.
+
+## 3. C — materialize custom lines as milestones
+
+Every line without a `scheduleId` (a "custom" line — change-order lines are rejected outright, §2.5) now gets a brand-new Pending `PaymentSchedule` at creation: `name` = the line's description, `amount` = the line's split amount (milestone units), no qb/stripe ids, `sourceScheduleId: null`. The invoice's `totalAmount`/`balanceDue` are incremented by the sum of all such materialized amounts in one update, mirroring `addInvoiceMilestone`'s status ladder (`Paid` → `Partially Paid`, else unchanged) exactly. Milestone-referencing lines are untouched — a split conserves the invoice total, it never grows it.
+
+Result: `settleProgressBillingPaidCore` (see §3 QB settle path in round 1, extracted further below) needs no special case for a custom line — every `ProgressBillingLine` ends up with a `scheduleId`, so every line settles through the same milestone rail.
+
+## 4. D — conditional claim on the split (closes the stale-read race)
+
+Both the invoice-side `PaymentSchedule.update` and the estimate-side `EstimatePaymentSchedule.update` inside AUTO-SPLIT are now `updateMany` calls whose `WHERE` pins `{ id, status: "Pending", stripeSessionId: null, stripePaymentIntentId: null, amount: <exact amount read at the top of the transaction> }` (the invoice-side claim also pins `qbInvoiceId: null`). A miss (`count !== 1`) throws `"...changed while this billing was being built — refresh and try again."` instead of silently overwriting a concurrent write (e.g. the legacy `pushMilestoneToQuickBooks` linking a QBO invoice, or a settle, between validation and this write).
+
+## 5. E — compensate an orphaned QBO invoice on staging failure
+
+In `stageProgressBillingToQuickBooksCore`, everything after `createQBMilestoneInvoice` (the pay-link fetch, the conditional link claim, and the claim's own thrown error) is now inside one `try`. Any failure in that block attempts `deleteQBInvoice`; if the delete also fails, the re-thrown error names the doc number + QBO id so it can be removed by hand. Previously only the "claim missed" branch compensated — a failure in the pay-link fetch itself (a real network call) used to leave the just-created QBO invoice orphaned with no error mentioning it at all.
+
+## 6. F — smaller fixes
+
+1. **Billing code reuse.** Numbering switched from `count()` to parsing every existing code's `-P<n>` suffix and taking `max + 1`. A count-based scheme reused a code after a non-last Draft was deleted, colliding with an existing billing's QuickBooks `DocNumber`. Covered by the "billing codes do not repeat after deleting a middle draft" test.
+2. **`taxExempt` no longer loses the rate.** `ProgressBilling.taxRate` is now *always* `toNum(invoice.taxRate)` at creation, regardless of `taxExempt` — `taxExempt` only zeroes the tax/total *computation*, never the stored rate. `updateProgressBillingCore` recomputes `taxAmount`/`total` off that stored rate whenever `taxExempt` flips, so un-exempting a billing that was saved exempt now correctly recomputes tax instead of staying stuck at 0. Covered by an added assertion in the existing update test (round-trip exempt → un-exempt).
+3. **Cent-safe rounding.** `r2` is now `Math.round((x + Number.EPSILON) * 100) / 100` everywhere in this file (was a bare `Math.round(x*100)/100`, which under-rounds values like `1.005` due to float representation).
+4. **Unlinked legacy schedules documented.** Added an `else if (invLink?.estimateId)` branch in AUTO-SPLIT (previously silent) with a comment explaining why a `PaymentSchedule` with no `sourceScheduleId` on an invoice that DOES have an estimate is deliberately not mirrored (nothing on the estimate side to split against) rather than a bug.
+
+## 7. G — tests (all rewritten/added in `e2e/progress-billing.spec.ts`)
+
+Every pre-existing test in the file was rewritten for the new contract (no `amountMode`/`targetTotal` anywhere — the pre-fix function signature doesn't even accept these calls, so every test in the file fails to compile/run against the pre-fix code on that basis alone). On top of the contract-shape change, these specifically exercise runtime bugs that are independent of the contract and would misbehave even against a hypothetically-adapted old implementation:
+
+- `createProgressBillingCore — core cases`: full/partial/legacy-gross/new-vintage-mirror/taxExempt/qb-linked-rejected tests (rewritten), plus new: **unit-mismatch rejected** (`grossTotal: 50` vs lines summing to `$100`), **rescale-to-$0 rejected** (two custom lines + a synthetic 999% tax rate to force one line's proportional share of subtotal to round to `$0.00`).
+- `createProgressBillingCore — consumption guard`: **double-billing rejected** (bill a milestone in FULL, bill it again), and **rejects re-billing a milestone's already-consumed original row after a partial split** — deliberately using `$300` against the reduced `$400` row rather than the brief's illustrative `$700`, because `$700` already exceeds the reduced row's `amount` under the *pre-fix* plain over-bill check too and wouldn't prove the new guard did anything (documented inline in the test).
+- `createProgressBillingCore — consumption guard` also carries the new **change-order rejection test** required by the course change (§2.5) in place of the CO over-cap/duplicate-CO tests it replaced.
+- `createProgressBillingCore — custom lines`: materializes a Pending milestone and raises `invoice.totalAmount`/`balanceDue`.
+- `createProgressBillingCore — billing codes`: create P1/P2, delete P1, create again → must be P3, not a P2 collision (fails under the pre-fix count-based numbering).
+- `updateProgressBillingCore / deleteProgressBillingCore`: rewritten for the new contract; the update test now also asserts a full exempt → un-exempt round-trip recomputes tax at the stored real rate (F.2).
+- `settleProgressBillingPaidCore` (new, exported from `quickbooks-payments.ts` specifically so this could be tested without a live QuickBooks connection — see §2.6): settles a custom-only billing, asserts `invoice.balanceDue` drops to 0, the materialized `PaymentSchedule` goes `Paid`, and a second settle call is a no-op (idempotency).
+
+**What I did NOT build**: a "pre-tax vintage split test [with] a real estimate-side schedule + sourceScheduleId" mirror test was added as required (`NEW vintage split creates a real estimate-side mirror`), replacing the old test that asserted nothing about mirroring.
+
+### 2.5 — Course change: change orders removed from progress billing
+
+Mid-implementation, the orchestrator flagged that `billChangeOrderCore` (`src/lib/billing-core.ts`) already bills an approved change order by adding it to the invoice as a normal `PaymentSchedule` milestone (`handleChangeOrderApproved` calls it on approval, with its own row lock and duplicate-idempotency outcome). A `changeOrderId` field on a progress-billing line would therefore be a **second rail for the same money** — a genuine double-billing hole — and would also collide with a separate session working on change orders concurrently.
+
+Per that redirect, I:
+
+1. Removed `changeOrderId` from `ProgressBillingLineInput` and from every code path in `createProgressBillingCore` (validation loop, resolution/caching loop, consumption guard, AUTO-SPLIT comments, materialization). A line that supplies one (checked via a runtime duck-type check, since the field no longer exists on the type — guards against a stale caller) is rejected with: *"Change orders are billed by approving them, which adds a milestone to the invoice — bill that milestone here."*
+2. Dropped `changeOrderId` from the `ProgressBillingLine` Prisma model and from `scripts/apply-progress-billing-schema.mjs`'s `CREATE TABLE` statement. This column has never existed in any database (the table itself was never applied to prod), so this is a same-migration edit, not a drop-migration — nothing to backfill or roll back. Regenerated the Prisma client via PowerShell (`node_modules\.bin\prisma generate`) after the schema edit.
+3. Kept custom-line materialization (item C) exactly as specified — unaffected by this change.
+4. Deleted the CO-over-cap and duplicate-CO tests from `e2e/progress-billing.spec.ts` and replaced them with one test asserting a `changeOrderId` line is rejected with the message above (`createProgressBillingCore — consumption guard` describe block).
+5. This report section documents the redirect and rationale, per the coordinator's instruction.
+
+Everything else in the brief (A units, B milestone-only consumption guard, D conditional claim, E orphan compensation, F code numbering / taxExempt rate / cent-safe r2, remaining G tests) is unchanged by this course change.
+
+### 2.6 — `settleProgressBillingPaidCore` extraction (`src/lib/quickbooks-payments.ts`)
+
+The progress-billing settle transaction that used to be inlined in `syncQuickBooksPayments`'s second loop is now an exported standalone function, `settleProgressBillingPaidCore(billingId, payment)`, used both by `syncQuickBooksPayments` (unchanged behavior — same claim, same per-line settle via `settleMilestonePaidInTx`) and directly by the new e2e settle test, which simulates a Staged billing (no live QuickBooks in the test DB, same pattern the pre-existing "draft-only guard" test already used) rather than trying to fake a QBO probe response.
+
+## 8. What I ran, and what I could not
+
+- **`npm run build`** (PowerShell, `tsc --noEmit && next build`) — **passed, 0 errors**, run twice: once right after the A–F implementation, once again after the §2.5 course-change edits (schema + code + Prisma regen). Tail of the second run confirmed the full static/dynamic route listing completed with no `error TS`/`Failed to compile`/`Type error` lines (grepped explicitly, zero matches).
+- **`node_modules\.bin\prisma generate`** (PowerShell, per this repo's rule — never Git Bash) — succeeded after the `changeOrderId` column removal from `schema.prisma`.
+- **`npx playwright test --list e2e/progress-billing.spec.ts`** — succeeded, discovered and listed all 23 tests across 3 files (the 2 shared fixtures + 21 in this spec), confirming imports resolve and the file is syntactically well-formed. This does **not** type-check the file — `e2e/` is excluded from `tsconfig.json`'s `include`, so `npm run build`'s `tsc` pass never touches it, and Playwright's own loader (esbuild-based) strips types without checking them. I do not have independent type-level verification of the spec file beyond careful manual review.
+- **`npx playwright test` (actual execution against a throwaway Postgres) — did NOT run.** Docker CLI is present but the daemon was not running. I started Docker Desktop and polled `docker info` across three separate waits (roughly 2 min, 4.5 min, and a background poll up to ~6.5 min) — the daemon never came up in this environment within that combined ~13 minutes. **I could not execute any test in this file, round 1's tests, `e2e/money-pipeline.spec.ts`, or `e2e/milestone-rebalance.spec.ts`.** Per the task's own instruction ("If Docker/Postgres is unavailable, say so explicitly... CI runs them on the PR"), this is disclosed rather than papered over. All money-math assertions in the new/changed tests were hand-computed against the implementation's formulas (shown inline as comments in the test file, e.g. `108/1.088 = 100.0`, `25000 * 1.088 = 27200`) but are **not machine-verified**. This is the single biggest residual risk in this deliverable — CI will run the real suite on the PR and must be checked before merge.
+- Did not touch prod/Supabase at any point, per the hard constraint.
+
+## 9. Remaining risks
+
+- **Unexecuted test suite** (see §8) — the highest-priority thing to check once CI runs.
+- **`updateProgressBillingCore`'s narrow scope** (round-1 deviation, still true): line composition still isn't editable after creation; unchanged by this round.
+- **Committed-amount conversion for the consumption guard uses each historical line's OWN billing's `taxRate`/`taxExempt`** to gross it back up to milestone units (for legacy vintage) rather than the current billing's rate. This is correct as long as `taxRate`/`taxExempt` are immutable per billing after creation (they are, except `taxExempt` can flip via `updateProgressBillingCore`, which does NOT touch the stored `taxRate` — see F.2 — so the conversion stays correct even after an update). Flagging the reasoning here in case a future change to `updateProgressBillingCore` ever lets `taxRate` itself change.
+- **RLS on `ProgressBilling`/`ProgressBillingLine`** — unchanged from round 1 (off, matching the Invoice/PaymentSchedule precedent).
+- Change-order billing itself (via `billChangeOrderCore`/`handleChangeOrderApproved`) was not touched by this task and is owned by the concurrent session referenced in §2.5.

--- a/e2e/progress-billing.spec.ts
+++ b/e2e/progress-billing.spec.ts
@@ -1,0 +1,436 @@
+import { test, expect } from "@playwright/test";
+import { PrismaClient } from "@prisma/client";
+import {
+    createProgressBillingCore,
+    updateProgressBillingCore,
+    deleteProgressBillingCore,
+    stageProgressBillingToQuickBooksCore,
+} from "../src/lib/progress-billing";
+
+/**
+ * Progress billing core regression net.
+ *
+ * Covers the session-free cores in src/lib/progress-billing.ts directly
+ * against the throwaway CI Postgres (same established pattern as
+ * e2e/milestone-rebalance.spec.ts — actions.ts wrappers need a real Next.js
+ * request scope and come in the UI pass).
+ *
+ * No live QuickBooks connection exists in this test DB (no Integration row),
+ * so stageProgressBillingToQuickBooksCore's getFreshQBTokens() call always
+ * throws QBNotConnectedError before any QBO network call or DB write — the
+ * QBO tests below assert exactly that (rejection + DB unchanged), never a
+ * live QBO call.
+ */
+
+const prisma = new PrismaClient();
+const PFX = "pb-e2e";
+const num = (v: unknown) => Number(v);
+
+async function afterAllCleanup() {
+    try {
+        await prisma.progressBillingLine.deleteMany({ where: { billing: { invoiceId: { startsWith: PFX } } } });
+        await prisma.progressBilling.deleteMany({ where: { invoiceId: { startsWith: PFX } } });
+        await prisma.paymentSchedule.deleteMany({ where: { id: { startsWith: PFX } } });
+        await prisma.invoice.deleteMany({ where: { id: { startsWith: PFX } } });
+        await prisma.estimatePaymentSchedule.deleteMany({ where: { id: { startsWith: PFX } } });
+        await prisma.estimate.deleteMany({ where: { id: { startsWith: PFX } } });
+        await prisma.project.deleteMany({ where: { id: { startsWith: PFX } } });
+        await prisma.client.deleteMany({ where: { id: { startsWith: PFX } } });
+    } finally {
+        await prisma.$disconnect();
+    }
+}
+
+async function ensureClientAndProject() {
+    await prisma.client.upsert({
+        where: { id: `${PFX}-client` },
+        update: {},
+        create: { id: `${PFX}-client`, name: "PB Client", initials: "PB" },
+    });
+    await prisma.project.upsert({
+        where: { id: `${PFX}-project` },
+        update: {},
+        create: { id: `${PFX}-project`, name: "PB Project", clientId: `${PFX}-client` },
+    });
+}
+
+test.describe.serial("createProgressBillingCore", () => {
+    test.afterAll(afterAllCleanup);
+
+    test("rejects over-billing a milestone; DB unchanged", async () => {
+        await ensureClientAndProject();
+        const suffix = "overbill";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psId = `${PFX}-ps-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 500, balanceDue: 500 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psId, invoiceId, name: "Deposit", amount: 500, status: "Pending" } });
+
+        await expect(
+            createProgressBillingCore(invoiceId, {
+                description: "Overbill attempt",
+                lines: [{ scheduleId: psId, description: "Deposit", amount: 600 }],
+                amountMode: "preTax",
+            }),
+        ).rejects.toThrow(/exceeds the milestone/i);
+
+        const ps = await prisma.paymentSchedule.findUnique({ where: { id: psId } });
+        expect(num(ps!.amount)).toBe(500); // unchanged
+        const billings = await prisma.progressBilling.findMany({ where: { invoiceId } });
+        expect(billings.length).toBe(0); // nothing created
+    });
+
+    test("bills a milestone in FULL: no split, one line, milestone stays Pending, invoice totals unchanged", async () => {
+        await ensureClientAndProject();
+        const suffix = "full";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psId = `${PFX}-ps-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 500, balanceDue: 500, taxRate: 0 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psId, invoiceId, name: "Deposit", amount: 500, status: "Pending" } });
+
+        const billing = await createProgressBillingCore(invoiceId, {
+            description: "Full deposit billing",
+            lines: [{ scheduleId: psId, description: "Deposit", amount: 500 }],
+            amountMode: "preTax",
+        });
+
+        expect(billing.lines.length).toBe(1);
+        expect(billing.lines[0].scheduleId).toBe(psId);
+        expect(num(billing.lines[0].amount)).toBe(500);
+        expect(billing.status).toBe("Draft");
+        expect(billing.code).toBe(`INV-PB-${suffix}-P1`);
+
+        // No split: still exactly one PaymentSchedule row for this invoice, unchanged.
+        const schedules = await prisma.paymentSchedule.findMany({ where: { invoiceId } });
+        expect(schedules.length).toBe(1);
+        expect(schedules[0].status).toBe("Pending");
+        expect(num(schedules[0].amount)).toBe(500);
+
+        const invoice = await prisma.invoice.findUnique({ where: { id: invoiceId } });
+        expect(num(invoice!.totalAmount)).toBe(500);
+        expect(num(invoice!.balanceDue)).toBe(500);
+    });
+
+    test("PARTIAL bill auto-splits the milestone and mirrors the estimate side; no row deleted", async () => {
+        await ensureClientAndProject();
+        const suffix = "partial";
+        const estimateId = `${PFX}-est-${suffix}`;
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const epsId = `${PFX}-eps-${suffix}`;
+        const psId = `${PFX}-ps-${suffix}`;
+
+        await prisma.estimate.create({
+            data: { id: estimateId, title: "PB Estimate", code: `EST-PB-${suffix}`, projectId: `${PFX}-project`, status: "Approved", totalAmount: 1000, balanceDue: 1000 },
+        });
+        await prisma.estimatePaymentSchedule.create({
+            data: { id: epsId, estimateId, name: "Progress 1", amount: 1000, status: "Pending", order: 2 },
+        });
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, estimateId, status: "Issued", totalAmount: 1000, balanceDue: 1000, taxRate: 0 },
+        });
+        await prisma.paymentSchedule.create({
+            data: { id: psId, invoiceId, name: "Progress 1", amount: 1000, status: "Pending", sourceScheduleId: epsId, dueDate: new Date("2026-03-01") },
+        });
+
+        const billing = await createProgressBillingCore(invoiceId, {
+            description: "Partial progress billing",
+            lines: [{ scheduleId: psId, description: "Progress 1 (partial)", amount: 400 }],
+            amountMode: "preTax",
+        });
+
+        expect(billing.lines.length).toBe(1);
+        expect(billing.lines[0].scheduleId).toBe(psId); // original (now-reduced) row, not the remainder
+        expect(num(billing.lines[0].amount)).toBe(400);
+
+        // Original invoice-side milestone reduced to the billed amount.
+        const original = await prisma.paymentSchedule.findUnique({ where: { id: psId } });
+        expect(original).not.toBeNull(); // not deleted
+        expect(num(original!.amount)).toBe(400);
+        expect(original!.status).toBe("Pending");
+
+        // A NEW remainder row absorbs the rest.
+        const allSchedules = await prisma.paymentSchedule.findMany({ where: { invoiceId }, orderBy: { createdAt: "asc" } });
+        expect(allSchedules.length).toBe(2); // nothing deleted, one new row
+        const remainder = allSchedules.find((s) => s.id !== psId)!;
+        expect(remainder.name).toBe("Progress 1 (remaining)");
+        expect(remainder.status).toBe("Pending");
+        expect(num(remainder.amount)).toBe(600);
+        expect(remainder.dueDate?.toISOString()).toBe(new Date("2026-03-01").toISOString());
+        // The two pieces sum to the original.
+        expect(num(original!.amount) + num(remainder.amount)).toBe(1000);
+
+        // Estimate-side mirror split the same way.
+        const estOriginal = await prisma.estimatePaymentSchedule.findUnique({ where: { id: epsId } });
+        expect(estOriginal).not.toBeNull(); // not deleted
+        expect(num(estOriginal!.amount)).toBe(400);
+
+        const allEst = await prisma.estimatePaymentSchedule.findMany({ where: { estimateId }, orderBy: { createdAt: "asc" } });
+        expect(allEst.length).toBe(2); // nothing deleted, one new row
+        const estRemainder = allEst.find((e) => e.id !== epsId)!;
+        expect(estRemainder.name).toBe("Progress 1 (remaining)");
+        expect(num(estRemainder.amount)).toBe(600);
+        expect(estRemainder.order).toBe(2); // same order as the original
+        expect(estRemainder.percentage).toBeNull();
+        expect(num(estOriginal!.amount) + num(estRemainder.amount)).toBe(1000);
+
+        // The new invoice-side remainder row points at the new estimate-side row.
+        expect(remainder.sourceScheduleId).toBe(estRemainder.id);
+
+        // Invoice totalAmount/balanceDue are untouched by a split.
+        const invoice = await prisma.invoice.findUnique({ where: { id: invoiceId } });
+        expect(num(invoice!.totalAmount)).toBe(1000);
+        expect(num(invoice!.balanceDue)).toBe(1000);
+    });
+
+    test('amountMode "preTax" math: subtotal + tax(8.8%) = total', async () => {
+        await ensureClientAndProject();
+        const suffix = "pretax";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psId = `${PFX}-ps-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 1000, balanceDue: 1000, taxRate: 8.8 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psId, invoiceId, name: "Progress", amount: 1000, status: "Pending" } });
+
+        const billing = await createProgressBillingCore(invoiceId, {
+            description: "PreTax billing",
+            lines: [{ scheduleId: psId, description: "Progress", amount: 1000 }],
+            amountMode: "preTax",
+        });
+
+        expect(num(billing.subtotal)).toBe(1000);
+        expect(num(billing.taxAmount)).toBe(88); // round(1000 * 8.8 / 100)
+        expect(num(billing.total)).toBe(1088);
+        expect(num(billing.subtotal) + num(billing.taxAmount)).toBe(num(billing.total));
+    });
+
+    test('amountMode "targetTotal" with 33000 @ 8.8%: total is exactly 33000, subtotal+tax=total, lines sum to subtotal', async () => {
+        await ensureClientAndProject();
+        const suffix = "target";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psAId = `${PFX}-ps-a-${suffix}`;
+        const psBId = `${PFX}-ps-b-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 33000, balanceDue: 33000, taxRate: 8.8 },
+        });
+        // Both lines bill the milestone in FULL (raw amount === milestone amount)
+        // so no split occurs — this test isolates the targetTotal tax/rescale
+        // math from the auto-split mechanic (covered separately above).
+        await prisma.paymentSchedule.create({ data: { id: psAId, invoiceId, name: "Progress A", amount: 20000, status: "Pending" } });
+        await prisma.paymentSchedule.create({ data: { id: psBId, invoiceId, name: "Progress B", amount: 13000, status: "Pending" } });
+
+        const billing = await createProgressBillingCore(invoiceId, {
+            description: "Target total billing",
+            lines: [
+                { scheduleId: psAId, description: "Progress A", amount: 20000 },
+                { scheduleId: psBId, description: "Progress B", amount: 13000 },
+            ],
+            amountMode: "targetTotal",
+            targetTotal: 33000,
+        });
+
+        expect(num(billing.total)).toBe(33000);
+        expect(num(billing.subtotal)).toBe(30330.88); // round(33000 / 1.088)
+        expect(num(billing.taxAmount)).toBe(2669.12); // round(33000 - 30330.88)
+        expect(num(billing.subtotal) + num(billing.taxAmount)).toBe(num(billing.total));
+
+        const lineSum = billing.lines.reduce((s, l) => s + num(l.amount), 0);
+        expect(Math.round(lineSum * 100) / 100).toBe(num(billing.subtotal));
+
+        // No split occurred (both lines billed their milestone in full).
+        const psA = await prisma.paymentSchedule.findUnique({ where: { id: psAId } });
+        const psB = await prisma.paymentSchedule.findUnique({ where: { id: psBId } });
+        expect(num(psA!.amount)).toBe(20000);
+        expect(num(psB!.amount)).toBe(13000);
+        const allSchedules = await prisma.paymentSchedule.findMany({ where: { invoiceId } });
+        expect(allSchedules.length).toBe(2); // no remainder rows created
+    });
+
+    test("taxExempt: true forces taxRate 0 / taxAmount 0 / total === subtotal, overriding the invoice's rate", async () => {
+        await ensureClientAndProject();
+        const suffix = "exempt";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psId = `${PFX}-ps-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 750, balanceDue: 750, taxRate: 8.8 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psId, invoiceId, name: "Progress", amount: 750, status: "Pending" } });
+
+        const billing = await createProgressBillingCore(invoiceId, {
+            description: "Exempt billing",
+            lines: [{ scheduleId: psId, description: "Progress", amount: 750 }],
+            amountMode: "preTax",
+            taxExempt: true,
+        });
+
+        expect(billing.taxExempt).toBe(true);
+        expect(num(billing.taxRate)).toBe(0);
+        expect(num(billing.taxAmount)).toBe(0);
+        expect(num(billing.total)).toBe(num(billing.subtotal));
+        expect(num(billing.subtotal)).toBe(750);
+    });
+
+    test("rejects a milestone carrying a legacy qbInvoiceId with the Break-QB-Link message", async () => {
+        await ensureClientAndProject();
+        const suffix = "qblinked";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psId = `${PFX}-ps-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 500, balanceDue: 500 },
+        });
+        await prisma.paymentSchedule.create({
+            data: { id: psId, invoiceId, name: "Deposit", amount: 500, status: "Pending", qbInvoiceId: "fake-qbo-legacy" },
+        });
+
+        await expect(
+            createProgressBillingCore(invoiceId, {
+                description: "Should be rejected",
+                lines: [{ scheduleId: psId, description: "Deposit", amount: 500 }],
+                amountMode: "preTax",
+            }),
+        ).rejects.toThrow(/break the quickbooks link/i);
+
+        const ps = await prisma.paymentSchedule.findUnique({ where: { id: psId } });
+        expect(ps!.qbInvoiceId).toBe("fake-qbo-legacy"); // untouched
+        const billings = await prisma.progressBilling.findMany({ where: { invoiceId } });
+        expect(billings.length).toBe(0);
+    });
+});
+
+test.describe.serial("updateProgressBillingCore / deleteProgressBillingCore", () => {
+    test.afterAll(afterAllCleanup);
+
+    async function createDraftBilling(suffix: string) {
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psId = `${PFX}-ps-${suffix}`;
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 500, balanceDue: 500 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psId, invoiceId, name: "Deposit", amount: 500, status: "Pending" } });
+        const billing = await createProgressBillingCore(invoiceId, {
+            description: "Original description",
+            lines: [{ scheduleId: psId, description: "Deposit", amount: 500 }],
+            amountMode: "preTax",
+        });
+        return { invoiceId, psId, billing };
+    }
+
+    test("draft-only guard rejects update/delete once a QuickBooks invoice is staged", async () => {
+        await ensureClientAndProject();
+        const { billing } = await createDraftBilling("guard");
+
+        // Simulate a staged billing directly (no live QuickBooks in this test DB).
+        await prisma.progressBilling.update({
+            where: { id: billing.id },
+            data: { status: "Staged", qbInvoiceId: "fake-qbo-staged" },
+        });
+
+        await expect(updateProgressBillingCore(billing.id, { description: "New description" })).rejects.toThrow(/only draft billings/i);
+        await expect(deleteProgressBillingCore(billing.id)).rejects.toThrow(/only draft billings/i);
+
+        const stillThere = await prisma.progressBilling.findUnique({ where: { id: billing.id } });
+        expect(stillThere).not.toBeNull();
+        expect(stillThere!.description).toBe("Original description"); // unchanged
+    });
+
+    test("updates description/taxExempt on a Draft billing and recomputes tax", async () => {
+        await ensureClientAndProject();
+        const suffix = "update";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psId = `${PFX}-ps-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 500, balanceDue: 500, taxRate: 8.8 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psId, invoiceId, name: "Deposit", amount: 500, status: "Pending" } });
+
+        const billing = await createProgressBillingCore(invoiceId, {
+            description: "Original description",
+            lines: [{ scheduleId: psId, description: "Deposit", amount: 500 }],
+            amountMode: "preTax",
+        });
+        expect(num(billing.taxAmount)).toBe(44); // round(500 * 8.8 / 100)
+
+        const updated = await updateProgressBillingCore(billing.id, { description: "Revised description", taxExempt: true });
+        expect(updated.description).toBe("Revised description");
+        expect(updated.taxExempt).toBe(true);
+        expect(num(updated.taxAmount)).toBe(0);
+        expect(num(updated.total)).toBe(num(updated.subtotal));
+    });
+
+    test("delete leaves an already-applied split intact", async () => {
+        await ensureClientAndProject();
+        const suffix = "delete-split";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psId = `${PFX}-ps-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 1000, balanceDue: 1000, taxRate: 0 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psId, invoiceId, name: "Progress 1", amount: 1000, status: "Pending" } });
+
+        const billing = await createProgressBillingCore(invoiceId, {
+            description: "Partial to be deleted",
+            lines: [{ scheduleId: psId, description: "Progress 1 (partial)", amount: 350 }],
+            amountMode: "preTax",
+        });
+
+        const beforeDelete = await prisma.paymentSchedule.findMany({ where: { invoiceId } });
+        expect(beforeDelete.length).toBe(2); // split already applied
+
+        const res = await deleteProgressBillingCore(billing.id);
+        expect(res.success).toBe(true);
+
+        const gone = await prisma.progressBilling.findUnique({ where: { id: billing.id } });
+        expect(gone).toBeNull();
+        const goneLines = await prisma.progressBillingLine.findMany({ where: { billingId: billing.id } });
+        expect(goneLines.length).toBe(0);
+
+        // The split's two milestone pieces are untouched by the delete.
+        const afterDelete = await prisma.paymentSchedule.findMany({ where: { invoiceId }, orderBy: { createdAt: "asc" } });
+        expect(afterDelete.length).toBe(2);
+        expect(num(afterDelete[0].amount)).toBe(350);
+        expect(afterDelete[0].status).toBe("Pending");
+        expect(afterDelete[1].name).toBe("Progress 1 (remaining)");
+        expect(num(afterDelete[1].amount)).toBe(650);
+        expect(afterDelete[1].status).toBe("Pending");
+    });
+});
+
+test.describe.serial("stageProgressBillingToQuickBooksCore (no live QuickBooks in this test DB)", () => {
+    test.afterAll(afterAllCleanup);
+
+    test("rejects with QuickBooks-not-connected; billing stays Draft with no qbInvoiceId", async () => {
+        await ensureClientAndProject();
+        const suffix = "stage";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psId = `${PFX}-ps-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 500, balanceDue: 500 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psId, invoiceId, name: "Deposit", amount: 500, status: "Pending" } });
+        const billing = await createProgressBillingCore(invoiceId, {
+            description: "Stage attempt",
+            lines: [{ scheduleId: psId, description: "Deposit", amount: 500 }],
+            amountMode: "preTax",
+        });
+
+        // No Integration row exists in this test DB → getFreshQBTokens() throws
+        // before any QBO network call or DB write is attempted.
+        await expect(stageProgressBillingToQuickBooksCore(billing.id)).rejects.toThrow(/quickbooks is not connected/i);
+
+        const stillDraft = await prisma.progressBilling.findUnique({ where: { id: billing.id } });
+        expect(stillDraft!.status).toBe("Draft");
+        expect(stillDraft!.qbInvoiceId).toBeNull();
+    });
+});

--- a/e2e/progress-billing.spec.ts
+++ b/e2e/progress-billing.spec.ts
@@ -6,20 +6,34 @@ import {
     deleteProgressBillingCore,
     stageProgressBillingToQuickBooksCore,
 } from "../src/lib/progress-billing";
+import { settleProgressBillingPaidCore } from "../src/lib/quickbooks-payments";
 
 /**
  * Progress billing core regression net.
  *
- * Covers the session-free cores in src/lib/progress-billing.ts directly
- * against the throwaway CI Postgres (same established pattern as
- * e2e/milestone-rebalance.spec.ts — actions.ts wrappers need a real Next.js
- * request scope and come in the UI pass).
+ * Covers the session-free cores in src/lib/progress-billing.ts (+ the settle
+ * helper in src/lib/quickbooks-payments.ts) directly against the throwaway CI
+ * Postgres (same established pattern as e2e/milestone-rebalance.spec.ts —
+ * actions.ts wrappers need a real Next.js request scope and come in the UI
+ * pass).
  *
  * No live QuickBooks connection exists in this test DB (no Integration row),
  * so stageProgressBillingToQuickBooksCore's getFreshQBTokens() call always
  * throws QBNotConnectedError before any QBO network call or DB write — the
- * QBO tests below assert exactly that (rejection + DB unchanged), never a
- * live QBO call.
+ * QBO staging test below asserts exactly that (rejection + DB unchanged),
+ * never a live QBO call. settleProgressBillingPaidCore is exercised directly
+ * (bypassing the QBO probe entirely) by simulating an already-Staged billing,
+ * same pattern the "draft-only guard" test below uses.
+ *
+ * CONTRACT NOTE: `createProgressBillingCore` no longer takes `amountMode` /
+ * `targetTotal` — every test below uses the current contract (`lines[].amount`
+ * in the milestone's own units + optional `grossTotal`). Because the old
+ * fields no longer exist, every test in this file already fails to even
+ * *compile* against the pre-fix signature — on top of that, the tests in the
+ * "consumption guard", "billing codes", and "rescale to zero" describe blocks
+ * below exercise bugs that are independent of the contract change (the guard
+ * simply didn't exist; the numbering was count-based) and would behave
+ * incorrectly even if hand-adapted to the old contract.
  */
 
 const prisma = new PrismaClient();
@@ -30,8 +44,10 @@ async function afterAllCleanup() {
     try {
         await prisma.progressBillingLine.deleteMany({ where: { billing: { invoiceId: { startsWith: PFX } } } });
         await prisma.progressBilling.deleteMany({ where: { invoiceId: { startsWith: PFX } } });
+        await prisma.paymentSchedule.deleteMany({ where: { invoiceId: { startsWith: PFX } } });
         await prisma.paymentSchedule.deleteMany({ where: { id: { startsWith: PFX } } });
         await prisma.invoice.deleteMany({ where: { id: { startsWith: PFX } } });
+        await prisma.changeOrder.deleteMany({ where: { id: { startsWith: PFX } } });
         await prisma.estimatePaymentSchedule.deleteMany({ where: { id: { startsWith: PFX } } });
         await prisma.estimate.deleteMany({ where: { id: { startsWith: PFX } } });
         await prisma.project.deleteMany({ where: { id: { startsWith: PFX } } });
@@ -54,7 +70,7 @@ async function ensureClientAndProject() {
     });
 }
 
-test.describe.serial("createProgressBillingCore", () => {
+test.describe.serial("createProgressBillingCore — core cases", () => {
     test.afterAll(afterAllCleanup);
 
     test("rejects over-billing a milestone; DB unchanged", async () => {
@@ -72,9 +88,8 @@ test.describe.serial("createProgressBillingCore", () => {
             createProgressBillingCore(invoiceId, {
                 description: "Overbill attempt",
                 lines: [{ scheduleId: psId, description: "Deposit", amount: 600 }],
-                amountMode: "preTax",
             }),
-        ).rejects.toThrow(/exceeds the milestone/i);
+        ).rejects.toThrow(/exceeds/i);
 
         const ps = await prisma.paymentSchedule.findUnique({ where: { id: psId } });
         expect(num(ps!.amount)).toBe(500); // unchanged
@@ -96,7 +111,6 @@ test.describe.serial("createProgressBillingCore", () => {
         const billing = await createProgressBillingCore(invoiceId, {
             description: "Full deposit billing",
             lines: [{ scheduleId: psId, description: "Deposit", amount: 500 }],
-            amountMode: "preTax",
         });
 
         expect(billing.lines.length).toBe(1);
@@ -140,7 +154,6 @@ test.describe.serial("createProgressBillingCore", () => {
         const billing = await createProgressBillingCore(invoiceId, {
             description: "Partial progress billing",
             lines: [{ scheduleId: psId, description: "Progress 1 (partial)", amount: 400 }],
-            amountMode: "preTax",
         });
 
         expect(billing.lines.length).toBe(1);
@@ -187,21 +200,24 @@ test.describe.serial("createProgressBillingCore", () => {
         expect(num(invoice!.balanceDue)).toBe(1000);
     });
 
-    test('amountMode "preTax" math: subtotal + tax(8.8%) = total', async () => {
+    test("NEW-VINTAGE (pre-tax) job: subtotal + tax(8.8%) = total, from a pre-tax raw line amount", async () => {
         await ensureClientAndProject();
-        const suffix = "pretax";
+        const suffix = "pretax-taxmath";
+        const estimateId = `${PFX}-est-${suffix}`;
         const invoiceId = `${PFX}-inv-${suffix}`;
         const psId = `${PFX}-ps-${suffix}`;
 
+        await prisma.estimate.create({
+            data: { id: estimateId, title: "PB PreTax", code: `EST-PB-${suffix}`, projectId: `${PFX}-project`, status: "Approved", totalAmount: 1088, balanceDue: 1088, taxInclusiveMilestones: false },
+        });
         await prisma.invoice.create({
-            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 1000, balanceDue: 1000, taxRate: 8.8 },
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, estimateId, status: "Issued", totalAmount: 1088, balanceDue: 1088, taxRate: 8.8 },
         });
         await prisma.paymentSchedule.create({ data: { id: psId, invoiceId, name: "Progress", amount: 1000, status: "Pending" } });
 
         const billing = await createProgressBillingCore(invoiceId, {
             description: "PreTax billing",
-            lines: [{ scheduleId: psId, description: "Progress", amount: 1000 }],
-            amountMode: "preTax",
+            lines: [{ scheduleId: psId, description: "Progress", amount: 1000 }], // pre-tax: new-vintage units
         });
 
         expect(num(billing.subtotal)).toBe(1000);
@@ -210,14 +226,18 @@ test.describe.serial("createProgressBillingCore", () => {
         expect(num(billing.subtotal) + num(billing.taxAmount)).toBe(num(billing.total));
     });
 
-    test("targetTotal + partial split on a LEGACY tax-inclusive job splits by the gross amount", async () => {
+    test('LEGACY vintage, no grossTotal: split is GROSS and the remainder is correct (the $108/$100 case)', async () => {
         // The live Mesplay case: a $25,000 check against a $39,998.25 milestone
-        // whose amount already includes 8.8% tax. The milestone must be carved at
-        // the GROSS $25,000 (leaving $14,998.25), while the billing line records
-        // the PRE-TAX $22,977.94 for QuickBooks. Splitting by the pre-tax figure
-        // instead would silently leave the client short by the tax.
+        // whose amount already includes 8.8% tax. Under the new contract the
+        // line amount for a legacy milestone IS the gross amount the client is
+        // paying — no amountMode/targetTotal needed. The milestone must be
+        // carved at the GROSS $25,000 (leaving $14,998.25), while the billing
+        // line records the PRE-TAX $22,977.94 for QuickBooks. Splitting by the
+        // pre-tax figure instead (the pre-round-2 "$108 milestone billed '$100
+        // preTax' actually charged $108 but left $8 owed" bug) would silently
+        // leave the client short by the tax.
         await ensureClientAndProject();
-        const suffix = "legacy-split";
+        const suffix = "legacy-gross-mirror";
         const estimateId = `${PFX}-est-${suffix}`;
         const invoiceId = `${PFX}-inv-${suffix}`;
         const epsId = `${PFX}-eps-${suffix}`;
@@ -238,9 +258,7 @@ test.describe.serial("createProgressBillingCore", () => {
 
         const billing = await createProgressBillingCore(invoiceId, {
             description: "Progress payment (check 1585)",
-            lines: [{ scheduleId: psId, description: "Mechanical Trades", amount: 25000 }],
-            amountMode: "targetTotal",
-            targetTotal: 25000,
+            lines: [{ scheduleId: psId, description: "Mechanical Trades", amount: 25000 }], // gross: legacy units, no grossTotal supplied
         });
 
         // Client pays exactly the check amount; tax is stated inside it.
@@ -272,46 +290,85 @@ test.describe.serial("createProgressBillingCore", () => {
         expect(num(invoice!.balanceDue)).toBe(39998.25);
     });
 
-    test("targetTotal + partial split on a PRE-TAX job splits by the pre-tax amount", async () => {
-        // Same shape, new-vintage estimate: milestone amounts exclude tax, so the
-        // pre-tax line amount is what comes out of the milestone and tax rides on top.
+    test("NEW vintage split creates a real estimate-side mirror (sourceScheduleId + split remainder)", async () => {
+        // Same shape, new-vintage estimate: milestone amounts exclude tax, so
+        // the pre-tax line amount is what comes out of the milestone and tax
+        // rides on top. Unlike a stale pre-round-2 test, this one wires up a
+        // real EstimatePaymentSchedule + sourceScheduleId so the mirror split
+        // is actually asserted, not just the invoice-side numbers.
         await ensureClientAndProject();
-        const suffix = "pretax-split";
+        const suffix = "pretax-mirror";
         const estimateId = `${PFX}-est-${suffix}`;
         const invoiceId = `${PFX}-inv-${suffix}`;
+        const epsId = `${PFX}-eps-${suffix}`;
         const psId = `${PFX}-ps-${suffix}`;
 
         await prisma.estimate.create({
-            data: { id: estimateId, title: "PB PreTax", code: `EST-PB-${suffix}`, projectId: `${PFX}-project`, status: "Approved", totalAmount: 40000, balanceDue: 40000, taxInclusiveMilestones: false },
+            data: { id: estimateId, title: "PB PreTax Mirror", code: `EST-PB-${suffix}`, projectId: `${PFX}-project`, status: "Approved", totalAmount: 40000, balanceDue: 40000, taxInclusiveMilestones: false },
+        });
+        await prisma.estimatePaymentSchedule.create({
+            data: { id: epsId, estimateId, name: "Mechanical", amount: 40000, status: "Pending", order: 1 },
         });
         await prisma.invoice.create({
             data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, estimateId, status: "Issued", totalAmount: 40000, balanceDue: 40000, taxRate: 8.8 },
         });
-        await prisma.paymentSchedule.create({ data: { id: psId, invoiceId, name: "Mechanical", amount: 40000, status: "Pending" } });
+        await prisma.paymentSchedule.create({
+            data: { id: psId, invoiceId, name: "Mechanical", amount: 40000, status: "Pending", sourceScheduleId: epsId },
+        });
 
         const billing = await createProgressBillingCore(invoiceId, {
             description: "Progress payment",
-            lines: [{ scheduleId: psId, description: "Mechanical", amount: 25000 }],
-            amountMode: "targetTotal",
-            targetTotal: 25000,
+            lines: [{ scheduleId: psId, description: "Mechanical", amount: 25000 }], // pre-tax: new-vintage units
         });
 
-        expect(num(billing.total)).toBe(25000);
-        expect(num(billing.subtotal)).toBe(22977.94);
+        expect(num(billing.total)).toBe(27200); // round(25000 * 1.088)
+        expect(num(billing.subtotal)).toBe(25000);
+        expect(num(billing.taxAmount)).toBe(2200);
 
         // Carved at the PRE-TAX amount this time.
         const billed = await prisma.paymentSchedule.findUnique({ where: { id: psId } });
-        expect(num(billed!.amount)).toBe(22977.94);
+        expect(num(billed!.amount)).toBe(25000);
         const remainder = await prisma.paymentSchedule.findFirst({
             where: { invoiceId, name: { contains: "(remaining)" } },
         });
-        expect(num(remainder!.amount)).toBe(17022.06);
+        expect(num(remainder!.amount)).toBe(15000);
         expect(num(billed!.amount) + num(remainder!.amount)).toBe(40000);
+
+        // The estimate-side mirror: original reduced, remainder created, linked.
+        const estOriginal = await prisma.estimatePaymentSchedule.findUnique({ where: { id: epsId } });
+        expect(num(estOriginal!.amount)).toBe(25000);
+        const estRemainder = await prisma.estimatePaymentSchedule.findFirst({
+            where: { estimateId, name: { contains: "(remaining)" } },
+        });
+        expect(estRemainder).not.toBeNull();
+        expect(num(estRemainder!.amount)).toBe(15000);
+        expect(remainder!.sourceScheduleId).toBe(estRemainder!.id);
     });
 
-    test('amountMode "targetTotal" with 33000 @ 8.8%: total is exactly 33000, subtotal+tax=total, lines sum to subtotal', async () => {
+    test('unit-mismatch rejected: lines summing to $100 with grossTotal: 50 throws', async () => {
         await ensureClientAndProject();
-        const suffix = "target";
+        const suffix = "unit-mismatch";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 0, balanceDue: 0, taxRate: 0 },
+        });
+
+        await expect(
+            createProgressBillingCore(invoiceId, {
+                description: "Mismatched units",
+                lines: [{ description: "Custom line", amount: 100 }],
+                grossTotal: 50,
+            }),
+        ).rejects.toThrow(/they must match/i);
+
+        const billings = await prisma.progressBilling.findMany({ where: { invoiceId } });
+        expect(billings.length).toBe(0);
+    });
+
+    test('explicit grossTotal matching the lines: 33000 @ 8.8%, total is exactly 33000, subtotal+tax=total, lines sum to subtotal', async () => {
+        await ensureClientAndProject();
+        const suffix = "grosstotal-match";
         const invoiceId = `${PFX}-inv-${suffix}`;
         const psAId = `${PFX}-ps-a-${suffix}`;
         const psBId = `${PFX}-ps-b-${suffix}`;
@@ -320,8 +377,8 @@ test.describe.serial("createProgressBillingCore", () => {
             data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 33000, balanceDue: 33000, taxRate: 8.8 },
         });
         // Both lines bill the milestone in FULL (raw amount === milestone amount)
-        // so no split occurs — this test isolates the targetTotal tax/rescale
-        // math from the auto-split mechanic (covered separately above).
+        // so no split occurs — this test isolates the grossTotal/tax math from
+        // the auto-split mechanic (covered separately above).
         await prisma.paymentSchedule.create({ data: { id: psAId, invoiceId, name: "Progress A", amount: 20000, status: "Pending" } });
         await prisma.paymentSchedule.create({ data: { id: psBId, invoiceId, name: "Progress B", amount: 13000, status: "Pending" } });
 
@@ -331,8 +388,7 @@ test.describe.serial("createProgressBillingCore", () => {
                 { scheduleId: psAId, description: "Progress A", amount: 20000 },
                 { scheduleId: psBId, description: "Progress B", amount: 13000 },
             ],
-            amountMode: "targetTotal",
-            targetTotal: 33000,
+            grossTotal: 33000,
         });
 
         expect(num(billing.total)).toBe(33000);
@@ -366,12 +422,13 @@ test.describe.serial("createProgressBillingCore", () => {
         const billing = await createProgressBillingCore(invoiceId, {
             description: "Exempt billing",
             lines: [{ scheduleId: psId, description: "Progress", amount: 750 }],
-            amountMode: "preTax",
             taxExempt: true,
         });
 
         expect(billing.taxExempt).toBe(true);
-        expect(num(billing.taxRate)).toBe(0);
+        // billing.taxRate always holds the invoice's REAL rate (item F.2) —
+        // taxExempt only zeroes the tax/total computation, not the stored rate.
+        expect(num(billing.taxRate)).toBe(8.8);
         expect(num(billing.taxAmount)).toBe(0);
         expect(num(billing.total)).toBe(num(billing.subtotal));
         expect(num(billing.subtotal)).toBe(750);
@@ -394,7 +451,6 @@ test.describe.serial("createProgressBillingCore", () => {
             createProgressBillingCore(invoiceId, {
                 description: "Should be rejected",
                 lines: [{ scheduleId: psId, description: "Deposit", amount: 500 }],
-                amountMode: "preTax",
             }),
         ).rejects.toThrow(/break the quickbooks link/i);
 
@@ -402,6 +458,216 @@ test.describe.serial("createProgressBillingCore", () => {
         expect(ps!.qbInvoiceId).toBe("fake-qbo-legacy"); // untouched
         const billings = await prisma.progressBilling.findMany({ where: { invoiceId } });
         expect(billings.length).toBe(0);
+    });
+
+    test("a rescaled line that would round to $0.00 is rejected", async () => {
+        // Two custom lines, weights [0.01, 99.99]. A synthetic, unrealistically
+        // high tax rate (999%) shrinks the pre-tax subtotal far enough below
+        // the raw total that the tiny line's proportional share of the
+        // subtotal rounds to $0.00 — exactly the case the "every persisted
+        // line amount must be > 0" guard exists for.
+        await ensureClientAndProject();
+        const suffix = "rescale-zero";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 0, balanceDue: 0, taxRate: 999 },
+        });
+
+        await expect(
+            createProgressBillingCore(invoiceId, {
+                description: "Rounds to zero",
+                lines: [
+                    { description: "Tiny", amount: 0.01 },
+                    { description: "Big", amount: 99.99 },
+                ],
+            }),
+        ).rejects.toThrow(/\$0\.00 or less/i);
+
+        const billings = await prisma.progressBilling.findMany({ where: { invoiceId } });
+        expect(billings.length).toBe(0);
+    });
+});
+
+test.describe.serial("createProgressBillingCore — consumption guard", () => {
+    test.afterAll(afterAllCleanup);
+
+    test("double-billing rejected: bill a milestone in FULL, then a second billing referencing the same milestone throws", async () => {
+        // A full bill never triggers AUTO-SPLIT, so the milestone's `amount`
+        // stays unchanged after billing #1 — without the consumption guard, a
+        // second billing referencing the same still-Pending row would be
+        // allowed to bill it again for up to that same (unchanged) amount.
+        await ensureClientAndProject();
+        const suffix = "double-full";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psId = `${PFX}-ps-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 500, balanceDue: 500, taxRate: 0 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psId, invoiceId, name: "Deposit", amount: 500, status: "Pending" } });
+
+        await createProgressBillingCore(invoiceId, {
+            description: "First billing",
+            lines: [{ scheduleId: psId, description: "Deposit", amount: 500 }],
+        });
+
+        // The milestone is still "Pending" with amount unchanged (no split
+        // occurred) — a second reference must be rejected as already-committed.
+        const afterFirst = await prisma.paymentSchedule.findUnique({ where: { id: psId } });
+        expect(afterFirst!.status).toBe("Pending");
+        expect(num(afterFirst!.amount)).toBe(500);
+
+        await expect(
+            createProgressBillingCore(invoiceId, {
+                description: "Second billing (double bill)",
+                lines: [{ scheduleId: psId, description: "Deposit again", amount: 500 }],
+            }),
+        ).rejects.toThrow(/already billed/i);
+
+        const billings = await prisma.progressBilling.findMany({ where: { invoiceId } });
+        expect(billings.length).toBe(1); // only the first one exists
+    });
+
+    test("rejects re-billing a milestone's already-consumed original row after a partial split", async () => {
+        // Bill $400 of a $1,000 milestone (partial split: original reduced to
+        // 400, a new $600 remainder row created — see the PARTIAL-bill test
+        // above). A second billing referencing the SAME (now-$400) original
+        // row for $300 would pass the plain "does this exceed the row's
+        // current amount" check (300 <= 400) — that's the residual double-dip
+        // bug the consumption guard closes: the original row's whole current
+        // amount was already committed by the first billing, so nothing is
+        // left to bill against it (available = 400 - 400 = 0).
+        //
+        // (The task's own illustrative "$700 against the same milestone"
+        // number is NOT used here: $700 already exceeds the reduced row's
+        // amount (400) under the OLD plain over-bill check too, so it would
+        // throw for an unrelated reason and wouldn't demonstrate this guard.)
+        await ensureClientAndProject();
+        const suffix = "double-partial";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psId = `${PFX}-ps-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 1000, balanceDue: 1000, taxRate: 0 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psId, invoiceId, name: "Progress 1", amount: 1000, status: "Pending" } });
+
+        await createProgressBillingCore(invoiceId, {
+            description: "Partial billing",
+            lines: [{ scheduleId: psId, description: "Progress 1 (partial)", amount: 400 }],
+        });
+
+        const afterSplit = await prisma.paymentSchedule.findUnique({ where: { id: psId } });
+        expect(num(afterSplit!.amount)).toBe(400); // reduced to the billed portion
+
+        await expect(
+            createProgressBillingCore(invoiceId, {
+                description: "Re-bill the already-consumed original row",
+                lines: [{ scheduleId: psId, description: "Progress 1 (again)", amount: 300 }],
+            }),
+        ).rejects.toThrow(/already billed/i);
+
+        const billings = await prisma.progressBilling.findMany({ where: { invoiceId } });
+        expect(billings.length).toBe(1); // only the first one exists
+
+        // The legitimate remainder ($600) is untouched and still billable —
+        // proves the guard is scoped to the specific committed row, not the
+        // whole milestone family.
+        const remainder = await prisma.paymentSchedule.findFirst({ where: { invoiceId, name: { contains: "(remaining)" } } });
+        expect(num(remainder!.amount)).toBe(600);
+    });
+
+    test("a changeOrderId line is rejected — change orders bill through approval, not progress billing", async () => {
+        // billChangeOrderCore (src/lib/billing-core.ts) already bills an
+        // approved change order by adding a normal PaymentSchedule milestone
+        // to the invoice (handleChangeOrderApproved calls it on approval).
+        // Letting a progress-billing line ALSO reference a changeOrderId would
+        // be a second rail for the same money, so it's rejected outright.
+        await ensureClientAndProject();
+        const suffix = "co-rejected";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 0, balanceDue: 0, taxRate: 0 },
+        });
+
+        await expect(
+            createProgressBillingCore(invoiceId, {
+                description: "CO line attempt",
+                // `changeOrderId` is no longer part of the typed contract — cast
+                // to simulate a caller (e.g. stale UI code) still sending one.
+                lines: [{ description: "Extra tile work", amount: 500, changeOrderId: `${PFX}-co-fake` } as never],
+            }),
+        ).rejects.toThrow(/billed by approving them/i);
+
+        const billings = await prisma.progressBilling.findMany({ where: { invoiceId } });
+        expect(billings.length).toBe(0);
+        const invoice = await prisma.invoice.findUnique({ where: { id: invoiceId } });
+        expect(num(invoice!.totalAmount)).toBe(0); // no phantom growth from the rejected line
+    });
+});
+
+test.describe.serial("createProgressBillingCore — custom lines", () => {
+    test.afterAll(afterAllCleanup);
+
+    test("a custom line materializes a Pending milestone and raises the invoice total", async () => {
+        await ensureClientAndProject();
+        const suffix = "materialize";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 0, balanceDue: 0, taxRate: 0 },
+        });
+
+        const billing = await createProgressBillingCore(invoiceId, {
+            description: "Extras billing",
+            lines: [{ description: "Extra demo work", amount: 250 }], // custom — no scheduleId
+        });
+
+        expect(billing.lines.length).toBe(1);
+        const customLine = billing.lines[0];
+        expect(customLine.scheduleId).not.toBeNull();
+
+        const customSchedule = await prisma.paymentSchedule.findUnique({ where: { id: customLine.scheduleId! } });
+        expect(customSchedule!.name).toBe("Extra demo work");
+        expect(num(customSchedule!.amount)).toBe(250);
+        expect(customSchedule!.status).toBe("Pending");
+        expect(customSchedule!.sourceScheduleId).toBeNull();
+
+        // Milestone-referencing lines never move invoice totals — but this is
+        // a custom line, so the invoice grows by exactly what was added.
+        const invoice = await prisma.invoice.findUnique({ where: { id: invoiceId } });
+        expect(num(invoice!.totalAmount)).toBe(250);
+        expect(num(invoice!.balanceDue)).toBe(250);
+    });
+});
+
+test.describe.serial("createProgressBillingCore — billing codes", () => {
+    test.afterAll(afterAllCleanup);
+
+    test("billing codes do not repeat after deleting a middle draft", async () => {
+        await ensureClientAndProject();
+        const suffix = "codes-reuse";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 0, balanceDue: 0, taxRate: 0 },
+        });
+
+        const b1 = await createProgressBillingCore(invoiceId, { description: "First", lines: [{ description: "Line A", amount: 100 }] });
+        const b2 = await createProgressBillingCore(invoiceId, { description: "Second", lines: [{ description: "Line B", amount: 100 }] });
+        expect(b1.code).toBe(`INV-PB-${suffix}-P1`);
+        expect(b2.code).toBe(`INV-PB-${suffix}-P2`);
+
+        await deleteProgressBillingCore(b1.id); // delete the middle/first draft, leaving only b2
+
+        const b3 = await createProgressBillingCore(invoiceId, { description: "Third", lines: [{ description: "Line C", amount: 100 }] });
+
+        // Count-based numbering (pre-fix) would see 1 remaining billing and
+        // generate "-P2" again, colliding with b2's existing code.
+        expect(b3.code).toBe(`INV-PB-${suffix}-P3`);
+        expect(b3.code).not.toBe(b2.code);
     });
 });
 
@@ -418,7 +684,6 @@ test.describe.serial("updateProgressBillingCore / deleteProgressBillingCore", ()
         const billing = await createProgressBillingCore(invoiceId, {
             description: "Original description",
             lines: [{ scheduleId: psId, description: "Deposit", amount: 500 }],
-            amountMode: "preTax",
         });
         return { invoiceId, psId, billing };
     }
@@ -454,16 +719,24 @@ test.describe.serial("updateProgressBillingCore / deleteProgressBillingCore", ()
 
         const billing = await createProgressBillingCore(invoiceId, {
             description: "Original description",
-            lines: [{ scheduleId: psId, description: "Deposit", amount: 500 }],
-            amountMode: "preTax",
+            lines: [{ scheduleId: psId, description: "Deposit", amount: 500 }], // gross (legacy, no estimate)
         });
-        expect(num(billing.taxAmount)).toBe(44); // round(500 * 8.8 / 100)
+        expect(num(billing.subtotal)).toBe(459.56); // round(500 / 1.088)
+        expect(num(billing.taxAmount)).toBe(40.44); // round(500 - 459.56)
+        expect(num(billing.taxRate)).toBe(8.8); // real rate stored even though not exempt
 
         const updated = await updateProgressBillingCore(billing.id, { description: "Revised description", taxExempt: true });
         expect(updated.description).toBe("Revised description");
         expect(updated.taxExempt).toBe(true);
         expect(num(updated.taxAmount)).toBe(0);
         expect(num(updated.total)).toBe(num(updated.subtotal));
+
+        // Un-exempting recomputes tax at the STORED real rate (item F.2) —
+        // never stuck at 0 from having been saved exempt once.
+        const reverted = await updateProgressBillingCore(billing.id, { taxExempt: false });
+        expect(num(reverted.taxRate)).toBe(8.8);
+        expect(num(reverted.taxAmount)).toBe(40.44);
+        expect(num(reverted.total)).toBe(500);
     });
 
     test("delete leaves an already-applied split intact", async () => {
@@ -480,7 +753,6 @@ test.describe.serial("updateProgressBillingCore / deleteProgressBillingCore", ()
         const billing = await createProgressBillingCore(invoiceId, {
             description: "Partial to be deleted",
             lines: [{ scheduleId: psId, description: "Progress 1 (partial)", amount: 350 }],
-            amountMode: "preTax",
         });
 
         const beforeDelete = await prisma.paymentSchedule.findMany({ where: { invoiceId } });
@@ -521,7 +793,6 @@ test.describe.serial("stageProgressBillingToQuickBooksCore (no live QuickBooks i
         const billing = await createProgressBillingCore(invoiceId, {
             description: "Stage attempt",
             lines: [{ scheduleId: psId, description: "Deposit", amount: 500 }],
-            amountMode: "preTax",
         });
 
         // No Integration row exists in this test DB → getFreshQBTokens() throws
@@ -531,5 +802,71 @@ test.describe.serial("stageProgressBillingToQuickBooksCore (no live QuickBooks i
         const stillDraft = await prisma.progressBilling.findUnique({ where: { id: billing.id } });
         expect(stillDraft!.status).toBe("Draft");
         expect(stillDraft!.qbInvoiceId).toBeNull();
+    });
+});
+
+test.describe.serial("settleProgressBillingPaidCore", () => {
+    test.afterAll(afterAllCleanup);
+
+    test("settling a custom-only billing reduces invoice.balanceDue and marks its materialized milestone Paid", async () => {
+        // Drives the settle helper directly against a simulated Staged billing
+        // (no live QuickBooks connection in this test DB — same pattern as the
+        // "draft-only guard" test above). Proves that a custom line's
+        // materialized PaymentSchedule (see the "materialize" describe block)
+        // settles through the exact same rail as any other milestone, with no
+        // special case.
+        await ensureClientAndProject();
+        const suffix = "settle";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 0, balanceDue: 0, taxRate: 0 },
+        });
+
+        const billing = await createProgressBillingCore(invoiceId, {
+            description: "Custom-only billing",
+            lines: [{ description: "Deposit (custom)", amount: 500 }],
+        });
+
+        const afterCreate = await prisma.invoice.findUnique({ where: { id: invoiceId } });
+        expect(num(afterCreate!.totalAmount)).toBe(500);
+        expect(num(afterCreate!.balanceDue)).toBe(500);
+
+        const scheduleId = billing.lines[0].scheduleId!;
+        expect(scheduleId).toBeTruthy();
+
+        // Simulate staging (no live QuickBooks in this test DB).
+        await prisma.progressBilling.update({
+            where: { id: billing.id },
+            data: { status: "Staged", qbInvoiceId: "fake-qbo-settle" },
+        });
+
+        const settled = await settleProgressBillingPaidCore(billing.id, {
+            paidAt: new Date("2026-07-27"),
+            referenceNumber: "REF-1",
+            qbPaymentId: "fake-payment-1",
+        });
+        expect(settled).toBe(true);
+
+        const billingAfter = await prisma.progressBilling.findUnique({ where: { id: billing.id } });
+        expect(billingAfter!.status).toBe("Paid");
+        expect(billingAfter!.qbPaymentId).toBe("fake-payment-1");
+
+        const schedule = await prisma.paymentSchedule.findUnique({ where: { id: scheduleId } });
+        expect(schedule!.status).toBe("Paid");
+        expect(schedule!.paymentMethod).toBe("quickbooks");
+        expect(schedule!.referenceNumber).toBe("REF-1");
+
+        const invoice = await prisma.invoice.findUnique({ where: { id: invoiceId } });
+        expect(num(invoice!.balanceDue)).toBe(0);
+        expect(invoice!.status).toBe("Paid");
+
+        // Idempotent: settling again (e.g. a re-run poller) is a no-op.
+        const settledAgain = await settleProgressBillingPaidCore(billing.id, {
+            paidAt: new Date(),
+            referenceNumber: "REF-2",
+            qbPaymentId: "fake-payment-2",
+        });
+        expect(settledAgain).toBe(false);
     });
 });

--- a/e2e/progress-billing.spec.ts
+++ b/e2e/progress-billing.spec.ts
@@ -210,6 +210,105 @@ test.describe.serial("createProgressBillingCore", () => {
         expect(num(billing.subtotal) + num(billing.taxAmount)).toBe(num(billing.total));
     });
 
+    test("targetTotal + partial split on a LEGACY tax-inclusive job splits by the gross amount", async () => {
+        // The live Mesplay case: a $25,000 check against a $39,998.25 milestone
+        // whose amount already includes 8.8% tax. The milestone must be carved at
+        // the GROSS $25,000 (leaving $14,998.25), while the billing line records
+        // the PRE-TAX $22,977.94 for QuickBooks. Splitting by the pre-tax figure
+        // instead would silently leave the client short by the tax.
+        await ensureClientAndProject();
+        const suffix = "legacy-split";
+        const estimateId = `${PFX}-est-${suffix}`;
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const epsId = `${PFX}-eps-${suffix}`;
+        const psId = `${PFX}-ps-${suffix}`;
+
+        await prisma.estimate.create({
+            data: { id: estimateId, title: "PB Legacy", code: `EST-PB-${suffix}`, projectId: `${PFX}-project`, status: "Approved", totalAmount: 39998.25, balanceDue: 39998.25, taxInclusiveMilestones: true },
+        });
+        await prisma.estimatePaymentSchedule.create({
+            data: { id: epsId, estimateId, name: "Mechanical Trades", amount: 39998.25, status: "Pending", order: 1 },
+        });
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, estimateId, status: "Issued", totalAmount: 39998.25, balanceDue: 39998.25, taxRate: 8.8 },
+        });
+        await prisma.paymentSchedule.create({
+            data: { id: psId, invoiceId, name: "Mechanical Trades", amount: 39998.25, status: "Pending", sourceScheduleId: epsId },
+        });
+
+        const billing = await createProgressBillingCore(invoiceId, {
+            description: "Progress payment (check 1585)",
+            lines: [{ scheduleId: psId, description: "Mechanical Trades", amount: 25000 }],
+            amountMode: "targetTotal",
+            targetTotal: 25000,
+        });
+
+        // Client pays exactly the check amount; tax is stated inside it.
+        expect(num(billing.total)).toBe(25000);
+        expect(num(billing.subtotal)).toBe(22977.94);
+        expect(num(billing.taxAmount)).toBe(2022.06);
+        expect(num(billing.lines[0].amount)).toBe(22977.94); // pre-tax, feeds QuickBooks
+
+        // Milestone carved at the GROSS amount, remainder preserved, nothing lost.
+        const billed = await prisma.paymentSchedule.findUnique({ where: { id: psId } });
+        expect(num(billed!.amount)).toBe(25000);
+        const remainder = await prisma.paymentSchedule.findFirst({
+            where: { invoiceId, name: { contains: "(remaining)" } },
+        });
+        expect(num(remainder!.amount)).toBe(14998.25);
+        expect(num(billed!.amount) + num(remainder!.amount)).toBe(39998.25);
+
+        // Estimate mirror split the same way, and the invoice totals never moved.
+        const estOriginal = await prisma.estimatePaymentSchedule.findUnique({ where: { id: epsId } });
+        expect(num(estOriginal!.amount)).toBe(25000);
+        const estRemainder = await prisma.estimatePaymentSchedule.findFirst({
+            where: { estimateId, name: { contains: "(remaining)" } },
+        });
+        expect(num(estRemainder!.amount)).toBe(14998.25);
+        expect(remainder!.sourceScheduleId).toBe(estRemainder!.id);
+
+        const invoice = await prisma.invoice.findUnique({ where: { id: invoiceId } });
+        expect(num(invoice!.totalAmount)).toBe(39998.25);
+        expect(num(invoice!.balanceDue)).toBe(39998.25);
+    });
+
+    test("targetTotal + partial split on a PRE-TAX job splits by the pre-tax amount", async () => {
+        // Same shape, new-vintage estimate: milestone amounts exclude tax, so the
+        // pre-tax line amount is what comes out of the milestone and tax rides on top.
+        await ensureClientAndProject();
+        const suffix = "pretax-split";
+        const estimateId = `${PFX}-est-${suffix}`;
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psId = `${PFX}-ps-${suffix}`;
+
+        await prisma.estimate.create({
+            data: { id: estimateId, title: "PB PreTax", code: `EST-PB-${suffix}`, projectId: `${PFX}-project`, status: "Approved", totalAmount: 40000, balanceDue: 40000, taxInclusiveMilestones: false },
+        });
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, estimateId, status: "Issued", totalAmount: 40000, balanceDue: 40000, taxRate: 8.8 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psId, invoiceId, name: "Mechanical", amount: 40000, status: "Pending" } });
+
+        const billing = await createProgressBillingCore(invoiceId, {
+            description: "Progress payment",
+            lines: [{ scheduleId: psId, description: "Mechanical", amount: 25000 }],
+            amountMode: "targetTotal",
+            targetTotal: 25000,
+        });
+
+        expect(num(billing.total)).toBe(25000);
+        expect(num(billing.subtotal)).toBe(22977.94);
+
+        // Carved at the PRE-TAX amount this time.
+        const billed = await prisma.paymentSchedule.findUnique({ where: { id: psId } });
+        expect(num(billed!.amount)).toBe(22977.94);
+        const remainder = await prisma.paymentSchedule.findFirst({
+            where: { invoiceId, name: { contains: "(remaining)" } },
+        });
+        expect(num(remainder!.amount)).toBe(17022.06);
+        expect(num(billed!.amount) + num(remainder!.amount)).toBe(40000);
+    });
+
     test('amountMode "targetTotal" with 33000 @ 8.8%: total is exactly 33000, subtotal+tax=total, lines sum to subtotal', async () => {
         await ensureClientAndProject();
         const suffix = "target";

--- a/e2e/progress-billing.spec.ts
+++ b/e2e/progress-billing.spec.ts
@@ -706,7 +706,7 @@ test.describe.serial("updateProgressBillingCore / deleteProgressBillingCore", ()
         expect(stillThere!.description).toBe("Original description"); // unchanged
     });
 
-    test("updates description/taxExempt on a Draft billing and recomputes tax", async () => {
+    test("updates the description on a Draft billing; money is untouched", async () => {
         await ensureClientAndProject();
         const suffix = "update";
         const invoiceId = `${PFX}-inv-${suffix}`;
@@ -725,18 +725,111 @@ test.describe.serial("updateProgressBillingCore / deleteProgressBillingCore", ()
         expect(num(billing.taxAmount)).toBe(40.44); // round(500 - 459.56)
         expect(num(billing.taxRate)).toBe(8.8); // real rate stored even though not exempt
 
-        const updated = await updateProgressBillingCore(billing.id, { description: "Revised description", taxExempt: true });
+        const updated = await updateProgressBillingCore(billing.id, { description: "Revised description" });
         expect(updated.description).toBe("Revised description");
-        expect(updated.taxExempt).toBe(true);
-        expect(num(updated.taxAmount)).toBe(0);
-        expect(num(updated.total)).toBe(num(updated.subtotal));
+        expect(num(updated.subtotal)).toBe(459.56);
+        expect(num(updated.taxAmount)).toBe(40.44);
+        expect(num(updated.total)).toBe(500);
+    });
 
-        // Un-exempting recomputes tax at the STORED real rate (item F.2) —
-        // never stuck at 0 from having been saved exempt once.
-        const reverted = await updateProgressBillingCore(billing.id, { taxExempt: false });
-        expect(num(reverted.taxRate)).toBe(8.8);
-        expect(num(reverted.taxAmount)).toBe(40.44);
-        expect(num(reverted.total)).toBe(500);
+    test("refuses to flip taxExempt on an existing draft (would desync QuickBooks from the milestone)", async () => {
+        // Round-2 blocker: un-exempting recomputed the billing's total ($500 →
+        // $544) while the milestone it carved stayed at $500, so QuickBooks would
+        // charge $544 and settlement would only ever credit $500.
+        await ensureClientAndProject();
+        const suffix = "update-exempt";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psId = `${PFX}-ps-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 500, balanceDue: 500, taxRate: 8.8 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psId, invoiceId, name: "Deposit", amount: 500, status: "Pending" } });
+
+        const billing = await createProgressBillingCore(invoiceId, {
+            description: "Exempt billing",
+            lines: [{ scheduleId: psId, description: "Deposit", amount: 500 }],
+            taxExempt: true,
+        });
+        expect(billing.taxExempt).toBe(true);
+        expect(num(billing.total)).toBe(500);
+
+        await expect(
+            updateProgressBillingCore(billing.id, { taxExempt: false }),
+        ).rejects.toThrow(/delete this draft/i);
+
+        // Nothing moved.
+        const after = await prisma.progressBilling.findUnique({ where: { id: billing.id } });
+        expect(after!.taxExempt).toBe(true);
+        expect(num(after!.total)).toBe(500);
+        const ps = await prisma.paymentSchedule.findUnique({ where: { id: psId } });
+        expect(num(ps!.amount)).toBe(500);
+    });
+
+    test("records splitAmount per line so a fully-billed milestone can't be re-billed for a rounding cent", async () => {
+        // Round-2 blocker: the guard rebuilt gross from the rounded pre-tax amount
+        // ($1.05 → $0.96 → $1.04) and left a cent claimable on a milestone that
+        // was already billed in full.
+        await ensureClientAndProject();
+        const suffix = "cent";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psA = `${PFX}-ps-a-${suffix}`;
+        const psB = `${PFX}-ps-b-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 2.05, balanceDue: 2.05, taxRate: 8.8 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psA, invoiceId, name: "Tiny A", amount: 1.0, status: "Pending" } });
+        await prisma.paymentSchedule.create({ data: { id: psB, invoiceId, name: "Tiny B", amount: 1.05, status: "Pending" } });
+
+        const billing = await createProgressBillingCore(invoiceId, {
+            description: "Two tiny lines",
+            lines: [
+                { scheduleId: psA, description: "Tiny A", amount: 1.0 },
+                { scheduleId: psB, description: "Tiny B", amount: 1.05 },
+            ],
+        });
+
+        // splitAmount is stored in milestone (gross) units, exactly as billed.
+        const lineB = billing.lines.find((l) => l.scheduleId === psB)!;
+        expect(num(lineB.splitAmount)).toBe(1.05);
+
+        // Both milestones are fully consumed — no cent left to claim.
+        await expect(
+            createProgressBillingCore(invoiceId, {
+                description: "Sneak a cent",
+                lines: [{ scheduleId: psB, description: "Tiny B again", amount: 0.01 }],
+            }),
+        ).rejects.toThrow(/already billed/i);
+    });
+
+    test("refuses to bill a milestone whose estimate mirror row no longer exists", async () => {
+        await ensureClientAndProject();
+        const suffix = "dangling";
+        const estimateId = `${PFX}-est-${suffix}`;
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psId = `${PFX}-ps-${suffix}`;
+
+        await prisma.estimate.create({
+            data: { id: estimateId, title: "PB Dangling", code: `EST-PB-${suffix}`, projectId: `${PFX}-project`, status: "Approved", totalAmount: 1000, balanceDue: 1000 },
+        });
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, estimateId, status: "Issued", totalAmount: 1000, balanceDue: 1000, taxRate: 0 },
+        });
+        // sourceScheduleId is not an FK — point it at a row that does not exist.
+        await prisma.paymentSchedule.create({
+            data: { id: psId, invoiceId, name: "Orphaned mirror", amount: 1000, status: "Pending", sourceScheduleId: `${PFX}-eps-gone-${suffix}` },
+        });
+
+        await expect(
+            createProgressBillingCore(invoiceId, {
+                description: "Partial against a dangling mirror",
+                lines: [{ scheduleId: psId, description: "Orphaned mirror", amount: 400 }],
+            }),
+        ).rejects.toThrow(/no longer exists/i);
+
+        const ps = await prisma.paymentSchedule.findUnique({ where: { id: psId } });
+        expect(num(ps!.amount)).toBe(1000); // untouched
     });
 
     test("delete leaves an already-applied split intact", async () => {

--- a/e2e/progress-billing.spec.ts
+++ b/e2e/progress-billing.spec.ts
@@ -6,7 +6,7 @@ import {
     deleteProgressBillingCore,
     stageProgressBillingToQuickBooksCore,
 } from "../src/lib/progress-billing";
-import { settleProgressBillingPaidCore } from "../src/lib/quickbooks-payments";
+import { settleProgressBillingPaidCore, pushMilestoneToQuickBooks } from "../src/lib/quickbooks-payments";
 
 /**
  * Progress billing core regression net.
@@ -801,6 +801,69 @@ test.describe.serial("updateProgressBillingCore / deleteProgressBillingCore", ()
                 lines: [{ scheduleId: psB, description: "Tiny B again", amount: 0.01 }],
             }),
         ).rejects.toThrow(/already billed/i);
+    });
+
+    test("refuses to bill a milestone whose estimate mirror row no longer exists — even on a FULL bill", async () => {
+        // The mirror check used to sit behind the full-bill early exit, so a full
+        // bill skipped it entirely and its settle-time mirror would later no-op,
+        // leaving the estimate showing the milestone still owed.
+        await ensureClientAndProject();
+        const suffix = "dangling-full";
+        const estimateId = `${PFX}-est-${suffix}`;
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psId = `${PFX}-ps-${suffix}`;
+
+        await prisma.estimate.create({
+            data: { id: estimateId, title: "PB Dangling Full", code: `EST-PB-${suffix}`, projectId: `${PFX}-project`, status: "Approved", totalAmount: 1000, balanceDue: 1000 },
+        });
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, estimateId, status: "Issued", totalAmount: 1000, balanceDue: 1000, taxRate: 0 },
+        });
+        await prisma.paymentSchedule.create({
+            data: { id: psId, invoiceId, name: "Orphaned mirror", amount: 1000, status: "Pending", sourceScheduleId: `${PFX}-eps-gone-${suffix}` },
+        });
+
+        await expect(
+            createProgressBillingCore(invoiceId, {
+                description: "Full bill against a dangling mirror",
+                lines: [{ scheduleId: psId, description: "Orphaned mirror", amount: 1000 }], // FULL
+            }),
+        ).rejects.toThrow(/no longer exists/i);
+
+        const ps = await prisma.paymentSchedule.findUnique({ where: { id: psId } });
+        expect(num(ps!.amount)).toBe(1000); // untouched
+    });
+
+    test("legacy per-milestone QuickBooks staging refuses a milestone already claimed by a progress billing", async () => {
+        // Closes the double-collection hole: a FULL bill leaves the milestone
+        // Pending and unlinked, which is exactly the state pushMilestoneToQuickBooks
+        // otherwise accepts — it would create a SECOND collectible QBO invoice for
+        // money a progress billing already covers.
+        await ensureClientAndProject();
+        const suffix = "legacy-guard";
+        const invoiceId = `${PFX}-inv-${suffix}`;
+        const psId = `${PFX}-ps-${suffix}`;
+
+        await prisma.invoice.create({
+            data: { id: invoiceId, code: `INV-PB-${suffix}`, projectId: `${PFX}-project`, clientId: `${PFX}-client`, status: "Issued", totalAmount: 500, balanceDue: 500, taxRate: 0 },
+        });
+        await prisma.paymentSchedule.create({ data: { id: psId, invoiceId, name: "Deposit", amount: 500, status: "Pending" } });
+
+        const billing = await createProgressBillingCore(invoiceId, {
+            description: "Covers the deposit",
+            lines: [{ scheduleId: psId, description: "Deposit", amount: 500 }],
+        });
+
+        // The milestone is deliberately still Pending + unlinked after a full bill.
+        const ps = await prisma.paymentSchedule.findUnique({ where: { id: psId } });
+        expect(ps!.status).toBe("Pending");
+        expect(ps!.qbInvoiceId).toBeNull();
+
+        // The legacy rail must refuse it, naming the billing that owns it. This
+        // throws before any QuickBooks call, so it holds even with no QBO connection.
+        await expect(pushMilestoneToQuickBooks(psId)).rejects.toThrow(
+            new RegExp(`already covered by progress invoice ${billing.code}`, "i"),
+        );
     });
 
     test("refuses to bill a milestone whose estimate mirror row no longer exists", async () => {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -372,6 +372,10 @@ model Estimate {
   taxExempt           Boolean   @default(false)
   taxRateName         String?
   taxRatePercent      Decimal?
+  // Progress billing core: legacy estimates carry tax-inclusive milestone
+  // amounts (the historical behavior); new estimates set this false once the
+  // UI switches to tax-exclusive milestone entry. Read by progress-billing.ts.
+  taxInclusiveMilestones Boolean @default(true)
 
   // AI budget fill: target overall margin for the estimate (gross margin %, not markup)
   targetMarginPercent Float     @default(25)
@@ -541,6 +545,7 @@ model Invoice {
   createdAt   DateTime  @default(now())
 
   payments PaymentSchedule[]
+  progressBillings ProgressBilling[]
 
   @@index([projectId])
   @@index([createdAt])
@@ -588,6 +593,53 @@ model PaymentSchedule {
   @@index([qbInvoiceId])
   @@index([sourceScheduleId])
   @@index([scheduleTaskId])
+}
+
+// Progress billing: the billable artifact the user builds by picking
+// milestones and/or approved change orders and/or a custom amount, writing
+// one client-facing description, and staging exactly ONE QuickBooks invoice.
+// Milestones (PaymentSchedule) remain the record of what has been satisfied —
+// see src/lib/progress-billing.ts for the auto-split mechanic that keeps every
+// ProgressBillingLine mapped 1:1 to a whole milestone.
+model ProgressBilling {
+  id          String   @id @default(cuid())
+  invoiceId   String
+  invoice     Invoice  @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
+  code        String   // "INV-00171-P1" — sequential per invoice
+  description String   // client-facing: what this payment covers
+  status      String   @default("Draft") // Draft | Staged | Sent | Paid | Void
+  subtotal    Decimal  @default(0)  // pre-tax
+  taxExempt   Boolean  @default(false)
+  taxRate     Decimal  @default(0)  // percent snapshot at build time
+  taxAmount   Decimal  @default(0)
+  total       Decimal  @default(0)  // subtotal + taxAmount
+  qbInvoiceId     String?
+  qbInvoiceLink   String?
+  qbInvoiceSentAt DateTime?
+  qbPaymentId     String?
+  qbSyncedAt      DateTime?
+  qbSyncError     String?
+  sentAt      DateTime?
+  paidAt      DateTime?
+  createdAt   DateTime @default(now())
+  lines       ProgressBillingLine[]
+
+  @@index([invoiceId])
+  @@index([status])
+}
+
+model ProgressBillingLine {
+  id            String @id @default(cuid())
+  billingId     String
+  billing       ProgressBilling @relation(fields: [billingId], references: [id], onDelete: Cascade)
+  scheduleId    String?  // PaymentSchedule this line bills (null = custom line)
+  changeOrderId String?  // or an approved ChangeOrder
+  description   String
+  amount        Decimal  // pre-tax
+  order         Int      @default(0)
+
+  @@index([billingId])
+  @@index([scheduleId])
 }
 
 model Budget {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -643,7 +643,13 @@ model ProgressBillingLine {
   billing       ProgressBilling @relation(fields: [billingId], references: [id], onDelete: Cascade)
   scheduleId    String?  // PaymentSchedule this line bills (null = custom line)
   description   String
-  amount        Decimal  // pre-tax
+  amount        Decimal  // pre-tax — feeds the QuickBooks taxable line
+  // What was actually carved out of the milestone, in the milestone's own units
+  // (gross on tax-inclusive/legacy jobs, pre-tax on new ones). Recorded rather
+  // than recomputed from `amount`: reconstructing it re-applies tax to a rounded
+  // number and can land a cent low, which let a second billing claim the
+  // difference on an already fully-billed milestone.
+  splitAmount   Decimal  @default(0)
   order         Int      @default(0)
 
   @@index([billingId])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -601,8 +601,12 @@ model PaymentSchedule {
 }
 
 // Progress billing: the billable artifact the user builds by picking
-// milestones and/or approved change orders and/or a custom amount, writing
-// one client-facing description, and staging exactly ONE QuickBooks invoice.
+// milestones and/or a custom amount, writing one client-facing description,
+// and staging exactly ONE QuickBooks invoice. An approved change order is
+// billed by approving it — billChangeOrderCore (src/lib/billing-core.ts)
+// already adds it to the invoice as a normal PaymentSchedule milestone, so it
+// arrives here like any other milestone line rather than as its own line
+// type (a second rail for the same money would be a double-billing hole).
 // Milestones (PaymentSchedule) remain the record of what has been satisfied —
 // see src/lib/progress-billing.ts for the auto-split mechanic that keeps every
 // ProgressBillingLine mapped 1:1 to a whole milestone.
@@ -638,7 +642,6 @@ model ProgressBillingLine {
   billingId     String
   billing       ProgressBilling @relation(fields: [billingId], references: [id], onDelete: Cascade)
   scheduleId    String?  // PaymentSchedule this line bills (null = custom line)
-  changeOrderId String?  // or an approved ChangeOrder
   description   String
   amount        Decimal  // pre-tax
   order         Int      @default(0)

--- a/scripts/apply-progress-billing-schema.mjs
+++ b/scripts/apply-progress-billing-schema.mjs
@@ -73,7 +73,6 @@ const statements = [
      "id" TEXT NOT NULL,
      "billingId" TEXT NOT NULL,
      "scheduleId" TEXT,
-     "changeOrderId" TEXT,
      "description" TEXT NOT NULL,
      "amount" DECIMAL(65,30) NOT NULL,
      "order" INTEGER NOT NULL DEFAULT 0,

--- a/scripts/apply-progress-billing-schema.mjs
+++ b/scripts/apply-progress-billing-schema.mjs
@@ -1,0 +1,106 @@
+// One-off additive migration for progress billing core (models ProgressBilling,
+// ProgressBillingLine in prisma/schema.prisma, plus Estimate.taxInclusiveMilestones).
+// Additive only: new tables + one new column, no drops/renames. Safe to re-run
+// while the previous build is live and safe to run twice (every statement is
+// IF NOT EXISTS / guarded).
+//
+// Run only through the release orchestrator:
+//   node scripts/apply-progress-billing-schema.mjs
+//
+// Do not run this against prod during implementation handoff — the new Prisma
+// client selects these columns/tables immediately, so this must be applied
+// before deploy (see CLAUDE.md's pre-deploy checklist).
+// (DDL via $executeRawUnsafe over the Supabase transaction pooler — the working
+//  path in this project; psql / prisma db push / migrate dev do not work here.)
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+function resolveDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const file of [".env", ".env.local"]) {
+    if (!fs.existsSync(file)) continue;
+    const match = fs.readFileSync(file, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+    if (match) return match[1];
+  }
+  throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const prisma = new PrismaClient({
+  datasources: { db: { url: resolveDatabaseUrl() } },
+});
+
+const statements = [
+  `ALTER TABLE "Estimate" ADD COLUMN IF NOT EXISTS "taxInclusiveMilestones" BOOLEAN NOT NULL DEFAULT true`,
+
+  `CREATE TABLE IF NOT EXISTS "ProgressBilling" (
+     "id" TEXT NOT NULL,
+     "invoiceId" TEXT NOT NULL,
+     "code" TEXT NOT NULL,
+     "description" TEXT NOT NULL,
+     "status" TEXT NOT NULL DEFAULT 'Draft',
+     "subtotal" DECIMAL(65,30) NOT NULL DEFAULT 0,
+     "taxExempt" BOOLEAN NOT NULL DEFAULT false,
+     "taxRate" DECIMAL(65,30) NOT NULL DEFAULT 0,
+     "taxAmount" DECIMAL(65,30) NOT NULL DEFAULT 0,
+     "total" DECIMAL(65,30) NOT NULL DEFAULT 0,
+     "qbInvoiceId" TEXT,
+     "qbInvoiceLink" TEXT,
+     "qbInvoiceSentAt" TIMESTAMP(3),
+     "qbPaymentId" TEXT,
+     "qbSyncedAt" TIMESTAMP(3),
+     "qbSyncError" TEXT,
+     "sentAt" TIMESTAMP(3),
+     "paidAt" TIMESTAMP(3),
+     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+     CONSTRAINT "ProgressBilling_pkey" PRIMARY KEY ("id")
+   )`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'ProgressBilling_invoiceId_fkey'
+         AND conrelid = '"ProgressBilling"'::regclass
+     ) THEN
+       ALTER TABLE "ProgressBilling"
+         ADD CONSTRAINT "ProgressBilling_invoiceId_fkey"
+         FOREIGN KEY ("invoiceId") REFERENCES "Invoice"("id")
+         ON DELETE CASCADE ON UPDATE CASCADE;
+     END IF;
+   END $$`,
+  `CREATE INDEX IF NOT EXISTS "ProgressBilling_invoiceId_idx" ON "ProgressBilling" ("invoiceId")`,
+  `CREATE INDEX IF NOT EXISTS "ProgressBilling_status_idx" ON "ProgressBilling" ("status")`,
+
+  `CREATE TABLE IF NOT EXISTS "ProgressBillingLine" (
+     "id" TEXT NOT NULL,
+     "billingId" TEXT NOT NULL,
+     "scheduleId" TEXT,
+     "changeOrderId" TEXT,
+     "description" TEXT NOT NULL,
+     "amount" DECIMAL(65,30) NOT NULL,
+     "order" INTEGER NOT NULL DEFAULT 0,
+     CONSTRAINT "ProgressBillingLine_pkey" PRIMARY KEY ("id")
+   )`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'ProgressBillingLine_billingId_fkey'
+         AND conrelid = '"ProgressBillingLine"'::regclass
+     ) THEN
+       ALTER TABLE "ProgressBillingLine"
+         ADD CONSTRAINT "ProgressBillingLine_billingId_fkey"
+         FOREIGN KEY ("billingId") REFERENCES "ProgressBilling"("id")
+         ON DELETE CASCADE ON UPDATE CASCADE;
+     END IF;
+   END $$`,
+  `CREATE INDEX IF NOT EXISTS "ProgressBillingLine_billingId_idx" ON "ProgressBillingLine" ("billingId")`,
+  `CREATE INDEX IF NOT EXISTS "ProgressBillingLine_scheduleId_idx" ON "ProgressBillingLine" ("scheduleId")`,
+];
+
+try {
+  for (const sql of statements) {
+    await prisma.$executeRawUnsafe(sql);
+    console.log("applied:", sql.split("\n")[0]);
+  }
+  console.log("Progress billing schema applied successfully.");
+} finally {
+  await prisma.$disconnect();
+}

--- a/scripts/apply-progress-billing-schema.mjs
+++ b/scripts/apply-progress-billing-schema.mjs
@@ -75,9 +75,13 @@ const statements = [
      "scheduleId" TEXT,
      "description" TEXT NOT NULL,
      "amount" DECIMAL(65,30) NOT NULL,
+     "splitAmount" DECIMAL(65,30) NOT NULL DEFAULT 0,
      "order" INTEGER NOT NULL DEFAULT 0,
      CONSTRAINT "ProgressBillingLine_pkey" PRIMARY KEY ("id")
    )`,
+  // Separate ADD COLUMN so a database that already has the table from an
+  // earlier run of this script still picks up splitAmount.
+  `ALTER TABLE "ProgressBillingLine" ADD COLUMN IF NOT EXISTS "splitAmount" DECIMAL(65,30) NOT NULL DEFAULT 0`,
   `DO $$ BEGIN
      IF NOT EXISTS (
        SELECT 1 FROM pg_constraint

--- a/src/lib/progress-billing.ts
+++ b/src/lib/progress-billing.ts
@@ -49,19 +49,16 @@ export type ProgressBillingWithLines = ProgressBilling & { lines: ProgressBillin
 /**
  * Build one progress billing.
  *
- * KNOWN DESIGN NOTE (targetTotal mode — see PROGRESS_BILLING_REPORT.md for the
- * full writeup): the over-billing check and the AUTO-SPLIT below both use the
- * RAW per-line amount the caller supplies (what the user typed against that
- * milestone) — that is the amount carved out of the milestone. The amount that
- * actually lands on the persisted ProgressBillingLine (and therefore on the
- * QuickBooks invoice) is the tax-mode-adjusted amount computed afterward. In
- * "preTax" mode these are always identical (no adjustment happens). In
- * "targetTotal" mode the persisted line amount is the raw amount rescaled so
- * the whole billing's subtotal lands exactly on the client's target total
- * after tax — it can differ from the raw amount used for the split by the
- * rescale factor. Flagged as a risk, not fixed here: no test in this pass
- * exercises split+targetTotal together, and reconciling the two would require
- * a product decision this pass isn't scoped to make.
+ * TWO AMOUNTS, DELIBERATELY DIFFERENT. Every line carries:
+ *   • the PERSISTED amount (ProgressBillingLine.amount) — always PRE-TAX, since
+ *     it feeds the QuickBooks invoice's taxable line; and
+ *   • the SPLIT amount — what gets carved out of the milestone, expressed in
+ *     that milestone's own units (see the "Split units" block below).
+ * On a legacy tax-inclusive job these differ by exactly the tax and that is
+ * correct: a $25,000 check against a $39,998.25 tax-inclusive milestone leaves
+ * $14,998.25 behind while the QuickBooks line reads $22,977.94 + $2,022.06 tax.
+ * On a pre-tax job they are identical. In "preTax" mode they are always
+ * identical regardless of vintage.
  */
 export async function createProgressBillingCore(
     invoiceId: string,
@@ -134,9 +131,8 @@ export async function createProgressBillingCore(
                 if (schedule.stripeSessionId || schedule.stripePaymentIntentId) {
                     throw new Error(`A payment is in progress on "${schedule.name}" — wait for it to finish or void it before billing.`);
                 }
-                if (rawAmount > toNum(schedule.amount) + 0.005) {
-                    throw new Error(`"${schedule.name}": billed amount $${rawAmount.toFixed(2)} exceeds the milestone's amount $${toNum(schedule.amount).toFixed(2)}`);
-                }
+                // Over-billing is checked AFTER the tax math, against the amount
+                // expressed in the milestone's own units (see splitAmounts below).
                 scheduleCache.set(line.scheduleId, schedule);
             } else if (line.changeOrderId) {
                 const co = await tx.changeOrder.findUnique({ where: { id: line.changeOrderId } });
@@ -185,27 +181,59 @@ export async function createProgressBillingCore(
             throw new Error("Internal error: line amounts do not sum to the subtotal");
         }
 
+        // ── Split units ─────────────────────────────────────────────────────
+        // A milestone must be carved up in ITS OWN units, which differ by vintage:
+        //   • legacy estimates (taxInclusiveMilestones = true, every job priced
+        //     before progressive billing): milestone amounts INCLUDE tax, so the
+        //     gross amount the client is paying is what comes out of the milestone
+        //     — a $25,000 check against Mesplay's $39,998.25 leaves $14,998.25.
+        //   • new estimates (false): milestone amounts are PRE-TAX, so the pre-tax
+        //     line amount is what comes out; the tax rides on top of the billing.
+        // In "preTax" mode finalAmounts === rawAmounts, so both branches agree and
+        // this reduces to a no-op. Getting this wrong silently mis-splits live
+        // milestones by exactly the tax, which is why over-billing is validated
+        // here against the same units rather than against the caller's raw input.
+        const estimateForUnits = invLink?.estimateId
+            ? await tx.estimate.findUnique({ where: { id: invLink.estimateId }, select: { taxInclusiveMilestones: true } })
+            : null;
+        // No estimate (ad-hoc invoice) → treat as legacy tax-inclusive, matching
+        // how every existing invoice in the system was priced.
+        const milestonesAreTaxInclusive = estimateForUnits?.taxInclusiveMilestones ?? true;
+        const splitAmounts = milestonesAreTaxInclusive ? rawAmounts : finalAmounts;
+
+        for (let i = 0; i < input.lines.length; i++) {
+            const scheduleId = input.lines[i].scheduleId;
+            if (!scheduleId) continue;
+            const schedule = scheduleCache.get(scheduleId)!;
+            if (splitAmounts[i] > toNum(schedule.amount) + 0.005) {
+                throw new Error(
+                    `"${schedule.name}": billed amount $${splitAmounts[i].toFixed(2)} exceeds the milestone's amount $${toNum(schedule.amount).toFixed(2)}`
+                );
+            }
+        }
+
         // ── AUTO-SPLIT ──────────────────────────────────────────────────────
-        // Uses the RAW per-line amount (see the KNOWN DESIGN NOTE on this
-        // function) — the amount actually carved out of the milestone. Never
-        // deletes a PaymentSchedule/EstimatePaymentSchedule row: the original
-        // is reduced in place and a NEW row absorbs the remainder.
+        // Carves the billed portion out of the milestone using splitAmounts (the
+        // milestone's own units — see above). Never deletes a PaymentSchedule /
+        // EstimatePaymentSchedule row: the original is reduced in place and a NEW
+        // row absorbs the remainder, so the two always sum to what was there
+        // before and the invoice's totalAmount/balanceDue are untouched.
         const resolvedScheduleIds = new Map<number, string>(); // line index -> PaymentSchedule.id billed (whole, post-split)
         for (let i = 0; i < input.lines.length; i++) {
             const line = input.lines[i];
             if (!line.scheduleId) continue;
             const schedule = scheduleCache.get(line.scheduleId)!;
-            const rawAmount = rawAmounts[i];
+            const splitAmount = splitAmounts[i];
             const scheduleAmount = toNum(schedule.amount);
             resolvedScheduleIds.set(i, schedule.id);
 
-            if (rawAmount >= scheduleAmount - 0.005) continue; // full bill — no split needed
+            if (splitAmount >= scheduleAmount - 0.005) continue; // full bill — no split needed
 
-            const remainder = r2(scheduleAmount - rawAmount);
+            const remainder = r2(scheduleAmount - splitAmount);
 
             await tx.paymentSchedule.update({
                 where: { id: schedule.id },
-                data: { amount: rawAmount },
+                data: { amount: splitAmount },
             });
 
             let newSourceScheduleId: string | null = null;
@@ -214,7 +242,7 @@ export async function createProgressBillingCore(
                 if (originalEst) {
                     await tx.estimatePaymentSchedule.update({
                         where: { id: originalEst.id },
-                        data: { amount: rawAmount },
+                        data: { amount: splitAmount },
                     });
                     const newEst = await tx.estimatePaymentSchedule.create({
                         data: {

--- a/src/lib/progress-billing.ts
+++ b/src/lib/progress-billing.ts
@@ -252,13 +252,13 @@ export async function createProgressBillingCore(
                 const schedule = scheduleCache.get(line.scheduleId)!;
                 const otherLines = await tx.progressBillingLine.findMany({
                     where: { scheduleId: line.scheduleId, billing: { status: { not: "Void" } } },
-                    select: { amount: true, billing: { select: { code: true, taxRate: true, taxExempt: true } } },
+                    select: { splitAmount: true, billing: { select: { code: true } } },
                 });
-                const committed = r2(otherLines.reduce((sum, l) => {
-                    const preTax = toNum(l.amount);
-                    const gross = l.billing.taxExempt ? preTax : r2(preTax * (1 + toNum(l.billing.taxRate) / 100));
-                    return sum + (legacy ? gross : preTax);
-                }, 0));
+                // Sum the RECORDED split amounts. Reconstructing them from the
+                // pre-tax `amount` re-applies tax to an already-rounded number and
+                // can come out a cent low, which let a second billing claim that
+                // cent on a milestone that was already fully billed.
+                const committed = r2(otherLines.reduce((sum, l) => sum + toNum(l.splitAmount), 0));
                 const available = r2(toNum(schedule.amount) - committed);
                 if (splitAmounts[i] > available + 0.005) {
                     const codes = [...new Set(otherLines.map((l) => l.billing.code))].join(", ");
@@ -288,10 +288,16 @@ export async function createProgressBillingCore(
             const scheduleAmount = toNum(schedule.amount);
             resolvedScheduleIds.set(i, schedule.id);
 
-            if (splitAmount >= scheduleAmount - 0.005) continue; // full bill — no split needed
+            const isFullBill = splitAmount >= scheduleAmount - 0.005;
+            const remainder = isFullBill ? 0 : r2(scheduleAmount - splitAmount);
 
-            const remainder = r2(scheduleAmount - splitAmount);
-
+            // Claim runs on EVERY bill, full or partial — not just splits. A full
+            // bill writes the amount back unchanged, but the pinned WHERE is what
+            // proves the row is still Pending, unlinked and untouched since
+            // validation. Skipping it on full bills left a window where the legacy
+            // pushMilestoneToQuickBooks could link its own QBO invoice to this same
+            // milestone concurrently, leaving TWO collectible invoices for one
+            // milestone (Codex round-2 blocker).
             const claim = await tx.paymentSchedule.updateMany({
                 where: {
                     id: schedule.id,
@@ -307,10 +313,22 @@ export async function createProgressBillingCore(
                 throw new Error(`"${schedule.name}" changed while this billing was being built — refresh and try again.`);
             }
 
+            if (isFullBill) continue; // claimed above; nothing to carve
+
             let newSourceScheduleId: string | null = null;
             if (schedule.sourceScheduleId) {
                 const originalEst = await tx.estimatePaymentSchedule.findUnique({ where: { id: schedule.sourceScheduleId } });
-                if (originalEst) {
+                // A sourceScheduleId pointing at a row that no longer exists means
+                // the estimate mirror is already inconsistent. Refuse rather than
+                // silently splitting invoice-side only, which would leave the
+                // estimate overstating what is still owed (sourceScheduleId is not
+                // an FK, so this is reachable).
+                if (!originalEst) {
+                    throw new Error(
+                        `"${schedule.name}" points at an estimate milestone that no longer exists — fix the estimate's payment schedule before billing this.`
+                    );
+                }
+                {
                     const estClaim = await tx.estimatePaymentSchedule.updateMany({
                         where: {
                             id: originalEst.id,
@@ -437,6 +455,7 @@ export async function createProgressBillingCore(
                 scheduleId: resolvedScheduleIds.get(i) ?? null,
                 description: line.description.trim(),
                 amount: finalAmounts[i],
+                splitAmount: splitAmounts[i],
                 order: i,
             })),
         });
@@ -463,10 +482,10 @@ export type UpdateProgressBillingInput = {
  * Draft (safe — any split it already applied stays applied, see
  * deleteProgressBillingCore below) and create a fresh one.
  *
- * `billing.taxRate` always holds the invoice's real rate (see
- * createProgressBillingCore), so flipping `taxExempt` here correctly
- * recomputes tax at that rate rather than being stuck at whatever the rate
- * happened to be the first time the billing was saved exempt.
+ * Tax treatment is NOT editable here either, for the same reason: the milestone
+ * amounts were carved at creation from a total that depends on it, and changing
+ * one without the other desynchronizes what QuickBooks charges from what
+ * settlement credits. Delete and rebuild the Draft instead.
  */
 export async function updateProgressBillingCore(
     billingId: string,
@@ -485,16 +504,23 @@ export async function updateProgressBillingCore(
 
         const description = input.description !== undefined ? input.description.trim() : billing.description;
         if (!description) throw new Error("A description is required");
-        const taxExempt = input.taxExempt !== undefined ? !!input.taxExempt : billing.taxExempt;
 
-        const subtotal = toNum(billing.subtotal);
-        const rate = taxExempt ? 0 : toNum(billing.taxRate);
-        const taxAmount = taxExempt ? 0 : r2(subtotal * rate / 100);
-        const total = r2(subtotal + taxAmount);
+        // Description only — no money field is editable here. Flipping taxExempt
+        // used to recompute the billing's tax and total while leaving the milestone
+        // amounts carved at creation untouched: a legacy exempt $500 billing became
+        // $544 when un-exempted, so QuickBooks charged $544 while settlement only
+        // ever credited the $500 milestone, quietly stranding $44 (Codex round-2
+        // blocker). Changing tax treatment or amounts means deleting this Draft and
+        // creating a fresh one, which re-derives the splits from scratch.
+        if (input.taxExempt !== undefined && !!input.taxExempt !== billing.taxExempt) {
+            throw new Error(
+                "Tax treatment can't be changed on an existing draft — delete this draft and create a new one so the milestone amounts are recalculated."
+            );
+        }
 
         await tx.progressBilling.update({
             where: { id: billingId },
-            data: { description, taxExempt, taxAmount, total },
+            data: { description },
         });
 
         const withLines = await tx.progressBilling.findUnique({

--- a/src/lib/progress-billing.ts
+++ b/src/lib/progress-billing.ts
@@ -1,0 +1,444 @@
+/**
+ * Progress billing core.
+ *
+ * Product model: estimate/invoice milestones (PaymentSchedule/EstimatePaymentSchedule)
+ * are SUGGESTIONS. The billable artifact is a "progress billing" (ProgressBilling):
+ * the user picks milestones and/or approved change orders and/or a custom amount,
+ * writes one client-facing description, confirms tax, and stages exactly ONE
+ * QuickBooks invoice. Milestones remain the record of truth for what has been
+ * satisfied, so a billing that covers only PART of a milestone AUTO-SPLITS that
+ * milestone — every billing line ends up mapped 1:1 to a whole milestone.
+ *
+ * Session-free cores (no auth checks) — actions.ts wrappers come in the UI pass,
+ * same convention as billing-core.ts.
+ *
+ * HARD CONSTRAINTS carried through this whole file (owner-stated, non-negotiable):
+ *   - No customer data loss: every write here is additive (new rows) or shrinks
+ *     an existing PaymentSchedule/EstimatePaymentSchedule's `amount` — a split
+ *     NEVER deletes or merges a milestone row.
+ *   - No customer notifications: nothing in this file calls sendNotification /
+ *     notifyMilestonePaid / drainPaymentNotifications / any send path. Staging
+ *     to QuickBooks does not send a QuickBooks-hosted email either (QBO invoices
+ *     are created without relying on Intuit's own invoice-email flow).
+ */
+import { prisma } from "@/lib/prisma";
+import { withTxRetry, lockMoneyParents } from "./tx-retry";
+import { toNum } from "./prisma-helpers";
+import type { ProgressBilling, ProgressBillingLine } from "@prisma/client";
+
+// Cent-round helper shared by every money computation below.
+const r2 = (n: number) => Math.round(n * 100) / 100;
+
+export type ProgressBillingLineInput = {
+    scheduleId?: string;
+    changeOrderId?: string;
+    description: string;
+    amount: number;
+};
+
+export type CreateProgressBillingInput = {
+    description: string;
+    lines: ProgressBillingLineInput[];
+    taxExempt?: boolean;
+    amountMode: "preTax" | "targetTotal";
+    targetTotal?: number;
+};
+
+export type ProgressBillingWithLines = ProgressBilling & { lines: ProgressBillingLine[] };
+
+/**
+ * Build one progress billing.
+ *
+ * KNOWN DESIGN NOTE (targetTotal mode — see PROGRESS_BILLING_REPORT.md for the
+ * full writeup): the over-billing check and the AUTO-SPLIT below both use the
+ * RAW per-line amount the caller supplies (what the user typed against that
+ * milestone) — that is the amount carved out of the milestone. The amount that
+ * actually lands on the persisted ProgressBillingLine (and therefore on the
+ * QuickBooks invoice) is the tax-mode-adjusted amount computed afterward. In
+ * "preTax" mode these are always identical (no adjustment happens). In
+ * "targetTotal" mode the persisted line amount is the raw amount rescaled so
+ * the whole billing's subtotal lands exactly on the client's target total
+ * after tax — it can differ from the raw amount used for the split by the
+ * rescale factor. Flagged as a risk, not fixed here: no test in this pass
+ * exercises split+targetTotal together, and reconciling the two would require
+ * a product decision this pass isn't scoped to make.
+ */
+export async function createProgressBillingCore(
+    invoiceId: string,
+    input: CreateProgressBillingInput,
+): Promise<ProgressBillingWithLines> {
+    const description = (input.description || "").trim();
+    if (!description) throw new Error("A description is required");
+    if (!input.lines?.length) throw new Error("At least one line is required");
+    if (input.amountMode !== "preTax" && input.amountMode !== "targetTotal") {
+        throw new Error(`Unknown amountMode: ${input.amountMode}`);
+    }
+
+    const rawAmounts = input.lines.map((l) => r2(Number(l.amount)));
+    rawAmounts.forEach((amt, i) => {
+        if (!Number.isFinite(amt) || amt <= 0) {
+            throw new Error(`Line ${i + 1} ("${input.lines[i].description || "untitled"}"): amount must be greater than zero`);
+        }
+    });
+
+    let targetTotal = 0;
+    if (input.amountMode === "targetTotal") {
+        targetTotal = r2(Number(input.targetTotal));
+        if (!Number.isFinite(targetTotal) || targetTotal <= 0) {
+            throw new Error('targetTotal must be greater than zero for amountMode "targetTotal"');
+        }
+    }
+
+    const seenScheduleIds = new Set<string>();
+    for (const line of input.lines) {
+        if (line.scheduleId && line.changeOrderId) {
+            throw new Error("A line cannot reference both a milestone and a change order");
+        }
+        if (line.scheduleId) {
+            if (seenScheduleIds.has(line.scheduleId)) {
+                throw new Error("The same milestone was referenced by more than one line");
+            }
+            seenScheduleIds.add(line.scheduleId);
+        }
+        if (!line.description || !line.description.trim()) {
+            throw new Error("Every line needs a description");
+        }
+    }
+
+    return withTxRetry(() => prisma.$transaction(async (tx) => {
+        // Canonical lock order: Estimate → Invoice → schedules (tx-retry.ts).
+        const invLink = await tx.invoice.findUnique({ where: { id: invoiceId }, select: { estimateId: true } });
+        await lockMoneyParents(tx, { estimateId: invLink?.estimateId, invoiceId });
+
+        const invoice = await tx.invoice.findUnique({ where: { id: invoiceId } });
+        if (!invoice) throw new Error("Invoice not found");
+
+        // Resolve + validate every line under the lock (no writes yet).
+        const scheduleCache = new Map<string, NonNullable<Awaited<ReturnType<typeof prisma.paymentSchedule.findUnique>>>>();
+
+        for (let i = 0; i < input.lines.length; i++) {
+            const line = input.lines[i];
+            const rawAmount = rawAmounts[i];
+
+            if (line.scheduleId) {
+                const schedule = await tx.paymentSchedule.findUnique({ where: { id: line.scheduleId } });
+                if (!schedule || schedule.invoiceId !== invoiceId) {
+                    throw new Error(`Milestone not found on this invoice: ${line.scheduleId}`);
+                }
+                if (schedule.status !== "Pending") {
+                    throw new Error(`"${schedule.name}" is not Pending — only pending milestones can be billed`);
+                }
+                if (schedule.qbInvoiceId) {
+                    throw new Error(`"${schedule.name}" already has a QuickBooks invoice staged — break the QuickBooks link first, then bill it here.`);
+                }
+                if (schedule.stripeSessionId || schedule.stripePaymentIntentId) {
+                    throw new Error(`A payment is in progress on "${schedule.name}" — wait for it to finish or void it before billing.`);
+                }
+                if (rawAmount > toNum(schedule.amount) + 0.005) {
+                    throw new Error(`"${schedule.name}": billed amount $${rawAmount.toFixed(2)} exceeds the milestone's amount $${toNum(schedule.amount).toFixed(2)}`);
+                }
+                scheduleCache.set(line.scheduleId, schedule);
+            } else if (line.changeOrderId) {
+                const co = await tx.changeOrder.findUnique({ where: { id: line.changeOrderId } });
+                if (!co || co.projectId !== invoice.projectId) {
+                    throw new Error(`Change order not found on this invoice's project: ${line.changeOrderId}`);
+                }
+                if (co.status !== "Approved") {
+                    throw new Error(`Change order ${co.code} is "${co.status}" — only Approved change orders can be billed`);
+                }
+            }
+        }
+
+        // ── Tax math ────────────────────────────────────────────────────────
+        const taxExempt = !!input.taxExempt;
+        const effectiveRate = taxExempt ? 0 : toNum(invoice.taxRate);
+
+        let subtotal: number;
+        let taxAmount: number;
+        let total: number;
+        let finalAmounts: number[];
+
+        if (input.amountMode === "preTax") {
+            subtotal = r2(rawAmounts.reduce((s, a) => s + a, 0));
+            taxAmount = taxExempt ? 0 : r2(subtotal * effectiveRate / 100);
+            total = r2(subtotal + taxAmount);
+            finalAmounts = rawAmounts.slice();
+        } else {
+            total = targetTotal;
+            subtotal = taxExempt ? total : r2(total / (1 + effectiveRate / 100));
+            taxAmount = taxExempt ? 0 : r2(total - subtotal);
+
+            const rawSum = rawAmounts.reduce((s, a) => s + a, 0);
+            finalAmounts = rawAmounts.map((a) => r2((a * subtotal) / rawSum));
+            const usedSum = r2(finalAmounts.slice(0, -1).reduce((s, a) => s + a, 0));
+            finalAmounts[finalAmounts.length - 1] = r2(subtotal - usedSum);
+            if (finalAmounts[finalAmounts.length - 1] <= 0) {
+                throw new Error("Rescaling to the target total left the last line at $0 or less — adjust the line amounts.");
+            }
+        }
+
+        if (Math.abs(r2(subtotal + taxAmount) - total) > 0.005) {
+            throw new Error("Internal error: subtotal + tax does not equal total");
+        }
+        const finalSum = r2(finalAmounts.reduce((s, a) => s + a, 0));
+        if (Math.abs(finalSum - subtotal) > 0.005) {
+            throw new Error("Internal error: line amounts do not sum to the subtotal");
+        }
+
+        // ── AUTO-SPLIT ──────────────────────────────────────────────────────
+        // Uses the RAW per-line amount (see the KNOWN DESIGN NOTE on this
+        // function) — the amount actually carved out of the milestone. Never
+        // deletes a PaymentSchedule/EstimatePaymentSchedule row: the original
+        // is reduced in place and a NEW row absorbs the remainder.
+        const resolvedScheduleIds = new Map<number, string>(); // line index -> PaymentSchedule.id billed (whole, post-split)
+        for (let i = 0; i < input.lines.length; i++) {
+            const line = input.lines[i];
+            if (!line.scheduleId) continue;
+            const schedule = scheduleCache.get(line.scheduleId)!;
+            const rawAmount = rawAmounts[i];
+            const scheduleAmount = toNum(schedule.amount);
+            resolvedScheduleIds.set(i, schedule.id);
+
+            if (rawAmount >= scheduleAmount - 0.005) continue; // full bill — no split needed
+
+            const remainder = r2(scheduleAmount - rawAmount);
+
+            await tx.paymentSchedule.update({
+                where: { id: schedule.id },
+                data: { amount: rawAmount },
+            });
+
+            let newSourceScheduleId: string | null = null;
+            if (schedule.sourceScheduleId) {
+                const originalEst = await tx.estimatePaymentSchedule.findUnique({ where: { id: schedule.sourceScheduleId } });
+                if (originalEst) {
+                    await tx.estimatePaymentSchedule.update({
+                        where: { id: originalEst.id },
+                        data: { amount: rawAmount },
+                    });
+                    const newEst = await tx.estimatePaymentSchedule.create({
+                        data: {
+                            estimateId: originalEst.estimateId,
+                            name: `${originalEst.name} (remaining)`,
+                            amount: remainder,
+                            dueDate: originalEst.dueDate || null,
+                            status: "Pending",
+                            order: originalEst.order,
+                            percentage: null,
+                        },
+                    });
+                    newSourceScheduleId = newEst.id;
+                }
+            }
+
+            await tx.paymentSchedule.create({
+                data: {
+                    invoiceId,
+                    name: `${schedule.name} (remaining)`,
+                    amount: remainder,
+                    status: "Pending",
+                    dueDate: schedule.dueDate || null,
+                    sourceScheduleId: newSourceScheduleId,
+                },
+            });
+        }
+
+        // ── Persist the billing ────────────────────────────────────────────
+        const existingCount = await tx.progressBilling.count({ where: { invoiceId } });
+        const code = `${invoice.code}-P${existingCount + 1}`;
+
+        const billing = await tx.progressBilling.create({
+            data: {
+                invoiceId,
+                code,
+                description,
+                status: "Draft",
+                subtotal,
+                taxExempt,
+                taxRate: effectiveRate,
+                taxAmount,
+                total,
+            },
+        });
+
+        await tx.progressBillingLine.createMany({
+            data: input.lines.map((line, i) => ({
+                billingId: billing.id,
+                scheduleId: resolvedScheduleIds.get(i) || null,
+                changeOrderId: line.changeOrderId || null,
+                description: line.description.trim(),
+                amount: finalAmounts[i],
+                order: i,
+            })),
+        });
+
+        const withLines = await tx.progressBilling.findUnique({
+            where: { id: billing.id },
+            include: { lines: { orderBy: { order: "asc" } } },
+        });
+        return withLines!;
+    }));
+}
+
+export type UpdateProgressBillingInput = {
+    description?: string;
+    taxExempt?: boolean;
+};
+
+/**
+ * Draft-only edit: description and/or tax-exempt status. Line composition
+ * (which milestones/change orders/custom amounts make up the billing) is
+ * intentionally NOT re-editable here — re-running AUTO-SPLIT against a changed
+ * line set is exactly the kind of ambiguous, high-risk money logic this pass
+ * avoids (see PROGRESS_BILLING_REPORT.md). To change the lines, delete this
+ * Draft (safe — any split it already applied stays applied, see
+ * deleteProgressBillingCore below) and create a fresh one.
+ */
+export async function updateProgressBillingCore(
+    billingId: string,
+    input: UpdateProgressBillingInput,
+): Promise<ProgressBillingWithLines> {
+    return withTxRetry(() => prisma.$transaction(async (tx) => {
+        const link = await tx.progressBilling.findUnique({ where: { id: billingId }, select: { invoiceId: true } });
+        if (!link) throw new Error("Progress billing not found");
+        await lockMoneyParents(tx, { invoiceId: link.invoiceId });
+
+        const billing = await tx.progressBilling.findUnique({ where: { id: billingId } });
+        if (!billing) throw new Error("Progress billing not found");
+        if (billing.status !== "Draft" || billing.qbInvoiceId) {
+            throw new Error(`This billing is "${billing.status}"${billing.qbInvoiceId ? " and has a QuickBooks invoice staged" : ""} — only Draft billings without a staged QuickBooks invoice can be edited`);
+        }
+
+        const description = input.description !== undefined ? input.description.trim() : billing.description;
+        if (!description) throw new Error("A description is required");
+        const taxExempt = input.taxExempt !== undefined ? !!input.taxExempt : billing.taxExempt;
+
+        const subtotal = toNum(billing.subtotal);
+        const rate = taxExempt ? 0 : toNum(billing.taxRate);
+        const taxAmount = taxExempt ? 0 : r2(subtotal * rate / 100);
+        const total = r2(subtotal + taxAmount);
+
+        await tx.progressBilling.update({
+            where: { id: billingId },
+            data: { description, taxExempt, taxAmount, total },
+        });
+
+        const withLines = await tx.progressBilling.findUnique({
+            where: { id: billingId },
+            include: { lines: { orderBy: { order: "asc" } } },
+        });
+        return withLines!;
+    }));
+}
+
+/**
+ * Delete a Draft billing. Removes the billing + its lines only (lines cascade
+ * via the DB FK — see prisma/schema.prisma's ProgressBillingLine.billing
+ * relation). Any PaymentSchedule/EstimatePaymentSchedule split this billing
+ * already applied (see createProgressBillingCore's AUTO-SPLIT) is NOT undone
+ * or merged back — the two milestone pieces it created stay as independent
+ * Pending rows. This matches the hard constraint that a split, once applied,
+ * only ever creates rows; it never deletes or merges them.
+ */
+export async function deleteProgressBillingCore(
+    billingId: string,
+): Promise<{ success: true; invoiceId: string; projectId: string }> {
+    return withTxRetry(() => prisma.$transaction(async (tx) => {
+        const link = await tx.progressBilling.findUnique({
+            where: { id: billingId },
+            select: { invoiceId: true, invoice: { select: { projectId: true } } },
+        });
+        if (!link) throw new Error("Progress billing not found");
+        await lockMoneyParents(tx, { invoiceId: link.invoiceId });
+
+        const billing = await tx.progressBilling.findUnique({ where: { id: billingId } });
+        if (!billing) throw new Error("Progress billing not found");
+        if (billing.status !== "Draft" || billing.qbInvoiceId) {
+            throw new Error(`This billing is "${billing.status}"${billing.qbInvoiceId ? " and has a QuickBooks invoice staged" : ""} — only Draft billings without a staged QuickBooks invoice can be deleted`);
+        }
+
+        await tx.progressBilling.delete({ where: { id: billingId } }); // cascades to ProgressBillingLine only
+
+        return { success: true as const, invoiceId: link.invoiceId, projectId: link.invoice.projectId };
+    }));
+}
+
+/**
+ * Stage a Draft billing's ONE QuickBooks invoice. Never sends any email —
+ * deliberately: this pass ships no customer notifications (owner's hard
+ * constraint; see PROGRESS_BILLING_REPORT.md). A later UI pass wires an
+ * explicit "send" action on top of this, same split as the milestone rail
+ * (pushMilestoneToQuickBooks stages; sendMilestoneInvoicesCore sends).
+ */
+export async function stageProgressBillingToQuickBooksCore(
+    billingId: string,
+): Promise<{ success: true; qbInvoiceId: string; qbInvoiceLink: string | null }> {
+    const billing = await prisma.progressBilling.findUnique({
+        where: { id: billingId },
+        include: {
+            invoice: {
+                include: {
+                    client: { select: { id: true, name: true, email: true, qbCustomerId: true } },
+                },
+            },
+        },
+    });
+    if (!billing) throw new Error("Progress billing not found");
+    if (billing.status !== "Draft") {
+        throw new Error(`This billing is "${billing.status}" — only Draft billings can be staged to QuickBooks`);
+    }
+    if (billing.qbInvoiceId) {
+        throw new Error("This billing already has a QuickBooks invoice staged");
+    }
+
+    const invoice = billing.invoice;
+    const { getFreshQBTokens, resolveCustomerAndItem } = await import("./quickbooks-payments");
+    const { createQBMilestoneInvoice, getQBInvoicePaymentLink, deleteQBInvoice } = await import("./quickbooks");
+
+    const tokens = await getFreshQBTokens();
+    const { customerId, itemId } = await resolveCustomerAndItem(tokens, invoice.clientId);
+
+    const subtotal = toNum(billing.subtotal);
+    const taxAmount = toNum(billing.taxAmount);
+    const total = toNum(billing.total);
+
+    const { qbId } = await createQBMilestoneInvoice(tokens, {
+        docNumber: billing.code,
+        customerId,
+        itemId,
+        description: billing.description,
+        amount: total,
+        tax: taxAmount > 0 ? { preTaxAmount: subtotal, taxAmount } : null,
+        billEmail: invoice.client?.email || null,
+        privateNote: `ProBuild ${invoice.code} · ${billing.code}`,
+    });
+
+    const payLink = await getQBInvoicePaymentLink(tokens, qbId);
+
+    // Conditional claim mirroring pushMilestoneToQuickBooks: guards pin id,
+    // Draft status, no existing qbInvoiceId, and the exact content snapshot
+    // (subtotal/total/description) this QBO invoice was created from — a
+    // mid-stage edit or concurrent stage can't silently attach to a row it no
+    // longer describes. On a miss, compensate by deleting the just-created QBO
+    // invoice instead of leaving it orphaned and unattached.
+    const linked = await prisma.progressBilling.updateMany({
+        where: {
+            id: billing.id,
+            status: "Draft",
+            qbInvoiceId: null,
+            subtotal: billing.subtotal,
+            total: billing.total,
+            description: billing.description,
+        },
+        data: { status: "Staged", qbInvoiceId: qbId, qbInvoiceLink: payLink, qbSyncedAt: new Date() },
+    });
+    if (linked.count !== 1) {
+        const compensated = await deleteQBInvoice(tokens, qbId).catch(() => false);
+        if (!compensated) {
+            throw new Error(`This billing changed while staging its QuickBooks invoice, and the abandoned QuickBooks invoice ${billing.code} (id ${qbId}) could not be deleted — remove it in QuickBooks, then retry.`);
+        }
+        throw new Error("This billing changed while staging its QuickBooks invoice — refresh and try again.");
+    }
+
+    return { success: true as const, qbInvoiceId: qbId, qbInvoiceLink: payLink };
+}

--- a/src/lib/progress-billing.ts
+++ b/src/lib/progress-billing.ts
@@ -3,11 +3,19 @@
  *
  * Product model: estimate/invoice milestones (PaymentSchedule/EstimatePaymentSchedule)
  * are SUGGESTIONS. The billable artifact is a "progress billing" (ProgressBilling):
- * the user picks milestones and/or approved change orders and/or a custom amount,
- * writes one client-facing description, confirms tax, and stages exactly ONE
- * QuickBooks invoice. Milestones remain the record of truth for what has been
- * satisfied, so a billing that covers only PART of a milestone AUTO-SPLITS that
- * milestone — every billing line ends up mapped 1:1 to a whole milestone.
+ * the user picks milestones and/or a custom amount, writes one client-facing
+ * description, confirms tax, and stages exactly ONE QuickBooks invoice.
+ * Milestones remain the record of truth for what has been satisfied, so a
+ * billing that covers only PART of a milestone AUTO-SPLITS that milestone —
+ * every billing line ends up mapped 1:1 to a whole milestone.
+ *
+ * Change orders are NOT a line type here. `billChangeOrderCore`
+ * (src/lib/billing-core.ts) already bills an approved change order by adding
+ * it to the invoice as a normal PaymentSchedule milestone (called from
+ * `handleChangeOrderApproved` on approval) — it arrives here like any other
+ * milestone line. A `changeOrderId` field on a progress-billing line would be
+ * a second rail for the same money, so `createProgressBillingCore` rejects
+ * any line that supplies one.
  *
  * Session-free cores (no auth checks) — actions.ts wrappers come in the UI pass,
  * same convention as billing-core.ts.
@@ -26,12 +34,13 @@ import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { toNum } from "./prisma-helpers";
 import type { ProgressBilling, ProgressBillingLine } from "@prisma/client";
 
-// Cent-round helper shared by every money computation below.
-const r2 = (n: number) => Math.round(n * 100) / 100;
+// Cent-round helper shared by every money computation below. EPSILON nudges
+// values like 1.005 (which float as 1.00499999999...) up to the cent they were
+// meant to land on instead of truncating down.
+const r2 = (n: number) => Math.round((n + Number.EPSILON) * 100) / 100;
 
 export type ProgressBillingLineInput = {
     scheduleId?: string;
-    changeOrderId?: string;
     description: string;
     amount: number;
 };
@@ -40,8 +49,15 @@ export type CreateProgressBillingInput = {
     description: string;
     lines: ProgressBillingLineInput[];
     taxExempt?: boolean;
-    amountMode: "preTax" | "targetTotal";
-    targetTotal?: number;
+    /**
+     * Optional: when supplied, the client pays exactly this (tax-inclusive)
+     * amount. Cross-checked against what the lines say they add up to
+     * (`expectedGross`, within 2 cents) — a mismatch almost always means the
+     * lines were entered in the wrong units (pre-tax vs gross), not that the
+     * user wants an arbitrary rescale, so it throws rather than silently
+     * redistributing the difference.
+     */
+    grossTotal?: number;
 };
 
 export type ProgressBillingWithLines = ProgressBilling & { lines: ProgressBillingLine[] };
@@ -49,16 +65,25 @@ export type ProgressBillingWithLines = ProgressBilling & { lines: ProgressBillin
 /**
  * Build one progress billing.
  *
- * TWO AMOUNTS, DELIBERATELY DIFFERENT. Every line carries:
- *   • the PERSISTED amount (ProgressBillingLine.amount) — always PRE-TAX, since
- *     it feeds the QuickBooks invoice's taxable line; and
- *   • the SPLIT amount — what gets carved out of the milestone, expressed in
- *     that milestone's own units (see the "Split units" block below).
- * On a legacy tax-inclusive job these differ by exactly the tax and that is
- * correct: a $25,000 check against a $39,998.25 tax-inclusive milestone leaves
- * $14,998.25 behind while the QuickBooks line reads $22,977.94 + $2,022.06 tax.
- * On a pre-tax job they are identical. In "preTax" mode they are always
- * identical regardless of vintage.
+ * UNITS. `lines[].amount` is always expressed in the milestone's OWN units,
+ * which differ by vintage (`Estimate.taxInclusiveMilestones`, defaulting to
+ * legacy/true when the invoice has no estimate):
+ *   • legacy vintage: milestone amounts are GROSS (tax-inclusive) — the line
+ *     amount is literally what the client is paying against that milestone.
+ *   • new vintage: milestone amounts are PRE-TAX — tax rides on top.
+ * This applies uniformly to milestone lines and custom lines (materialized
+ * into a brand-new milestone in the same units).
+ *
+ * TWO AMOUNTS PER LINE, DELIBERATELY DIFFERENT:
+ *   • the PERSISTED amount (ProgressBillingLine.amount) — always PRE-TAX,
+ *     since it feeds the QuickBooks invoice's taxable line; and
+ *   • the SPLIT amount — what gets carved out of the milestone (or, for a
+ *     custom line, what the newly-materialized milestone is sized to),
+ *     expressed in that milestone's own units.
+ * On a legacy tax-inclusive job these differ by exactly the tax: a $25,000
+ * check against a $39,998.25 tax-inclusive milestone leaves $14,998.25
+ * behind, while the QuickBooks line reads $22,977.94 + $2,022.06 tax. On a
+ * pre-tax job they are identical.
  */
 export async function createProgressBillingCore(
     invoiceId: string,
@@ -67,9 +92,6 @@ export async function createProgressBillingCore(
     const description = (input.description || "").trim();
     if (!description) throw new Error("A description is required");
     if (!input.lines?.length) throw new Error("At least one line is required");
-    if (input.amountMode !== "preTax" && input.amountMode !== "targetTotal") {
-        throw new Error(`Unknown amountMode: ${input.amountMode}`);
-    }
 
     const rawAmounts = input.lines.map((l) => r2(Number(l.amount)));
     rawAmounts.forEach((amt, i) => {
@@ -78,18 +100,22 @@ export async function createProgressBillingCore(
         }
     });
 
-    let targetTotal = 0;
-    if (input.amountMode === "targetTotal") {
-        targetTotal = r2(Number(input.targetTotal));
-        if (!Number.isFinite(targetTotal) || targetTotal <= 0) {
-            throw new Error('targetTotal must be greater than zero for amountMode "targetTotal"');
+    let grossTotal: number | undefined;
+    if (input.grossTotal !== undefined && input.grossTotal !== null) {
+        grossTotal = r2(Number(input.grossTotal));
+        if (!Number.isFinite(grossTotal) || grossTotal <= 0) {
+            throw new Error("grossTotal must be greater than zero");
         }
     }
 
     const seenScheduleIds = new Set<string>();
     for (const line of input.lines) {
-        if (line.scheduleId && line.changeOrderId) {
-            throw new Error("A line cannot reference both a milestone and a change order");
+        // Change orders are billed by approving them (billChangeOrderCore adds
+        // a milestone to the invoice on approval) — see this file's top
+        // docstring. A changeOrderId here would be a second rail for the same
+        // money, so it's rejected outright rather than silently accepted.
+        if ((line as { changeOrderId?: unknown }).changeOrderId) {
+            throw new Error("Change orders are billed by approving them, which adds a milestone to the invoice — bill that milestone here.");
         }
         if (line.scheduleId) {
             if (seenScheduleIds.has(line.scheduleId)) {
@@ -110,12 +136,20 @@ export async function createProgressBillingCore(
         const invoice = await tx.invoice.findUnique({ where: { id: invoiceId } });
         if (!invoice) throw new Error("Invoice not found");
 
+        // Vintage: which units milestone amounts (and therefore every line in
+        // this billing) are expressed in. No estimate (ad-hoc invoice) →
+        // legacy/tax-inclusive, matching how every pre-existing invoice in the
+        // system was priced.
+        const estimateForUnits = invLink?.estimateId
+            ? await tx.estimate.findUnique({ where: { id: invLink.estimateId }, select: { taxInclusiveMilestones: true } })
+            : null;
+        const legacy = estimateForUnits?.taxInclusiveMilestones ?? true;
+
         // Resolve + validate every line under the lock (no writes yet).
         const scheduleCache = new Map<string, NonNullable<Awaited<ReturnType<typeof prisma.paymentSchedule.findUnique>>>>();
 
         for (let i = 0; i < input.lines.length; i++) {
             const line = input.lines[i];
-            const rawAmount = rawAmounts[i];
 
             if (line.scheduleId) {
                 const schedule = await tx.paymentSchedule.findUnique({ where: { id: line.scheduleId } });
@@ -131,17 +165,10 @@ export async function createProgressBillingCore(
                 if (schedule.stripeSessionId || schedule.stripePaymentIntentId) {
                     throw new Error(`A payment is in progress on "${schedule.name}" — wait for it to finish or void it before billing.`);
                 }
-                // Over-billing is checked AFTER the tax math, against the amount
-                // expressed in the milestone's own units (see splitAmounts below).
+                // Over-billing (including double-billing an already-committed
+                // milestone) is checked AFTER the tax math, in the consumption
+                // guard below.
                 scheduleCache.set(line.scheduleId, schedule);
-            } else if (line.changeOrderId) {
-                const co = await tx.changeOrder.findUnique({ where: { id: line.changeOrderId } });
-                if (!co || co.projectId !== invoice.projectId) {
-                    throw new Error(`Change order not found on this invoice's project: ${line.changeOrderId}`);
-                }
-                if (co.status !== "Approved") {
-                    throw new Error(`Change order ${co.code} is "${co.status}" — only Approved change orders can be billed`);
-                }
             }
         }
 
@@ -149,66 +176,96 @@ export async function createProgressBillingCore(
         const taxExempt = !!input.taxExempt;
         const effectiveRate = taxExempt ? 0 : toNum(invoice.taxRate);
 
-        let subtotal: number;
-        let taxAmount: number;
-        let total: number;
-        let finalAmounts: number[];
+        const rawSum = r2(rawAmounts.reduce((s, a) => s + a, 0));
+        const expectedGross = legacy ? rawSum : r2(rawSum * (1 + effectiveRate / 100));
 
-        if (input.amountMode === "preTax") {
-            subtotal = r2(rawAmounts.reduce((s, a) => s + a, 0));
-            taxAmount = taxExempt ? 0 : r2(subtotal * effectiveRate / 100);
-            total = r2(subtotal + taxAmount);
-            finalAmounts = rawAmounts.slice();
-        } else {
-            total = targetTotal;
-            subtotal = taxExempt ? total : r2(total / (1 + effectiveRate / 100));
-            taxAmount = taxExempt ? 0 : r2(total - subtotal);
-
-            const rawSum = rawAmounts.reduce((s, a) => s + a, 0);
-            finalAmounts = rawAmounts.map((a) => r2((a * subtotal) / rawSum));
-            const usedSum = r2(finalAmounts.slice(0, -1).reduce((s, a) => s + a, 0));
-            finalAmounts[finalAmounts.length - 1] = r2(subtotal - usedSum);
-            if (finalAmounts[finalAmounts.length - 1] <= 0) {
-                throw new Error("Rescaling to the target total left the last line at $0 or less — adjust the line amounts.");
-            }
+        if (grossTotal !== undefined && Math.abs(grossTotal - expectedGross) > 0.02) {
+            throw new Error(
+                `The selected amounts total $${expectedGross.toFixed(2)} but the invoice total says $${grossTotal.toFixed(2)} — they must match.`
+            );
         }
+
+        const total = grossTotal ?? expectedGross;
+        const subtotal = taxExempt ? total : r2(total / (1 + effectiveRate / 100));
+        const taxAmount = taxExempt ? 0 : r2(total - subtotal);
 
         if (Math.abs(r2(subtotal + taxAmount) - total) > 0.005) {
             throw new Error("Internal error: subtotal + tax does not equal total");
         }
+
+        // Persisted amounts (ProgressBillingLine.amount) are ALWAYS pre-tax:
+        // each line's proportional share of subtotal, weighted by the raw
+        // line amounts, with the rounding remainder landing on the LAST line.
+        const finalAmounts = rawAmounts.map((a) => r2((a * subtotal) / rawSum));
+        const usedSum = r2(finalAmounts.slice(0, -1).reduce((s, a) => s + a, 0));
+        finalAmounts[finalAmounts.length - 1] = r2(subtotal - usedSum);
+        finalAmounts.forEach((amt, i) => {
+            if (amt <= 0) {
+                throw new Error(
+                    `Line ${i + 1} ("${input.lines[i].description || "untitled"}"): rescaled amount is $0.00 or less — adjust the line amounts or the total.`
+                );
+            }
+        });
         const finalSum = r2(finalAmounts.reduce((s, a) => s + a, 0));
         if (Math.abs(finalSum - subtotal) > 0.005) {
             throw new Error("Internal error: line amounts do not sum to the subtotal");
         }
 
         // ── Split units ─────────────────────────────────────────────────────
-        // A milestone must be carved up in ITS OWN units, which differ by vintage:
-        //   • legacy estimates (taxInclusiveMilestones = true, every job priced
-        //     before progressive billing): milestone amounts INCLUDE tax, so the
-        //     gross amount the client is paying is what comes out of the milestone
-        //     — a $25,000 check against Mesplay's $39,998.25 leaves $14,998.25.
-        //   • new estimates (false): milestone amounts are PRE-TAX, so the pre-tax
-        //     line amount is what comes out; the tax rides on top of the billing.
-        // In "preTax" mode finalAmounts === rawAmounts, so both branches agree and
-        // this reduces to a no-op. Getting this wrong silently mis-splits live
-        // milestones by exactly the tax, which is why over-billing is validated
-        // here against the same units rather than against the caller's raw input.
-        const estimateForUnits = invLink?.estimateId
-            ? await tx.estimate.findUnique({ where: { id: invLink.estimateId }, select: { taxInclusiveMilestones: true } })
-            : null;
-        // No estimate (ad-hoc invoice) → treat as legacy tax-inclusive, matching
-        // how every existing invoice in the system was priced.
-        const milestonesAreTaxInclusive = estimateForUnits?.taxInclusiveMilestones ?? true;
-        const splitAmounts = milestonesAreTaxInclusive ? rawAmounts : finalAmounts;
+        // What gets carved out of a milestone (or sizes a newly-materialized
+        // one), in that milestone's own units:
+        //   • legacy (tax-inclusive): the line's proportional share of TOTAL
+        //     (gross) — a $25,000 check against Mesplay's $39,998.25 leaves
+        //     $14,998.25 behind.
+        //   • new vintage (pre-tax): identical to the persisted amount —
+        //     finalAmounts already IS the milestone's own units.
+        // Getting this wrong silently mis-splits live milestones by exactly
+        // the tax, which is why every downstream check (consumption guard,
+        // AUTO-SPLIT, custom-line materialization) uses splitAmounts rather
+        // than the caller's raw input.
+        let splitAmounts: number[];
+        if (legacy) {
+            splitAmounts = rawAmounts.map((a) => r2((a * total) / rawSum));
+            const usedSplitSum = r2(splitAmounts.slice(0, -1).reduce((s, a) => s + a, 0));
+            splitAmounts[splitAmounts.length - 1] = r2(total - usedSplitSum);
+        } else {
+            splitAmounts = finalAmounts.slice();
+        }
+        const splitCheckTarget = legacy ? total : subtotal;
+        const splitSum = r2(splitAmounts.reduce((s, a) => s + a, 0));
+        if (Math.abs(splitSum - splitCheckTarget) > 0.005) {
+            throw new Error("Internal error: split amounts do not sum to the expected total");
+        }
 
+        // ── Consumption guard ──────────────────────────────────────────────
+        // A milestone can only ever be claimed for its full amount, across
+        // EVERY non-Void progress billing that has referenced it — not just
+        // within this one call. Without this: a milestone billed in FULL
+        // never triggers AUTO-SPLIT (its PaymentSchedule.amount never
+        // changes), and a milestone's post-split ORIGINAL row keeps whatever
+        // amount was billed into it — both stay "Pending" and can be billed
+        // again for up to that same amount, silently double-billing the
+        // client.
         for (let i = 0; i < input.lines.length; i++) {
-            const scheduleId = input.lines[i].scheduleId;
-            if (!scheduleId) continue;
-            const schedule = scheduleCache.get(scheduleId)!;
-            if (splitAmounts[i] > toNum(schedule.amount) + 0.005) {
-                throw new Error(
-                    `"${schedule.name}": billed amount $${splitAmounts[i].toFixed(2)} exceeds the milestone's amount $${toNum(schedule.amount).toFixed(2)}`
-                );
+            const line = input.lines[i];
+            if (line.scheduleId) {
+                const schedule = scheduleCache.get(line.scheduleId)!;
+                const otherLines = await tx.progressBillingLine.findMany({
+                    where: { scheduleId: line.scheduleId, billing: { status: { not: "Void" } } },
+                    select: { amount: true, billing: { select: { code: true, taxRate: true, taxExempt: true } } },
+                });
+                const committed = r2(otherLines.reduce((sum, l) => {
+                    const preTax = toNum(l.amount);
+                    const gross = l.billing.taxExempt ? preTax : r2(preTax * (1 + toNum(l.billing.taxRate) / 100));
+                    return sum + (legacy ? gross : preTax);
+                }, 0));
+                const available = r2(toNum(schedule.amount) - committed);
+                if (splitAmounts[i] > available + 0.005) {
+                    const codes = [...new Set(otherLines.map((l) => l.billing.code))].join(", ");
+                    throw new Error(
+                        `"${schedule.name}": billed amount $${splitAmounts[i].toFixed(2)} exceeds what's left — $${committed.toFixed(2)} of $${toNum(schedule.amount).toFixed(2)} is already billed${codes ? ` on ${codes}` : ""}.`
+                    );
+                }
             }
         }
 
@@ -217,7 +274,11 @@ export async function createProgressBillingCore(
         // milestone's own units — see above). Never deletes a PaymentSchedule /
         // EstimatePaymentSchedule row: the original is reduced in place and a NEW
         // row absorbs the remainder, so the two always sum to what was there
-        // before and the invoice's totalAmount/balanceDue are untouched.
+        // before and the invoice's totalAmount/balanceDue are untouched. Every
+        // update is a conditional claim pinned to the exact amount read at the
+        // top of this transaction, so a concurrent write (e.g. the legacy
+        // pushMilestoneToQuickBooks linking a QBO invoice) between validation
+        // and this write can't be silently overwritten.
         const resolvedScheduleIds = new Map<number, string>(); // line index -> PaymentSchedule.id billed (whole, post-split)
         for (let i = 0; i < input.lines.length; i++) {
             const line = input.lines[i];
@@ -231,19 +292,38 @@ export async function createProgressBillingCore(
 
             const remainder = r2(scheduleAmount - splitAmount);
 
-            await tx.paymentSchedule.update({
-                where: { id: schedule.id },
+            const claim = await tx.paymentSchedule.updateMany({
+                where: {
+                    id: schedule.id,
+                    status: "Pending",
+                    qbInvoiceId: null,
+                    stripeSessionId: null,
+                    stripePaymentIntentId: null,
+                    amount: schedule.amount,
+                },
                 data: { amount: splitAmount },
             });
+            if (claim.count !== 1) {
+                throw new Error(`"${schedule.name}" changed while this billing was being built — refresh and try again.`);
+            }
 
             let newSourceScheduleId: string | null = null;
             if (schedule.sourceScheduleId) {
                 const originalEst = await tx.estimatePaymentSchedule.findUnique({ where: { id: schedule.sourceScheduleId } });
                 if (originalEst) {
-                    await tx.estimatePaymentSchedule.update({
-                        where: { id: originalEst.id },
+                    const estClaim = await tx.estimatePaymentSchedule.updateMany({
+                        where: {
+                            id: originalEst.id,
+                            status: "Pending",
+                            stripeSessionId: null,
+                            stripePaymentIntentId: null,
+                            amount: originalEst.amount,
+                        },
                         data: { amount: splitAmount },
                     });
+                    if (estClaim.count !== 1) {
+                        throw new Error(`"${originalEst.name}" changed while this billing was being built — refresh and try again.`);
+                    }
                     const newEst = await tx.estimatePaymentSchedule.create({
                         data: {
                             estimateId: originalEst.estimateId,
@@ -257,6 +337,15 @@ export async function createProgressBillingCore(
                     });
                     newSourceScheduleId = newEst.id;
                 }
+            } else if (invLink?.estimateId) {
+                // No estimate-side row to mirror even though this invoice HAS an
+                // estimate: this PaymentSchedule has no sourceScheduleId, e.g. it
+                // was materialized by an earlier progress billing's custom line
+                // (see "materialize custom lines" below) or is a legacy ad-hoc
+                // milestone that predates the mirror link. There is nothing on
+                // the estimate side to split, so the split stays invoice-only.
+                // Deliberate, not a bug — documented so the gap stays
+                // reviewable rather than silently missed.
             }
 
             await tx.paymentSchedule.create({
@@ -271,9 +360,58 @@ export async function createProgressBillingCore(
             });
         }
 
+        // ── Materialize custom lines as milestones ─────────────────────────
+        // Every line must end up with a scheduleId. Milestone lines already
+        // have one (resolvedScheduleIds, above); a custom amount (no
+        // scheduleId — change-order lines are rejected up front, see above)
+        // gets a brand-new Pending PaymentSchedule here, sized to its split
+        // amount (milestone units). Unlike a milestone split, this GROWS the
+        // invoice total — the money wasn't already part of the contract until
+        // now — mirroring addInvoiceMilestone's status ladder exactly. This is
+        // what lets a custom line settle through the normal milestone rail
+        // with no special case.
+        let materializedTotal = 0;
+        for (let i = 0; i < input.lines.length; i++) {
+            if (resolvedScheduleIds.has(i)) continue; // milestone line, already resolved
+            const line = input.lines[i];
+            const amount = splitAmounts[i];
+            const newSchedule = await tx.paymentSchedule.create({
+                data: {
+                    invoiceId,
+                    name: line.description.trim(),
+                    amount,
+                    status: "Pending",
+                    sourceScheduleId: null,
+                },
+            });
+            resolvedScheduleIds.set(i, newSchedule.id);
+            materializedTotal = r2(materializedTotal + amount);
+        }
+
+        if (materializedTotal > 0) {
+            const nextStatus = invoice.status === "Paid" ? "Partially Paid" : invoice.status;
+            await tx.invoice.update({
+                where: { id: invoiceId },
+                data: {
+                    totalAmount: { increment: materializedTotal },
+                    balanceDue: { increment: materializedTotal },
+                    ...(nextStatus !== invoice.status ? { status: nextStatus } : {}),
+                },
+            });
+        }
+
         // ── Persist the billing ────────────────────────────────────────────
-        const existingCount = await tx.progressBilling.count({ where: { invoiceId } });
-        const code = `${invoice.code}-P${existingCount + 1}`;
+        // Code numbering: parse existing codes for this invoice and take the
+        // max numeric "-P<n>" suffix + 1, rather than a raw count — a count
+        // reuses a code (and collides with QuickBooks' DocNumber) after a
+        // non-last Draft billing is deleted.
+        const existingBillings = await tx.progressBilling.findMany({ where: { invoiceId }, select: { code: true } });
+        const maxSuffix = existingBillings.reduce((max, b) => {
+            const m = /-P(\d+)$/.exec(b.code);
+            const n = m ? parseInt(m[1], 10) : 0;
+            return Number.isFinite(n) && n > max ? n : max;
+        }, 0);
+        const code = `${invoice.code}-P${maxSuffix + 1}`;
 
         const billing = await tx.progressBilling.create({
             data: {
@@ -283,7 +421,11 @@ export async function createProgressBillingCore(
                 status: "Draft",
                 subtotal,
                 taxExempt,
-                taxRate: effectiveRate,
+                // Always the invoice's real rate, even when taxExempt is true —
+                // taxExempt only zeroes the *computation* above. That way,
+                // un-exempting this billing later (updateProgressBillingCore)
+                // recomputes tax at the correct rate instead of forever at 0.
+                taxRate: toNum(invoice.taxRate),
                 taxAmount,
                 total,
             },
@@ -292,8 +434,7 @@ export async function createProgressBillingCore(
         await tx.progressBillingLine.createMany({
             data: input.lines.map((line, i) => ({
                 billingId: billing.id,
-                scheduleId: resolvedScheduleIds.get(i) || null,
-                changeOrderId: line.changeOrderId || null,
+                scheduleId: resolvedScheduleIds.get(i) ?? null,
                 description: line.description.trim(),
                 amount: finalAmounts[i],
                 order: i,
@@ -315,12 +456,17 @@ export type UpdateProgressBillingInput = {
 
 /**
  * Draft-only edit: description and/or tax-exempt status. Line composition
- * (which milestones/change orders/custom amounts make up the billing) is
- * intentionally NOT re-editable here — re-running AUTO-SPLIT against a changed
+ * (which milestones/custom amounts make up the billing) is intentionally NOT
+ * re-editable here — re-running AUTO-SPLIT against a changed
  * line set is exactly the kind of ambiguous, high-risk money logic this pass
  * avoids (see PROGRESS_BILLING_REPORT.md). To change the lines, delete this
  * Draft (safe — any split it already applied stays applied, see
  * deleteProgressBillingCore below) and create a fresh one.
+ *
+ * `billing.taxRate` always holds the invoice's real rate (see
+ * createProgressBillingCore), so flipping `taxExempt` here correctly
+ * recomputes tax at that rate rather than being stuck at whatever the rate
+ * happened to be the first time the billing was saved exempt.
  */
 export async function updateProgressBillingCore(
     billingId: string,
@@ -366,7 +512,11 @@ export async function updateProgressBillingCore(
  * already applied (see createProgressBillingCore's AUTO-SPLIT) is NOT undone
  * or merged back — the two milestone pieces it created stay as independent
  * Pending rows. This matches the hard constraint that a split, once applied,
- * only ever creates rows; it never deletes or merges them.
+ * only ever creates rows; it never deletes or merges them. Likewise, a
+ * milestone this billing materialized from a custom line (and the invoice
+ * total bump that came with it) is NOT undone either — deleting the Draft
+ * just removes the billing record; the money it already added to the
+ * contract stays.
  */
 export async function deleteProgressBillingCore(
     billingId: string,
@@ -397,6 +547,13 @@ export async function deleteProgressBillingCore(
  * constraint; see PROGRESS_BILLING_REPORT.md). A later UI pass wires an
  * explicit "send" action on top of this, same split as the milestone rail
  * (pushMilestoneToQuickBooks stages; sendMilestoneInvoicesCore sends).
+ *
+ * Compensation: EVERYTHING after createQBMilestoneInvoice (the pay-link
+ * fetch, the conditional link claim, and the claim's own error) runs inside
+ * one try/catch. Any failure in that block attempts to delete the
+ * just-created QBO invoice so it never sits orphaned and unreferenced in
+ * QuickBooks; if the delete also fails, the error names the doc number + QBO
+ * id so it can be removed by hand.
  */
 export async function stageProgressBillingToQuickBooksCore(
     billingId: string,
@@ -441,32 +598,42 @@ export async function stageProgressBillingToQuickBooksCore(
         privateNote: `ProBuild ${invoice.code} · ${billing.code}`,
     });
 
-    const payLink = await getQBInvoicePaymentLink(tokens, qbId);
+    try {
+        const payLink = await getQBInvoicePaymentLink(tokens, qbId);
 
-    // Conditional claim mirroring pushMilestoneToQuickBooks: guards pin id,
-    // Draft status, no existing qbInvoiceId, and the exact content snapshot
-    // (subtotal/total/description) this QBO invoice was created from — a
-    // mid-stage edit or concurrent stage can't silently attach to a row it no
-    // longer describes. On a miss, compensate by deleting the just-created QBO
-    // invoice instead of leaving it orphaned and unattached.
-    const linked = await prisma.progressBilling.updateMany({
-        where: {
-            id: billing.id,
-            status: "Draft",
-            qbInvoiceId: null,
-            subtotal: billing.subtotal,
-            total: billing.total,
-            description: billing.description,
-        },
-        data: { status: "Staged", qbInvoiceId: qbId, qbInvoiceLink: payLink, qbSyncedAt: new Date() },
-    });
-    if (linked.count !== 1) {
+        // Conditional claim mirroring pushMilestoneToQuickBooks: guards pin id,
+        // Draft status, no existing qbInvoiceId, and the exact content snapshot
+        // (subtotal/total/description) this QBO invoice was created from — a
+        // mid-stage edit or concurrent stage can't silently attach to a row it no
+        // longer describes.
+        const linked = await prisma.progressBilling.updateMany({
+            where: {
+                id: billing.id,
+                status: "Draft",
+                qbInvoiceId: null,
+                subtotal: billing.subtotal,
+                total: billing.total,
+                description: billing.description,
+            },
+            data: { status: "Staged", qbInvoiceId: qbId, qbInvoiceLink: payLink, qbSyncedAt: new Date() },
+        });
+        if (linked.count !== 1) {
+            throw new Error("This billing changed while staging its QuickBooks invoice — refresh and try again.");
+        }
+
+        return { success: true as const, qbInvoiceId: qbId, qbInvoiceLink: payLink };
+    } catch (err) {
+        // Compensate: never leave a created QBO invoice unreferenced and
+        // unmentioned. Re-throw the informative "changed while staging" error
+        // once compensation succeeds; otherwise name the orphan so a human can
+        // remove it by hand.
         const compensated = await deleteQBInvoice(tokens, qbId).catch(() => false);
         if (!compensated) {
-            throw new Error(`This billing changed while staging its QuickBooks invoice, and the abandoned QuickBooks invoice ${billing.code} (id ${qbId}) could not be deleted — remove it in QuickBooks, then retry.`);
+            throw new Error(
+                `Staging this billing's QuickBooks invoice failed (${err instanceof Error ? err.message : String(err)}), and the abandoned QuickBooks invoice ${billing.code} (id ${qbId}) could not be deleted — remove it in QuickBooks by hand, then retry.`
+            );
         }
-        throw new Error("This billing changed while staging its QuickBooks invoice — refresh and try again.");
+        if (err instanceof Error) throw err;
+        throw new Error(`Staging this billing's QuickBooks invoice failed: ${String(err)}`);
     }
-
-    return { success: true as const, qbInvoiceId: qbId, qbInvoiceLink: payLink };
 }

--- a/src/lib/progress-billing.ts
+++ b/src/lib/progress-billing.ts
@@ -250,6 +250,25 @@ export async function createProgressBillingCore(
             const line = input.lines[i];
             if (line.scheduleId) {
                 const schedule = scheduleCache.get(line.scheduleId)!;
+                // A sourceScheduleId pointing at a row that no longer exists means
+                // the estimate mirror is already inconsistent. Refuse up front —
+                // for ANY bill, full or partial. A partial would split
+                // invoice-side only; a full one settles later and its
+                // settle-time mirror silently no-ops, leaving the estimate
+                // showing the milestone still owed. (sourceScheduleId is not an
+                // FK, so this state is reachable.)
+                if (schedule.sourceScheduleId) {
+                    const mirror = await tx.estimatePaymentSchedule.findUnique({
+                        where: { id: schedule.sourceScheduleId },
+                        select: { id: true },
+                    });
+                    if (!mirror) {
+                        throw new Error(
+                            `"${schedule.name}" points at an estimate milestone that no longer exists — fix the estimate's payment schedule before billing this.`
+                        );
+                    }
+                }
+
                 const otherLines = await tx.progressBillingLine.findMany({
                     where: { scheduleId: line.scheduleId, billing: { status: { not: "Void" } } },
                     select: { splitAmount: true, billing: { select: { code: true } } },
@@ -288,7 +307,11 @@ export async function createProgressBillingCore(
             const scheduleAmount = toNum(schedule.amount);
             resolvedScheduleIds.set(i, schedule.id);
 
-            const isFullBill = splitAmount >= scheduleAmount - 0.005;
+            // Full only when it covers the milestone exactly or more — never via a
+            // half-cent tolerance, which would let a stored 100.004 be "fully"
+            // billed at 100.00 and silently drop the remainder when the amount is
+            // written back.
+            const isFullBill = splitAmount >= scheduleAmount;
             const remainder = isFullBill ? 0 : r2(scheduleAmount - splitAmount);
 
             // Claim runs on EVERY bill, full or partial — not just splits. A full
@@ -307,7 +330,9 @@ export async function createProgressBillingCore(
                     stripePaymentIntentId: null,
                     amount: schedule.amount,
                 },
-                data: { amount: splitAmount },
+                // A full bill writes the amount back UNCHANGED — the point of the
+                // claim there is the pinned WHERE, not the value.
+                data: { amount: isFullBill ? schedule.amount : splitAmount },
             });
             if (claim.count !== 1) {
                 throw new Error(`"${schedule.name}" changed while this billing was being built — refresh and try again.`);
@@ -318,11 +343,8 @@ export async function createProgressBillingCore(
             let newSourceScheduleId: string | null = null;
             if (schedule.sourceScheduleId) {
                 const originalEst = await tx.estimatePaymentSchedule.findUnique({ where: { id: schedule.sourceScheduleId } });
-                // A sourceScheduleId pointing at a row that no longer exists means
-                // the estimate mirror is already inconsistent. Refuse rather than
-                // silently splitting invoice-side only, which would leave the
-                // estimate overstating what is still owed (sourceScheduleId is not
-                // an FK, so this is reachable).
+                // Existence was already validated above (under the same lock and
+                // transaction); this re-read is just to get the row's fields.
                 if (!originalEst) {
                     throw new Error(
                         `"${schedule.name}" points at an estimate milestone that no longer exists — fix the estimate's payment schedule before billing this.`

--- a/src/lib/quickbooks-payments.ts
+++ b/src/lib/quickbooks-payments.ts
@@ -343,6 +343,54 @@ async function settleMilestonePaidInTx(
 }
 
 /**
+ * Settle ONE progress billing (src/lib/progress-billing.ts) from a QuickBooks
+ * payment: claim the billing Paid, then settle every milestone line it
+ * carries (custom/CO lines are materialized into a real PaymentSchedule at
+ * billing-creation time — see createProgressBillingCore — so every line has a
+ * scheduleId here; there is no special case). Exported (not just inlined in
+ * syncQuickBooksPayments below) so it can be driven directly — by a caller
+ * that already has a settlement to record, or by a test with no live
+ * QuickBooks connection.
+ */
+export async function settleProgressBillingPaidCore(
+    billingId: string,
+    payment: { paidAt: Date; referenceNumber: string | null; qbPaymentId: string | null },
+): Promise<boolean> {
+    const billing = await prisma.progressBilling.findUnique({
+        where: { id: billingId },
+        select: {
+            id: true,
+            invoiceId: true,
+            lines: { select: { scheduleId: true } },
+            invoice: { select: { estimateId: true } },
+        },
+    });
+    if (!billing) return false;
+
+    return withTxRetry(() => prisma.$transaction(async (t) => {
+        // Canonical lock order: Estimate → Invoice → schedules. Every line of
+        // this billing shares the same invoiceId, so one lock covers them all.
+        await lockMoneyParents(t, { estimateId: billing.invoice.estimateId, invoiceId: billing.invoiceId });
+
+        const claim = await t.progressBilling.updateMany({
+            where: { id: billing.id, status: { in: ["Staged", "Sent"] }, qbPaymentId: null },
+            data: { status: "Paid", paidAt: payment.paidAt, qbPaymentId: payment.qbPaymentId, qbSyncedAt: new Date() },
+        });
+        if (claim.count === 0) return false;
+
+        for (const line of billing.lines) {
+            if (!line.scheduleId) continue; // defensive — every line should have one by creation time
+            await settleMilestonePaidInTx(t, line.scheduleId, billing.invoiceId, payment);
+        }
+        // TODO(progress-billing): route paid-billing notifications through
+        // notifyMilestonePaid in the UI pass — deliberately not enqueued here
+        // (this pass ships no customer notifications, per the owner's hard
+        // constraint; see PROGRESS_BILLING_REPORT.md).
+        return true;
+    }));
+}
+
+/**
  * Mark a milestone Paid from a QuickBooks settlement. Mirrors the Stripe
  * webhook's claim-then-recalculate transaction so balances never drift.
  */
@@ -642,11 +690,11 @@ export async function syncQuickBooksPayments(scope?: { invoiceId?: string; proje
 
     // ── Progress billings ───────────────────────────────────────────────────
     // Same probe → settle shape as the milestone loop above, but claims ONE
-    // ProgressBilling row and then settles every milestone line it carries
-    // (custom/change-order lines have no scheduleId and are skipped — there is
-    // no milestone to mark Paid for them) under a single lock+transaction, since
-    // every line of a billing is scoped to the same invoice (createProgressBillingCore
-    // enforces this at build time).
+    // ProgressBilling row and settles it via settleProgressBillingPaidCore,
+    // which walks every line the billing carries under a single lock+transaction
+    // (custom/change-order lines were materialized into a real PaymentSchedule
+    // at billing-creation time — see createProgressBillingCore — so every line
+    // has a scheduleId and settles like any other milestone; no special case).
     for (const billing of pendingBillings) {
         try {
             const probe = await probeQBInvoice(tokens, billing.qbInvoiceId!);
@@ -665,27 +713,7 @@ export async function syncQuickBooksPayments(scope?: { invoiceId?: string; proje
                     if (p?.txnDate) paidAt = new Date(`${p.txnDate}T12:00:00`);
                     referenceNumber = p?.referenceNumber || null;
                 }
-                const settled = await withTxRetry(() => prisma.$transaction(async (t) => {
-                    // Canonical lock order: Estimate → Invoice → schedules. Every line of
-                    // this billing shares the same invoiceId, so one lock covers them all.
-                    await lockMoneyParents(t, { estimateId: billing.invoice.estimateId, invoiceId: billing.invoiceId });
-
-                    const claim = await t.progressBilling.updateMany({
-                        where: { id: billing.id, status: { in: ["Staged", "Sent"] }, qbPaymentId: null },
-                        data: { status: "Paid", paidAt, qbPaymentId: paymentId, qbSyncedAt: new Date() },
-                    });
-                    if (claim.count === 0) return false;
-
-                    for (const line of billing.lines) {
-                        if (!line.scheduleId) continue; // custom / change-order line — no milestone to settle
-                        await settleMilestonePaidInTx(t, line.scheduleId, billing.invoiceId, { paidAt, referenceNumber, qbPaymentId: paymentId });
-                    }
-                    // TODO(progress-billing): route paid-billing notifications through
-                    // notifyMilestonePaid in the UI pass — deliberately not enqueued here
-                    // (this pass ships no customer notifications, per the owner's hard
-                    // constraint; see PROGRESS_BILLING_REPORT.md).
-                    return true;
-                }));
+                const settled = await settleProgressBillingPaidCore(billing.id, { paidAt, referenceNumber, qbPaymentId: paymentId });
                 if (settled) result.progressBillingsSettled++;
             } else if (probe.balance < probe.total) {
                 result.partiallyPaid++;

--- a/src/lib/quickbooks-payments.ts
+++ b/src/lib/quickbooks-payments.ts
@@ -137,6 +137,22 @@ export async function pushMilestoneToQuickBooks(paymentScheduleId: string, passe
     if (!schedule) throw new Error("Payment milestone not found");
     if (schedule.status === "Paid") throw new Error("Milestone is already paid");
 
+    // A milestone already claimed by a progress billing must never get its own
+    // legacy QBO invoice: the billing stages one covering it, so a second one here
+    // would leave TWO collectible invoices for the same money. Checked (and
+    // re-checked below, immediately before the link write) because a full-milestone
+    // billing leaves the row Pending and unlinked — exactly the state this function
+    // otherwise accepts.
+    const claimedBy = await prisma.progressBillingLine.findFirst({
+        where: { scheduleId: paymentScheduleId, billing: { status: { not: "Void" } } },
+        select: { billing: { select: { code: true, status: true } } },
+    });
+    if (claimedBy) {
+        throw new Error(
+            `This milestone is already covered by progress invoice ${claimedBy.billing.code} (${claimedBy.billing.status}) — stage that instead of creating a separate QuickBooks invoice here.`
+        );
+    }
+
     const tokens = passedTokens ?? await getFreshQBTokens();
 
     if (schedule.qbInvoiceId) {
@@ -210,19 +226,34 @@ export async function pushMilestoneToQuickBooks(paymentScheduleId: string, passe
     // silently out of sync. If the claim misses, the just-created QBO invoice is
     // deleted (compensation) instead of being attached to a row it no longer
     // describes.
-    const linked = await prisma.paymentSchedule.updateMany({
-        where: {
-            id: schedule.id,
-            status: "Pending",
-            qbPaymentId: null,
-            qbInvoiceId: null,
-            amount: schedule.amount,
-            name: schedule.name,
-            dueDate: schedule.dueDate,
-        },
-        // qbSyncError: null — a fresh invoice clears any prior voided/notFound flag (self-heal).
-        data: { qbInvoiceId: qbId, qbInvoiceLink: payLink, qbSyncedAt: new Date(), qbSyncError: null },
-    });
+    // Taken under the invoice lock and paired with a progress-billing re-check:
+    // createProgressBillingCore locks the same invoice row, so the two paths
+    // serialize instead of interleaving. Without this a progress billing could
+    // claim this milestone in the window between the guard at the top of this
+    // function and the write below (a full-milestone billing leaves the row
+    // Pending and unlinked, so every pinned column here would still match) and
+    // the client would end up with two collectible QuickBooks invoices.
+    const linked = await withTxRetry(() => prisma.$transaction(async (tx) => {
+        await lockMoneyParents(tx, { invoiceId: schedule.invoiceId });
+        const claimedNow = await tx.progressBillingLine.findFirst({
+            where: { scheduleId: schedule.id, billing: { status: { not: "Void" } } },
+            select: { id: true },
+        });
+        if (claimedNow) return { count: 0 };
+        return tx.paymentSchedule.updateMany({
+            where: {
+                id: schedule.id,
+                status: "Pending",
+                qbPaymentId: null,
+                qbInvoiceId: null,
+                amount: schedule.amount,
+                name: schedule.name,
+                dueDate: schedule.dueDate,
+            },
+            // qbSyncError: null — a fresh invoice clears any prior voided/notFound flag (self-heal).
+            data: { qbInvoiceId: qbId, qbInvoiceLink: payLink, qbSyncedAt: new Date(), qbSyncError: null },
+        });
+    }));
     if (linked.count !== 1) {
         const compensated = await deleteQBInvoice(tokens, qbId).catch(() => false);
         if (!compensated) {

--- a/src/lib/quickbooks-payments.ts
+++ b/src/lib/quickbooks-payments.ts
@@ -88,7 +88,9 @@ export async function claimQBInvoiceUnlink(
     return cleared.count === 1;
 }
 
-async function resolveCustomerAndItem(tokens: QBTokens, clientId: string): Promise<{ customerId: string; itemId: string }> {
+// Exported for stageProgressBillingToQuickBooksCore (src/lib/progress-billing.ts),
+// which needs the same customer/item resolution pushMilestoneToQuickBooks uses.
+export async function resolveCustomerAndItem(tokens: QBTokens, clientId: string): Promise<{ customerId: string; itemId: string }> {
     const client = await prisma.client.findUnique({
         where: { id: clientId },
         select: { id: true, name: true, email: true, qbCustomerId: true },
@@ -234,6 +236,113 @@ export async function pushMilestoneToQuickBooks(paymentScheduleId: string, passe
 }
 
 /**
+ * Shared bookkeeping for settling ONE milestone from a QuickBooks payment:
+ * claim it Paid, recompute the parent invoice's balance/status from every
+ * milestone, and mirror the settle onto the linked estimate-side copy.
+ *
+ * Caller-locked: the caller must already hold the canonical Estimate→Invoice
+ * locks (via `lockMoneyParents`) for this milestone's invoice BEFORE calling
+ * this — it does no locking of its own so it can be called more than once
+ * inside one transaction (progressBillingSettleLoop below settles every
+ * milestone line of a multi-line progress billing under ONE lock+transaction).
+ *
+ * Deliberately does NOT enqueue a paid notification — that is the caller's
+ * job, so a caller that must not notify (progress billing settle, this pass)
+ * can skip it without a second/duplicate writer for the same lifecycle event.
+ */
+async function settleMilestonePaidInTx(
+    t: Prisma.TransactionClient,
+    paymentScheduleId: string,
+    invoiceId: string,
+    payment: { paidAt: Date; referenceNumber: string | null; qbPaymentId: string | null }
+): Promise<boolean> {
+    // INVARIANT: do NOT pin qbInvoiceId in this claim. A real QBO settlement must
+    // win over a concurrent breakQBInvoiceLink (which nulls qbInvoiceId): pinning it
+    // would drop a genuinely-received payment (the row would be excluded from the next
+    // sync's `pending` query forever → client could be double-billed). The settle
+    // wins; qbPaymentId below preserves the QBO audit link even if the id was cleared.
+    const claim = await t.paymentSchedule.updateMany({
+        where: { id: paymentScheduleId, status: { not: "Paid" } },
+        data: {
+            status: "Paid",
+            paymentMethod: "quickbooks",
+            paidAt: payment.paidAt,
+            paymentDate: payment.paidAt,
+            referenceNumber: payment.referenceNumber,
+            qbPaymentId: payment.qbPaymentId,
+            qbSyncedAt: new Date(),
+        },
+    });
+    if (claim.count === 0) return false;
+
+    const invoice = await t.invoice.findUnique({ where: { id: invoiceId } });
+    if (!invoice) return false;
+    const allSchedules = await t.paymentSchedule.findMany({ where: { invoiceId } });
+    const totalPaid = allSchedules
+        .filter(s => s.status === "Paid")
+        .reduce((sum, s) => sum + toNum(s.amount), 0);
+    const newBalance = Math.max(0, toNum(invoice.totalAmount) - totalPaid);
+    await t.invoice.update({
+        where: { id: invoiceId },
+        data: {
+            balanceDue: newBalance,
+            status: newBalance <= 0 ? "Paid" : totalPaid > 0 ? "Partially Paid" : invoice.status,
+        },
+    });
+
+    // Mirror the settle onto the estimate-side milestone copy so the
+    // estimate editor/balance track the QuickBooks rail too (link-first,
+    // name+amount fallback for pre-link rows; claimed update).
+    if (invoice.estimateId) {
+        const settled = allSchedules.find(s => s.id === paymentScheduleId);
+        let estCopy: { id: string } | null = null;
+        if (settled?.sourceScheduleId) {
+            estCopy = await t.estimatePaymentSchedule.findFirst({
+                where: { id: settled.sourceScheduleId, estimateId: invoice.estimateId, status: { not: "Paid" } },
+            });
+        } else if (settled) {
+            // Fallback for pre-link rows: only safe when exactly one candidate matches.
+            const candidates = await t.estimatePaymentSchedule.findMany({
+                where: { estimateId: invoice.estimateId, status: { not: "Paid" }, name: settled.name },
+                take: 2,
+            });
+            const matching = candidates.filter(c => toNum(c.amount) === toNum(settled.amount));
+            estCopy = matching.length === 1 ? matching[0] : null;
+        }
+        if (estCopy && settled) {
+            const mirrorClaim = await t.estimatePaymentSchedule.updateMany({
+                where: { id: estCopy.id, status: { not: "Paid" } },
+                data: {
+                    status: "Paid",
+                    paymentMethod: "quickbooks",
+                    paidAt: payment.paidAt,
+                    paymentDate: payment.paidAt,
+                    referenceNumber: payment.referenceNumber,
+                },
+            });
+            if (mirrorClaim.count > 0) {
+                const estimate = await t.estimate.findUnique({ where: { id: invoice.estimateId } });
+                if (estimate) {
+                    const estSiblings = await t.estimatePaymentSchedule.findMany({ where: { estimateId: invoice.estimateId } });
+                    const estPaid = estSiblings.filter(s => s.status === "Paid").reduce((sum, s) => sum + toNum(s.amount), 0);
+                    const estBalance = Math.max(0, toNum(estimate.totalAmount) - estPaid);
+                    const estFirstPayment = !["Paid", "Partially Paid"].includes(estimate.status);
+                    await t.estimate.update({
+                        where: { id: invoice.estimateId },
+                        data: {
+                            balanceDue: estBalance,
+                            status: estBalance <= 0 ? "Paid" : estPaid > 0 ? "Partially Paid" : estimate.status,
+                            ...(estFirstPayment && { statusBeforePayment: estimate.status }),
+                        },
+                    });
+                }
+            }
+        }
+    }
+    return true;
+}
+
+/**
  * Mark a milestone Paid from a QuickBooks settlement. Mirrors the Stripe
  * webhook's claim-then-recalculate transaction so balances never drift.
  */
@@ -249,89 +358,9 @@ async function markMilestonePaidFromQB(
         const invLink = await t.invoice.findUnique({ where: { id: invoiceId }, select: { estimateId: true } });
         await lockMoneyParents(t, { estimateId: invLink?.estimateId, invoiceId });
 
-        // INVARIANT: do NOT pin qbInvoiceId in this claim. A real QBO settlement must
-        // win over a concurrent breakQBInvoiceLink (which nulls qbInvoiceId): pinning it
-        // would drop a genuinely-received payment (the row would be excluded from the next
-        // sync's `pending` query forever → client could be double-billed). The settle
-        // wins; qbPaymentId below preserves the QBO audit link even if the id was cleared.
-        const claim = await t.paymentSchedule.updateMany({
-            where: { id: paymentScheduleId, status: { not: "Paid" } },
-            data: {
-                status: "Paid",
-                paymentMethod: "quickbooks",
-                paidAt: payment.paidAt,
-                paymentDate: payment.paidAt,
-                referenceNumber: payment.referenceNumber,
-                qbPaymentId: payment.qbPaymentId,
-                qbSyncedAt: new Date(),
-            },
-        });
-        if (claim.count === 0) return false;
+        const claimed = await settleMilestonePaidInTx(t, paymentScheduleId, invoiceId, payment);
+        if (!claimed) return false;
 
-        const invoice = await t.invoice.findUnique({ where: { id: invoiceId } });
-        if (!invoice) return false;
-        const allSchedules = await t.paymentSchedule.findMany({ where: { invoiceId } });
-        const totalPaid = allSchedules
-            .filter(s => s.status === "Paid")
-            .reduce((sum, s) => sum + toNum(s.amount), 0);
-        const newBalance = Math.max(0, toNum(invoice.totalAmount) - totalPaid);
-        await t.invoice.update({
-            where: { id: invoiceId },
-            data: {
-                balanceDue: newBalance,
-                status: newBalance <= 0 ? "Paid" : totalPaid > 0 ? "Partially Paid" : invoice.status,
-            },
-        });
-
-        // Mirror the settle onto the estimate-side milestone copy so the
-        // estimate editor/balance track the QuickBooks rail too (link-first,
-        // name+amount fallback for pre-link rows; claimed update).
-        if (invoice.estimateId) {
-            const settled = allSchedules.find(s => s.id === paymentScheduleId);
-            let estCopy: { id: string } | null = null;
-            if (settled?.sourceScheduleId) {
-                estCopy = await t.estimatePaymentSchedule.findFirst({
-                    where: { id: settled.sourceScheduleId, estimateId: invoice.estimateId, status: { not: "Paid" } },
-                });
-            } else if (settled) {
-                // Fallback for pre-link rows: only safe when exactly one candidate matches.
-                const candidates = await t.estimatePaymentSchedule.findMany({
-                    where: { estimateId: invoice.estimateId, status: { not: "Paid" }, name: settled.name },
-                    take: 2,
-                });
-                const matching = candidates.filter(c => toNum(c.amount) === toNum(settled.amount));
-                estCopy = matching.length === 1 ? matching[0] : null;
-            }
-            if (estCopy && settled) {
-                const mirrorClaim = await t.estimatePaymentSchedule.updateMany({
-                    where: { id: estCopy.id, status: { not: "Paid" } },
-                    data: {
-                        status: "Paid",
-                        paymentMethod: "quickbooks",
-                        paidAt: payment.paidAt,
-                        paymentDate: payment.paidAt,
-                        referenceNumber: payment.referenceNumber,
-                    },
-                });
-                if (mirrorClaim.count > 0) {
-                    const estimate = await t.estimate.findUnique({ where: { id: invoice.estimateId } });
-                    if (estimate) {
-                        const estSiblings = await t.estimatePaymentSchedule.findMany({ where: { estimateId: invoice.estimateId } });
-                        const estPaid = estSiblings.filter(s => s.status === "Paid").reduce((sum, s) => sum + toNum(s.amount), 0);
-                        const estBalance = Math.max(0, toNum(estimate.totalAmount) - estPaid);
-                        const estFirstPayment = !["Paid", "Partially Paid"].includes(estimate.status);
-                        await t.estimate.update({
-                            where: { id: invoice.estimateId },
-                            data: {
-                                balanceDue: estBalance,
-                                status: estBalance <= 0 ? "Paid" : estPaid > 0 ? "Partially Paid" : estimate.status,
-                                ...(estFirstPayment && { statusBeforePayment: estimate.status }),
-                            },
-                        });
-                    }
-                }
-            }
-        }
         // Durable notification, enqueued in-tx (delivered by the drainer after commit).
         await enqueueMilestonePaid(t, { scheduleId: paymentScheduleId, scheduleType: "invoice" });
         return true;
@@ -479,6 +508,10 @@ export interface QBPaymentSyncResult {
     settled: number;
     partiallyPaid: number;
     errors: string[];
+    // Progress billings (src/lib/progress-billing.ts) settled this run — a
+    // separate counter from `settled` (which counts individual milestones)
+    // since one progress billing can carry several milestone lines.
+    progressBillingsSettled: number;
 }
 
 /**
@@ -486,7 +519,7 @@ export interface QBPaymentSyncResult {
  * Safe to run repeatedly (cron + on-view). Never throws on a single bad row.
  */
 export async function syncQuickBooksPayments(scope?: { invoiceId?: string; projectId?: string }): Promise<QBPaymentSyncResult> {
-    const result: QBPaymentSyncResult = { checked: 0, settled: 0, partiallyPaid: 0, errors: [] };
+    const result: QBPaymentSyncResult = { checked: 0, settled: 0, partiallyPaid: 0, errors: [], progressBillingsSettled: 0 };
 
     const pending = await prisma.paymentSchedule.findMany({
         where: {
@@ -501,7 +534,28 @@ export async function syncQuickBooksPayments(scope?: { invoiceId?: string; proje
         },
         take: 100,
     });
-    if (pending.length === 0) return result;
+
+    // Progress billings (src/lib/progress-billing.ts) staged/sent to QuickBooks
+    // — a second, independent pass over the same QBO connection. Milestones
+    // billed through a ProgressBilling are NOT in `pending` above (billing
+    // them there doesn't touch PaymentSchedule.qbInvoiceId), so this pass is
+    // the only place they get settled from a QuickBooks payment.
+    const pendingBillings = await prisma.progressBilling.findMany({
+        where: {
+            qbInvoiceId: { not: null },
+            status: { in: ["Staged", "Sent"] },
+            ...(scope?.invoiceId ? { invoiceId: scope.invoiceId } : {}),
+            ...(scope?.projectId ? { invoice: { projectId: scope.projectId } } : {}),
+        },
+        select: {
+            id: true, invoiceId: true, qbInvoiceId: true, code: true,
+            lines: { select: { scheduleId: true } },
+            invoice: { select: { code: true, estimateId: true } },
+        },
+        take: 100,
+    });
+
+    if (pending.length === 0 && pendingBillings.length === 0) return result;
 
     let tokens: QBTokens;
     try {
@@ -583,6 +637,61 @@ export async function syncQuickBooksPayments(scope?: { invoiceId?: string; proje
             }
         } catch (e) {
             result.errors.push(`${schedule.invoice.code}/${schedule.name}: ${e instanceof Error ? e.message : "sync failed"}`);
+        }
+    }
+
+    // ── Progress billings ───────────────────────────────────────────────────
+    // Same probe → settle shape as the milestone loop above, but claims ONE
+    // ProgressBilling row and then settles every milestone line it carries
+    // (custom/change-order lines have no scheduleId and are skipped — there is
+    // no milestone to mark Paid for them) under a single lock+transaction, since
+    // every line of a billing is scoped to the same invoice (createProgressBillingCore
+    // enforces this at build time).
+    for (const billing of pendingBillings) {
+        try {
+            const probe = await probeQBInvoice(tokens, billing.qbInvoiceId!);
+            if (probe.state === "error") continue; // transient — retry next run
+            if (probe.state === "voided" || probe.state === "notFound") {
+                result.errors.push(`${billing.invoice.code}/${billing.code}: QBO invoice ${probe.state}`);
+                continue;
+            }
+            // probe.state === "ok"
+            if (probe.total > 0 && probe.balance <= 0) {
+                const paymentId = probe.paymentTxnIds[0] || null;
+                let paidAt = new Date();
+                let referenceNumber: string | null = null;
+                if (paymentId) {
+                    const p = await getQBPayment(tokens, paymentId);
+                    if (p?.txnDate) paidAt = new Date(`${p.txnDate}T12:00:00`);
+                    referenceNumber = p?.referenceNumber || null;
+                }
+                const settled = await withTxRetry(() => prisma.$transaction(async (t) => {
+                    // Canonical lock order: Estimate → Invoice → schedules. Every line of
+                    // this billing shares the same invoiceId, so one lock covers them all.
+                    await lockMoneyParents(t, { estimateId: billing.invoice.estimateId, invoiceId: billing.invoiceId });
+
+                    const claim = await t.progressBilling.updateMany({
+                        where: { id: billing.id, status: { in: ["Staged", "Sent"] }, qbPaymentId: null },
+                        data: { status: "Paid", paidAt, qbPaymentId: paymentId, qbSyncedAt: new Date() },
+                    });
+                    if (claim.count === 0) return false;
+
+                    for (const line of billing.lines) {
+                        if (!line.scheduleId) continue; // custom / change-order line — no milestone to settle
+                        await settleMilestonePaidInTx(t, line.scheduleId, billing.invoiceId, { paidAt, referenceNumber, qbPaymentId: paymentId });
+                    }
+                    // TODO(progress-billing): route paid-billing notifications through
+                    // notifyMilestonePaid in the UI pass — deliberately not enqueued here
+                    // (this pass ships no customer notifications, per the owner's hard
+                    // constraint; see PROGRESS_BILLING_REPORT.md).
+                    return true;
+                }));
+                if (settled) result.progressBillingsSettled++;
+            } else if (probe.balance < probe.total) {
+                result.partiallyPaid++;
+            }
+        } catch (e) {
+            result.errors.push(`${billing.invoice.code}/${billing.code}: ${e instanceof Error ? e.message : "sync failed"}`);
         }
     }
 


### PR DESCRIPTION
Phase 2a of the progressive-billing rework. **Core only — no UI in this PR**, so the money path can be reviewed before anything is built on it.

## What this adds
- **Schema (additive only):** `ProgressBilling` + `ProgressBillingLine`, and one column `Estimate.taxInclusiveMilestones` (default true = every job priced to date). Nothing dropped or rewritten. `scripts/apply-progress-billing-schema.mjs` is idempotent and **has not been run against prod**.
- **`src/lib/progress-billing.ts`:** build a billing from milestones / approved COs / custom lines with one client-facing description; tax computed in either direction (enter pre-tax → tax on top, or enter the target total → tax backed out so the invoice totals the check exactly); draft-only edit/delete; stage exactly one QuickBooks invoice with a conditional link claim + compensating delete.
- **Auto-split:** billing part of a milestone reduces the original and creates a `(remaining)` row, mirrored on the estimate side. **No row is ever deleted**, and the two pieces always sum to the original so invoice totals never move.
- **Settle path:** a second loop in `syncQuickBooksPayments` settles paid billings and their member milestones. The existing per-milestone loop is untouched — in-flight jobs (Mesplay/Berg/Hoppe) keep riding it.

## Deliberately not included
**No customer notifications.** The settle path records the money but enqueues nothing, with a marked TODO to route paid-billing receipts through the existing single writer (`notifyMilestonePaid`) in the UI pass. This is at the owner's explicit instruction while the feature is being built.

## Review focus
`81ca2aa` fixes the one defect found in self-review: milestones are now carved in **their own tax units** (gross for legacy tax-inclusive jobs, pre-tax for new ones), validated over-billing against the same units, with regression tests using the live Mesplay figures ($25,000 against $39,998.25 leaves $14,998.25).

Tests could not be executed locally (no Docker daemon on the dev machine) — CI is their first real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)