### PR TITLE
feat(schedule): evidence layer — show what field reality actually confirms

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1042,15 +1042,16 @@ model TaskCommentPhoto {
 }
 
 model TaskPunchItem {
-  id        String       @id @default(cuid())
-  taskId    String
-  task      ScheduleTask @relation(fields: [taskId], references: [id], onDelete: Cascade)
-  name      String
-  completed Boolean      @default(false)
-  assignee  String?
-  photoUrl  String?
-  order     Int          @default(0)
-  createdAt DateTime     @default(now())
+  id          String       @id @default(cuid())
+  taskId      String
+  task        ScheduleTask @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  name        String
+  completed   Boolean      @default(false)
+  completedAt DateTime?
+  assignee    String?
+  photoUrl    String?
+  order       Int          @default(0)
+  createdAt   DateTime     @default(now())
 }
 
 model TaskAssignment {

--- a/scripts/apply-task-evidence-schema.mjs
+++ b/scripts/apply-task-evidence-schema.mjs
@@ -1,0 +1,52 @@
+// One-off additive migration for punch-item completion evidence.
+// Adds TaskPunchItem.completedAt so a punch-item completion can be used as
+// dated evidence. Safe to re-run while the old build is live.
+//
+// Run only through the release orchestrator:
+//   node scripts/apply-task-evidence-schema.mjs
+//
+// Do not run this during implementation handoff. The new Prisma client selects
+// TaskPunchItem.completedAt immediately, so the schema must be applied before deploy.
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+function resolveDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const file of [".env", ".env.local"]) {
+    if (!fs.existsSync(file)) continue;
+    const match = fs.readFileSync(file, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+    if (match) return match[1];
+  }
+  throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const prisma = new PrismaClient({
+  datasources: { db: { url: resolveDatabaseUrl() } },
+});
+
+const statements = [
+  // Backfill nothing: existing completed items keep a NULL completedAt. We do not know
+  // when they were actually completed, and inventing a date would fabricate evidence.
+  `ALTER TABLE "TaskPunchItem"
+     ADD COLUMN IF NOT EXISTS "completedAt" TIMESTAMP(3)`,
+  // RLS is table-level, so the new column needs no policy of its own — but no
+  // migration in this repo ever enabled RLS on TaskPunchItem, unlike the
+  // comparable server-only TaskMaterial (apply-task-materials-schema.mjs).
+  // Enabling it is idempotent and closes that gap. All access is server-side
+  // through Prisma with the service role, which bypasses RLS, so no policy is
+  // required for the app to keep working.
+  `ALTER TABLE "TaskPunchItem" ENABLE ROW LEVEL SECURITY`,
+];
+
+try {
+  for (const sql of statements) {
+    await prisma.$executeRawUnsafe(sql);
+    console.log("✔ applied:", sql.split("\n")[0]);
+  }
+  console.log("Done.");
+} catch (error) {
+  console.error("Migration failed:", error);
+  process.exitCode = 1;
+} finally {
+  await prisma.$disconnect();
+}

--- a/scripts/backfill-punch-task-binding.mjs
+++ b/scripts/backfill-punch-task-binding.mjs
@@ -1,0 +1,254 @@
+// Report-only audit of existing TimeEntry rows that have no scheduleTaskId.
+//
+// ============================================================================
+// READ-ONLY REPORT — this script NEVER writes to the database.
+//
+// It calls only findMany()/groupBy() queries below. No Prisma mutation method
+// (create/update/updateMany/upsert/delete/deleteMany/$executeRaw*) is imported
+// or invoked anywhere in this file. Do not add one.
+// ============================================================================
+//
+// Context: src/lib/punch-task-binding.ts is the canonical resolver every new
+// TimeEntry write path now calls. This script looks backward at rows that
+// predate that resolver (or that it left unresolved) and classifies them:
+//
+//   write-eligible   — the punch's estimateItemId matches exactly one
+//                       ScheduleTask.estimateItemId in the same project.
+//                       This is the ONLY class that would ever be safe to
+//                       write, because estimateItemId is a stable 1:1
+//                       mapping (ScheduleTask.estimateItemId is @unique) that
+//                       doesn't change when crew or dates move.
+//
+//   unsafe/report-only — resolvable only via CURRENT crew assignments
+//                       (TaskAssignment) on the punch's local calendar day.
+//                       TaskAssignment has no validity interval and task
+//                       dates are mutable, so replaying today's assignments
+//                       over historical punches fabricates attribution — the
+//                       crew member assigned to a task today may not be who
+//                       was assigned when the punch was made, and the task's
+//                       dates may since have moved off the punch's day
+//                       entirely. Writing this backfill would also
+//                       immediately change the task-hours roll-up shown in
+//                       the task drawer, silently rewriting history. This
+//                       script only counts and reports these; it never binds
+//                       them.
+//
+//   unresolvable      — no candidate at all (no estimateItemId match, and
+//                       either zero or more than one crew-assignment
+//                       candidate on the punch's day).
+//
+// Usage:
+//   node scripts/backfill-punch-task-binding.mjs
+//   node scripts/backfill-punch-task-binding.mjs --limit 500
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+function resolveDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const file of [".env", ".env.local"]) {
+    if (!fs.existsSync(file)) continue;
+    const match = fs.readFileSync(file, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+    if (match) return match[1];
+  }
+  throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+function parseLimit(argv) {
+  const flagIndex = argv.indexOf("--limit");
+  if (flagIndex === -1) return undefined;
+  const raw = argv[flagIndex + 1];
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`--limit requires a positive integer, got: ${raw ?? "(none)"}`);
+  }
+  return value;
+}
+
+const DATABASE_URL = resolveDatabaseUrl();
+const LIMIT = parseLimit(process.argv.slice(2));
+
+const prisma = new PrismaClient({
+  datasources: { db: { url: DATABASE_URL } },
+});
+
+// Mirrors src/lib/punch-task-binding.ts's toLocalDayKey. Kept as a local copy
+// (rather than importing the TS module) because this script runs under plain
+// `node`, matching the other standalone scripts/*.mjs in this repo. Keep this
+// in sync with punch-task-binding.ts if that logic ever changes.
+const LA_DAY_KEY = new Intl.DateTimeFormat("en-CA", {
+  timeZone: "America/Los_Angeles",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+function toLocalDayKey(instant) {
+  return LA_DAY_KEY.format(instant);
+}
+
+// Mirrors isTaskActiveOnDay in
+// src/app/company-dashboard/schedule-board/dispatch-exceptions.ts.
+function isTaskActiveOnDay(task, dayKey) {
+  const startKey = task.startDate.toISOString().slice(0, 10);
+  if (task.type === "milestone" || task.type === "appointment") return startKey === dayKey;
+  const endKey = task.endDate.toISOString().slice(0, 10);
+  return startKey <= dayKey && dayKey < endKey;
+}
+
+// Same conservative rule as resolveScheduleTaskForPunch's step 2: exactly one
+// active, assigned, non-complete leaf task on the punch's local day.
+function findSoleAssignedCandidate(scheduleTasks, parentIds, userId, dayKey) {
+  const candidates = scheduleTasks.filter(task =>
+    task.type === "task"
+    && task.status !== "Complete"
+    && !parentIds.has(task.id)
+    && task.assignments.some(a => a.userId === userId)
+    && isTaskActiveOnDay(task, dayKey));
+  return candidates.length === 1 ? candidates[0] : null;
+}
+
+function emptyCounts() {
+  return { writeEligible: 0, unsafeReportOnly: 0, unresolvable: 0 };
+}
+
+async function main() {
+  console.log("================================================================");
+  console.log(" READ-ONLY REPORT — this script NEVER writes to the database.");
+  console.log(" It only reads TimeEntry / ScheduleTask / TaskAssignment rows and");
+  console.log(" prints a classification report. No mutation is performed.");
+  console.log("================================================================\n");
+
+  if (DATABASE_URL.includes("supabase.c")) {
+    console.log("[backfill-punch-task-binding] DATABASE_URL points at Supabase. Proceeding — this script is read-only, so it is safe against production.\n");
+  }
+
+  if (LIMIT !== undefined) {
+    console.log(`Row scan capped at --limit ${LIMIT}.\n`);
+  }
+
+  const unbound = await prisma.timeEntry.findMany({
+    where: { scheduleTaskId: null },
+    select: { id: true, userId: true, projectId: true, startTime: true, estimateItemId: true },
+    orderBy: { startTime: "asc" },
+    ...(LIMIT !== undefined ? { take: LIMIT } : {}),
+  });
+
+  console.log(`Scanned ${unbound.length} TimeEntry row(s) with scheduleTaskId IS NULL.\n`);
+
+  if (unbound.length === 0) {
+    console.log("Nothing to report.");
+    return;
+  }
+
+  const byProject = new Map();
+  for (const entry of unbound) {
+    if (!byProject.has(entry.projectId)) byProject.set(entry.projectId, []);
+    byProject.get(entry.projectId).push(entry);
+  }
+
+  const projectIds = [...byProject.keys()];
+  const projects = await prisma.project.findMany({
+    where: { id: { in: projectIds } },
+    select: { id: true, name: true },
+  });
+  const projectNameById = new Map(projects.map(p => [p.id, p.name]));
+
+  const overall = emptyCounts();
+  const rows = [];
+
+  for (const projectId of projectIds) {
+    const entries = byProject.get(projectId);
+    const scheduleTasks = await prisma.scheduleTask.findMany({
+      where: { projectId },
+      select: {
+        id: true,
+        parentId: true,
+        startDate: true,
+        endDate: true,
+        status: true,
+        type: true,
+        estimateItemId: true,
+        assignments: { select: { userId: true } },
+      },
+    });
+    const parentIds = new Set(scheduleTasks.map(t => t.parentId).filter(Boolean));
+    const taskByEstimateItemId = new Map(
+      scheduleTasks.filter(t => t.estimateItemId).map(t => [t.estimateItemId, t]),
+    );
+
+    const projectCounts = emptyCounts();
+
+    for (const entry of entries) {
+      if (entry.estimateItemId && taskByEstimateItemId.has(entry.estimateItemId)) {
+        projectCounts.writeEligible++;
+        continue;
+      }
+
+      const dayKey = toLocalDayKey(entry.startTime);
+      const candidate = findSoleAssignedCandidate(scheduleTasks, parentIds, entry.userId, dayKey);
+      if (candidate) {
+        projectCounts.unsafeReportOnly++;
+        continue;
+      }
+
+      projectCounts.unresolvable++;
+    }
+
+    overall.writeEligible += projectCounts.writeEligible;
+    overall.unsafeReportOnly += projectCounts.unsafeReportOnly;
+    overall.unresolvable += projectCounts.unresolvable;
+
+    rows.push({
+      projectId,
+      projectName: projectNameById.get(projectId) ?? "(unknown project)",
+      total: entries.length,
+      ...projectCounts,
+    });
+  }
+
+  console.log("Per project:");
+  console.log("-".repeat(96));
+  console.log(
+    [
+      "Project".padEnd(40),
+      "Total".padStart(7),
+      "WriteElig".padStart(11),
+      "UnsafeOnly".padStart(11),
+      "Unresolv".padStart(10),
+    ].join(" "),
+  );
+  console.log("-".repeat(96));
+  for (const row of rows) {
+    console.log(
+      [
+        `${row.projectName} (${row.projectId})`.slice(0, 40).padEnd(40),
+        String(row.total).padStart(7),
+        String(row.writeEligible).padStart(11),
+        String(row.unsafeReportOnly).padStart(11),
+        String(row.unresolvable).padStart(10),
+      ].join(" "),
+    );
+  }
+  console.log("-".repeat(96));
+  console.log(
+    [
+      "TOTAL".padEnd(40),
+      String(unbound.length).padStart(7),
+      String(overall.writeEligible).padStart(11),
+      String(overall.unsafeReportOnly).padStart(11),
+      String(overall.unresolvable).padStart(10),
+    ].join(" "),
+  );
+  console.log();
+  console.log(`write-eligible:    ${overall.writeEligible} (safe to backfill via estimateItemId — a future script could write these)`);
+  console.log(`unsafe/report-only: ${overall.unsafeReportOnly} (resolvable only via today's crew assignments — never write these)`);
+  console.log(`unresolvable:      ${overall.unresolvable} (no candidate at all)`);
+}
+
+main()
+  .catch(error => {
+    console.error("Report failed:", error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/verify-task-evidence.ts
+++ b/scripts/verify-task-evidence.ts
@@ -1,0 +1,617 @@
+// Behavioral verification for the evidence layer (src/lib/task-evidence.ts)
+// and its DST-sensitive day-key helper (src/lib/punch-task-binding.ts).
+//
+// Everything under test here is a PURE function over in-memory fixtures.
+// This script must NEVER connect to a database — see BEHAVIORAL note below.
+//
+// Usage:
+//   npx tsx scripts/verify-task-evidence.ts
+import assert from "node:assert/strict";
+
+import { dayKeyFromDateOnly, toCompanyDayKey } from "../src/lib/company-day";
+import {
+    classifyTaskEvidence,
+    daysBetweenDayKeys,
+    findContradiction,
+    foldTaskEvidence,
+    isEvidenceEligible,
+    summarizeEvidenceCoverage,
+    sumEvidenceCoverage,
+    type EvidenceTaskInput,
+} from "../src/lib/task-evidence";
+import {
+    getDispatchExceptions,
+    getEvidenceExceptions,
+    type DispatchProjectInput,
+    type DispatchTaskInput,
+} from "../src/app/company-dashboard/schedule-board/dispatch-exceptions";
+
+// ── fixture helpers ──────────────────────────────────────────────────────
+
+// A wide default window so fixtures that only care about freshness (not
+// findContradiction's start/end boundary checks) never accidentally trip a
+// contradiction. Tests that specifically exercise findContradiction's
+// boundary rules pass their own narrow startDate/endDate explicitly.
+const WIDE_START = "2026-01-01T00:00:00.000Z";
+const WIDE_END = "2026-12-31T00:00:00.000Z";
+
+function task(overrides: Partial<EvidenceTaskInput> & { id: string }): EvidenceTaskInput {
+    return {
+        startDate: WIDE_START,
+        endDate: WIDE_END,
+        status: "In Progress",
+        type: "task",
+        parentId: null,
+        lastDirectEvidenceAt: null,
+        lastIndirectEvidenceAt: null,
+        ...overrides,
+    };
+}
+
+function dispatchTask(overrides: Partial<DispatchTaskInput> & { id: string }): DispatchTaskInput {
+    return {
+        name: overrides.id,
+        startDate: WIDE_START,
+        endDate: WIDE_END,
+        status: "In Progress",
+        type: "task",
+        blockedReason: null,
+        assignments: [],
+        parentId: null,
+        lastDirectEvidenceAt: null,
+        lastIndirectEvidenceAt: null,
+        ...overrides,
+    };
+}
+
+function project(overrides: Partial<DispatchProjectInput> & { id: string; tasks: DispatchTaskInput[] }): DispatchProjectInput {
+    return {
+        name: overrides.id,
+        status: "In Progress",
+        crew: [],
+        ...overrides,
+    };
+}
+
+const NO_PARENTS: ReadonlySet<string> = new Set();
+
+// ── toCompanyDayKey: DST is the highest-risk logic here ─────────────────
+
+{
+    // A 7pm PDT instant on 2026-07-27 is the *next* UTC calendar day.
+    assert.equal(
+        toCompanyDayKey(new Date("2026-07-28T02:00:00.000Z")),
+        "2026-07-27",
+        "a UTC instant that is the previous LA calendar day must map to the LA day, not the UTC day",
+    );
+
+    // Spring forward: America/Los_Angeles jumps 2:00am PST -> 3:00am PDT at
+    // 2026-03-08T10:00:00Z. The transition must not corrupt the day key on
+    // either side of it.
+    assert.equal(
+        toCompanyDayKey(new Date("2026-03-08T09:59:00.000Z")),
+        "2026-03-08",
+        "just before spring-forward (1:59am PST) must still be 2026-03-08",
+    );
+    assert.equal(
+        toCompanyDayKey(new Date("2026-03-08T10:01:00.000Z")),
+        "2026-03-08",
+        "just after spring-forward (3:01am PDT) must still be 2026-03-08",
+    );
+
+    // Fall back: America/Los_Angeles repeats 1:00am-2:00am at
+    // 2026-11-01T09:00:00Z (2:00am PDT -> 1:00am PST). The repeated hour must
+    // not push the day key backward or forward.
+    assert.equal(
+        toCompanyDayKey(new Date("2026-11-01T08:59:00.000Z")),
+        "2026-11-01",
+        "just before fall-back (1:59am PDT) must still be 2026-11-01",
+    );
+    assert.equal(
+        toCompanyDayKey(new Date("2026-11-01T09:01:00.000Z")),
+        "2026-11-01",
+        "just after fall-back (1:01am PST, repeated hour) must still be 2026-11-01",
+    );
+
+    // An ordinary midday UTC instant maps to the same calendar day.
+    assert.equal(
+        toCompanyDayKey(new Date("2026-07-15T18:00:00.000Z")),
+        "2026-07-15",
+        "a midday UTC instant (11am PDT) must map to the same calendar day",
+    );
+
+    // Invalid input must return "" rather than throw or produce "Invalid Date"-ish garbage.
+    assert.equal(
+        toCompanyDayKey(new Date("not-a-date")),
+        "",
+        "an invalid Date object must return empty string, not throw",
+    );
+    assert.equal(
+        toCompanyDayKey("not-a-date"),
+        "",
+        "an invalid date string must return empty string, not throw",
+    );
+
+    console.log("PASS toCompanyDayKey DST behavior");
+}
+
+// ── dayKeyFromDateOnly: manual-timesheet off-by-one regression guard ────
+
+{
+    // new Date("2026-07-27") is UTC midnight, which is 2026-07-26 in company
+    // time. dayKeyFromDateOnly must take the string verbatim instead of routing
+    // it through an instant conversion, or every manually-entered timesheet row
+    // silently shifts back one day.
+    assert.equal(
+        dayKeyFromDateOnly("2026-07-27"),
+        "2026-07-27",
+        "a date-only string must be returned verbatim, NOT shifted to 2026-07-26 by a UTC-midnight instant conversion",
+    );
+
+    console.log("PASS dayKeyFromDateOnly");
+}
+
+// ── daysBetweenDayKeys ───────────────────────────────────────────────────
+
+{
+    assert.equal(daysBetweenDayKeys("2026-07-27", "2026-07-27"), 0, "same day must be 0");
+    assert.equal(daysBetweenDayKeys("2026-07-27", "2026-07-28"), 1, "consecutive days must be 1");
+    assert.equal(
+        daysBetweenDayKeys("2026-03-07", "2026-03-09"),
+        2,
+        "date-only math across the spring-forward boundary must be immune to DST (still exactly 2 days)",
+    );
+    assert.equal(daysBetweenDayKeys("2026-03-09", "2026-03-07"), -2, "order matters — reversed args negate the delta");
+    assert.equal(daysBetweenDayKeys("not-a-date", "2026-07-27"), Infinity, "malformed 'from' must return Infinity, not NaN or throw");
+    assert.equal(daysBetweenDayKeys("2026-07-27", "not-a-date"), Infinity, "malformed 'to' must return Infinity, not NaN or throw");
+    assert.equal(daysBetweenDayKeys("", ""), Infinity, "empty input must return Infinity");
+
+    console.log("PASS daysBetweenDayKeys");
+}
+
+// ── isEvidenceEligible ───────────────────────────────────────────────────
+//
+// isEvidenceEligible now takes a third `dayKey` arg. Eligibility follows the
+// SCHEDULE (a half-open startDate <= dayKey < endDate window, matching
+// isTaskActiveOnDay), not the status field — a prod survey found all 307
+// schedule tasks sitting at "Not Started" (nobody advances task status), so
+// status-gated eligibility reported zero forever. Status now only excludes
+// Complete.
+
+{
+    const DAY = "2026-07-12"; // inside the WIDE fixture window
+
+    assert.equal(
+        isEvidenceEligible(task({ id: "t1", type: "milestone", status: "In Progress" }), NO_PARENTS, DAY),
+        false,
+        "milestones must be excluded regardless of status",
+    );
+    assert.equal(
+        isEvidenceEligible(task({ id: "t2", type: "appointment", status: "In Progress" }), NO_PARENTS, DAY),
+        false,
+        "appointments must be excluded regardless of status",
+    );
+    assert.equal(
+        isEvidenceEligible(task({ id: "t3", type: "task", status: "In Progress" }), new Set(["t3"]), DAY),
+        false,
+        "a task whose id is in parentIds (a phase parent) must be excluded",
+    );
+    assert.equal(
+        isEvidenceEligible(task({ id: "t4", type: "task", status: "Not Started" }), NO_PARENTS, DAY),
+        true,
+        "a Not Started leaf task inside its scheduled window IS eligible — status no longer gates beyond excluding Complete",
+    );
+    assert.equal(
+        isEvidenceEligible(task({ id: "t5", type: "task", status: "Complete" }), NO_PARENTS, DAY),
+        false,
+        "Complete leaf tasks are not eligible, regardless of the window",
+    );
+    assert.equal(
+        isEvidenceEligible(task({ id: "t6", type: "task", status: "In Progress" }), NO_PARENTS, DAY),
+        true,
+        "an In Progress leaf task inside its scheduled window must be eligible",
+    );
+    assert.equal(
+        isEvidenceEligible(task({ id: "t7", type: "task", status: "Blocked" }), NO_PARENTS, DAY),
+        true,
+        "a Blocked leaf task inside its scheduled window must be eligible",
+    );
+    assert.equal(
+        isEvidenceEligible(
+            task({
+                id: "t8",
+                type: "task",
+                status: "In Progress",
+                startDate: "2026-06-01T00:00:00.000Z",
+                endDate: "2026-07-01T00:00:00.000Z",
+            }),
+            NO_PARENTS,
+            DAY,
+        ),
+        false,
+        "a task whose window already closed before dayKey must be ineligible even while status still says In Progress",
+    );
+    assert.equal(
+        isEvidenceEligible(
+            task({
+                id: "t9",
+                type: "task",
+                status: "In Progress",
+                startDate: "2026-08-01T00:00:00.000Z",
+                endDate: "2026-09-01T00:00:00.000Z",
+            }),
+            NO_PARENTS,
+            DAY,
+        ),
+        false,
+        "a task whose window has not yet opened after dayKey must be ineligible even while status says In Progress",
+    );
+    assert.equal(
+        isEvidenceEligible(
+            task({ id: "t10", type: "task", status: "In Progress", startDate: DAY, endDate: "2026-07-13T00:00:00.000Z" }),
+            NO_PARENTS,
+            DAY,
+        ),
+        true,
+        "the window is half-open — dayKey equal to startDate is eligible",
+    );
+    assert.equal(
+        isEvidenceEligible(
+            task({ id: "t11", type: "task", status: "In Progress", startDate: "2026-07-11T00:00:00.000Z", endDate: DAY }),
+            NO_PARENTS,
+            DAY,
+        ),
+        false,
+        "the window is half-open — dayKey equal to endDate is NOT eligible (end-exclusive)",
+    );
+
+    console.log("PASS isEvidenceEligible");
+}
+
+// ── findContradiction ────────────────────────────────────────────────────
+
+{
+    assert.equal(
+        findContradiction(task({ id: "c1", lastDirectEvidenceAt: null })),
+        null,
+        "no direct evidence at all must never be a contradiction",
+    );
+
+    // The "Not Started" rule was deliberately removed: it is the resting state
+    // of nearly every prod task, so flagging it made the contradiction bucket
+    // meaningless. Evidence inside the window on a Not Started task must NOT
+    // be a contradiction.
+    assert.equal(
+        findContradiction(task({
+            id: "c2",
+            status: "Not Started",
+            lastDirectEvidenceAt: "2026-07-11T12:00:00.000Z",
+        })),
+        null,
+        "evidence inside the window on a Not Started task must NOT be flagged — the Not-Started rule was deliberately removed",
+    );
+
+    // Removing the status-specific rule doesn't blanket-exempt Not Started —
+    // the generic past-end-date rule still applies to any non-Complete status.
+    assert.match(
+        findContradiction(task({
+            id: "c2b",
+            status: "Not Started",
+            startDate: "2026-07-10T00:00:00.000Z",
+            endDate: "2026-07-15T00:00:00.000Z",
+            lastDirectEvidenceAt: "2026-07-16T09:00:00.000Z", // past the end day
+        })) ?? "",
+        /Still active past the scheduled end date/,
+        "a Not Started task with evidence past its end date must still be flagged via the generic rule",
+    );
+
+    assert.match(
+        findContradiction(task({
+            id: "c3",
+            status: "Complete",
+            startDate: "2026-07-10T00:00:00.000Z",
+            endDate: "2026-07-15T00:00:00.000Z",
+            lastDirectEvidenceAt: "2026-07-15T09:00:00.000Z", // on the end day itself
+        })) ?? "",
+        /Field activity after this was marked complete/,
+        "work at/after the end day on a Complete task must be flagged as logged-after-complete",
+    );
+
+    assert.match(
+        findContradiction(task({
+            id: "c4",
+            status: "In Progress",
+            startDate: "2026-07-10T00:00:00.000Z",
+            endDate: "2026-07-15T00:00:00.000Z",
+            lastDirectEvidenceAt: "2026-07-16T09:00:00.000Z", // past the end day
+        })) ?? "",
+        /Still active past the scheduled end date/,
+        "work past the scheduled end date on a non-Complete task must be flagged",
+    );
+
+    assert.match(
+        findContradiction(task({
+            id: "c5",
+            status: "In Progress",
+            startDate: "2026-07-10T00:00:00.000Z",
+            endDate: "2026-07-15T00:00:00.000Z",
+            lastDirectEvidenceAt: "2026-07-09T09:00:00.000Z", // before start day
+        })) ?? "",
+        /Field activity before the scheduled start date/,
+        "work before the scheduled start date must be flagged",
+    );
+
+    assert.equal(
+        findContradiction(task({
+            id: "c6",
+            status: "In Progress",
+            startDate: "2026-07-10T00:00:00.000Z",
+            endDate: "2026-07-15T00:00:00.000Z",
+            lastDirectEvidenceAt: "2026-07-12T09:00:00.000Z", // inside the window
+        })),
+        null,
+        "an ordinary in-window In Progress task must not be flagged",
+    );
+
+    console.log("PASS findContradiction");
+}
+
+// ── classifyTaskEvidence ─────────────────────────────────────────────────
+
+{
+    // Contradiction wins over everything, including ineligibility: a task
+    // whose window already closed before dayKey (ineligible under the
+    // date-gated rule) but whose evidence is dated past its end must still
+    // surface as needsReview, not silently disappear as notApplicable.
+    const closedWindowWithLateEvidence = task({
+        id: "cl1",
+        status: "In Progress",
+        startDate: "2026-06-01T00:00:00.000Z",
+        endDate: "2026-07-01T00:00:00.000Z",
+        lastDirectEvidenceAt: "2026-07-05T12:00:00.000Z",
+    });
+    assert.equal(
+        isEvidenceEligible(closedWindowWithLateEvidence, NO_PARENTS, "2026-07-12"),
+        false,
+        "sanity: a task whose window closed before dayKey is ineligible on its own",
+    );
+    assert.notEqual(
+        findContradiction(closedWindowWithLateEvidence),
+        null,
+        "sanity: evidence past the end date is a contradiction on its own",
+    );
+    assert.equal(
+        classifyTaskEvidence(closedWindowWithLateEvidence, NO_PARENTS, "2026-07-12"),
+        "needsReview",
+        "a task with a contradiction must classify needsReview even when the date window also makes it ineligible — contradiction wins",
+    );
+
+    assert.equal(
+        classifyTaskEvidence(task({ id: "cl2", status: "In Progress", lastDirectEvidenceAt: null }), NO_PARENTS, "2026-07-12"),
+        "unknown",
+        "eligible + no direct evidence must be unknown",
+    );
+
+    assert.equal(
+        classifyTaskEvidence(
+            task({ id: "cl3", status: "In Progress", lastDirectEvidenceAt: "2026-07-10T12:00:00.000Z" }),
+            NO_PARENTS,
+            "2026-07-12",
+            2,
+        ),
+        "confirmed",
+        "eligible + evidence exactly at the staleAfterDays boundary must be confirmed",
+    );
+
+    assert.equal(
+        classifyTaskEvidence(
+            task({ id: "cl4", status: "In Progress", lastDirectEvidenceAt: "2026-07-09T12:00:00.000Z" }),
+            NO_PARENTS,
+            "2026-07-12",
+            2,
+        ),
+        "stale",
+        "eligible + evidence one day older than the boundary must be stale",
+    );
+
+    assert.equal(
+        classifyTaskEvidence(task({ id: "cl5", type: "milestone", status: "In Progress" }), NO_PARENTS, "2026-07-12"),
+        "notApplicable",
+        "ineligible with no contradiction must be notApplicable",
+    );
+
+    // unknown and stale are mutually exclusive for the same task: flip the
+    // clock across the staleAfterDays boundary and confirm exactly one state
+    // ever applies, never both.
+    const borderline = task({ id: "cl6", status: "In Progress", lastDirectEvidenceAt: "2026-07-10T12:00:00.000Z" });
+    const justInside = classifyTaskEvidence(borderline, NO_PARENTS, "2026-07-12", 2);
+    const justOutside = classifyTaskEvidence(borderline, NO_PARENTS, "2026-07-13", 2);
+    assert.equal(justInside, "confirmed");
+    assert.equal(justOutside, "stale");
+    assert.notEqual(justInside, justOutside, "unknown and stale (here: confirmed and stale) must never coincide for the same task");
+
+    // Regression guard: a task ending 2026-07-28, with direct evidence at
+    // 2026-07-28T02:00:00.000Z (7pm PDT on the 27th — the last active day).
+    // Under the old UTC-slice logic, that timestamp sliced to "2026-07-28",
+    // which equals the end day and fired a false "still active past the
+    // scheduled end date" contradiction on perfectly legitimate evening work.
+    // toCompanyDayKey must resolve it to the 27th, so it classifies confirmed.
+    const eveningWork = task({
+        id: "cl7",
+        status: "In Progress",
+        startDate: "2026-07-20T00:00:00.000Z",
+        endDate: "2026-07-28T00:00:00.000Z",
+        lastDirectEvidenceAt: "2026-07-28T02:00:00.000Z",
+    });
+    assert.equal(findContradiction(eveningWork), null, "7pm PDT evidence on the last active day must not be a contradiction");
+    assert.equal(
+        classifyTaskEvidence(eveningWork, NO_PARENTS, "2026-07-27", 2),
+        "confirmed",
+        "evening work logged in company-local time on the last active day must classify confirmed, NOT needsReview",
+    );
+
+    // Future evidence: a timestamp dated after dayKey is a clock/data fault, not
+    // confirmation, and must never satisfy the freshness window.
+    const futureEvidence = task({
+        id: "cl8",
+        status: "In Progress",
+        lastDirectEvidenceAt: "2026-07-15T12:00:00.000Z",
+    });
+    assert.equal(
+        classifyTaskEvidence(futureEvidence, NO_PARENTS, "2026-07-10", 2),
+        "needsReview",
+        "evidence dated after dayKey (negative age) must classify needsReview, not confirmed",
+    );
+
+    console.log("PASS classifyTaskEvidence");
+}
+
+// ── foldTaskEvidence ─────────────────────────────────────────────────────
+
+{
+    const directMax = foldTaskEvidence({
+        lastTimeEntryAt: "2026-07-10T08:00:00.000Z",
+        lastPunchItemCompletedAt: "2026-07-11T08:00:00.000Z",
+    });
+    assert.equal(directMax.lastDirectEvidenceAt, new Date("2026-07-11T08:00:00.000Z").toISOString(), "direct must take the max of time-entry and punch-item timestamps");
+
+    const directMaxReversed = foldTaskEvidence({
+        lastTimeEntryAt: "2026-07-12T08:00:00.000Z",
+        lastPunchItemCompletedAt: "2026-07-11T08:00:00.000Z",
+    });
+    assert.equal(directMaxReversed.lastDirectEvidenceAt, new Date("2026-07-12T08:00:00.000Z").toISOString(), "direct max must work regardless of which input is newer");
+
+    const indirectMax = foldTaskEvidence({
+        lastCommentAt: "2026-07-10T08:00:00.000Z",
+        lastMaterialStatusAt: "2026-07-12T08:00:00.000Z",
+        lastProjectDailyLogAt: "2026-07-11T08:00:00.000Z",
+    });
+    assert.equal(indirectMax.lastIndirectEvidenceAt, new Date("2026-07-12T08:00:00.000Z").toISOString(), "indirect must take the max of comment/material/project-daily-log");
+
+    // The critical guard: a project daily log must NEVER land in the direct
+    // field, even when it is newer than everything else.
+    const dailyLogOnly = foldTaskEvidence({
+        lastProjectDailyLogAt: "2026-12-01T00:00:00.000Z",
+    });
+    assert.equal(dailyLogOnly.lastDirectEvidenceAt, null, "a project daily log must never land in the direct field");
+    assert.equal(dailyLogOnly.lastIndirectEvidenceAt, new Date("2026-12-01T00:00:00.000Z").toISOString());
+
+    const allNull = foldTaskEvidence({});
+    assert.equal(allNull.lastDirectEvidenceAt, null, "all-null input must yield null direct");
+    assert.equal(allNull.lastIndirectEvidenceAt, null, "all-null input must yield null indirect");
+
+    // Date and ISO-string inputs must be interchangeable.
+    const mixedInputTypes = foldTaskEvidence({
+        lastTimeEntryAt: new Date("2026-07-10T08:00:00.000Z"),
+        lastPunchItemCompletedAt: "2026-07-09T08:00:00.000Z",
+    });
+    assert.equal(mixedInputTypes.lastDirectEvidenceAt, new Date("2026-07-10T08:00:00.000Z").toISOString());
+
+    console.log("PASS foldTaskEvidence");
+}
+
+// ── summarizeEvidenceCoverage / sumEvidenceCoverage ─────────────────────
+
+{
+    const tasks: EvidenceTaskInput[] = [
+        task({ id: "s1", status: "In Progress", lastDirectEvidenceAt: "2026-07-11T12:00:00.000Z" }), // confirmed
+        task({ id: "s2", status: "In Progress", lastDirectEvidenceAt: "2026-07-01T12:00:00.000Z" }), // stale
+        task({ id: "s3", status: "In Progress", lastDirectEvidenceAt: null }), // unknown
+        task({ id: "s4", type: "milestone", status: "In Progress" }), // notApplicable
+        task({
+            id: "s5",
+            status: "In Progress",
+            startDate: "2026-06-01T00:00:00.000Z",
+            endDate: "2026-07-01T00:00:00.000Z",
+            lastDirectEvidenceAt: "2026-07-05T12:00:00.000Z",
+        }), // needsReview: window closed before dayKey (ineligible) AND evidence past its end (contradiction)
+    ];
+    const coverage = summarizeEvidenceCoverage(tasks, NO_PARENTS, "2026-07-12", { staleAfterDays: 2, unboundPunches: 3 });
+
+    assert.equal(coverage.confirmed, 1);
+    assert.equal(coverage.stale, 1);
+    assert.equal(coverage.unknown, 1);
+    assert.equal(coverage.needsReview, 1);
+    assert.ok(
+        coverage.confirmed + coverage.stale + coverage.unknown <= coverage.eligible,
+        "confirmed + stale + unknown must not exceed eligible",
+    );
+    assert.equal(coverage.eligible, 3, "s1/s2/s3 are eligible; s4 is not a leaf task; s5 is ineligible (its window already closed)");
+    assert.equal(
+        coverage.needsReview,
+        1,
+        "a needsReview task whose date window makes it ineligible (s5) must increment needsReview without inflating eligible",
+    );
+    assert.equal(coverage.unboundPunches, 3, "unboundPunches must pass through unchanged");
+
+    // sum over parts is componentwise
+    const partA = summarizeEvidenceCoverage(tasks.slice(0, 2), NO_PARENTS, "2026-07-12", { unboundPunches: 1 });
+    const partB = summarizeEvidenceCoverage(tasks.slice(2), NO_PARENTS, "2026-07-12", { unboundPunches: 2 });
+    const summed = sumEvidenceCoverage([partA, partB]);
+    assert.deepEqual(summed, coverage, "summing coverage over parts must equal summarizing the whole set at once");
+
+    console.log("PASS summarizeEvidenceCoverage / sumEvidenceCoverage");
+}
+
+// ── getEvidenceExceptions ─────────────────────────────────────────────────
+
+{
+    const inProgressProject = project({
+        id: "p1",
+        status: "In Progress",
+        tasks: [
+            dispatchTask({ id: "p1-unknown", status: "In Progress", lastDirectEvidenceAt: null }),
+            dispatchTask({ id: "p1-stale", status: "In Progress", lastDirectEvidenceAt: "2026-07-01T12:00:00.000Z" }),
+            dispatchTask({
+                id: "p1-review",
+                status: "In Progress",
+                endDate: "2026-07-05T00:00:00.000Z", // schedule says done by the 5th
+                lastDirectEvidenceAt: "2026-07-11T12:00:00.000Z", // but evidence lands after — contradiction
+            }),
+            dispatchTask({ id: "p1-confirmed", status: "In Progress", lastDirectEvidenceAt: "2026-07-11T12:00:00.000Z" }),
+        ],
+    });
+    const notStartedProject = project({
+        id: "p2",
+        status: "Waiting to Start",
+        tasks: [
+            dispatchTask({ id: "p2-unknown", status: "In Progress", lastDirectEvidenceAt: null }),
+        ],
+    });
+
+    const exceptions = getEvidenceExceptions([inProgressProject, notStartedProject], "2026-07-12");
+
+    // Only In Progress projects contribute.
+    assert.ok(
+        ![...exceptions.unknownState, ...exceptions.staleEvidence, ...exceptions.needsReview]
+            .some(item => item.projectId === "p2"),
+        "a non-In-Progress project must not contribute to any evidence exception group",
+    );
+
+    assert.deepEqual(exceptions.unknownState.map(item => item.taskId), ["p1-unknown"]);
+    assert.deepEqual(exceptions.staleEvidence.map(item => item.taskId), ["p1-stale"]);
+    assert.deepEqual(exceptions.needsReview.map(item => item.taskId), ["p1-review"]);
+
+    // The three groups are disjoint.
+    const allIds = [
+        ...exceptions.unknownState.map(item => item.taskId),
+        ...exceptions.staleEvidence.map(item => item.taskId),
+        ...exceptions.needsReview.map(item => item.taskId),
+    ];
+    assert.equal(new Set(allIds).size, allIds.length, "no task id may appear in two evidence exception groups");
+
+    // needsReview entries carry a non-null reason.
+    for (const entry of exceptions.needsReview) {
+        assert.ok(entry.reason, `needsReview entry for ${entry.taskId} must carry a non-null reason`);
+    }
+
+    // Sanity: getDispatchExceptions wires the evidence groups through unchanged.
+    const full = getDispatchExceptions([inProgressProject, notStartedProject], [], "2026-07-12");
+    assert.deepEqual(full.unknownState, exceptions.unknownState);
+    assert.deepEqual(full.staleEvidence, exceptions.staleEvidence);
+    assert.deepEqual(full.needsReview, exceptions.needsReview);
+
+    console.log("PASS getEvidenceExceptions");
+}
+
+console.log("task-evidence verification: PASS");

--- a/src/app/api/time-entries/[id]/route.ts
+++ b/src/app/api/time-entries/[id]/route.ts
@@ -3,6 +3,8 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { toNum } from "@/lib/prisma-helpers";
 import { authenticateMobileOrSession } from "@/lib/mobile-auth";
+import { resolveScheduleTaskIdForPunch } from "@/lib/punch-task-binding";
+import { toCompanyDayKey } from "@/lib/company-day";
 
 // Mobile + web hybrid. Two distinct flows, both routed through PATCH:
 //
@@ -153,6 +155,19 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
     if (isPrivileged && !isOwner) {
         data.editedByManagerId = user.id;
         data.editedAt = new Date();
+    }
+
+    // Re-resolve the schedule-task binding only when the edit moves the punch to a
+    // different local day — the board may have changed mid-shift, so we must not
+    // repick the day on every edit. Binding follows the entry's OWNER, not the
+    // editing manager (costs already follow the owner).
+    if (toCompanyDayKey(newStart) !== toCompanyDayKey(existing.startTime)) {
+        data.scheduleTaskId = await resolveScheduleTaskIdForPunch({
+            userId: existing.userId,
+            projectId: existing.projectId,
+            dayKey: toCompanyDayKey(newStart),
+            estimateItemId: existing.estimateItemId,
+        });
     }
 
     const updated = await prisma.timeEntry.update({ where: { id }, data });

--- a/src/app/api/time-entries/route.ts
+++ b/src/app/api/time-entries/route.ts
@@ -3,6 +3,8 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { toNum } from "@/lib/prisma-helpers";
 import { authenticateMobileOrSession, assertProjectAccess } from "@/lib/mobile-auth";
+import { resolveScheduleTaskIdForPunch } from "@/lib/punch-task-binding";
+import { toCompanyDayKey } from "@/lib/company-day";
 
 export async function GET(req: Request) {
     const auth = await authenticateMobileOrSession(req);
@@ -50,15 +52,24 @@ export async function POST(req: Request) {
     const fail = await assertProjectAccess(user, projectId);
     if (fail) return fail;
 
+    const entryStartTime = startTime ? new Date(startTime) : new Date();
+    const scheduleTaskId = await resolveScheduleTaskIdForPunch({
+        userId: user.id,
+        projectId,
+        dayKey: toCompanyDayKey(entryStartTime),
+        estimateItemId,
+    });
+
     const timeEntry = await prisma.timeEntry.create({
         data: {
             userId: user.id,
             projectId,
             costCodeId: costCodeId || null,
             estimateItemId: estimateItemId || null,
-            startTime: startTime ? new Date(startTime) : new Date(),
+            startTime: entryStartTime,
             latitude,
             longitude,
+            scheduleTaskId,
         }
     });
 

--- a/src/app/company-dashboard/schedule-board/DispatchExceptions.tsx
+++ b/src/app/company-dashboard/schedule-board/DispatchExceptions.tsx
@@ -3,6 +3,7 @@
 import { motion } from "framer-motion";
 import type { CrewConflict, DashboardProjectRow } from "@/lib/schedule-core";
 import { getDispatchExceptions } from "./dispatch-exceptions";
+import { summarizeEvidenceCoverage, sumEvidenceCoverage } from "@/lib/task-evidence";
 
 interface DispatchExceptionsProps {
     projects: DashboardProjectRow[];
@@ -55,7 +56,54 @@ export function DispatchExceptions({ projects, crewConflicts, dayKey, onActivate
             title: groups.crewless.map(item => item.projectName).join("\n"),
             activate: () => groups.crewless[0] && onProjectFocus(groups.crewless[0].projectId),
         },
+        {
+            key: "needs-review",
+            label: "Needs review",
+            count: groups.needsReview.length,
+            tone: "border-red-300 bg-red-50 text-red-700",
+            title: groups.needsReview.map(item => `${item.projectName}: ${item.taskName}${item.reason ? ` — ${item.reason}` : ""}`).join("\n"),
+            activate: () => groups.needsReview[0] && onActivate(groups.needsReview[0].taskId),
+        },
+        {
+            key: "unknown-state",
+            label: "No field update",
+            count: groups.unknownState.length,
+            tone: "border-slate-300 bg-slate-100 text-slate-700",
+            title: groups.unknownState.map(item => `${item.projectName}: ${item.taskName}`).join("\n"),
+            activate: () => groups.unknownState[0] && onActivate(groups.unknownState[0].taskId),
+        },
+        {
+            key: "stale-evidence",
+            label: "Going stale",
+            count: groups.staleEvidence.length,
+            tone: "border-amber-300 bg-amber-50 text-amber-800",
+            title: groups.staleEvidence.map(item => `${item.projectName}: ${item.taskName}`).join("\n"),
+            activate: () => groups.staleEvidence[0] && onActivate(groups.staleEvidence[0].taskId),
+        },
     ].filter(pill => pill.count > 0);
+
+    // Counts, deliberately not a single "% true" score: recent activity proves
+    // someone worked, not that dates/crew/status are right, so a percentage
+    // would read healthy while the schedule was wrong.
+    const coverage = sumEvidenceCoverage(projects
+        .filter(project => project.status === "In Progress")
+        .map(project => summarizeEvidenceCoverage(
+            project.tasks,
+            new Set(project.tasks.map(task => task.parentId).filter((id): id is string => !!id)),
+            dayKey,
+            { unboundPunches: project.unboundPunches },
+        )));
+    // Render whenever there is anything to say — not just when eligible > 0.
+    // Unbound punches with no eligible task is precisely the case where the
+    // board would otherwise claim "Day clear" while dropping evidence.
+    const showCoverage = coverage.eligible > 0 || coverage.unboundPunches > 0 || coverage.needsReview > 0;
+    const coverageParts = [
+        coverage.eligible > 0 ? `${coverage.confirmed} of ${coverage.eligible} active tasks confirmed` : null,
+        coverage.stale > 0 ? `${coverage.stale} going stale` : null,
+        coverage.unknown > 0 ? `${coverage.unknown} with no field update` : null,
+        coverage.needsReview > 0 ? `${coverage.needsReview} needs review` : null,
+        coverage.unboundPunches > 0 ? `${coverage.unboundPunches} unlinked punches` : null,
+    ].filter((part): part is string => !!part);
 
     return (
         <motion.div
@@ -84,6 +132,11 @@ export function DispatchExceptions({ projects, crewConflicts, dayKey, onActivate
                         </button>
                     ))}
                 </div>
+            )}
+            {showCoverage && (
+                <p className="mt-1.5 text-[11px] text-slate-500" aria-label="Evidence coverage">
+                    {coverageParts.join(" \u00b7 ")}
+                </p>
             )}
         </motion.div>
     );

--- a/src/app/company-dashboard/schedule-board/DispatchJobCard.tsx
+++ b/src/app/company-dashboard/schedule-board/DispatchJobCard.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
 import type { DashboardProjectRow, DashboardTaskRow } from "@/lib/schedule-core";
 import { getFallbackProjectColor } from "@/app/projects/[id]/schedule/schedule-utils";
+import { classifyTaskEvidence, findContradiction, type EvidenceState } from "@/lib/task-evidence";
 
 const STATUS_STYLES: Record<string, string> = {
     "Not Started": "bg-slate-100 text-slate-700",
@@ -16,9 +17,45 @@ function initials(name: string): string {
     return name.split(/\s+/).filter(Boolean).map(part => part[0]).join("").toUpperCase().slice(0, 2) || "?";
 }
 
+// Evidence badge sits beside the materials badge — per-task indicators belong on
+// the dispatch card, never on the calendar chips (board no-clutter contract, and
+// it keeps drag geometry untouched).
+function describeTaskEvidence(
+    task: DashboardTaskRow,
+    parentIds: ReadonlySet<string>,
+    dayKey: string,
+): { state: EvidenceState; label: string; tone: string; title: string } | null {
+    const input = {
+        id: task.id,
+        startDate: task.startDate,
+        endDate: task.endDate,
+        status: task.status,
+        type: task.type,
+        parentId: task.parentId,
+        lastDirectEvidenceAt: task.lastDirectEvidenceAt,
+        lastIndirectEvidenceAt: task.lastIndirectEvidenceAt,
+    };
+    const state = classifyTaskEvidence(input, parentIds, dayKey);
+    const seenOn = task.lastDirectEvidenceAt?.slice(0, 10);
+    switch (state) {
+        case "confirmed":
+            return { state, label: "✓ confirmed", tone: "bg-green-100 text-green-700", title: `Field activity on ${seenOn}` };
+        case "stale":
+            return { state, label: "going stale", tone: "bg-amber-100 text-amber-800", title: `Last field activity ${seenOn}` };
+        case "unknown":
+            return { state, label: "no field update", tone: "bg-slate-100 text-slate-600", title: "No hours or punch-item activity has landed on this task" };
+        case "needsReview":
+            return { state, label: "needs review", tone: "bg-red-100 text-red-700", title: findContradiction(input) ?? "Evidence disagrees with the board" };
+        default:
+            return null;
+    }
+}
+
 interface DispatchJobCardProps {
     project: DashboardProjectRow;
     tasks: DashboardTaskRow[];
+    /** Local day the dispatch view is showing; drives evidence freshness. */
+    dayKey: string;
     highlighted: boolean;
     canCreate: boolean;
     crewDrafts: Readonly<Record<string, { addUserIds: string[]; removeUserIds: string[] }>>;
@@ -32,6 +69,7 @@ interface DispatchJobCardProps {
 export function DispatchJobCard({
     project,
     tasks,
+    dayKey,
     highlighted,
     canCreate,
     crewDrafts,
@@ -42,6 +80,9 @@ export function DispatchJobCard({
     onDraftCrewRemove,
 }: DispatchJobCardProps) {
     const projectColor = project.color || getFallbackProjectColor(project.id);
+    // Parents come from the FULL project task list, not today's filtered subset —
+    // a phase parent whose children are elsewhere in the week must still be excluded.
+    const taskParentIds = new Set(project.tasks.map(task => task.parentId).filter((id): id is string => !!id));
 
     return (
         <article
@@ -82,6 +123,7 @@ export function DispatchJobCard({
                             : task.pendingMaterials > 0
                                 ? "bg-amber-100 text-amber-800"
                                 : "bg-green-100 text-green-700";
+                        const evidenceBadge = describeTaskEvidence(task, taskParentIds, dayKey);
                         return (
                             <section key={task.id} data-dispatch-task-id={task.id} className="px-4 py-3">
                                 <div className="flex flex-wrap items-start justify-between gap-2">
@@ -100,6 +142,15 @@ export function DispatchJobCard({
                                                     title={`${task.stagedMaterials} staged, ${task.pendingMaterials} pending, ${task.missingMaterials} missing`}
                                                 >
                                                     {"\u{1F4E6}"} {materialCount} {"\u00B7"} {task.missingMaterials} missing
+                                                </span>
+                                            )}
+                                            {evidenceBadge && (
+                                                <span
+                                                    data-evidence-state={evidenceBadge.state}
+                                                    className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${evidenceBadge.tone}`}
+                                                    title={evidenceBadge.title}
+                                                >
+                                                    {evidenceBadge.label}
                                                 </span>
                                             )}
                                         </div>

--- a/src/app/company-dashboard/schedule-board/DispatchView.tsx
+++ b/src/app/company-dashboard/schedule-board/DispatchView.tsx
@@ -456,6 +456,7 @@ export function DispatchView({
                                     key={project.id}
                                     project={project}
                                     tasks={activeTodayByProject.get(project.id) ?? []}
+                                    dayKey={todayKey}
                                     highlighted={highlightedProjectId === project.id}
                                     canCreate={data.canEdit}
                                     crewDrafts={crewDrafts}

--- a/src/app/company-dashboard/schedule-board/dispatch-exceptions.ts
+++ b/src/app/company-dashboard/schedule-board/dispatch-exceptions.ts
@@ -1,4 +1,5 @@
 import { isConflictedDay } from "./availability";
+import { classifyTaskEvidence, findContradiction, type EvidenceTaskInput } from "@/lib/task-evidence";
 
 export interface DispatchAssignmentInput {
     userId: string;
@@ -17,6 +18,11 @@ export interface DispatchTaskInput {
     type: string;
     blockedReason: string | null;
     assignments: DispatchAssignmentInput[];
+    // Evidence freshness. Optional so existing fixtures/callers keep compiling;
+    // absent is treated the same as "no direct evidence".
+    parentId?: string | null;
+    lastDirectEvidenceAt?: string | null;
+    lastIndirectEvidenceAt?: string | null;
 }
 
 export interface DispatchCrewInput {
@@ -74,6 +80,11 @@ export interface DispatchExceptionGroups {
     conflicts: DispatchConflictException[];
     blocked: DispatchTaskException[];
     crewless: DispatchProjectException[];
+    // Evidence gaps: the board says work is underway but nothing confirms it.
+    unknownState: DispatchTaskException[];
+    staleEvidence: DispatchTaskException[];
+    // Evidence contradicts the board — reason carries the specific mismatch.
+    needsReview: DispatchTaskException[];
 }
 
 export function isTaskActiveOnDay(task: Pick<DispatchTaskInput, "startDate" | "endDate" | "type">, dayKey: string): boolean {
@@ -134,10 +145,64 @@ export function getCrewlessJobs(projects: readonly DispatchProjectInput[], dayKe
         .map(project => ({ projectId: project.id, projectName: project.name }));
 }
 
+function evidenceTask(task: DispatchTaskInput): EvidenceTaskInput {
+    return {
+        id: task.id,
+        startDate: task.startDate,
+        endDate: task.endDate,
+        status: task.status,
+        type: task.type,
+        parentId: task.parentId ?? null,
+        lastDirectEvidenceAt: task.lastDirectEvidenceAt ?? null,
+        lastIndirectEvidenceAt: task.lastIndirectEvidenceAt ?? null,
+    };
+}
+
+function projectParentIds(project: DispatchProjectInput): Set<string> {
+    return new Set(project.tasks.map(task => task.parentId).filter((id): id is string => !!id));
+}
+
+/**
+ * Evidence-based exceptions, in one pass so the three groups stay mutually
+ * exclusive — a task with no evidence ever is `unknown`, never also `stale`.
+ */
+export function getEvidenceExceptions(
+    projects: readonly DispatchProjectInput[],
+    dayKey: string,
+    staleAfterDays = 2,
+): Pick<DispatchExceptionGroups, "unknownState" | "staleEvidence" | "needsReview"> {
+    const unknownState: DispatchTaskException[] = [];
+    const staleEvidence: DispatchTaskException[] = [];
+    const needsReview: DispatchTaskException[] = [];
+
+    for (const project of projects) {
+        if (project.status !== "In Progress") continue;
+        const parentIds = projectParentIds(project);
+        for (const task of project.tasks) {
+            const input = evidenceTask(task);
+            switch (classifyTaskEvidence(input, parentIds, dayKey, staleAfterDays)) {
+                case "unknown":
+                    unknownState.push(taskException(project, task));
+                    break;
+                case "stale":
+                    staleEvidence.push(taskException(project, task));
+                    break;
+                case "needsReview":
+                    needsReview.push({ ...taskException(project, task), reason: findContradiction(input) });
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+    return { unknownState, staleEvidence, needsReview };
+}
+
 export function getDispatchExceptions(
     projects: readonly DispatchProjectInput[],
     conflicts: readonly DispatchCrewConflictInput[],
     dayKey: string,
+    staleAfterDays = 2,
 ): DispatchExceptionGroups {
     return {
         unstaffed: getUnstaffedToday(projects, dayKey),
@@ -145,5 +210,6 @@ export function getDispatchExceptions(
         conflicts: getTodayConflicts(conflicts, dayKey),
         blocked: getBlockedTasks(projects),
         crewless: getCrewlessJobs(projects, dayKey),
+        ...getEvidenceExceptions(projects, dayKey, staleAfterDays),
     };
 }

--- a/src/app/projects/[id]/timeclock/actions.ts
+++ b/src/app/projects/[id]/timeclock/actions.ts
@@ -4,6 +4,20 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import { resolveScheduleTaskIdForPunch } from "@/lib/punch-task-binding";
+import { dayKeyFromDateOnly } from "@/lib/company-day";
+import { canUseDevAuthFallback, getCurrentUserWithPermissions, hasPermission, canAccessProject } from "@/lib/permissions";
+
+// A bare session check let any signed-in account write hours against any
+// project. These rows are now direct field evidence on the schedule board, so
+// they get the same permission + project-access gate the rest of the app uses.
+async function assertTimeclockProjectAccess(projectId: string) {
+    const user = await getCurrentUserWithPermissions();
+    if (!user && await canUseDevAuthFallback()) return;
+    if (!user) throw new Error("Unauthorized");
+    if (!hasPermission(user, "timeClock")) throw new Error("Forbidden");
+    if (user.role !== "FINANCE" && !canAccessProject(user, projectId)) throw new Error("Forbidden");
+}
 
 export async function createTimeEntry(data: {
     projectId: string;
@@ -16,8 +30,18 @@ export async function createTimeEntry(data: {
     const session = await getServerSession(authOptions);
     if (!session?.user?.email) throw new Error("Unauthorized");
 
+    await assertTimeclockProjectAccess(data.projectId);
+
     // Start time at midnight of the selected date (simplified for this context)
     const startTime = new Date(data.date);
+    // Day comes from the date STRING: new Date("2026-07-27") is UTC midnight,
+    // which is the 26th in company time.
+    const scheduleTaskId = await resolveScheduleTaskIdForPunch({
+        userId: data.userId,
+        projectId: data.projectId,
+        dayKey: dayKeyFromDateOnly(data.date),
+        estimateItemId: null,
+    });
 
     await prisma.timeEntry.create({
         data: {
@@ -26,7 +50,8 @@ export async function createTimeEntry(data: {
             costCodeId: data.costCodeId,
             startTime,
             durationHours: data.durationHours,
-            laborCost: data.laborCost
+            laborCost: data.laborCost,
+            scheduleTaskId
         }
     });
 
@@ -47,6 +72,22 @@ export async function updateTimeEntry(id: string, data: {
 
     const startTime = new Date(data.date);
 
+    // Resolve against the STORED row: this action never writes projectId, so a
+    // supplied one could attach another project's task, and a null estimate item
+    // would drop a good mobile binding on an ordinary hours edit.
+    const existing = await prisma.timeEntry.findUnique({
+        where: { id },
+        select: { projectId: true, estimateItemId: true },
+    });
+    if (!existing) throw new Error("Not found");
+    await assertTimeclockProjectAccess(existing.projectId);
+    const scheduleTaskId = await resolveScheduleTaskIdForPunch({
+        userId: data.userId,
+        projectId: existing.projectId,
+        dayKey: dayKeyFromDateOnly(data.date),
+        estimateItemId: existing.estimateItemId,
+    });
+
     await prisma.timeEntry.update({
         where: { id },
         data: {
@@ -54,7 +95,8 @@ export async function updateTimeEntry(id: string, data: {
             costCodeId: data.costCodeId,
             startTime,
             durationHours: data.durationHours,
-            laborCost: data.laborCost
+            laborCost: data.laborCost,
+            scheduleTaskId
         }
     });
 

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -7425,12 +7425,24 @@ export async function addTaskPunchItem(taskId: string, name: string) {
 }
 
 export async function togglePunchItem(id: string) {
-    const item = await prisma.taskPunchItem.findUnique({ where: { id } });
-    if (!item) return null;
-    return prisma.taskPunchItem.update({
-        where: { id },
-        data: { completed: !item.completed },
+    const current = await prisma.taskPunchItem.findUnique({ where: { id } });
+    if (!current) return null;
+    // Completing a punch item is now DIRECT field evidence on the schedule
+    // board, so this needs the same access gate as every other task mutation.
+    await assertScheduleTaskAccess(current.taskId);
+    const nextCompleted = !current.completed;
+    const nextCompletedAt = nextCompleted ? new Date() : null;
+    // Guarded flip: the WHERE clause pins the expected `completed` value, so two concurrent
+    // taps can't both read false and both write true. The loser's updateMany matches 0 rows
+    // and falls back to reading the winner's result instead of double-flipping.
+    const result = await prisma.taskPunchItem.updateMany({
+        where: { id, completed: current.completed },
+        data: { completed: nextCompleted, completedAt: nextCompletedAt },
     });
+    if (result.count === 0) {
+        return prisma.taskPunchItem.findUnique({ where: { id } });
+    }
+    return { ...current, completed: nextCompleted, completedAt: nextCompletedAt };
 }
 
 export async function deletePunchItem(id: string) {

--- a/src/lib/company-day.ts
+++ b/src/lib/company-day.ts
@@ -1,0 +1,55 @@
+// Company-local calendar days. Browser-safe: no prisma, no server-only imports —
+// the evidence classifiers that use this render in client components.
+//
+// The board's day keys are calendar days ("YYYY-MM-DD" compared lexically, see
+// isTaskActiveOnDay). Timestamps are instants. Converting an instant with
+// `.toISOString().slice(0,10)` silently uses the UTC day, which is WRONG for
+// this company for most of the working evening: a 7pm PDT punch on the 27th
+// serializes as the 28th, which both inflates freshness by a day and fires
+// false "work logged past the scheduled end" contradictions.
+
+// Kept in sync with DEFAULT_COMPANY_TIME_ZONE in company-timezone.ts, which is
+// the server-side configurable source (CompanySettings.timeZone -> env ->
+// default). That module is NOT importable here: it imports prisma at the top,
+// and these classifiers render in client components. If the company ever moves
+// off the default, this constant has to move with it.
+export const COMPANY_TIME_ZONE = "America/Los_Angeles";
+
+// formatToParts (rather than format) so the result is YYYY-MM-DD regardless of
+// how the runtime's locale data orders en-CA date fields.
+const DAY_PARTS = new Intl.DateTimeFormat("en-CA", {
+    timeZone: COMPANY_TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+});
+
+/** Calendar day an instant falls on in company-local time. DST-correct. */
+export function toCompanyDayKey(instant: Date | string): string {
+    const date = typeof instant === "string" ? new Date(instant) : instant;
+    if (Number.isNaN(date.getTime())) return "";
+    const parts = DAY_PARTS.formatToParts(date);
+    const get = (type: string) => parts.find(part => part.type === type)?.value ?? "";
+    return `${get("year")}-${get("month")}-${get("day")}`;
+}
+
+/**
+ * Interpret a date-only string (an `<input type="date">` value) as that calendar
+ * day, verbatim.
+ *
+ * `new Date("2026-07-27")` is UTC midnight, which is 2026-07-26 in company time
+ * — so deriving the day from the instant moves every manually-entered timesheet
+ * row to the previous day. Manual entry surfaces must use this instead.
+ */
+export function dayKeyFromDateOnly(value: string): string {
+    const match = /^(\d{4}-\d{2}-\d{2})/.exec(value.trim());
+    return match ? match[1] : toCompanyDayKey(new Date(value));
+}
+
+/** Whole days between two YYYY-MM-DD keys. Date-only, so DST never applies. */
+export function daysBetweenDayKeys(from: string, to: string): number {
+    const fromMs = Date.parse(`${from}T00:00:00Z`);
+    const toMs = Date.parse(`${to}T00:00:00Z`);
+    if (Number.isNaN(fromMs) || Number.isNaN(toMs)) return Number.POSITIVE_INFINITY;
+    return Math.round((toMs - fromMs) / 86_400_000);
+}

--- a/src/lib/punch-task-binding.ts
+++ b/src/lib/punch-task-binding.ts
@@ -1,0 +1,145 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { isTaskActiveOnDay } from "@/app/company-dashboard/schedule-board/dispatch-exceptions";
+import { toCompanyDayKey } from "@/lib/company-day";
+
+// Canonical resolver for TimeEntry -> ScheduleTask binding.
+//
+// Every TimeEntry create/edit surface calls this; nothing binds inline. Before
+// this existed `TimeEntry.scheduleTaskId` was never written by ANY writer, so
+// the task drawer's hours roll-up (timeEntry.aggregate by scheduleTaskId in
+// actions.ts) reported zero on every task in the system.
+//
+// The rule is deliberately conservative: bind only when the answer is
+// unambiguous, otherwise leave null and report why. A wrong binding silently
+// moves labor hours onto the wrong task, which is worse than no binding.
+
+export type PunchBindingBasis =
+    /** Punch carries an estimateItemId mapping 1:1 to a LEAF task. Strongest signal. */
+    | "estimateItem"
+    /** Exactly one active assigned non-complete leaf task on the punch's local day. */
+    | "soleAssignedTask";
+
+export type PunchBindingSkipReason =
+    /** No eligible task at all for this user/project/day. */
+    | "noCandidate"
+    /** More than one eligible task — the crew member was on several that day. */
+    | "ambiguous";
+
+export interface PunchBindingInput {
+    userId: string;
+    projectId: string;
+    /**
+     * The company-local calendar day the punch belongs to ("YYYY-MM-DD").
+     *
+     * Callers pass this explicitly rather than handing over an instant, because
+     * the two kinds of caller derive it differently: clock-in/out has a real
+     * timestamp (use `toCompanyDayKey`), while manual timesheet entry has a
+     * date-only string whose UTC-midnight instant lands on the PREVIOUS company
+     * day (use `dayKeyFromDateOnly`). Deriving it here from a Date would silently
+     * shift every manually-entered row back one day.
+     */
+    dayKey: string;
+    /** Budget bucket chosen at clock-in, when the surface collects one. */
+    estimateItemId?: string | null;
+}
+
+export type PunchBindingResult =
+    | { taskId: string; basis: PunchBindingBasis; candidateIds: string[] }
+    | { taskId: null; skipped: PunchBindingSkipReason; candidateIds: string[] };
+
+type DbClient = PrismaClient | Prisma.TransactionClient;
+
+export { toCompanyDayKey };
+
+/**
+ * Resolve the schedule task a punch belongs to, or null when it isn't certain.
+ *
+ * Order matters: `estimateItemId` wins because the crew member picked that
+ * budget bucket explicitly at clock-in, and `ScheduleTask.estimateItemId` is
+ * `@unique`, so the mapping is 1:1 and stable over time. Crew assignments are
+ * current-state only (TaskAssignment has no validity interval), so they are a
+ * weaker, present-tense signal — good enough for a live punch, never safe to
+ * replay over history.
+ */
+export async function resolveScheduleTaskForPunch(
+    input: PunchBindingInput,
+    db: DbClient = prisma,
+): Promise<PunchBindingResult> {
+    const { userId, projectId, dayKey, estimateItemId } = input;
+
+    const projectTasks = await db.scheduleTask.findMany({
+        where: { projectId },
+        select: {
+            id: true,
+            parentId: true,
+            estimateItemId: true,
+            startDate: true,
+            endDate: true,
+            status: true,
+            type: true,
+            assignments: { where: { userId }, select: { id: true } },
+        },
+    });
+
+    // A phase parent spans all of its children, so it is active on every day any
+    // child is, and the evidence classifier excludes parents outright. Binding to
+    // one would park hours on a task that can never show as confirmed.
+    const parentIds = new Set(projectTasks.map(task => task.parentId).filter((id): id is string => !!id));
+
+    // 1) Explicit budget-bucket mapping — but only to a leaf. Schedule generation
+    // links a top-level estimate item to the PHASE PARENT task, and the clock UI
+    // offers exactly those top-level items, so this match is often a parent.
+    // Fall through to the assignment path rather than binding to it.
+    if (estimateItemId) {
+        const byEstimateItem = projectTasks.find(task =>
+            task.estimateItemId === estimateItemId && task.type === "task" && !parentIds.has(task.id));
+        if (byEstimateItem) {
+            return { taskId: byEstimateItem.id, basis: "estimateItem", candidateIds: [byEstimateItem.id] };
+        }
+    }
+
+    // 2) Sole active assigned leaf task on the punch's local day.
+    const candidates = projectTasks.filter(task =>
+        task.type === "task"
+        && task.status !== "Complete"
+        && !parentIds.has(task.id)
+        && task.assignments.length > 0
+        && isTaskActiveOnDay(
+            {
+                startDate: task.startDate.toISOString(),
+                endDate: task.endDate.toISOString(),
+                type: task.type,
+            },
+            dayKey,
+        ));
+
+    const candidateIds = candidates.map(task => task.id);
+    if (candidateIds.length === 1) {
+        return { taskId: candidateIds[0], basis: "soleAssignedTask", candidateIds };
+    }
+    return {
+        taskId: null,
+        skipped: candidateIds.length === 0 ? "noCandidate" : "ambiguous",
+        candidateIds,
+    };
+}
+
+/**
+ * Convenience wrapper for write paths: returns the value to store, never throws.
+ *
+ * Binding is best-effort telemetry sitting beside a payroll write — a resolver
+ * fault must never fail a crew member's clock-in or a manager's hour edit.
+ */
+export async function resolveScheduleTaskIdForPunch(
+    input: PunchBindingInput,
+    db: DbClient = prisma,
+): Promise<string | null> {
+    try {
+        const result = await resolveScheduleTaskForPunch(input, db);
+        return result.taskId;
+    } catch (error) {
+        console.error("[punch-task-binding] resolve failed", { projectId: input.projectId, dayKey: input.dayKey, error });
+        return null;
+    }
+}

--- a/src/lib/schedule-core.ts
+++ b/src/lib/schedule-core.ts
@@ -4,6 +4,7 @@ import { withTxRetry } from "./tx-retry";
 import { OPEN_PROJECT_STATUSES } from "./project-status";
 import { CLOSED_PROJECT_STATUSES, CLOSED_LEAD_STAGES } from "./gpt-estimate";
 import { coSignedAmount, coTaxRate } from "./co-tax";
+import { foldTaskEvidence } from "./task-evidence";
 import { formatDate, parseUTCDate, addDays, getMonthGrid, getDefaultColorForTaskName } from "@/app/projects/[id]/schedule/schedule-utils";
 
 // Session-free core of the company pipeline dashboard + start-calendar flows
@@ -2099,6 +2100,12 @@ export interface DashboardTaskRow {
     // comments, newest first — same TaskComment source the project schedule
     // page already shows, no new writes/schema.
     latestComments: DashboardTaskComment[];
+    // Evidence freshness (see lib/task-evidence.ts). Direct = someone worked
+    // this task (bound punch, completed punch item). Indirect = office activity
+    // near it (comment, material move, project-level daily log). Kept apart so
+    // one project daily log can't mark every overlapping task confirmed.
+    lastDirectEvidenceAt: string | null;
+    lastIndirectEvidenceAt: string | null;
 }
 
 export interface DashboardProjectRow extends PipelineProject {
@@ -2109,6 +2116,9 @@ export interface DashboardProjectRow extends PipelineProject {
     // Expandable task list with per-task crew (assignments carry user status so
     // the picker can render inactive-removable entries).
     tasks: DashboardTaskRow[];
+    // Recent punches the binding resolver left unattached — evidence collected
+    // but unusable. Surfaced so ambiguity can't quietly erode the coverage read.
+    unboundPunches: number;
 }
 
 export interface ProjectMonthStripRow {
@@ -2353,7 +2363,7 @@ export async function getCompanyDashboardData(
         ...pipeline.inProgress.map(p => p.id),
         ...pipeline.substantialCompletion.map(p => p.id),
     ];
-    const [taskRows, qualifying, unappliedByProject, materialCounts] = await Promise.all([
+    const [taskRows, qualifying, unappliedByProject, materialCounts, punchEvidence, punchItemEvidence, dailyLogEvidence, unboundPunches] = await Promise.all([
         prisma.scheduleTask.findMany({
             where: { projectId: { in: rowIds } },
             orderBy: [{ order: "asc" }, { startDate: "asc" }, { id: "asc" }],
@@ -2376,22 +2386,67 @@ export async function getCompanyDashboardData(
         }),
         prisma.estimate.groupBy({ by: ["projectId"], where: { projectId: { in: rowIds }, status: { in: CONTRACT_ESTIMATE_STATUSES } }, _count: { id: true } }),
         getUnappliedChangeOrders(rowIds),
+        // All statuses, not just the three counted ones: `resolved` is the final
+        // transition, so filtering it out here would hide the most recent
+        // statusChangedAt. Resolved rows are dropped from the COUNTS below.
         prisma.taskMaterial.groupBy({
             by: ["taskId", "status"],
+            where: { task: { projectId: { in: rowIds } } },
+            _count: { id: true },
+            _max: { statusChangedAt: true },
+        }),
+        // ── Evidence aggregates (3 queries, batched — never per chip) ──
+        prisma.timeEntry.groupBy({
+            by: ["scheduleTaskId"],
+            where: { projectId: { in: rowIds }, scheduleTaskId: { not: null } },
+            _max: { startTime: true },
+        }),
+        prisma.taskPunchItem.groupBy({
+            by: ["taskId"],
+            where: { task: { projectId: { in: rowIds } }, completed: true },
+            _max: { completedAt: true },
+        }),
+        prisma.dailyLog.groupBy({
+            by: ["projectId"],
+            where: { projectId: { in: rowIds } },
+            _max: { date: true },
+        }),
+        // Punches the resolver couldn't tie to a task. Windowed to the recent
+        // past so pre-feature history doesn't pin this at a permanent large
+        // number — it's meant to show evidence we're losing NOW.
+        prisma.timeEntry.groupBy({
+            by: ["projectId"],
             where: {
-                task: { projectId: { in: rowIds } },
-                status: { in: ["pending", "staged", "missing"] },
+                projectId: { in: rowIds },
+                scheduleTaskId: null,
+                startTime: { gte: new Date(Date.now() - 14 * 86_400_000) },
             },
             _count: { id: true },
         }),
     ]);
     const materialCountsByTask = new Map<string, { pending: number; staged: number; missing: number }>();
+    const materialStatusAtByTask = new Map<string, Date>();
     for (const count of materialCounts) {
         const current = materialCountsByTask.get(count.taskId) ?? { pending: 0, staged: 0, missing: 0 };
         if (count.status === "pending" || count.status === "staged" || count.status === "missing") {
             current[count.status] = count._count.id;
         }
         materialCountsByTask.set(count.taskId, current);
+        const changedAt = count._max.statusChangedAt;
+        const seen = materialStatusAtByTask.get(count.taskId);
+        if (changedAt && (!seen || changedAt > seen)) materialStatusAtByTask.set(count.taskId, changedAt);
+    }
+    const punchAtByTask = new Map<string, Date>();
+    for (const row of punchEvidence) {
+        if (row.scheduleTaskId && row._max.startTime) punchAtByTask.set(row.scheduleTaskId, row._max.startTime);
+    }
+    const punchItemAtByTask = new Map<string, Date>();
+    for (const row of punchItemEvidence) {
+        if (row._max.completedAt) punchItemAtByTask.set(row.taskId, row._max.completedAt);
+    }
+    const dailyLogAtByProject = new Map<string, Date>();
+    for (const row of dailyLogEvidence) {
+        if (row._max.date) dailyLogAtByProject.set(row.projectId, row._max.date);
     }
     const tasksByProject = new Map<string, DashboardTaskRow[]>();
     for (const task of taskRows) {
@@ -2429,9 +2484,20 @@ export async function getCompanyDashboardData(
                 authorName: c.user?.name ?? c.user?.email ?? c.subcontractorName ?? "Unknown",
                 createdAt: c.createdAt.toISOString(),
             })),
+            // Comments are already loaded newest-first (take: 2), so the head IS
+            // the max createdAt — no fourth aggregate needed for it.
+            ...foldTaskEvidence({
+                lastTimeEntryAt: punchAtByTask.get(task.id),
+                lastPunchItemCompletedAt: punchItemAtByTask.get(task.id),
+                lastCommentAt: task.comments[0]?.createdAt,
+                lastMaterialStatusAt: materialStatusAtByTask.get(task.id),
+                lastProjectDailyLogAt: dailyLogAtByProject.get(task.projectId),
+            }),
         });
         tasksByProject.set(task.projectId, rows);
     }
+    const unboundPunchesByProject = new Map<string, number>();
+    for (const row of unboundPunches) unboundPunchesByProject.set(row.projectId, row._count.id);
     const hasQualifying = new Set(qualifying.map(q => q.projectId));
     const enrich = (p: PipelineProject): DashboardProjectRow => ({
         ...p,
@@ -2439,6 +2505,7 @@ export async function getCompanyDashboardData(
         hasQualifyingEstimate: hasQualifying.has(p.id),
         tasks: tasksByProject.get(p.id) ?? [],
         unappliedChangeOrders: unappliedByProject[p.id] ?? { count: 0, items: [] },
+        unboundPunches: unboundPunchesByProject.get(p.id) ?? 0,
     });
 
     // Picker list is pre-filtered to ACTIVATED, non-FINANCE (getTeamMembers

--- a/src/lib/task-evidence.ts
+++ b/src/lib/task-evidence.ts
@@ -1,0 +1,223 @@
+// Evidence layer: how recently did reality confirm what the board claims?
+//
+// Everything here is a PURE fold over rows the dashboard query already loads
+// (plus three cheap aggregates). Nothing fetches per task — the board serializer
+// contract is that per-chip data is small scalars folded from batched queries,
+// the same shape as `materialCountsByTask` in schedule-core.
+//
+// The central distinction is direct vs indirect evidence. A bound time punch or
+// a completed punch item means a person physically worked that task. A comment,
+// a material status change, or a project-level daily log means somebody in the
+// office touched something nearby. Collapsing the two would let one daily log
+// on a kitchen job mark all four overlapping tasks "confirmed" off a note that
+// only mentioned cabinets.
+
+import { toCompanyDayKey, daysBetweenDayKeys } from "./company-day";
+
+export { toCompanyDayKey, daysBetweenDayKeys };
+
+export interface TaskEvidenceSignals {
+    /** Newest bound TimeEntry.startTime for this task. Direct. */
+    lastTimeEntryAt?: Date | string | null;
+    /** Newest TaskPunchItem.completedAt for this task. Direct. */
+    lastPunchItemCompletedAt?: Date | string | null;
+    /** Newest TaskComment.createdAt. Indirect — often a manager, not the field. */
+    lastCommentAt?: Date | string | null;
+    /** Newest TaskMaterial.statusChangedAt. Indirect — usually the shop, not the site. */
+    lastMaterialStatusAt?: Date | string | null;
+    /** Newest DailyLog.date on the parent PROJECT. Indirect: no task linkage exists. */
+    lastProjectDailyLogAt?: Date | string | null;
+}
+
+export interface TaskEvidence {
+    lastDirectEvidenceAt: string | null;
+    lastIndirectEvidenceAt: string | null;
+}
+
+/** Task shape the classifiers need. Mirrors DashboardTaskRow's relevant fields. */
+export interface EvidenceTaskInput extends TaskEvidence {
+    id: string;
+    startDate: string;
+    endDate: string;
+    status: string;
+    type: string;
+    parentId: string | null;
+}
+
+export type EvidenceState =
+    /** Active leaf with direct evidence inside the freshness window. */
+    | "confirmed"
+    /** Active leaf, direct evidence older than the window. */
+    | "stale"
+    /** Active leaf, no direct evidence has ever landed. */
+    | "unknown"
+    /** Evidence and board state disagree — a human should look. */
+    | "needsReview"
+    /** Not an active leaf work task: parents, milestones, appointments, done work. */
+    | "notApplicable";
+
+function toIso(value: Date | string | null | undefined): string | null {
+    if (!value) return null;
+    return typeof value === "string" ? value : value.toISOString();
+}
+
+function newest(...values: (Date | string | null | undefined)[]): string | null {
+    let best: string | null = null;
+    for (const value of values) {
+        const iso = toIso(value);
+        if (iso && (!best || iso > best)) best = iso;
+    }
+    return best;
+}
+
+/** Fold raw signals into the two scalars each task chip carries. */
+export function foldTaskEvidence(signals: TaskEvidenceSignals): TaskEvidence {
+    return {
+        lastDirectEvidenceAt: newest(signals.lastTimeEntryAt, signals.lastPunchItemCompletedAt),
+        lastIndirectEvidenceAt: newest(
+            signals.lastCommentAt,
+            signals.lastMaterialStatusAt,
+            signals.lastProjectDailyLogAt,
+        ),
+    };
+}
+
+/**
+ * A task is judged on evidence only if the schedule says it is work in flight
+ * on this day.
+ *
+ * Phase parents span every child, so they would inherit any child's freshness;
+ * milestones and appointments are single points, not work someone logs hours
+ * against; Complete work needs no confirmation.
+ *
+ * Eligibility follows the SCHEDULE, not the status field. Gating on
+ * `status === "In Progress"` was the obvious reading, but a survey of production
+ * found all 307 schedule tasks sitting at "Not Started" — nobody advances task
+ * status, which is the same neglect this layer exists to expose. Status-gated
+ * eligibility would report zero forever. "The dates say this should be happening
+ * today and nothing confirms it" is both answerable and worth showing.
+ *
+ * The window is half-open (`start <= day < end`), matching isTaskActiveOnDay —
+ * inlined rather than imported because dispatch-exceptions imports from here.
+ */
+export function isEvidenceEligible(
+    task: EvidenceTaskInput,
+    parentIds: ReadonlySet<string>,
+    dayKey: string,
+): boolean {
+    if (task.type !== "task") return false;
+    if (parentIds.has(task.id)) return false;
+    if (task.status === "Complete") return false;
+    return task.startDate.slice(0, 10) <= dayKey && dayKey < task.endDate.slice(0, 10);
+}
+
+/**
+ * Contradictions between evidence and board state.
+ *
+ * These are the cases where the board is provably out of sync — not merely
+ * unconfirmed. They must raise "needs review" rather than count as freshness,
+ * otherwise the coverage readout gets greener the more wrong the board is.
+ */
+export function findContradiction(task: EvidenceTaskInput): string | null {
+    const direct = task.lastDirectEvidenceAt;
+    if (!direct) return null;
+    // Company-local day, NOT the UTC prefix: a 7pm PDT punch serializes as the
+    // next UTC day, which would fire a false "past the end date" on the very
+    // last active day of a task.
+    const directDay = toCompanyDayKey(direct);
+    const endDay = task.endDate.slice(0, 10);
+    const startDay = task.startDate.slice(0, 10);
+    if (!directDay) return null;
+
+    // No rule on status === "Not Started": in this company that is the resting
+    // state of every task, so flagging it would make the contradiction bucket
+    // meaningless. Work genuinely ahead of plan is caught by the start-date rule
+    // below, which is the same signal without the false positives.
+    if (task.status === "Complete" && directDay >= endDay) return "Field activity after this was marked complete";
+    // End-exclusive: a task ending on the 28th is active through the 27th. Work
+    // on or after the end day means the job is running past its planned window.
+    if (directDay >= endDay) return "Still active past the scheduled end date";
+    if (directDay < startDay) return "Field activity before the scheduled start date";
+    return null;
+}
+
+/**
+ * Classify one task. `dayKey` and `staleAfterDays` are passed in rather than
+ * read from the clock so this stays pure and testable, matching the convention
+ * dispatch-exceptions.ts already uses.
+ */
+export function classifyTaskEvidence(
+    task: EvidenceTaskInput,
+    parentIds: ReadonlySet<string>,
+    dayKey: string,
+    staleAfterDays = 2,
+): EvidenceState {
+    if (findContradiction(task)) return "needsReview";
+    if (!isEvidenceEligible(task, parentIds, dayKey)) return "notApplicable";
+    if (!task.lastDirectEvidenceAt) return "unknown";
+
+    const evidenceDay = toCompanyDayKey(task.lastDirectEvidenceAt);
+    if (!evidenceDay) return "unknown";
+    const age = daysBetweenDayKeys(evidenceDay, dayKey);
+    // Negative age = evidence dated in the future. That's a clock or data fault,
+    // not confirmation — without this guard it would satisfy `<= staleAfterDays`
+    // and read as the freshest possible state.
+    if (age < 0) return "needsReview";
+    return age <= staleAfterDays ? "confirmed" : "stale";
+}
+
+export interface EvidenceCoverage {
+    /** Active leaf tasks that evidence should exist for. */
+    eligible: number;
+    confirmed: number;
+    stale: number;
+    unknown: number;
+    needsReview: number;
+    /** Punches that couldn't be tied to a task — evidence we collected but can't use. */
+    unboundPunches: number;
+}
+
+export const EMPTY_COVERAGE: EvidenceCoverage = {
+    eligible: 0, confirmed: 0, stale: 0, unknown: 0, needsReview: 0, unboundPunches: 0,
+};
+
+/**
+ * Roll tasks into the counts shown on the board.
+ *
+ * Deliberately NOT a single "% true" score. Recent activity proves someone
+ * worked, not that dates, crew, or status are correct — a percentage would read
+ * healthy while the schedule was wrong. Counts force the ambiguity into view.
+ */
+export function summarizeEvidenceCoverage(
+    tasks: readonly EvidenceTaskInput[],
+    parentIds: ReadonlySet<string>,
+    dayKey: string,
+    options: { staleAfterDays?: number; unboundPunches?: number } = {},
+): EvidenceCoverage {
+    const coverage: EvidenceCoverage = { ...EMPTY_COVERAGE, unboundPunches: options.unboundPunches ?? 0 };
+    for (const task of tasks) {
+        const state = classifyTaskEvidence(task, parentIds, dayKey, options.staleAfterDays);
+        if (state === "notApplicable") continue;
+        // needsReview covers ineligible tasks too (hours on Not Started work), so
+        // it is counted without being gated on eligibility.
+        if (state === "needsReview") {
+            coverage.needsReview += 1;
+            if (isEvidenceEligible(task, parentIds, dayKey)) coverage.eligible += 1;
+            continue;
+        }
+        coverage.eligible += 1;
+        coverage[state] += 1;
+    }
+    return coverage;
+}
+
+export function sumEvidenceCoverage(parts: readonly EvidenceCoverage[]): EvidenceCoverage {
+    return parts.reduce<EvidenceCoverage>((acc, part) => ({
+        eligible: acc.eligible + part.eligible,
+        confirmed: acc.confirmed + part.confirmed,
+        stale: acc.stale + part.stale,
+        unknown: acc.unknown + part.unknown,
+        needsReview: acc.needsReview + part.needsReview,
+        unboundPunches: acc.unboundPunches + part.unboundPunches,
+    }), { ...EMPTY_COVERAGE });
+}

--- a/src/lib/time-expense-actions.ts
+++ b/src/lib/time-expense-actions.ts
@@ -11,6 +11,9 @@ import {
     tagExpensesToChangeOrderCore,
     tagTimeEntriesToChangeOrderCore,
 } from "@/lib/time-expense-core";
+import { dateInputInTimeZone, resolveCompanyTimeZone } from "@/lib/company-timezone";
+import { resolveScheduleTaskIdForPunch } from "@/lib/punch-task-binding";
+import { toCompanyDayKey } from "@/lib/company-day";
 
 async function assertTimeExpenseProjectAccess(projectId: string) {
     const user = await getCurrentUserWithPermissions();
@@ -58,11 +61,26 @@ export async function updateTimeEntry(
     if (!hasPermission(user, "timeClock")) throw new Error("Forbidden");
     if (!Number.isFinite(data.durationHours) || data.durationHours <= 0) throw new Error("Hours must be greater than zero");
     if (!Number.isFinite(data.laborCost) || data.laborCost < 0) throw new Error("Labor cost cannot be negative");
-    const startTime = new Date(data.date);
-    if (Number.isNaN(startTime.getTime())) throw new Error("A valid time-entry date is required");
-    const current = await prisma.timeEntry.findUnique({ where: { id }, select: { projectId: true, invoiceId: true, invoicedAt: true } });
+    // Date-only input goes through the company-timezone helper, not new Date():
+    // new Date("2026-07-27") is UTC midnight, which is the 26th in company time,
+    // so a plain parse silently moves the entry back a day. createTimeEntryCore
+    // already does this; the edit path did not.
+    const timeZone = await resolveCompanyTimeZone();
+    const startTime = dateInputInTimeZone(data.date, timeZone, "Time entry date");
+    if (!startTime || Number.isNaN(startTime.getTime())) throw new Error("A valid time-entry date is required");
+    const current = await prisma.timeEntry.findUnique({ where: { id }, select: { projectId: true, invoiceId: true, invoicedAt: true, estimateItemId: true } });
     if (!current || current.projectId !== data.projectId || !canAccessProject(user, current.projectId)) throw new Error("Forbidden");
     if (current.invoiceId || current.invoicedAt) throw new Error("Billed time entries cannot be edited");
+
+    // Re-bind against the STORED row: this action never writes projectId, so a
+    // client-supplied one could attach another project's task, and dropping the
+    // estimate item would lose a good mobile binding on an ordinary hours edit.
+    const scheduleTaskId = await resolveScheduleTaskIdForPunch({
+        userId: data.userId,
+        projectId: current.projectId,
+        dayKey: toCompanyDayKey(startTime),
+        estimateItemId: current.estimateItemId,
+    });
 
     const updated = await prisma.timeEntry.updateMany({
         where: { id, invoiceId: null, invoicedAt: null },
@@ -70,6 +88,7 @@ export async function updateTimeEntry(
             userId: data.userId,
             costCodeId: data.costCodeId,
             startTime,
+            scheduleTaskId,
             durationHours: data.durationHours,
             laborCost: data.laborCost,
         },

--- a/src/lib/time-expense-core.ts
+++ b/src/lib/time-expense-core.ts
@@ -1,5 +1,7 @@
 import { prisma } from "./prisma";
 import { dateOnlyInTimeZone, resolveCompanyTimeZone } from "./company-timezone";
+import { resolveScheduleTaskIdForPunch } from "./punch-task-binding";
+import { toCompanyDayKey } from "./company-day";
 
 const cents = (value: number) => Math.round(value * 100);
 const dollars = (value: number) => cents(value) / 100;
@@ -80,9 +82,21 @@ export async function createTimeEntryCore(data: CreateTimeEntryCoreInput, actor:
     if (!project) throw new Error("Project not found");
     if (!user) throw new Error("Crew member not found");
 
+    // Bind the punch to the schedule task it belongs to. This is the canonical
+    // create for manual time entry, so binding here covers every caller rather
+    // than each server action separately. startTime is already a company-local
+    // instant (date-only values are stored at local noon), so the day key is safe.
+    const scheduleTaskId = await resolveScheduleTaskIdForPunch({
+        userId: data.userId,
+        projectId,
+        dayKey: toCompanyDayKey(startTime),
+        estimateItemId: null,
+    });
+
     return prisma.timeEntry.create({
         data: {
             projectId,
+            scheduleTaskId,
             userId: data.userId,
             costCodeId: data.costCodeId || null,
             startTime,


### PR DESCRIPTION
## Why

The company board is only as true as what someone typed. Nothing flowed from the field into it, and nothing told you whether it was currently true. This is PR-1 of the field-evidence arc: the no-AI foundation every later inference lands on.

Three pre-existing bugs surfaced while building it:

- **`TimeEntry.scheduleTaskId` was never written by ANY write surface.** `actions.ts` already reads hours-per-task through that column, so the task drawer has been reporting **zero logged hours on every task in the system**.
- **`togglePunchItem` was a race-prone read-then-write** with no auth.
- **`updateTimeEntry` parsed date-only input with `new Date(...)`**, which is UTC midnight — i.e. the *previous* company day. #254 fixed this for creates via `dateOnlyInTimeZone` but missed the edit path; fixed here with the same helper.

## What lands

- **`punch-task-binding.ts`** — one canonical resolver. `estimateItemId` → leaf task first (skipping phase parents, which is what schedule generation actually links), then the sole active assigned leaf on the punch's company-local day, else `null`. Ambiguity is never guessed.
- **Binding placed in `createTimeEntryCore`**, not in each server action, so it covers every caller — including `createTimeEntryFromStoredRatesCore`, the sixth writer #254 introduced. All six write surfaces confirmed bound.
- **`company-day.ts`** — company-local calendar days, browser-safe (the classifiers render client-side, so `company-timezone.ts` isn't importable here — it pulls in Prisma. The two constants are commented as needing to stay in sync).
- **`task-evidence.ts`** — direct evidence (bound punch, completed punch item) kept apart from indirect (comment, material move, project-level daily log), so one project log can't mark every overlapping task confirmed.
- **Dashboard query** gains three batched aggregates on the existing `Promise.all`, following the `materialCountsByTask` precedent. No N+1.
- **`unknown` / `stale` / `needsReview` exceptions** plus a counts-based coverage readout.
- **`TaskPunchItem.completedAt`** (additive, no backfill) + RLS enabled.

## Two design calls worth reviewing

**Counts, not a "% true" score.** Recent activity proves someone worked, not that dates, crew, or status are right — a percentage would read healthy while the schedule was wrong. Contradictions raise the needs-review count instead of making the board greener.

**Eligibility follows the schedule dates, not task status.** A production survey found **all 307 schedule tasks parked at "Not Started"** — nobody advances status, which is the same neglect this layer exists to expose. A status-gated rule would report zero forever. This is the one call made from the data rather than from the approved plan.

## Peer review (Codex gpt-5.6-sol, xhigh)

Five blockers found and fixed. Two confirmed by direct repro:

- `new Date("2026-07-27")` is UTC midnight = **the 26th** in company time.
- A 7pm punch serialized as the **next** UTC day, firing a false "past the end date" on a task's last active day.

Also: `estimateItemId` usually points at a **phase parent** (the clock UI offers top-level estimate items), so hours would have parked on tasks the classifier can never confirm; and future-dated evidence read as `confirmed`.

## Deploy note

`TaskPunchItem.completedAt` + RLS are **already applied to production**. Any other environment needs `scripts/apply-task-evidence-schema.mjs` run **before** deploying this build, or the dashboard throws P2022.

## Verification

- `scripts/verify-task-evidence.ts` — 9 groups, incl. DST boundaries and both date regressions
- `npx tsc --noEmit` clean; `npm run build` clean (rebased onto current main)
- Board rendered against production data, no server errors

**Honest limit:** the readout cannot be seen lighting up yet. Production has zero daily logs, zero task comments, zero completed punch items, 12 time entries ever, and nothing inside its scheduled window today. The layer correctly displays nothing rather than manufacturing confidence — which is the finding, not a gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)