### PR TITLE
feat(mcp): PM phase 1 — Richard's key, standard folders, multi-upload, daily logs, punch, contacts

### DIFF
--- a/e2e/cost-plus-change-order.spec.ts
+++ b/e2e/cost-plus-change-order.spec.ts
@@ -823,9 +823,13 @@ test.describe.serial("PB-pipeline-004 cost-plus and split change orders", () => 
     await anonymous.dispose();
   });
 
-  test("CPCO10: MCP is v1.12.0 and exposes the required voice-first tools and UI copy", () => {
+  // NOTE: this pins the MCP server version exactly, so it must be bumped in
+  // lockstep with serverInfo in the route. 1.12.0 -> 1.13.0 when the PM tools
+  // (files/folders, daily logs, punch, contacts) landed; the voice-first
+  // cost-plus tools asserted below are unaffected and must keep working.
+  test("CPCO10: MCP is v1.13.0 and exposes the required voice-first tools and UI copy", () => {
     const mcp = readFileSync(join(process.cwd(), "src/app/api/mcp/[transport]/route.ts"), "utf8");
-    expect(mcp).toContain('version: "1.12.0"');
+    expect(mcp).toContain('version: "1.13.0"');
     for (const tool of ["list_change_orders", "log_time", "log_expense", "bill_change_order"]) {
       expect(mcp).toContain(`"${tool}"`);
     }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model User {
   dispatchPublications DispatchPublication[] @relation("DispatchPublisher")
   createdTaskMaterials TaskMaterial[] @relation("TaskMaterialCreator")
   taskMaterialStatusChanges TaskMaterial[] @relation("TaskMaterialStatusChanger")
+  createdPunchItems TaskPunchItem[] @relation("TaskPunchItemCreator")
   clippedProducts    ProductLibraryItem[]
   addedFavorites     ProjectProductFavorite[]
   decidedProposals   SelectionProposal[]
@@ -1051,7 +1052,11 @@ model TaskPunchItem {
   assignee    String?
   photoUrl    String?
   order       Int          @default(0)
+  createdById String?
+  createdBy   User?        @relation("TaskPunchItemCreator", fields: [createdById], references: [id], onDelete: SetNull)
   createdAt   DateTime     @default(now())
+
+  @@index([createdById])
 }
 
 model TaskAssignment {
@@ -1070,6 +1075,7 @@ model McpConfirmation {
   id         String    @id @default(cuid())
   token      String    @unique
   toolName   String
+  actorLabel String    @default("justin-ai")
   argsHash   String
   preview    String
   createdAt  DateTime  @default(now())

--- a/scripts/apply-mcp-pm-schema.mjs
+++ b/scripts/apply-mcp-pm-schema.mjs
@@ -1,0 +1,57 @@
+// One-off additive migration for MCP PM Phase 1 actor attribution.
+// Safe to re-run while the previous build is live.
+//
+// Run only through release orchestration before deploying the new build:
+//   node scripts/apply-mcp-pm-schema.mjs
+//
+// Do not run this during implementation handoff.
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+function resolveDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const file of [".env", ".env.local"]) {
+    if (!fs.existsSync(file)) continue;
+    const match = fs.readFileSync(file, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+    if (match) return match[1];
+  }
+  throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const prisma = new PrismaClient({
+  datasources: { db: { url: resolveDatabaseUrl() } },
+});
+
+const statements = [
+  `ALTER TABLE "McpConfirmation"
+     ADD COLUMN IF NOT EXISTS "actorLabel" TEXT NOT NULL DEFAULT 'justin-ai'`,
+  `ALTER TABLE "TaskPunchItem"
+     ADD COLUMN IF NOT EXISTS "createdById" TEXT`,
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'TaskPunchItem_createdById_fkey'
+         AND conrelid = '"TaskPunchItem"'::regclass
+     ) THEN
+       ALTER TABLE "TaskPunchItem"
+         ADD CONSTRAINT "TaskPunchItem_createdById_fkey"
+         FOREIGN KEY ("createdById") REFERENCES "User"("id")
+         ON DELETE SET NULL ON UPDATE CASCADE;
+     END IF;
+   END $$`,
+  `CREATE INDEX IF NOT EXISTS "TaskPunchItem_createdById_idx"
+     ON "TaskPunchItem" ("createdById")`,
+];
+
+try {
+  for (const sql of statements) {
+    await prisma.$executeRawUnsafe(sql);
+    console.log("applied:", sql.split("\n")[0]);
+  }
+  console.log("MCP PM schema applied successfully.");
+} catch (error) {
+  console.error("Migration failed:", error);
+  process.exitCode = 1;
+} finally {
+  await prisma.$disconnect();
+}

--- a/scripts/backfill-standard-folders.mjs
+++ b/scripts/backfill-standard-folders.mjs
@@ -1,0 +1,67 @@
+// Backfill the standard project folder scaffold.
+//
+// Dry-run is the default:
+//   npx tsx scripts/backfill-standard-folders.mjs
+//
+// Apply only after reviewing the dry-run:
+//   npx tsx scripts/backfill-standard-folders.mjs --write
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+import {
+  STANDARD_PROJECT_FOLDERS,
+  ensureStandardFolders,
+} from "../src/lib/project-folders.ts";
+
+function resolveDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const file of [".env", ".env.local"]) {
+    if (!fs.existsSync(file)) continue;
+    const match = fs.readFileSync(file, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+    if (match) return match[1];
+  }
+  throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const write = process.argv.includes("--write");
+const prisma = new PrismaClient({
+  datasources: { db: { url: resolveDatabaseUrl() } },
+});
+
+try {
+  const projects = await prisma.project.findMany({
+    orderBy: [{ name: "asc" }, { id: "asc" }],
+    select: {
+      id: true,
+      name: true,
+      folders: {
+        where: { parentId: null },
+        select: { name: true },
+      },
+    },
+  });
+
+  let totalMissing = 0;
+  for (const project of projects) {
+    const existing = new Set(project.folders.map(folder => folder.name.trim().toLocaleLowerCase()));
+    const missing = STANDARD_PROJECT_FOLDERS.filter(name => !existing.has(name.toLocaleLowerCase()));
+    totalMissing += missing.length;
+    console.log(
+      `${project.name} (${project.id}): ${missing.length > 0 ? missing.join(" | ") : "(complete)"}`,
+    );
+    if (write && missing.length > 0) {
+      await ensureStandardFolders(project.id, prisma);
+    }
+  }
+
+  console.log(
+    write
+      ? `WRITE complete: ensured the scaffold on ${projects.length} projects (${totalMissing} folders were missing before the run).`
+      : `DRY-RUN: ${totalMissing} folders would be created across ${projects.length} projects. Re-run with --write to apply.`,
+  );
+} catch (error) {
+  console.error("Standard-folder backfill failed:", error);
+  process.exitCode = 1;
+} finally {
+  await prisma.$disconnect();
+}

--- a/scripts/seed-richard-ai-user.mjs
+++ b/scripts/seed-richard-ai-user.mjs
@@ -1,0 +1,47 @@
+// Idempotently creates the nonschedulable attribution row used by Richard's
+// MCP connector. This script does not create auth credentials or permissions.
+//
+// Run only through release orchestration:
+//   node scripts/seed-richard-ai-user.mjs
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+const RICHARD_AI_EMAIL = "richard-ai@goldentouchremodeling.com";
+
+function resolveDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const file of [".env", ".env.local"]) {
+    if (!fs.existsSync(file)) continue;
+    const match = fs.readFileSync(file, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+    if (match) return match[1];
+  }
+  throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const prisma = new PrismaClient({
+  datasources: { db: { url: resolveDatabaseUrl() } },
+});
+
+try {
+  const user = await prisma.user.upsert({
+    where: { email: RICHARD_AI_EMAIL },
+    update: {
+      name: "Richard's AI",
+      status: "ACTIVATED",
+      role: "FINANCE",
+    },
+    create: {
+      email: RICHARD_AI_EMAIL,
+      name: "Richard's AI",
+      status: "ACTIVATED",
+      role: "FINANCE",
+    },
+    select: { id: true, email: true, name: true, status: true, role: true },
+  });
+  console.log("Richard AI attribution user ready:", user);
+} catch (error) {
+  console.error("Richard AI attribution seed failed:", error);
+  process.exitCode = 1;
+} finally {
+  await prisma.$disconnect();
+}

--- a/scripts/verify-mcp-pm-tools.ts
+++ b/scripts/verify-mcp-pm-tools.ts
@@ -1,0 +1,589 @@
+// Behavioral verification for SPEC-mcp-pm-phase1.
+//
+// This verifier never applies schema and never runs either seed/backfill script.
+// Release orchestration must apply scripts/apply-mcp-pm-schema.mjs first.
+//
+// Usage against Supabase:
+//   $env:ALLOW_PROD_VERIFY="1"
+//   npx tsx --env-file=.env.local scripts/verify-mcp-pm-tools.ts
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+
+import { prisma } from "../src/lib/prisma";
+
+const RUN_ID = randomUUID().replaceAll("-", "").slice(0, 12);
+const FIXTURE_PREFIX = `MCP PM VERIFY ${RUN_ID}`;
+
+function source(path: string): string {
+    return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
+function loadDatabaseUrl(): string {
+    if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+    for (const file of [".env.local", ".env"]) {
+        if (!existsSync(file)) continue;
+        const match = readFileSync(file, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\r\n]+)"?/m);
+        if (match) {
+            process.env.DATABASE_URL = match[1];
+            return match[1];
+        }
+    }
+    return "";
+}
+
+async function rejectsWith(run: () => Promise<unknown>, pattern: RegExp): Promise<void> {
+    let message = "";
+    try {
+        await run();
+    } catch (error) {
+        message = String((error as Error)?.message ?? error);
+    }
+    assert.match(message, pattern);
+}
+
+function confirmationToken(result: any): string {
+    assert.equal(result.confirmationRequired, true);
+    assert.equal(typeof result.preview, "string");
+    assert.ok(result.preview.length > 0);
+    assert.match(result.confirmToken, /^[a-f0-9]{64}$/);
+    assert.ok(Date.parse(result.expiresAt) > Date.now());
+    return result.confirmToken;
+}
+
+function assertNoForbiddenContactKeys(value: unknown, path = "contacts"): void {
+    if (Array.isArray(value)) {
+        value.forEach((child, index) => assertNoForbiddenContactKeys(child, `${path}[${index}]`));
+        return;
+    }
+    if (!value || typeof value !== "object") return;
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+        const normalized = key.replace(/[^a-z0-9]/gi, "").toLowerCase();
+        assert.ok(
+            ![
+                "hourlyrate",
+                "burdenrate",
+                "rate",
+                "cost",
+                "amount",
+                "budget",
+                "addressline1",
+                "addressline2",
+                "city",
+                "state",
+                "zipcode",
+                "country",
+                "licenseNumber",
+            ].map(item => item.toLowerCase()).includes(normalized),
+            `${path}.${key} crosses the MCP contact PII boundary`,
+        );
+        assertNoForbiddenContactKeys(child, `${path}.${key}`);
+    }
+}
+
+async function main() {
+    const expectedFiles = [
+        "../src/lib/mcp-actor.ts",
+        "../src/lib/project-folders.ts",
+        "../src/lib/project-file-core.ts",
+        "../src/lib/daily-log-core.ts",
+        "../src/lib/mcp-pm-tools.ts",
+        "./seed-richard-ai-user.mjs",
+        "./backfill-standard-folders.mjs",
+        "./apply-mcp-pm-schema.mjs",
+    ];
+    for (const path of expectedFiles) {
+        assert.ok(existsSync(new URL(path, import.meta.url)), `${path} must exist`);
+    }
+
+    const routeSource = source("../src/app/api/mcp/[transport]/route.ts");
+    const schemaSource = source("../prisma/schema.prisma");
+    const actorSource = source("../src/lib/mcp-actor.ts");
+    const folderSource = source("../src/lib/project-folders.ts");
+    const fileCoreSource = source("../src/lib/project-file-core.ts");
+    const pmCoreSource = source("../src/lib/mcp-pm-tools.ts");
+    const dailyCoreSource = source("../src/lib/daily-log-core.ts");
+    const actionSource = source("../src/lib/actions.ts");
+    const confirmationSource = source("../src/lib/mcp-schedule-tools.ts");
+    const applySource = source("./apply-mcp-pm-schema.mjs");
+    const seedSource = source("./seed-richard-ai-user.mjs");
+    const backfillSource = source("./backfill-standard-folders.mjs");
+
+    // Static registry, security, migration, and no-Phase-2 contracts.
+    assert.match(routeSource, /MCP_SECRET_RICHARD/);
+    assert.match(routeSource, /timingSafeEqual/);
+    assert.match(routeSource, /serverInfo:\s*\{\s*name:\s*"probuild",\s*version:\s*"1\.13\.0"\s*\}/);
+    for (const toolName of [
+        "upload_file",
+        "upload_files",
+        "list_project_files",
+        "create_folder",
+        "move_file",
+        "list_daily_logs",
+        "create_daily_log",
+        "list_punch_items",
+        "add_punch_items",
+        "get_project_contacts",
+    ]) {
+        assert.match(routeSource, new RegExp(`"${toolName}"`), `${toolName} must be registered`);
+    }
+    assert.doesNotMatch(routeSource, /registerTool\(\s*"complete_punch_item"/);
+    assert.match(routeSource, /complete_punch_item[\s\S]{0,300}(?:cut|absent|not registered|human reported)/i);
+    assert.match(routeSource, /Project management/i);
+    assert.match(routeSource, /download is not available/i);
+    assert.match(routeSource, /list_project_files[\s\S]{0,800}(?:never returns|no) URLs/i);
+    assert.match(schemaSource, /model McpConfirmation \{[\s\S]*\bactorLabel\s+String/);
+    assert.match(schemaSource, /model TaskPunchItem \{[\s\S]*\bcreatedById\s+String\?/);
+    assert.match(applySource, /ADD COLUMN IF NOT EXISTS "actorLabel"/);
+    assert.match(applySource, /ADD COLUMN IF NOT EXISTS "createdById"/);
+    assert.match(seedSource, /richard-ai@goldentouchremodeling\.com/);
+    assert.match(seedSource, /Richard's AI/);
+    assert.match(seedSource, /ACTIVATED/);
+    assert.doesNotMatch(seedSource, /FIELD_CREW/);
+    assert.match(backfillSource, /--write/);
+    assert.match(backfillSource, /dry.run/i);
+    assert.match(folderSource, /mode:\s*"insensitive"|toLocaleLowerCase|toLowerCase/);
+    assert.match(fileCoreSource, /MAX_UPLOAD_BYTES\s*=\s*3_300_000/);
+    assert.match(fileCoreSource, /visibility\s*\?\?\s*"team"/);
+    assert.match(dailyCoreSource, /createdById:\s*actorUserId/);
+    assert.match(actionSource, /createDailyLogCore/);
+    assert.match(confirmationSource, /actorLabel/);
+    assert.match(confirmationSource, /consumedAt:\s*null/);
+    assert.match(confirmationSource, /expiresAt:\s*\{\s*gt:/);
+    assert.match(pmCoreSource, /SYSTEM:/);
+    console.log("PASS static auth, schema, registry, no-download, and no-punch-completion contracts");
+
+    const [
+        actorModule,
+        folderModule,
+        fileModule,
+        pmModule,
+        routeModule,
+    ]: any[] = await Promise.all([
+        import("../src/lib/mcp-actor"),
+        import("../src/lib/project-folders"),
+        import("../src/lib/project-file-core"),
+        import("../src/lib/mcp-pm-tools"),
+        import("../src/app/api/mcp/[transport]/route"),
+    ]);
+
+    // Auth is tested without touching the DB. Both comparisons execute in the
+    // same helper, unset/empty values never authenticate, and the label is exact.
+    const originalJustin = process.env.MCP_SECRET;
+    const originalRichard = process.env.MCP_SECRET_RICHARD;
+    try {
+        process.env.MCP_SECRET = `justin-${RUN_ID}`;
+        process.env.MCP_SECRET_RICHARD = `richard-${RUN_ID}`;
+        const request = (key: string) => new Request(`https://example.invalid/api/mcp/mcp?key=${encodeURIComponent(key)}`);
+        assert.equal(routeModule.resolveMcpActorLabel(request(process.env.MCP_SECRET)), "justin-ai");
+        assert.equal(routeModule.resolveMcpActorLabel(request(process.env.MCP_SECRET_RICHARD)), "richard-ai");
+        assert.equal(routeModule.resolveMcpActorLabel(request(`wrong-${RUN_ID}`)), null);
+        process.env.MCP_SECRET_RICHARD = "";
+        assert.equal(routeModule.resolveMcpActorLabel(request("")), null);
+    } finally {
+        if (originalJustin === undefined) delete process.env.MCP_SECRET;
+        else process.env.MCP_SECRET = originalJustin;
+        if (originalRichard === undefined) delete process.env.MCP_SECRET_RICHARD;
+        else process.env.MCP_SECRET_RICHARD = originalRichard;
+    }
+    console.log("PASS dual-key auth labels, wrong key, and empty-key refusal");
+
+    // The static + auth contracts above are DB-free and must run everywhere.
+    // Only the behavioral matrix below creates/deletes fixtures, so the prod
+    // guard fences exactly that — not the whole script (it originally sat at
+    // the top of main(), which silently skipped every static check on any
+    // machine whose DATABASE_URL points at Supabase).
+    const databaseUrl = loadDatabaseUrl();
+    if (databaseUrl.includes("supabase.c") && process.env.ALLOW_PROD_VERIFY !== "1") {
+        console.log(
+            "[verify-mcp-pm-tools] static + auth contracts PASS; skipping the DB-backed behavioral matrix\n" +
+            "  (DATABASE_URL points at Supabase and this phase creates/deletes fixtures — run against a\n" +
+            "  disposable database, or set ALLOW_PROD_VERIFY=1 to opt in).",
+        );
+        return;
+    }
+
+    const confirmationDelegate = (prisma as any).mcpConfirmation;
+    await confirmationDelegate.findFirst({ select: { id: true, actorLabel: true } });
+    await (prisma as any).taskPunchItem.findFirst({ select: { id: true, createdById: true } });
+
+    const collected = {
+        clientIds: [] as string[],
+        projectIds: [] as string[],
+        userIds: [] as string[],
+        subcontractorIds: [] as string[],
+        confirmationTokens: [] as string[],
+    };
+    let cleanupPassed = false;
+
+    try {
+        const client = await prisma.client.create({
+            data: {
+                name: `${FIXTURE_PREFIX} CLIENT DELETE ME`,
+                initials: "MP",
+                email: `mcp-pm-client-${RUN_ID}@example.invalid`,
+                primaryPhone: "555-0101",
+                addressLine1: "PII boundary sentinel",
+            },
+        });
+        collected.clientIds.push(client.id);
+        const actorUser = await prisma.user.create({
+            data: {
+                email: `mcp-pm-actor-${RUN_ID}@example.invalid`,
+                name: "MCP PM Actor",
+                role: "FINANCE",
+                status: "ACTIVATED",
+            },
+        });
+        const crewUser = await prisma.user.create({
+            data: {
+                email: `mcp-pm-crew-${RUN_ID}@example.invalid`,
+                name: "MCP Crew",
+                role: "FIELD_CREW",
+                status: "ACTIVATED",
+                hourlyRate: 999,
+                burdenRate: 999,
+            },
+        });
+        collected.userIds.push(actorUser.id, crewUser.id);
+        const project = await prisma.project.create({
+            data: {
+                name: `${FIXTURE_PREFIX} PROJECT DELETE ME`,
+                clientId: client.id,
+                status: "In Progress",
+                location: "Project location is allowed",
+                managerId: actorUser.id,
+                crew: { connect: { id: crewUser.id } },
+            },
+        });
+        const secondProject = await prisma.project.create({
+            data: {
+                name: `${FIXTURE_PREFIX} SECOND PROJECT DELETE ME`,
+                clientId: client.id,
+                status: "In Progress",
+            },
+        });
+        collected.projectIds.push(project.id, secondProject.id);
+        const justinActor = { actorLabel: "justin-ai", actorUserId: actorUser.id };
+        const richardActor = { actorLabel: "richard-ai", actorUserId: actorUser.id };
+
+        // Confirmation tokens are actor-bound and cannot cross connector keys.
+        const folderArgs = { projectId: project.id, name: "Cross-key probe", visibility: "team" };
+        const folderPreview = await pmModule.createFolderWithConfirmation(folderArgs, justinActor);
+        const folderToken = confirmationToken(folderPreview);
+        collected.confirmationTokens.push(folderToken);
+        await rejectsWith(
+            () => pmModule.createFolderWithConfirmation({ ...folderArgs, confirmToken: folderToken }, richardActor),
+            /actor|key|confirmation/i,
+        );
+        assert.equal(await prisma.fileFolder.count({ where: { projectId: project.id, name: folderArgs.name } }), 0);
+        console.log("PASS cross-key confirmation refusal");
+
+        // Standard folders create once and dedupe case-insensitively.
+        await prisma.fileFolder.create({
+            data: { projectId: project.id, name: "01 plans & specs", visibility: "team" },
+        });
+        const firstEnsure = await folderModule.ensureStandardFolders(project.id);
+        assert.equal(firstEnsure.created.length, 7);
+        const secondEnsure = await folderModule.ensureStandardFolders(project.id);
+        assert.equal(secondEnsure.created.length, 0);
+        assert.equal(
+            await prisma.fileFolder.count({ where: { projectId: project.id, parentId: null } }),
+            folderModule.STANDARD_PROJECT_FOLDERS.length,
+        );
+        console.log("PASS standard-folder scaffold idempotency and case-insensitive dedup");
+
+        const saveWithoutStorage = async (input: any) => {
+            if (input.fileName === "storage-fails.pdf") {
+                return { ok: false as const, error: "Synthetic storage failure" };
+            }
+            const file = await prisma.projectFile.create({
+                data: {
+                    name: input.fileName,
+                    url: `https://example.invalid/${RUN_ID}/${input.fileName}`,
+                    size: input.buffer.length,
+                    mimeType: input.mimeType,
+                    visibility: input.visibility,
+                    projectId: input.projectId,
+                    leadId: input.leadId,
+                    folderId: input.folderId,
+                    uploadedById: input.uploadedById,
+                },
+                select: { id: true, name: true, size: true, url: true },
+            });
+            return { ok: true as const, file };
+        };
+
+        // The single-file core owns every portal-safety invariant.
+        const teamUpload = await fileModule.uploadProjectFileCore({
+            projectId: project.id,
+            fileName: "internal.pdf",
+            contentBase64: Buffer.from("internal").toString("base64"),
+            actor: richardActor,
+        }, { saveProjectFile: saveWithoutStorage });
+        assert.equal(teamUpload.ok, true);
+        const teamFile = await prisma.projectFile.findUniqueOrThrow({ where: { id: teamUpload.data.fileId } });
+        assert.equal(teamFile.visibility, "team");
+        assert.equal(teamFile.uploadedById, actorUser.id);
+
+        const teamFolder = await prisma.fileFolder.create({
+            data: { projectId: project.id, name: "Internal only", visibility: "team" },
+        });
+        const refusedShared = await fileModule.uploadProjectFileCore({
+            projectId: project.id,
+            fileName: "shared.pdf",
+            contentBase64: Buffer.from("shared").toString("base64"),
+            folder: teamFolder.name,
+            visibility: "shared",
+            actor: richardActor,
+        }, { saveProjectFile: saveWithoutStorage });
+        assert.equal(refusedShared.ok, false);
+        assert.match(refusedShared.error, /not a shared folder/i);
+
+        const sharedUpload = await fileModule.uploadProjectFileCore({
+            projectId: project.id,
+            fileName: "shared-photo.jpg",
+            contentBase64: Buffer.from("image").toString("base64"),
+            folder: "Customer photos",
+            visibility: "shared",
+            actor: richardActor,
+        }, { saveProjectFile: saveWithoutStorage });
+        assert.equal(sharedUpload.ok, true);
+        assert.equal(
+            (await prisma.fileFolder.findFirstOrThrow({
+                where: { projectId: project.id, name: "Customer photos" },
+            })).visibility,
+            "shared",
+        );
+        console.log("PASS upload core explicit visibility, team-folder refusal, and shared-folder creation");
+
+        const oversized = Buffer.alloc(fileModule.MAX_UPLOAD_BYTES + 1, 1).toString("base64");
+        assert.throws(
+            () => fileModule.validateUploadFilesBatch([
+                { fileName: "one.pdf", contentBase64: oversized },
+            ]),
+            /~3 MB|3 MB|total/i,
+        );
+        let invalidWriteCalls = 0;
+        const invalidBatch = await fileModule.uploadProjectFilesCore({
+            projectId: project.id,
+            files: [
+                { fileName: "valid.pdf", contentBase64: Buffer.from("valid").toString("base64") },
+                { fileName: "invalid.exe", contentBase64: Buffer.from("invalid").toString("base64") },
+            ],
+            actor: richardActor,
+        }, {
+            saveProjectFile: async () => {
+                invalidWriteCalls++;
+                return { ok: false as const, error: "must not run" };
+            },
+        });
+        assert.equal(invalidBatch.ok, false);
+        assert.equal(invalidWriteCalls, 0);
+
+        const conflictingBatch = await fileModule.uploadProjectFilesCore({
+            projectId: project.id,
+            files: [
+                {
+                    fileName: "new-shared.pdf",
+                    contentBase64: Buffer.from("new shared").toString("base64"),
+                    folder: "Must not be created",
+                    visibility: "shared",
+                },
+                {
+                    fileName: "conflicting-shared.pdf",
+                    contentBase64: Buffer.from("conflict").toString("base64"),
+                    folder: teamFolder.name,
+                    visibility: "shared",
+                },
+            ],
+            actor: richardActor,
+        }, { saveProjectFile: saveWithoutStorage });
+        assert.equal(conflictingBatch.ok, false);
+        assert.equal(
+            await prisma.fileFolder.count({
+                where: { projectId: project.id, name: "Must not be created" },
+            }),
+            0,
+        );
+
+        const partialBatch = await fileModule.uploadProjectFilesCore({
+            projectId: project.id,
+            files: [
+                { fileName: "batch-ok.pdf", contentBase64: Buffer.from("ok").toString("base64") },
+                { fileName: "storage-fails.pdf", contentBase64: Buffer.from("fail").toString("base64") },
+            ],
+            actor: richardActor,
+        }, { saveProjectFile: saveWithoutStorage });
+        assert.equal(partialBatch.ok, true);
+        assert.deepEqual(
+            partialBatch.results.map((row: any) => ({ fileName: row.fileName, ok: row.ok, hasFileId: !!row.fileId, error: row.error })),
+            [
+                { fileName: "batch-ok.pdf", ok: true, hasFileId: true, error: undefined },
+                { fileName: "storage-fails.pdf", ok: false, hasFileId: false, error: "Synthetic storage failure" },
+            ],
+        );
+        console.log("PASS multi-upload total cap, whole-batch validation, and partial storage-result shape");
+
+        // Moving cannot cross owners or accidentally expose team content.
+        const sharedTarget = await prisma.fileFolder.create({
+            data: { projectId: project.id, name: "Shared target", visibility: "shared" },
+        });
+        const otherTarget = await prisma.fileFolder.create({
+            data: { projectId: secondProject.id, name: "Other project", visibility: "team" },
+        });
+        await rejectsWith(
+            () => pmModule.moveFileWithConfirmation({
+                fileId: teamFile.id,
+                folderId: otherTarget.id,
+            }, richardActor),
+            /same project|cross-project|different project/i,
+        );
+        await rejectsWith(
+            () => pmModule.moveFileWithConfirmation({
+                fileId: teamFile.id,
+                folderId: sharedTarget.id,
+            }, richardActor),
+            /visibility.*shared|expose|customer/i,
+        );
+        const moveArgs = { fileId: teamFile.id, folderId: sharedTarget.id, visibility: "shared" as const };
+        const movePreview = await pmModule.moveFileWithConfirmation(moveArgs, richardActor);
+        const moveToken = confirmationToken(movePreview);
+        collected.confirmationTokens.push(moveToken);
+        await pmModule.moveFileWithConfirmation({ ...moveArgs, confirmToken: moveToken }, richardActor);
+        const moved = await prisma.projectFile.findUniqueOrThrow({ where: { id: teamFile.id } });
+        assert.equal(moved.folderId, sharedTarget.id);
+        assert.equal(moved.visibility, "shared");
+        console.log("PASS move_file cross-owner and visibility-refusal matrix");
+
+        // Daily logs bind the explicit actor FK and copy same-project file URLs.
+        const photo = await prisma.projectFile.create({
+            data: {
+                projectId: project.id,
+                name: "daily-photo.jpg",
+                url: `https://example.invalid/${RUN_ID}/daily-photo.jpg`,
+                size: 5,
+                mimeType: "image/jpeg",
+                visibility: "team",
+            },
+        });
+        const logArgs = {
+            projectId: project.id,
+            date: "2048-05-04",
+            weather: "Clear",
+            crewOnSite: "MCP Crew",
+            workPerformed: "Completed the verifier work.",
+            materialsDelivered: "Verification fixtures",
+            issues: "None",
+            photos: [{ fileId: photo.id, caption: "Verifier photo" }],
+        };
+        const logPreview = await pmModule.createDailyLogWithConfirmation(logArgs, richardActor);
+        const logToken = confirmationToken(logPreview);
+        collected.confirmationTokens.push(logToken);
+        const logResult = await pmModule.createDailyLogWithConfirmation({ ...logArgs, confirmToken: logToken }, richardActor);
+        const log = await prisma.dailyLog.findUniqueOrThrow({
+            where: { id: logResult.dailyLogId },
+            include: { photos: true },
+        });
+        assert.equal(log.createdById, actorUser.id);
+        assert.equal(log.sharedToPortal, false);
+        assert.equal(log.photos[0]?.url, photo.url);
+        console.log("PASS daily-log actor provenance, no portal-sharing input, and ProjectFile photo attachment");
+
+        // Punch additions preserve contiguous ordering and creator provenance.
+        const task = await prisma.scheduleTask.create({
+            data: {
+                projectId: project.id,
+                name: "Punch verifier task",
+                startDate: new Date("2048-05-04T00:00:00.000Z"),
+                endDate: new Date("2048-05-05T00:00:00.000Z"),
+            },
+        });
+        const punchArgs = { taskId: task.id, items: ["First punch", "Second punch"] };
+        const punchPreview = await pmModule.addPunchItemsWithConfirmation(punchArgs, richardActor);
+        const punchToken = confirmationToken(punchPreview);
+        collected.confirmationTokens.push(punchToken);
+        await pmModule.addPunchItemsWithConfirmation({ ...punchArgs, confirmToken: punchToken }, richardActor);
+        const punchItems = await prisma.taskPunchItem.findMany({ where: { taskId: task.id }, orderBy: { order: "asc" } });
+        assert.deepEqual(punchItems.map(item => item.order), [0, 1]);
+        assert.ok(punchItems.every((item: any) => item.createdById === actorUser.id));
+        const listedPunch = await pmModule.listPunchItems({ taskId: task.id, status: "open" });
+        assert.equal(listedPunch.items.length, 2);
+        assert.ok(listedPunch.items.every((item: any) => item.completed === false && item.completedAt === null));
+        console.log("PASS punch bulk ordering, creator provenance, and read surface");
+
+        const subcontractor = await prisma.subcontractor.create({
+            data: {
+                companyName: `${FIXTURE_PREFIX} SUB DELETE ME`,
+                contactName: "Sub Contact",
+                email: `mcp-pm-sub-${RUN_ID}@example.invalid`,
+                phone: "555-0102",
+                trade: "Electrical",
+                licenseNumber: "PII-BOUNDARY-SENTINEL",
+            },
+        });
+        collected.subcontractorIds.push(subcontractor.id);
+        await prisma.subTaskAssignment.create({
+            data: { taskId: task.id, subcontractorId: subcontractor.id },
+        });
+        const contacts = await pmModule.getProjectContacts({ projectId: project.id });
+        assertNoForbiddenContactKeys(contacts);
+        assert.equal(contacts.project.location, project.location);
+        assert.equal(contacts.client.email, client.email);
+        assert.ok(contacts.crew.some((member: any) => member.name === crewUser.name));
+        assert.ok(contacts.subcontractors.some((sub: any) => sub.company === subcontractor.companyName));
+        console.log("PASS project-contact shape and PII boundary");
+    } finally {
+        try {
+            if (collected.confirmationTokens.length > 0) {
+                await confirmationDelegate.deleteMany({
+                    where: { token: { in: collected.confirmationTokens } },
+                });
+            }
+            if (collected.projectIds.length > 0) {
+                await prisma.project.deleteMany({ where: { id: { in: collected.projectIds } } });
+            }
+            if (collected.subcontractorIds.length > 0) {
+                await prisma.subcontractor.deleteMany({ where: { id: { in: collected.subcontractorIds } } });
+            }
+            if (collected.userIds.length > 0) {
+                await prisma.user.deleteMany({ where: { id: { in: collected.userIds } } });
+            }
+            if (collected.clientIds.length > 0) {
+                await prisma.client.deleteMany({ where: { id: { in: collected.clientIds } } });
+            }
+            const [confirmationsLeft, clientsLeft, projectsLeft, usersLeft, subcontractorsLeft] = await Promise.all([
+                confirmationDelegate.count({ where: { token: { in: collected.confirmationTokens } } }),
+                prisma.client.count({ where: { id: { in: collected.clientIds } } }),
+                prisma.project.count({ where: { id: { in: collected.projectIds } } }),
+                prisma.user.count({ where: { id: { in: collected.userIds } } }),
+                prisma.subcontractor.count({ where: { id: { in: collected.subcontractorIds } } }),
+            ]);
+            cleanupPassed = confirmationsLeft === 0
+                && clientsLeft === 0
+                && projectsLeft === 0
+                && usersLeft === 0
+                && subcontractorsLeft === 0;
+        } catch (error) {
+            console.error("Fixture cleanup error:", error);
+        }
+        console.log(`${cleanupPassed ? "PASS" : "FAIL"} fixture cleanup`);
+    }
+
+    assert.equal(cleanupPassed, true);
+    console.log("mcp-pm-tools verification: PASS");
+}
+
+main()
+    .catch(error => {
+        console.error("mcp-pm-tools verification: FAIL");
+        console.error(error);
+        process.exitCode = 1;
+    })
+    .finally(async () => {
+        try {
+            await prisma.$disconnect();
+        } catch {
+            // Static RED and missing-schema failures can happen before Prisma connects.
+        }
+    });

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -10,6 +10,15 @@ import { coTaxRate, coTaxLabel } from "@/lib/co-tax";
 import { ALLOWED_FILE_EXTENSIONS, fileExtension, mimeTypeForFileName, saveProjectFile } from "@/lib/project-files";
 import { calculateCrewTimeCosts, createExpenseCore, createTimeEntryCore, findCrewMatches } from "@/lib/time-expense-core";
 import {
+    MAX_UPLOAD_BASE64_CHARS,
+    uploadProjectFileCore,
+    uploadProjectFilesCore,
+} from "@/lib/project-file-core";
+import {
+    MCP_ACTOR_EMAILS,
+    type McpActorLabel,
+} from "@/lib/mcp-actor";
+import {
     applyChangeOrderToScheduleWithConfirmation,
     assignProjectCrewWithConfirmation,
     assignTaskCrew,
@@ -21,6 +30,16 @@ import {
     setTaskStatus,
     updateTaskDates,
 } from "@/lib/mcp-schedule-tools";
+import {
+    addPunchItemsWithConfirmation,
+    createDailyLogWithConfirmation,
+    createFolderWithConfirmation,
+    getProjectContacts,
+    listDailyLogs,
+    listProjectFiles,
+    listPunchItems,
+    moveFileWithConfirmation,
+} from "@/lib/mcp-pm-tools";
 
 // MCP connector for ChatGPT (streamable HTTP at POST /api/mcp/mcp).
 //
@@ -85,7 +104,27 @@ const milestoneSchema = z.object({
     percentage: z.number().positive().max(100).describe("Percent of the estimate total; all milestones together must sum to exactly 100"),
 });
 
-const handler = createMcpHandler(
+type RouteMcpActor = {
+    actorLabel: McpActorLabel;
+    resolveActorUserId: () => Promise<string | null>;
+};
+
+function createRouteMcpActor(actorLabel: McpActorLabel): RouteMcpActor {
+    let actorUserId: Promise<string | null> | null = null;
+    return {
+        actorLabel,
+        resolveActorUserId: () => {
+            actorUserId ??= prisma.user.findUnique({
+                where: { email: MCP_ACTOR_EMAILS[actorLabel] },
+                select: { id: true },
+            }).then(user => user?.id ?? null);
+            return actorUserId;
+        },
+    };
+}
+
+function createHandler(actor: RouteMcpActor) {
+    return createMcpHandler(
     server => {
         server.registerTool(
             "list_projects",
@@ -398,7 +437,13 @@ const handler = createMcpHandler(
                         instruction: "Show this to the user. Call again with this confirmToken ONLY after they explicitly approve.",
                     });
                 }
-                const result = await sendMilestoneInvoicesCore(invoiceId, paymentScheduleIds, overrideEmail, { reconcile }, "ChatGPT connector");
+                const result = await sendMilestoneInvoicesCore(
+                    invoiceId,
+                    paymentScheduleIds,
+                    overrideEmail,
+                    { reconcile },
+                    `SYSTEM:${actor.actorLabel}`,
+                );
                 return textResult(result);
             },
         );
@@ -644,7 +689,10 @@ const handler = createMcpHandler(
                     undefined,
                     customMessage,
                     undefined,
-                    process.env.MCP_SECRET,
+                    actor.actorLabel === "richard-ai"
+                        ? process.env.MCP_SECRET_RICHARD
+                        : process.env.MCP_SECRET,
+                    actor.actorLabel,
                 );
                 if (!result.success) return { ...textResult({ error: result.error }), isError: true };
                 return textResult({ ...result, note: "The customer reviews and signs via the portal link; signing auto-creates the invoice in ProBuild." });
@@ -915,107 +963,270 @@ const handler = createMcpHandler(
                     projectId: z.string().max(50).optional().describe("Target project id from list_projects / find_job (omit if using leadId)"),
                     leadId: z.string().max(50).optional().describe("Target lead id from list_leads / find_job (omit if using projectId)"),
                     fileName: z.string().min(1).max(200).describe("File name WITH extension, e.g. 'RFQ-plumbing-sub.pdf'. Allowed: pdf, doc/docx, xls/xlsx, csv, jpg/png/gif/webp/heic, txt, rtf, dwg, dxf"),
-                    contentBase64: z.string().min(1).max(4_400_000).describe("The file's raw bytes, standard base64-encoded (no data: URL prefix). Max ~3 MB decoded."),
+                    contentBase64: z.string().min(1).max(MAX_UPLOAD_BASE64_CHARS).describe("The file's raw bytes, standard base64-encoded (no data: URL prefix). Max ~3 MB decoded."),
                     folder: z.string().max(120).optional().describe("Optional top-level folder name on the job's Files tab, e.g. 'RFQs' — found case-insensitively or created"),
                     visibility: z.enum(["team", "shared"]).optional().describe("'team' = internal only (default); 'shared' = the customer sees it in their portal"),
                 },
             },
-            async ({ projectId, leadId, fileName, contentBase64, folder, visibility }) => {
-                if ((projectId ? 1 : 0) + (leadId ? 1 : 0) !== 1) {
-                    return { ...textResult({ error: "Provide exactly one of projectId or leadId (use find_job / list_projects / list_leads to resolve the target)." }), isError: true };
-                }
-                const ext = fileExtension(fileName);
-                if (!ALLOWED_FILE_EXTENSIONS.has(ext)) {
-                    return { ...textResult({ error: `File type "${ext || "(no extension)"}" not allowed. Allowed: ${[...ALLOWED_FILE_EXTENSIONS].join(", ")}.` }), isError: true };
-                }
-                // Closed/won jobs are accepted on purpose — find_job surfaces them and
-                // parking documents on a finished job is a normal filing action.
-                let targetProjectId: string | null = projectId ?? null;
-                let targetLeadId: string | null = leadId ?? null;
-                let movedToProjectNote: string | null = null;
-                if (targetProjectId) {
-                    const project = await prisma.project.findUnique({ where: { id: targetProjectId }, select: { id: true } });
-                    if (!project) return { ...textResult({ error: `No project with id ${targetProjectId}. Use find_job or list_projects.` }), isError: true };
-                } else {
-                    const lead = await prisma.lead.findUnique({ where: { id: targetLeadId! }, select: { id: true } });
-                    if (!lead) return { ...textResult({ error: `No lead with id ${targetLeadId}. Use find_job or list_leads.` }), isError: true };
-                    // A won lead becomes a project, and the customer portal only reads
-                    // project-owned folders — a "shared" folder filed on the lead would
-                    // be unreachable. Normalize converted leads to their project.
-                    const linkedProject = await prisma.project.findFirst({ where: { leadId: targetLeadId! }, select: { id: true, name: true } });
-                    if (linkedProject) {
-                        movedToProjectNote = `This lead was already converted to project "${linkedProject.name}" — the file was filed on the project.`;
-                        targetProjectId = linkedProject.id;
-                        targetLeadId = null;
-                    }
-                }
-
-                const b64 = contentBase64.replace(/\s+/g, "");
-                if (b64.length % 4 !== 0 || !/^[A-Za-z0-9+/]*={0,2}$/.test(b64)) {
-                    return { ...textResult({ error: "contentBase64 is not valid base64 — send the file's raw bytes standard-base64-encoded, without a data: URL prefix." }), isError: true };
-                }
-                const buffer = Buffer.from(b64, "base64");
-                if (buffer.length === 0) {
-                    return { ...textResult({ error: "contentBase64 decoded to 0 bytes." }), isError: true };
-                }
-                const MAX_UPLOAD_BYTES = 3_300_000; // stays under Vercel's 4.5 MB request cap after base64 expansion
-                if (buffer.length > MAX_UPLOAD_BYTES) {
-                    return { ...textResult({ error: `File is ${(buffer.length / 1_000_000).toFixed(1)} MB — the connector accepts up to ~3 MB. Upload larger files in ProBuild directly.` }), isError: true };
-                }
-
-                // Always store an EXPLICIT visibility (never null/inherit): the portal
-                // shows null-visibility files inside shared folders, so inheriting
-                // could silently expose a file this tool just reported as internal.
-                const fileVisibility = visibility ?? "team";
-
-                let folderId: string | null = null;
-                const folderName = folder?.trim();
-                if (folderName) {
-                    const scope = { projectId: targetProjectId, leadId: targetLeadId, parentId: null };
-                    const existing = await prisma.fileFolder.findFirst({
-                        where: { ...scope, name: { equals: folderName, mode: "insensitive" } },
-                        select: { id: true, name: true, visibility: true },
-                    });
-                    // The portal only traverses SHARED folders — a shared file inside a
-                    // team folder would be unreachable by the customer. Refuse the
-                    // combination rather than silently flipping an existing folder to
-                    // shared (that would expose everything already in it).
-                    if (existing && fileVisibility === "shared" && existing.visibility !== "shared") {
-                        return { ...textResult({ error: `Folder "${existing.name}" is not a shared folder, so the customer could never see a shared file inside it. Upload the shared file without a folder, use a folder that is already shared, or drop visibility to keep it internal.` }), isError: true };
-                    }
-                    folderId = existing
-                        ? existing.id
-                        // A folder created for a shared upload is created shared (it
-                        // contains only what this tool puts in it); otherwise team.
-                        : (await prisma.fileFolder.create({ data: { name: folderName, ...scope, visibility: fileVisibility === "shared" ? "shared" : "team" }, select: { id: true } })).id;
-                }
-
-                const saved = await saveProjectFile({
-                    buffer,
-                    fileName,
-                    mimeType: mimeTypeForFileName(fileName),
-                    projectId: targetProjectId,
-                    leadId: targetLeadId,
-                    folderId,
-                    visibility: fileVisibility,
+            async args => {
+                const actorUserId = actor.actorLabel === "richard-ai"
+                    ? await actor.resolveActorUserId()
+                    : null;
+                const result = await uploadProjectFileCore({
+                    ...args,
+                    actor: { actorLabel: actor.actorLabel, actorUserId },
                 });
-                if (!saved.ok) return { ...textResult({ error: saved.error }), isError: true };
+                if (!result.ok) {
+                    return { ...textResult({ error: result.error }), isError: true };
+                }
+                return textResult(result.data);
+            },
+        );
 
-                const filesUrl = targetProjectId
-                    ? `https://probuild.goldentouchremodeling.com/projects/${targetProjectId}/files`
-                    : `https://probuild.goldentouchremodeling.com/leads/${targetLeadId}/files`;
-                return textResult({
-                    fileId: saved.file.id,
-                    name: saved.file.name,
-                    sizeBytes: saved.file.size,
-                    folder: folderName ?? null,
-                    visibility: fileVisibility,
-                    url: filesUrl,
-                    ...(movedToProjectNote ? { movedToProject: movedToProjectNote } : {}),
-                    note: fileVisibility === "shared"
-                        ? "This file IS visible to the customer (in the client portal, once the job has a project with the portal's Files section enabled)."
-                        : "Internal file — the customer cannot see it.",
+        server.registerTool(
+            "upload_files",
+            {
+                title: "Upload multiple documents to a job's Files tab",
+                annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+                description:
+                    "Uploads 1–8 documents to a project's or lead's Files tab in one call, with a combined decoded limit of ~3 MB. " +
+                    "The whole batch is validated before storage starts; storage failures are returned per file so only failures need retrying. " +
+                    "Files are INTERNAL by default. visibility 'shared' is customer-visible and must only be used when the user explicitly asks. " +
+                    "Standard project folders are created implicitly when the project has no folders.",
+                inputSchema: {
+                    projectId: z.string().max(50).optional().describe("Target project id (omit if using leadId)"),
+                    leadId: z.string().max(50).optional().describe("Target lead id (omit if using projectId)"),
+                    defaultFolder: z.string().max(120).optional().describe("Default top-level folder for files that omit their own folder"),
+                    files: z.array(z.object({
+                        fileName: z.string().min(1).max(200),
+                        contentBase64: z.string().min(1).max(MAX_UPLOAD_BASE64_CHARS),
+                        folder: z.string().max(120).optional(),
+                        visibility: z.enum(["team", "shared"]).optional(),
+                    })).min(1).max(8),
+                },
+            },
+            async args => {
+                const actorUserId = actor.actorLabel === "richard-ai"
+                    ? await actor.resolveActorUserId()
+                    : null;
+                const result = await uploadProjectFilesCore({
+                    ...args,
+                    actor: { actorLabel: actor.actorLabel, actorUserId },
                 });
+                if (!result.ok) {
+                    return { ...textResult({ error: result.error }), isError: true };
+                }
+                return textResult(result.results);
+            },
+        );
+
+        server.registerTool(
+            "list_project_files",
+            {
+                title: "List a job's folder tree and files",
+                annotations: { readOnlyHint: true },
+                description:
+                    "Returns a project's or lead's folder tree and file metadata (id, name, size, mime type, visibility, folder, created date). " +
+                    "Standard project folders are created implicitly when a project has no folders. This tool NEVER returns URLs; file download is not available through MCP.",
+                inputSchema: {
+                    projectId: z.string().max(50).optional(),
+                    leadId: z.string().max(50).optional(),
+                },
+            },
+            async args => {
+                try {
+                    return textResult(await listProjectFiles(args));
+                } catch (error) {
+                    return { ...textResult({ error: error instanceof Error ? error.message : "Failed to list project files" }), isError: true };
+                }
+            },
+        );
+
+        server.registerTool(
+            "create_folder",
+            {
+                title: "Create a folder on a job's Files tab",
+                annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+                description:
+                    "Creates a top-level or nested team/shared folder on one project or lead. A shared child cannot be placed under a team folder. " +
+                    "TWO-STEP, SINGLE-USE: call without confirmToken for a preview, show it to the user, then repeat the exact arguments with the token after approval.",
+                inputSchema: {
+                    projectId: z.string().max(50).optional(),
+                    leadId: z.string().max(50).optional(),
+                    name: z.string().trim().min(1).max(120),
+                    parentFolderId: z.string().max(50).optional(),
+                    visibility: z.enum(["team", "shared"]).optional(),
+                    confirmToken: z.string().length(64).optional(),
+                },
+            },
+            async args => {
+                try {
+                    return textResult(await createFolderWithConfirmation(
+                        args,
+                        { actorLabel: actor.actorLabel, actorUserId: null },
+                    ));
+                } catch (error) {
+                    return { ...textResult({ error: error instanceof Error ? error.message : "Failed to create folder" }), isError: true };
+                }
+            },
+        );
+
+        server.registerTool(
+            "move_file",
+            {
+                title: "Move a file within the same job",
+                annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+                description:
+                    "Moves a ProjectFile to another folder (or the top level) on the SAME project/lead. Cross-job moves are refused. " +
+                    "A team file cannot move into a shared folder unless the same call explicitly passes visibility 'shared'; shared files cannot be hidden inside team folders. " +
+                    "TWO-STEP, SINGLE-USE: preview first, show the user, then repeat the exact arguments with confirmToken after approval.",
+                inputSchema: {
+                    fileId: z.string().max(50),
+                    folderId: z.string().max(50).nullable().describe("Destination folder id, or null for the job's top level"),
+                    visibility: z.enum(["team", "shared"]).optional().describe("Explicitly pass 'shared' to approve a customer-visibility change"),
+                    confirmToken: z.string().length(64).optional(),
+                },
+            },
+            async args => {
+                try {
+                    return textResult(await moveFileWithConfirmation(
+                        args,
+                        { actorLabel: actor.actorLabel, actorUserId: null },
+                    ));
+                } catch (error) {
+                    return { ...textResult({ error: error instanceof Error ? error.message : "Failed to move file" }), isError: true };
+                }
+            },
+        );
+
+        server.registerTool(
+            "list_daily_logs",
+            {
+                title: "List project daily logs",
+                annotations: { readOnlyHint: true },
+                description:
+                    "Lists one project's daily logs with date, weather, crew on site, work performed, deliveries, issues, photo count, and portal-sharing state.",
+                inputSchema: {
+                    projectId: z.string().max(50),
+                    since: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD").optional(),
+                    limit: z.number().int().min(1).max(100).optional(),
+                },
+            },
+            async args => {
+                try {
+                    return textResult(await listDailyLogs(args));
+                } catch (error) {
+                    return { ...textResult({ error: error instanceof Error ? error.message : "Failed to list daily logs" }), isError: true };
+                }
+            },
+        );
+
+        server.registerTool(
+            "create_daily_log",
+            {
+                title: "Create a project daily log",
+                annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+                description:
+                    "Creates an internal daily log on a project. sharedToPortal is deliberately not exposed; portal sharing remains a human in-app decision. " +
+                    "Attach photos by ProjectFile id after upload_files—bytes are not re-sent. Every photo must be an image on the same project. " +
+                    "TWO-STEP, SINGLE-USE: preview first, show the user, then repeat the exact arguments with confirmToken after approval.",
+                inputSchema: {
+                    projectId: z.string().max(50),
+                    date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD"),
+                    weather: z.string().max(300).optional(),
+                    crewOnSite: z.string().max(1000).optional(),
+                    workPerformed: z.string().trim().min(1).max(20_000),
+                    materialsDelivered: z.string().max(20_000).optional(),
+                    issues: z.string().max(20_000).optional(),
+                    photos: z.array(z.object({
+                        fileId: z.string().max(50),
+                        caption: z.string().max(500).optional(),
+                    })).max(20).optional(),
+                    confirmToken: z.string().length(64).optional(),
+                },
+            },
+            async args => {
+                try {
+                    const actorUserId = await actor.resolveActorUserId();
+                    return textResult(await createDailyLogWithConfirmation(
+                        args,
+                        { actorLabel: actor.actorLabel, actorUserId },
+                    ));
+                } catch (error) {
+                    return { ...textResult({ error: error instanceof Error ? error.message : "Failed to create daily log" }), isError: true };
+                }
+            },
+        );
+
+        server.registerTool(
+            "list_punch_items",
+            {
+                title: "List punch items by task or project",
+                annotations: { readOnlyHint: true },
+                description:
+                    "Lists open, completed, or all punch items for exactly one task or project, including completedAt. This is read-only field evidence.",
+                inputSchema: {
+                    taskId: z.string().max(50).optional(),
+                    projectId: z.string().max(50).optional(),
+                    status: z.enum(["open", "completed", "all"]).optional(),
+                },
+            },
+            async args => {
+                try {
+                    return textResult(await listPunchItems(args));
+                } catch (error) {
+                    return { ...textResult({ error: error instanceof Error ? error.message : "Failed to list punch items" }), isError: true };
+                }
+            },
+        );
+
+        server.registerTool(
+            "add_punch_items",
+            {
+                title: "Add punch items to a task",
+                annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+                description:
+                    "Adds 1–30 ordered punch items to one schedule task. TWO-STEP, SINGLE-USE: preview the entire list, show it to the user, then repeat the exact arguments with confirmToken after approval.",
+                inputSchema: {
+                    taskId: z.string().max(50),
+                    items: z.array(z.string().trim().min(1).max(500)).min(1).max(30),
+                    confirmToken: z.string().length(64).optional(),
+                },
+            },
+            async args => {
+                try {
+                    const actorUserId = await actor.resolveActorUserId();
+                    return textResult(await addPunchItemsWithConfirmation(
+                        args,
+                        { actorLabel: actor.actorLabel, actorUserId },
+                    ));
+                } catch (error) {
+                    return { ...textResult({ error: error instanceof Error ? error.message : "Failed to add punch items" }), isError: true };
+                }
+            },
+        );
+
+        // complete_punch_item is deliberately cut/not registered: completion is
+        // direct field evidence and must only follow a human-reported completion,
+        // never a model "tidying up" a punch list.
+
+        server.registerTool(
+            "get_project_contacts",
+            {
+                title: "Get project contacts",
+                annotations: { readOnlyHint: true },
+                description:
+                    "Returns the client, manager, assigned crew, and task subcontractors for one project. PII boundary: no rates, budgets, licenses, or addresses beyond the project location.",
+                inputSchema: {
+                    projectId: z.string().max(50),
+                },
+            },
+            async args => {
+                try {
+                    return textResult(await getProjectContacts(args));
+                } catch (error) {
+                    return { ...textResult({ error: error instanceof Error ? error.message : "Failed to get project contacts" }), isError: true };
+                }
             },
         );
 
@@ -1306,7 +1517,7 @@ const handler = createMcpHandler(
                 try {
                     // Pass the approved snapshot's fingerprint — the send action re-reads the
                     // contract and refuses if the text no longer matches what the user confirmed.
-                    const result = await sendContractToClient(contractId, undefined, fingerprint);
+                    const result = await sendContractToClient(contractId, undefined, fingerprint, actor.actorLabel);
                     return textResult({ ...result, note: "The client reviews and signs via the emailed portal link. Track status with list_contracts / get_contract." });
                 } catch (e) {
                     return { ...textResult({ error: e instanceof Error ? e.message : "Send failed" }), isError: true };
@@ -1432,7 +1643,7 @@ const handler = createMcpHandler(
             },
             async args => {
                 try {
-                    return textResult(await planSchedule(args));
+                    return textResult(await planSchedule(args, actor.actorLabel));
                 } catch (e: any) {
                     return { ...textResult({ error: e?.message ?? "Failed to plan schedule" }), isError: true };
                 }
@@ -1455,7 +1666,7 @@ const handler = createMcpHandler(
             },
             async args => {
                 try {
-                    return textResult(await updateTaskDates(args));
+                    return textResult(await updateTaskDates(args, actor.actorLabel));
                 } catch (e: any) {
                     return { ...textResult({ error: e?.message ?? "Failed to update task dates" }), isError: true };
                 }
@@ -1478,7 +1689,7 @@ const handler = createMcpHandler(
             },
             async args => {
                 try {
-                    return textResult(await setTaskStatus(args));
+                    return textResult(await setTaskStatus(args, actor.actorLabel));
                 } catch (e: any) {
                     return { ...textResult({ error: e?.message ?? "Failed to set task status" }), isError: true };
                 }
@@ -1501,7 +1712,7 @@ const handler = createMcpHandler(
             },
             async args => {
                 try {
-                    return textResult(await assignTaskCrew(args));
+                    return textResult(await assignTaskCrew(args, actor.actorLabel));
                 } catch (e: any) {
                     return { ...textResult({ error: e?.message ?? "Failed to assign task crew" }), isError: true };
                 }
@@ -1550,7 +1761,7 @@ const handler = createMcpHandler(
             },
             async args => {
                 try {
-                    return textResult(await setProjectStartDateWithConfirmation(args));
+                    return textResult(await setProjectStartDateWithConfirmation(args, actor.actorLabel));
                 } catch (e: any) {
                     return { ...textResult({ error: e?.message ?? "Failed to set project start date" }), isError: true };
                 }
@@ -1576,7 +1787,7 @@ const handler = createMcpHandler(
             },
             async args => {
                 try {
-                    return textResult(await generateProjectScheduleWithConfirmation(args));
+                    return textResult(await generateProjectScheduleWithConfirmation(args, actor.actorLabel));
                 } catch (e: any) {
                     return { ...textResult({ error: e?.message ?? "Failed to generate schedule" }), isError: true };
                 }
@@ -1599,7 +1810,7 @@ const handler = createMcpHandler(
             },
             async args => {
                 try {
-                    return textResult(await assignProjectCrewWithConfirmation(args));
+                    return textResult(await assignProjectCrewWithConfirmation(args, actor.actorLabel));
                 } catch (e: any) {
                     return { ...textResult({ error: e?.message ?? "Failed to assign crew" }), isError: true };
                 }
@@ -1623,7 +1834,7 @@ const handler = createMcpHandler(
             },
             async args => {
                 try {
-                    return textResult(await applyChangeOrderToScheduleWithConfirmation(args));
+                    return textResult(await applyChangeOrderToScheduleWithConfirmation(args, actor.actorLabel));
                 } catch (e: any) {
                     return { ...textResult({ error: e?.message ?? "Failed to apply change order to schedule" }), isError: true };
                 }
@@ -1631,7 +1842,7 @@ const handler = createMcpHandler(
         );
     },
     {
-        serverInfo: { name: "probuild", version: "1.12.0" },
+        serverInfo: { name: "probuild", version: "1.13.0" },
         capabilities: { tools: {} },
         instructions:
             "ProBuild is Golden Touch Remodeling's construction management system. " +
@@ -1653,6 +1864,10 @@ const handler = createMcpHandler(
             "once Approved, log_time/log_expense record cost-plus actuals and bill_change_order previews then bills them; fixed orders bill directly → send_milestone_invoice emails the payment link and T&M backup. " +
             "FILES: upload_file parks documents (RFQs, RFIs, spec sheets, generated spreadsheets) on a project's or lead's Files tab — base64 content, ~3 MB max, optional folder. " +
             "Uploads default to internal visibility; only pass visibility 'shared' (customer-visible in the portal) when the user explicitly asks. " +
+            "PROJECT MANAGEMENT: use find_job to resolve the project/lead; standard project folders are ensured implicitly by list_project_files and upload_files when needed. " +
+            "Use upload_files for up to 8 files / ~3 MB total, then create_daily_log with already-uploaded photo ProjectFile ids so image bytes are not sent twice. " +
+            "Use list_punch_items and add_punch_items for punch lists; punch completion is intentionally human-only. " +
+            "File download is not available through MCP. list_project_files returns metadata and folder structure, never URLs. " +
             "SCHEDULING: get_company_schedule answers 'what jobs are waiting to start?' and lists upcoming project starts (plus lead expected starts) " +
             "for the next N days, with each project's crew and a crewConflicts block (double-bookings across overlapping project windows). " +
             "get_project_schedule returns one job's task-level plan; list_crew_availability returns only field-crew bookings/free days and never rates or financials. " +
@@ -1667,28 +1882,37 @@ const handler = createMcpHandler(
             "assign_project_crew replaces a project's crew with the given ACTIVATED user ids (full list, not a delta). " +
             "QuickBooks is handled server-side; never ask the user for QuickBooks credentials.",
     },
-    { basePath: "/api/mcp", maxDuration: 60 },
-);
+        { basePath: "/api/mcp", maxDuration: 60 },
+    );
+}
 
 // Shared-secret gate. Hash both sides to a fixed length before the timing-safe
 // compare so neither content nor secret length leaks through timing.
-function authorized(req: Request): boolean {
-    const secret = process.env.MCP_SECRET;
-    if (!secret) return false;
+export function resolveMcpActorLabel(req: Request): McpActorLabel | null {
     const key = new URL(req.url).searchParams.get("key") ?? "";
-    const a = createHash("sha256").update(key).digest();
-    const b = createHash("sha256").update(secret).digest();
-    return timingSafeEqual(a, b);
+    const suppliedHash = createHash("sha256").update(key).digest();
+    let matched: McpActorLabel | null = null;
+    const candidates: Array<[McpActorLabel, string | undefined]> = [
+        ["justin-ai", process.env.MCP_SECRET],
+        ["richard-ai", process.env.MCP_SECRET_RICHARD],
+    ];
+    for (const [actorLabel, secret] of candidates) {
+        const configuredHash = createHash("sha256").update(secret ?? "").digest();
+        const equal = timingSafeEqual(suppliedHash, configuredHash);
+        if (key.length > 0 && secret && equal && matched === null) matched = actorLabel;
+    }
+    return matched;
 }
 
 function guarded(req: Request) {
-    if (!process.env.MCP_SECRET) {
+    if (!process.env.MCP_SECRET && !process.env.MCP_SECRET_RICHARD) {
         return Response.json({ error: "MCP connector not configured" }, { status: 503 });
     }
-    if (!authorized(req)) {
+    const actorLabel = resolveMcpActorLabel(req);
+    if (!actorLabel) {
         return Response.json({ error: "unauthorized" }, { status: 401 });
     }
-    return handler(req);
+    return createHandler(createRouteMcpActor(actorLabel))(req);
 }
 
 export { guarded as GET, guarded as POST, guarded as DELETE };

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -66,6 +66,8 @@ import {
     type CreateScheduleTaskInput,
     type UpdateScheduleTaskInput,
 } from "./schedule-task-core";
+import { ensureStandardFolders } from "./project-folders";
+import { createDailyLogCore } from "./daily-log-core";
 
 type NotificationToggleKey = "newLead" | "estimateViewed" | "estimateSigned" | "contractSigned" | "invoiceViewed" | "paymentReceived" | "messageReceived";
 
@@ -1153,6 +1155,15 @@ export async function convertLeadToProject(leadId: string) {
     // Auto-grant access to eligible team members
     const { autoGrantProjectAccessToEligibleUsers } = await import("@/lib/auto-grant-project-access");
     await autoGrantProjectAccessToEligibleUsers(project.id);
+
+    // The ProBuild Files tab gets its own canonical scaffold. This is
+    // deliberately independent of Drive provisioning and never rolls back a
+    // successfully-created project.
+    try {
+        await ensureStandardFolders(project.id);
+    } catch (folderErr) {
+        console.error("[Project folders] Failed to create the standard scaffold:", folderErr);
+    }
 
     // Provision Google Drive Folders in the background/async after project creation
     try {
@@ -4169,11 +4180,12 @@ async function assertInvoicePortalAccess(): Promise<string | null> {
 }
 
 async function assertEstimateSendPermission(mcpSecret?: string) {
-    const configuredSecret = process.env.MCP_SECRET;
-    if (mcpSecret && configuredSecret) {
-        const supplied = Buffer.from(mcpSecret);
-        const configured = Buffer.from(configuredSecret);
-        if (supplied.length === configured.length && timingSafeEqual(supplied, configured)) return;
+    if (mcpSecret) {
+        const supplied = createHash("sha256").update(mcpSecret).digest();
+        for (const configuredSecret of [process.env.MCP_SECRET, process.env.MCP_SECRET_RICHARD]) {
+            const configured = createHash("sha256").update(configuredSecret ?? "").digest();
+            if (configuredSecret && timingSafeEqual(supplied, configured)) return;
+        }
     }
     await assertEstimatePermission();
 }
@@ -5035,7 +5047,16 @@ export async function deleteDocumentTemplate(id: string) {
 // Send Estimate to Client
 // =============================================
 
-export async function sendEstimateToClient(estimateId: string, templateId?: string, overrideEmail?: string, ccEmails?: string[], customMessage?: string, capturedPdfUrl?: string, mcpSecret?: string): Promise<{ success: true; sentTo: string } | { success: false; error: string }> {
+export async function sendEstimateToClient(
+    estimateId: string,
+    templateId?: string,
+    overrideEmail?: string,
+    ccEmails?: string[],
+    customMessage?: string,
+    capturedPdfUrl?: string,
+    mcpSecret?: string,
+    mcpActorLabel?: "justin-ai" | "richard-ai",
+): Promise<{ success: true; sentTo: string } | { success: false; error: string }> {
     await assertEstimateSendPermission(mcpSecret);
     try {
     // --- Server-side CC validation ---
@@ -5336,8 +5357,10 @@ export async function sendEstimateToClient(estimateId: string, templateId?: stri
         await logActivity({
             projectId: estimate.project?.id,
             leadId: estimate.lead?.id,
-            actorType: "TEAM",
-            actorName: session?.user?.name || session?.user?.email || "Team",
+            actorType: mcpActorLabel ? "SYSTEM" : "TEAM",
+            actorName: mcpActorLabel
+                ? `SYSTEM:${mcpActorLabel}`
+                : session?.user?.name || session?.user?.email || "Team",
             action: "sent_estimate",
             entityType: "estimate",
             entityId: estimateId,
@@ -5852,7 +5875,12 @@ export async function deleteContract(id: string) {
     if (contract?.leadId) revalidatePath(`/leads/${contract.leadId}`);
 }
 
-export async function sendContractToClient(contractId: string, ccOverride?: string[], expectedFingerprint?: string) {
+export async function sendContractToClient(
+    contractId: string,
+    ccOverride?: string[],
+    expectedFingerprint?: string,
+    mcpActorLabel?: "justin-ai" | "richard-ai",
+) {
     const contract = await prisma.contract.findUnique({
         where: { id: contractId },
         include: {
@@ -5986,8 +6014,8 @@ export async function sendContractToClient(contractId: string, ccOverride?: stri
     if (contract.projectId) {
         await logActivity({
             projectId: contract.projectId,
-            actorType: "TEAM",
-            actorName: companyName,
+            actorType: mcpActorLabel ? "SYSTEM" : "TEAM",
+            actorName: mcpActorLabel ? `SYSTEM:${mcpActorLabel}` : companyName,
             action: "sent_contract",
             entityType: "contract",
             entityId: contractId,
@@ -11341,24 +11369,10 @@ export async function createDailyLog(projectId: string, data: {
 }) {
     // Hardened (dispatch-arc foundation): derive the author from an authorized staff session.
     const author = await assertDailyLogAccess(projectId);
-    const log = await prisma.dailyLog.create({
-        data: {
-            projectId,
-            date: new Date(data.date),
-            weather: data.weather || null,
-            crewOnSite: data.crewOnSite || null,
-            workPerformed: data.workPerformed,
-            materialsDelivered: data.materialsDelivered || null,
-            issues: data.issues || null,
-            createdById: author.id,
-            photos: data.photoUrls && data.photoUrls.length > 0 ? {
-                create: data.photoUrls.map(p => ({
-                    url: p.url,
-                    caption: p.caption || null,
-                })),
-            } : undefined,
-        },
-        include: { photos: true },
+    const log = await createDailyLogCore({
+        projectId,
+        actorUserId: author.id,
+        ...data,
     });
 
     revalidatePath(`/projects/${projectId}/dailylogs`);

--- a/src/lib/daily-log-core.ts
+++ b/src/lib/daily-log-core.ts
@@ -1,0 +1,53 @@
+import type { Prisma } from "@prisma/client";
+
+import { prisma } from "./prisma";
+
+export type CreateDailyLogCoreInput = {
+    projectId: string;
+    actorUserId: string;
+    date: string;
+    weather?: string;
+    crewOnSite?: string;
+    workPerformed: string;
+    materialsDelivered?: string;
+    issues?: string;
+    photoUrls?: Array<{ url: string; caption?: string }>;
+};
+
+type DailyLogDb = Pick<Prisma.TransactionClient, "dailyLog">;
+
+export async function createDailyLogCore(
+    input: CreateDailyLogCoreInput,
+    tx: DailyLogDb = prisma,
+) {
+    const {
+        projectId,
+        actorUserId,
+        date,
+        weather,
+        crewOnSite,
+        workPerformed,
+        materialsDelivered,
+        issues,
+        photoUrls,
+    } = input;
+    return tx.dailyLog.create({
+        data: {
+            projectId,
+            date: new Date(date),
+            weather: weather || null,
+            crewOnSite: crewOnSite || null,
+            workPerformed,
+            materialsDelivered: materialsDelivered || null,
+            issues: issues || null,
+            createdById: actorUserId,
+            photos: photoUrls && photoUrls.length > 0 ? {
+                create: photoUrls.map(photo => ({
+                    url: photo.url,
+                    caption: photo.caption || null,
+                })),
+            } : undefined,
+        },
+        include: { photos: true },
+    });
+}

--- a/src/lib/mcp-actor.ts
+++ b/src/lib/mcp-actor.ts
@@ -1,0 +1,15 @@
+export const MCP_ACTOR_EMAILS = {
+    "justin-ai": "gtrsupport@goldentouchremodeling.com",
+    "richard-ai": "richard-ai@goldentouchremodeling.com",
+} as const;
+
+export type McpActorLabel = keyof typeof MCP_ACTOR_EMAILS;
+
+export type McpActorContext = {
+    actorLabel: McpActorLabel;
+    actorUserId: string | null;
+};
+
+export function mcpActivityActorName(actorLabel: McpActorLabel): string {
+    return `SYSTEM:${actorLabel}`;
+}

--- a/src/lib/mcp-pm-tools.ts
+++ b/src/lib/mcp-pm-tools.ts
@@ -1,0 +1,789 @@
+import type { Prisma } from "@prisma/client";
+
+import { createDailyLogCore } from "./daily-log-core";
+import {
+    executeConfirmed,
+    issueConfirmation,
+} from "./mcp-schedule-tools";
+import type { McpActorContext } from "./mcp-actor";
+import { prisma } from "./prisma";
+import { ensureStandardFolders } from "./project-folders";
+
+type PmDb = Pick<
+    Prisma.TransactionClient,
+    "activityLog" | "dailyLog" | "fileFolder" | "lead" | "project" | "projectFile" | "scheduleTask" | "taskPunchItem"
+>;
+
+type OwnerInput = {
+    projectId?: string;
+    leadId?: string;
+};
+
+type FolderVisibility = "team" | "shared";
+
+function ownerWhere(owner: { projectId: string | null; leadId: string | null }) {
+    return {
+        projectId: owner.projectId,
+        leadId: owner.leadId,
+    };
+}
+
+function sameOwner(
+    left: { projectId: string | null; leadId: string | null },
+    right: { projectId: string | null; leadId: string | null },
+): boolean {
+    return left.projectId === right.projectId && left.leadId === right.leadId;
+}
+
+async function resolveOwner(
+    input: OwnerInput,
+    db: Pick<Prisma.TransactionClient, "lead" | "project"> = prisma,
+): Promise<{ projectId: string | null; leadId: string | null; name: string }> {
+    if ((input.projectId ? 1 : 0) + (input.leadId ? 1 : 0) !== 1) {
+        throw new Error("Provide exactly one of projectId or leadId.");
+    }
+    if (input.projectId) {
+        const project = await db.project.findUnique({
+            where: { id: input.projectId },
+            select: { id: true, name: true },
+        });
+        if (!project) throw new Error("Project not found");
+        return { projectId: project.id, leadId: null, name: project.name };
+    }
+    const lead = await db.lead.findUnique({
+        where: { id: input.leadId! },
+        select: { id: true, name: true },
+    });
+    if (!lead) throw new Error("Lead not found");
+    return { projectId: null, leadId: lead.id, name: lead.name };
+}
+
+async function writeActivity(
+    db: Pick<Prisma.TransactionClient, "activityLog">,
+    actor: McpActorContext,
+    input: {
+        projectId?: string | null;
+        leadId?: string | null;
+        action: string;
+        entityType: string;
+        entityId: string;
+        entityName: string;
+        metadata?: Record<string, unknown>;
+    },
+): Promise<void> {
+    const actorName = `SYSTEM:${actor.actorLabel}`;
+    await db.activityLog.create({
+        data: {
+            projectId: input.projectId ?? null,
+            leadId: input.leadId ?? null,
+            actorType: "SYSTEM",
+            actorName,
+            action: input.action,
+            entityType: input.entityType,
+            entityId: input.entityId,
+            entityName: input.entityName,
+            metadata: input.metadata ? JSON.stringify(input.metadata) : null,
+        },
+    });
+}
+
+async function executePmConfirmed<T extends Record<string, unknown>>(
+    toolName: string,
+    args: unknown,
+    confirmToken: string,
+    actor: McpActorContext,
+    write: (tx: Prisma.TransactionClient) => Promise<T>,
+) {
+    return executeConfirmed(toolName, args, confirmToken, write, actor.actorLabel, "MCP");
+}
+
+export async function listProjectFiles(input: OwnerInput) {
+    const owner = await resolveOwner(input);
+    if (owner.projectId) {
+        const topLevelCount = await prisma.fileFolder.count({
+            where: { projectId: owner.projectId, parentId: null },
+        });
+        if (topLevelCount === 0) await ensureStandardFolders(owner.projectId);
+    }
+
+    const [folders, files] = await Promise.all([
+        prisma.fileFolder.findMany({
+            where: ownerWhere(owner),
+            orderBy: [{ name: "asc" }, { id: "asc" }],
+            select: {
+                id: true,
+                name: true,
+                visibility: true,
+                parentId: true,
+                createdAt: true,
+            },
+        }),
+        prisma.projectFile.findMany({
+            where: ownerWhere(owner),
+            orderBy: [{ createdAt: "desc" }, { name: "asc" }],
+            select: {
+                id: true,
+                name: true,
+                size: true,
+                mimeType: true,
+                visibility: true,
+                folderId: true,
+                createdAt: true,
+                folder: { select: { name: true, visibility: true } },
+            },
+        }),
+    ]);
+
+    type FileRow = {
+        id: string;
+        name: string;
+        size: number;
+        mimeType: string;
+        visibility: string;
+        folder: string | null;
+        createdAt: Date;
+    };
+    type FolderNode = {
+        id: string;
+        name: string;
+        visibility: string;
+        parentFolderId: string | null;
+        createdAt: Date;
+        files: FileRow[];
+        children: FolderNode[];
+    };
+    const nodes = new Map<string, FolderNode>();
+    for (const folder of folders) {
+        nodes.set(folder.id, {
+            id: folder.id,
+            name: folder.name,
+            visibility: folder.visibility,
+            parentFolderId: folder.parentId,
+            createdAt: folder.createdAt,
+            files: [],
+            children: [],
+        });
+    }
+    const unfiled: FileRow[] = [];
+    for (const file of files) {
+        const row = {
+            id: file.id,
+            name: file.name,
+            size: file.size,
+            mimeType: file.mimeType,
+            visibility: file.visibility ?? file.folder?.visibility ?? "team",
+            folder: file.folder?.name ?? null,
+            createdAt: file.createdAt,
+        };
+        const node = file.folderId ? nodes.get(file.folderId) : null;
+        if (node) node.files.push(row);
+        else unfiled.push(row);
+    }
+    const roots: FolderNode[] = [];
+    for (const folder of folders) {
+        const node = nodes.get(folder.id)!;
+        const parent = folder.parentId ? nodes.get(folder.parentId) : null;
+        if (parent) parent.children.push(node);
+        else roots.push(node);
+    }
+    return {
+        target: {
+            projectId: owner.projectId,
+            leadId: owner.leadId,
+            name: owner.name,
+        },
+        folders: roots,
+        unfiled,
+        note: "No file URLs are returned. File download is not available through MCP.",
+    };
+}
+
+type CreateFolderInput = OwnerInput & {
+    name: string;
+    parentFolderId?: string;
+    visibility?: FolderVisibility;
+    confirmToken?: string;
+};
+
+async function resolveFolderCreate(
+    input: CreateFolderInput,
+    db: PmDb,
+) {
+    const owner = await resolveOwner(input, db);
+    const name = input.name.trim();
+    if (!name) throw new Error("Folder name is required");
+    const parentFolderId = input.parentFolderId ?? null;
+    const visibility = input.visibility ?? "team";
+    const parent = parentFolderId
+        ? await db.fileFolder.findUnique({
+            where: { id: parentFolderId },
+            select: { id: true, name: true, visibility: true, projectId: true, leadId: true },
+        })
+        : null;
+    if (parentFolderId && !parent) throw new Error("Parent folder not found");
+    if (parent && !sameOwner(owner, parent)) {
+        throw new Error("Parent folder must belong to the same project or lead.");
+    }
+    if (parent && visibility === "shared" && parent.visibility !== "shared") {
+        throw new Error(`Parent folder "${parent.name}" is not shared, so a shared child folder would be unreachable in the customer portal.`);
+    }
+    const existing = await db.fileFolder.findFirst({
+        where: {
+            ...ownerWhere(owner),
+            parentId: parentFolderId,
+            name: { equals: name, mode: "insensitive" },
+        },
+        select: { id: true, name: true },
+    });
+    if (existing) throw new Error(`Folder "${existing.name}" already exists at that level.`);
+    return { owner, name, parentFolderId, visibility };
+}
+
+export async function createFolderWithConfirmation(
+    input: CreateFolderInput,
+    actor: McpActorContext,
+) {
+    const args = {
+        projectId: input.projectId,
+        leadId: input.leadId,
+        name: input.name.trim(),
+        parentFolderId: input.parentFolderId,
+        visibility: input.visibility ?? "team",
+    };
+    if (!input.confirmToken) {
+        const plan = await resolveFolderCreate(input, prisma);
+        return issueConfirmation(
+            "create_folder",
+            args,
+            `Create ${plan.visibility} folder "${plan.name}"${plan.parentFolderId ? " inside the selected parent folder" : ""} on "${plan.owner.name}".`,
+            actor.actorLabel,
+        );
+    }
+    return executePmConfirmed("create_folder", args, input.confirmToken, actor, async tx => {
+        const plan = await resolveFolderCreate(input, tx);
+        const folder = await tx.fileFolder.create({
+            data: {
+                ...ownerWhere(plan.owner),
+                name: plan.name,
+                parentId: plan.parentFolderId,
+                visibility: plan.visibility,
+            },
+            select: { id: true, name: true, visibility: true, parentId: true },
+        });
+        await writeActivity(tx, actor, {
+            ...ownerWhere(plan.owner),
+            action: "created_folder",
+            entityType: "file_folder",
+            entityId: folder.id,
+            entityName: folder.name,
+            metadata: { visibility: folder.visibility, parentFolderId: folder.parentId },
+        });
+        return {
+            folderId: folder.id,
+            name: folder.name,
+            visibility: folder.visibility,
+            parentFolderId: folder.parentId,
+        };
+    });
+}
+
+type MoveFileInput = {
+    fileId: string;
+    folderId: string | null;
+    visibility?: FolderVisibility;
+    confirmToken?: string;
+};
+
+async function resolveMoveFile(input: MoveFileInput, db: PmDb) {
+    const file = await db.projectFile.findUnique({
+        where: { id: input.fileId },
+        select: {
+            id: true,
+            name: true,
+            projectId: true,
+            leadId: true,
+            folderId: true,
+            visibility: true,
+            folder: { select: { name: true, visibility: true } },
+        },
+    });
+    if (!file) throw new Error("File not found");
+    const targetFolder = input.folderId
+        ? await db.fileFolder.findUnique({
+            where: { id: input.folderId },
+            select: { id: true, name: true, visibility: true, projectId: true, leadId: true },
+        })
+        : null;
+    if (input.folderId && !targetFolder) throw new Error("Target folder not found");
+    if (targetFolder && !sameOwner(file, targetFolder)) {
+        throw new Error("Cross-project/lead moves are refused; the file and folder must belong to the same project or lead.");
+    }
+
+    const currentEffective = file.visibility ?? file.folder?.visibility ?? "team";
+    const targetFolderVisibility = targetFolder?.visibility ?? "team";
+    const nextEffective = input.visibility ?? file.visibility ?? targetFolderVisibility;
+    if (
+        currentEffective === "team"
+        && targetFolderVisibility === "shared"
+        && input.visibility !== "shared"
+    ) {
+        throw new Error("Moving this team file into a shared folder could expose it to the customer. Pass visibility \"shared\" explicitly in the same call to approve that change.");
+    }
+    if (targetFolder && targetFolder.visibility !== "shared" && nextEffective === "shared") {
+        throw new Error(`Folder "${targetFolder.name}" is not shared, so a shared file inside it would be unreachable in the customer portal.`);
+    }
+    return {
+        file,
+        targetFolder,
+        currentEffective,
+        nextVisibility: input.visibility,
+        nextEffective,
+    };
+}
+
+export async function moveFileWithConfirmation(
+    input: MoveFileInput,
+    actor: McpActorContext,
+) {
+    const args = {
+        fileId: input.fileId,
+        folderId: input.folderId,
+        visibility: input.visibility,
+    };
+    if (!input.confirmToken) {
+        const plan = await resolveMoveFile(input, prisma);
+        return issueConfirmation(
+            "move_file",
+            args,
+            `Move "${plan.file.name}" to ${plan.targetFolder ? `folder "${plan.targetFolder.name}"` : "the top level"} with effective visibility ${plan.nextEffective}.`,
+            actor.actorLabel,
+        );
+    }
+    return executePmConfirmed("move_file", args, input.confirmToken, actor, async tx => {
+        const plan = await resolveMoveFile(input, tx);
+        const file = await tx.projectFile.update({
+            where: { id: input.fileId },
+            data: {
+                folderId: input.folderId,
+                ...(input.visibility !== undefined ? { visibility: input.visibility } : {}),
+            },
+            select: {
+                id: true,
+                name: true,
+                folderId: true,
+                visibility: true,
+                projectId: true,
+                leadId: true,
+            },
+        });
+        await writeActivity(tx, actor, {
+            projectId: file.projectId,
+            leadId: file.leadId,
+            action: "moved_file",
+            entityType: "project_file",
+            entityId: file.id,
+            entityName: file.name,
+            metadata: {
+                fromFolderId: plan.file.folderId,
+                toFolderId: file.folderId,
+                visibility: file.visibility,
+            },
+        });
+        return {
+            fileId: file.id,
+            name: file.name,
+            folderId: file.folderId,
+            visibility: file.visibility ?? plan.nextEffective,
+        };
+    });
+}
+
+export async function listDailyLogs(input: {
+    projectId: string;
+    since?: string;
+    limit?: number;
+}) {
+    const project = await prisma.project.findUnique({
+        where: { id: input.projectId },
+        select: { id: true, name: true },
+    });
+    if (!project) throw new Error("Project not found");
+    const limit = input.limit ?? 30;
+    if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+        throw new Error("limit must be a whole number from 1 through 100");
+    }
+    const since = input.since ? new Date(`${input.since}T00:00:00.000Z`) : null;
+    if (since && Number.isNaN(since.getTime())) throw new Error("since must use YYYY-MM-DD");
+    const logs = await prisma.dailyLog.findMany({
+        where: {
+            projectId: input.projectId,
+            ...(since ? { date: { gte: since } } : {}),
+        },
+        take: limit,
+        orderBy: [{ date: "desc" }, { createdAt: "desc" }],
+        select: {
+            id: true,
+            date: true,
+            weather: true,
+            crewOnSite: true,
+            workPerformed: true,
+            materialsDelivered: true,
+            issues: true,
+            sharedToPortal: true,
+            _count: { select: { photos: true } },
+        },
+    });
+    return {
+        project: { id: project.id, name: project.name },
+        logs: logs.map(log => ({
+            id: log.id,
+            date: log.date.toISOString().slice(0, 10),
+            weather: log.weather,
+            crewOnSite: log.crewOnSite,
+            workPerformed: log.workPerformed,
+            materialsDelivered: log.materialsDelivered,
+            issues: log.issues,
+            photoCount: log._count.photos,
+            sharedToPortal: log.sharedToPortal,
+        })),
+    };
+}
+
+type CreateDailyLogInput = {
+    projectId: string;
+    date: string;
+    weather?: string;
+    crewOnSite?: string;
+    workPerformed: string;
+    materialsDelivered?: string;
+    issues?: string;
+    photos?: Array<{ fileId: string; caption?: string }>;
+    confirmToken?: string;
+};
+
+async function resolveDailyLogPhotos(
+    db: PmDb,
+    projectId: string,
+    photos: Array<{ fileId: string; caption?: string }>,
+) {
+    const uniqueIds = [...new Set(photos.map(photo => photo.fileId))];
+    const files = uniqueIds.length > 0
+        ? await db.projectFile.findMany({
+            where: { id: { in: uniqueIds } },
+            select: { id: true, name: true, url: true, mimeType: true, projectId: true },
+        })
+        : [];
+    const byId = new Map(files.map(file => [file.id, file]));
+    return photos.map(photo => {
+        const file = byId.get(photo.fileId);
+        if (!file) throw new Error(`ProjectFile not found: ${photo.fileId}`);
+        if (file.projectId !== projectId) {
+            throw new Error(`Photo file "${file.name}" must belong to the same project as the daily log.`);
+        }
+        if (!file.mimeType.startsWith("image/")) {
+            throw new Error(`ProjectFile "${file.name}" is not an image.`);
+        }
+        return {
+            fileId: file.id,
+            name: file.name,
+            url: file.url,
+            caption: photo.caption?.trim() || undefined,
+        };
+    });
+}
+
+export async function createDailyLogWithConfirmation(
+    input: CreateDailyLogInput,
+    actor: McpActorContext,
+) {
+    if (!actor.actorUserId) {
+        throw new Error(`The ${actor.actorLabel} attribution user is not seeded yet, so a daily log cannot be created safely.`);
+    }
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(input.date)) throw new Error("date must use YYYY-MM-DD");
+    const workPerformed = input.workPerformed.trim();
+    if (!workPerformed) throw new Error("workPerformed is required");
+    const photos = input.photos ?? [];
+    const args = {
+        projectId: input.projectId,
+        date: input.date,
+        weather: input.weather?.trim() || undefined,
+        crewOnSite: input.crewOnSite?.trim() || undefined,
+        workPerformed,
+        materialsDelivered: input.materialsDelivered?.trim() || undefined,
+        issues: input.issues?.trim() || undefined,
+        photos: photos.map(photo => ({
+            fileId: photo.fileId,
+            caption: photo.caption?.trim() || undefined,
+        })),
+    };
+    if (!input.confirmToken) {
+        const project = await prisma.project.findUnique({
+            where: { id: input.projectId },
+            select: { name: true },
+        });
+        if (!project) throw new Error("Project not found");
+        const resolvedPhotos = await resolveDailyLogPhotos(prisma, input.projectId, args.photos);
+        return issueConfirmation(
+            "create_daily_log",
+            args,
+            `Create the ${input.date} daily log on "${project.name}" with ${resolvedPhotos.length} photo${resolvedPhotos.length === 1 ? "" : "s"}: ${workPerformed}`,
+            actor.actorLabel,
+        );
+    }
+    return executePmConfirmed("create_daily_log", args, input.confirmToken, actor, async tx => {
+        const project = await tx.project.findUnique({
+            where: { id: input.projectId },
+            select: { id: true, name: true },
+        });
+        if (!project) throw new Error("Project not found");
+        const resolvedPhotos = await resolveDailyLogPhotos(tx, input.projectId, args.photos);
+        const log = await createDailyLogCore({
+            projectId: input.projectId,
+            actorUserId: actor.actorUserId!,
+            date: args.date,
+            weather: args.weather,
+            crewOnSite: args.crewOnSite,
+            workPerformed: args.workPerformed,
+            materialsDelivered: args.materialsDelivered,
+            issues: args.issues,
+            photoUrls: resolvedPhotos.map(photo => ({
+                url: photo.url,
+                caption: photo.caption,
+            })),
+        }, tx);
+        await writeActivity(tx, actor, {
+            projectId: input.projectId,
+            action: "created_daily_log",
+            entityType: "daily_log",
+            entityId: log.id,
+            entityName: `${project.name} daily log ${args.date}`,
+            metadata: { photoFileIds: resolvedPhotos.map(photo => photo.fileId) },
+        });
+        return {
+            dailyLogId: log.id,
+            projectId: input.projectId,
+            date: log.date.toISOString().slice(0, 10),
+            photoCount: log.photos.length,
+            sharedToPortal: log.sharedToPortal,
+        };
+    });
+}
+
+export async function listPunchItems(input: {
+    taskId?: string;
+    projectId?: string;
+    status?: "open" | "completed" | "all";
+}) {
+    if ((input.taskId ? 1 : 0) + (input.projectId ? 1 : 0) !== 1) {
+        throw new Error("Provide exactly one of taskId or projectId.");
+    }
+    const status = input.status ?? "open";
+    const items = await prisma.taskPunchItem.findMany({
+        where: {
+            ...(input.taskId ? { taskId: input.taskId } : { task: { projectId: input.projectId } }),
+            ...(status === "all" ? {} : { completed: status === "completed" }),
+        },
+        orderBy: [{ task: { order: "asc" } }, { order: "asc" }, { createdAt: "asc" }],
+        select: {
+            id: true,
+            taskId: true,
+            name: true,
+            completed: true,
+            completedAt: true,
+            assignee: true,
+            order: true,
+            task: {
+                select: {
+                    name: true,
+                    projectId: true,
+                },
+            },
+        },
+    });
+    return {
+        status,
+        items: items.map(item => ({
+            id: item.id,
+            taskId: item.taskId,
+            taskName: item.task.name,
+            projectId: item.task.projectId,
+            name: item.name,
+            assignee: item.assignee,
+            order: item.order,
+            completed: item.completed,
+            completedAt: item.completedAt,
+        })),
+    };
+}
+
+type AddPunchItemsInput = {
+    taskId: string;
+    items: string[];
+    confirmToken?: string;
+};
+
+export async function addPunchItemsWithConfirmation(
+    input: AddPunchItemsInput,
+    actor: McpActorContext,
+) {
+    if (input.items.length < 1 || input.items.length > 30) {
+        throw new Error("add_punch_items accepts between 1 and 30 items.");
+    }
+    const items = input.items.map(item => item.trim());
+    if (items.some(item => !item)) throw new Error("Punch item names cannot be empty.");
+    const args = { taskId: input.taskId, items };
+    if (!input.confirmToken) {
+        const task = await prisma.scheduleTask.findUnique({
+            where: { id: input.taskId },
+            select: { name: true, project: { select: { name: true } } },
+        });
+        if (!task) throw new Error("Task not found");
+        return issueConfirmation(
+            "add_punch_items",
+            args,
+            `Add ${items.length} punch item${items.length === 1 ? "" : "s"} to "${task.name}" on "${task.project?.name ?? "the job"}":\n${items.map((item, index) => `${index + 1}. ${item}`).join("\n")}`,
+            actor.actorLabel,
+        );
+    }
+    return executePmConfirmed("add_punch_items", args, input.confirmToken, actor, async tx => {
+        const task = await tx.scheduleTask.findUnique({
+            where: { id: input.taskId },
+            select: { id: true, name: true, projectId: true },
+        });
+        if (!task) throw new Error("Task not found");
+        const maxOrder = await tx.taskPunchItem.aggregate({
+            where: { taskId: input.taskId },
+            _max: { order: true },
+        });
+        let order = (maxOrder._max.order ?? -1) + 1;
+        const created = [];
+        for (const name of items) {
+            created.push(await tx.taskPunchItem.create({
+                data: {
+                    taskId: input.taskId,
+                    name,
+                    order: order++,
+                    createdById: actor.actorUserId,
+                },
+                select: { id: true, name: true, order: true },
+            }));
+        }
+        await writeActivity(tx, actor, {
+            projectId: task.projectId,
+            action: "added_punch_items",
+            entityType: "schedule_task",
+            entityId: task.id,
+            entityName: task.name,
+            metadata: { punchItemIds: created.map(item => item.id) },
+        });
+        return {
+            taskId: task.id,
+            created,
+        };
+    });
+}
+
+export async function getProjectContacts(input: { projectId: string }) {
+    const project = await prisma.project.findUnique({
+        where: { id: input.projectId },
+        select: {
+            id: true,
+            name: true,
+            location: true,
+            client: {
+                select: {
+                    name: true,
+                    email: true,
+                    primaryPhone: true,
+                },
+            },
+            manager: {
+                select: {
+                    id: true,
+                    name: true,
+                    email: true,
+                    role: true,
+                },
+            },
+            crew: {
+                orderBy: [{ name: "asc" }, { id: "asc" }],
+                select: {
+                    id: true,
+                    name: true,
+                    role: true,
+                },
+            },
+            scheduleTasks: {
+                select: {
+                    id: true,
+                    name: true,
+                    subAssignments: {
+                        select: {
+                            subcontractor: {
+                                select: {
+                                    id: true,
+                                    companyName: true,
+                                    trade: true,
+                                    contactName: true,
+                                    email: true,
+                                    phone: true,
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    });
+    if (!project) throw new Error("Project not found");
+
+    const subcontractors = new Map<string, {
+        id: string;
+        company: string;
+        trade: string | null;
+        contact: { name: string | null; email: string; phone: string | null };
+        tasks: Array<{ id: string; name: string }>;
+    }>();
+    for (const task of project.scheduleTasks) {
+        for (const assignment of task.subAssignments) {
+            const sub = assignment.subcontractor;
+            const current = subcontractors.get(sub.id) ?? {
+                id: sub.id,
+                company: sub.companyName,
+                trade: sub.trade,
+                contact: {
+                    name: sub.contactName,
+                    email: sub.email,
+                    phone: sub.phone,
+                },
+                tasks: [],
+            };
+            if (!current.tasks.some(existing => existing.id === task.id)) {
+                current.tasks.push({ id: task.id, name: task.name });
+            }
+            subcontractors.set(sub.id, current);
+        }
+    }
+
+    return {
+        project: {
+            id: project.id,
+            name: project.name,
+            location: project.location,
+        },
+        client: project.client ? {
+            name: project.client.name,
+            email: project.client.email,
+            phone: project.client.primaryPhone,
+        } : null,
+        manager: project.manager,
+        crew: project.crew.map(member => ({
+            id: member.id,
+            name: member.name,
+            role: member.role,
+        })),
+        subcontractors: [...subcontractors.values()].sort((left, right) =>
+            left.company.localeCompare(right.company),
+        ),
+    };
+}

--- a/src/lib/mcp-schedule-tools.ts
+++ b/src/lib/mcp-schedule-tools.ts
@@ -24,9 +24,17 @@ import {
     type ScheduleTaskType,
 } from "./schedule-task-core";
 import { withTxRetry } from "./tx-retry";
+import {
+    mcpActivityActorName,
+    type McpActorLabel,
+} from "./mcp-actor";
 
 const CONFIRMATION_TTL_MS = 10 * 60 * 1_000;
-const MCP_ACTOR: ScheduleActor = { type: "SYSTEM", name: "ChatGPT connector" };
+const DEFAULT_MCP_ACTOR_LABEL: McpActorLabel = "justin-ai";
+
+function scheduleActor(actorLabel: McpActorLabel): ScheduleActor {
+    return { type: "SYSTEM", name: mcpActivityActorName(actorLabel) };
+}
 
 type CanonicalValue =
     | null
@@ -82,10 +90,11 @@ export function scheduleArgsHash(value: unknown): string {
     return createHash("sha256").update(canonicalJson(value)).digest("hex");
 }
 
-async function issueConfirmation(
+export async function issueConfirmation(
     toolName: string,
     args: unknown,
     preview: string,
+    actorLabel: McpActorLabel = DEFAULT_MCP_ACTOR_LABEL,
 ): Promise<McpConfirmationPreview> {
     const token = randomBytes(32).toString("hex");
     const expiresAt = new Date(Date.now() + CONFIRMATION_TTL_MS);
@@ -93,6 +102,7 @@ async function issueConfirmation(
         data: {
             token,
             toolName,
+            actorLabel,
             argsHash: scheduleArgsHash(args),
             preview,
             expiresAt,
@@ -108,12 +118,14 @@ async function issueConfirmation(
     };
 }
 
-async function executeConfirmed<T extends Record<string, unknown>>(
+export async function executeConfirmed<T extends Record<string, unknown>>(
     toolName: string,
     args: unknown,
     confirmToken: string,
     // eslint-disable-next-line no-unused-vars
     write: (tx: Prisma.TransactionClient) => Promise<T>,
+    actorLabel: McpActorLabel = DEFAULT_MCP_ACTOR_LABEL,
+    confirmationKind = "schedule",
 ): Promise<T & { confirmed: true }> {
     const argsHash = scheduleArgsHash(args);
     return withTxRetry(() => prisma.$transaction(async tx => {
@@ -121,22 +133,27 @@ async function executeConfirmed<T extends Record<string, unknown>>(
             where: { token: confirmToken },
             select: {
                 toolName: true,
+                actorLabel: true,
                 argsHash: true,
                 expiresAt: true,
                 consumedAt: true,
             },
         });
-        if (!row) throw new Error("Invalid schedule confirmation token");
+        if (!row) throw new Error(`Invalid ${confirmationKind} confirmation token`);
+        if (row.actorLabel !== actorLabel) {
+            throw new Error("Confirmation token belongs to a different MCP actor/key; request a new preview");
+        }
         if (row.toolName !== toolName || row.argsHash !== argsHash) {
             throw new Error("Confirmation token does not match this tool and its arguments; request a new preview");
         }
-        if (row.expiresAt <= new Date()) throw new Error("Schedule confirmation token has expired");
-        if (row.consumedAt) throw new Error("Schedule confirmation token was already used");
+        if (row.expiresAt <= new Date()) throw new Error(`${confirmationKind[0].toUpperCase()}${confirmationKind.slice(1)} confirmation token has expired`);
+        if (row.consumedAt) throw new Error(`${confirmationKind[0].toUpperCase()}${confirmationKind.slice(1)} confirmation token was already used`);
 
         const claim = await tx.mcpConfirmation.updateMany({
             where: {
                 token: confirmToken,
                 toolName,
+                actorLabel,
                 argsHash,
                 expiresAt: { gt: new Date() },
                 consumedAt: null,
@@ -144,7 +161,7 @@ async function executeConfirmed<T extends Record<string, unknown>>(
             data: { consumedAt: new Date() },
         });
         if (claim.count !== 1) {
-            throw new Error("Schedule confirmation token was already consumed by another request");
+            throw new Error(`${confirmationKind[0].toUpperCase()}${confirmationKind.slice(1)} confirmation token was already consumed by another request`);
         }
 
         const result = await write(tx);
@@ -359,7 +376,8 @@ export async function planSchedule(input: {
     projectId: string;
     tasks: PlanScheduleTaskInput[];
     confirmToken?: string;
-}) {
+}, actorLabel: McpActorLabel = DEFAULT_MCP_ACTOR_LABEL) {
+    const actor = scheduleActor(actorLabel);
     if (input.tasks.length === 0) throw new Error("plan_schedule requires at least one task");
     if (input.tasks.length > 50) throw new Error("plan_schedule accepts at most 50 tasks");
     const args = { projectId: input.projectId, tasks: input.tasks };
@@ -383,7 +401,7 @@ export async function planSchedule(input: {
                 return `${index + 1}. ${source.name.trim()} — ${source.startDate} to ${source.endDate}; crew: ${crew}${task.lead ? `; lead: ${task.lead.name}` : ""}`;
             }),
         ].join("\n");
-        return issueConfirmation("plan_schedule", args, preview);
+        return issueConfirmation("plan_schedule", args, preview, actorLabel);
     }
 
     return executeConfirmed("plan_schedule", args, input.confirmToken, async tx => {
@@ -395,7 +413,7 @@ export async function planSchedule(input: {
         const created = [];
         for (const task of input.tasks) {
             const resolved = await resolvePlanTask(tx, task);
-            created.push(await createScheduleTaskInTransaction(tx, input.projectId, resolved.create, MCP_ACTOR));
+            created.push(await createScheduleTaskInTransaction(tx, input.projectId, resolved.create, actor));
         }
         return {
             projectId: input.projectId,
@@ -406,7 +424,7 @@ export async function planSchedule(input: {
                 endDate: task.endDate.toISOString().slice(0, 10),
             })),
         };
-    });
+    }, actorLabel);
 }
 
 async function validateTaskDates(input: { taskId: string; startDate?: string; endDate?: string }) {
@@ -432,7 +450,8 @@ export async function updateTaskDates(input: {
     startDate?: string;
     endDate?: string;
     confirmToken?: string;
-}) {
+}, actorLabel: McpActorLabel = DEFAULT_MCP_ACTOR_LABEL) {
+    const actor = scheduleActor(actorLabel);
     const args = { taskId: input.taskId, startDate: input.startDate, endDate: input.endDate };
     if (!input.confirmToken) {
         const { task, startDate, endDate } = await validateTaskDates(args);
@@ -440,19 +459,20 @@ export async function updateTaskDates(input: {
             "update_task_dates",
             args,
             `Move "${task.name}" from ${task.startDate.toISOString().slice(0, 10)}–${task.endDate.toISOString().slice(0, 10)} to ${startDate.toISOString().slice(0, 10)}–${endDate.toISOString().slice(0, 10)}.`,
+            actorLabel,
         );
     }
     return executeConfirmed("update_task_dates", args, input.confirmToken, async tx => {
         const task = await updateScheduleTaskInTransaction(tx, input.taskId, {
             startDate: input.startDate,
             endDate: input.endDate,
-        }, MCP_ACTOR);
+        }, actor);
         return {
             taskId: task.id,
             startDate: task.startDate.toISOString().slice(0, 10),
             endDate: task.endDate.toISOString().slice(0, 10),
         };
-    });
+    }, actorLabel);
 }
 
 export async function setTaskStatus(input: {
@@ -460,7 +480,8 @@ export async function setTaskStatus(input: {
     status: ScheduleTaskStatus;
     blockedReason?: string;
     confirmToken?: string;
-}) {
+}, actorLabel: McpActorLabel = DEFAULT_MCP_ACTOR_LABEL) {
+    const actor = scheduleActor(actorLabel);
     if (!(SCHEDULE_TASK_STATUSES as readonly string[]).includes(input.status)) {
         throw new Error(`Invalid schedule task status "${input.status}"`);
     }
@@ -477,15 +498,16 @@ export async function setTaskStatus(input: {
             "set_task_status",
             args,
             `Change "${task.name}" from ${task.status} to ${input.status}${blockedReason ? ` — ${blockedReason}` : ""}.`,
+            actorLabel,
         );
     }
     return executeConfirmed("set_task_status", args, input.confirmToken, async tx => {
         const task = await updateScheduleTaskInTransaction(tx, input.taskId, {
             status: input.status,
             blockedReason,
-        }, MCP_ACTOR);
+        }, actor);
         return { taskId: task.id, status: task.status, blockedReason: task.blockedReason };
-    });
+    }, actorLabel);
 }
 
 export async function assignTaskCrew(input: {
@@ -493,7 +515,8 @@ export async function assignTaskCrew(input: {
     crewNames: string[];
     leadName?: string;
     confirmToken?: string;
-}) {
+}, actorLabel: McpActorLabel = DEFAULT_MCP_ACTOR_LABEL) {
+    const actor = scheduleActor(actorLabel);
     const crewNames = cleanCrewNames(input.crewNames);
     const args = { taskId: input.taskId, crewNames, leadName: input.leadName?.trim() || undefined };
     const resolve = async (tx: Prisma.TransactionClient) => {
@@ -516,6 +539,7 @@ export async function assignTaskCrew(input: {
             "assign_task_crew",
             args,
             `Replace crew on "${resolved.task.name}" with ${resolved.crew.map(member => member.name).join(", ") || "nobody"}${resolved.lead ? `; lead: ${resolved.lead.name}` : ""}.`,
+            actorLabel,
         );
     }
     return executeConfirmed("assign_task_crew", args, input.confirmToken, async tx => {
@@ -523,13 +547,13 @@ export async function assignTaskCrew(input: {
         await setTaskCrewInTransaction(tx, {
             taskId: input.taskId,
             userIds: resolved.crew.map(member => member.id),
-            actor: MCP_ACTOR,
+            actor,
         });
         const assignments = await setTaskLeadInTransaction(
             tx,
             input.taskId,
             resolved.lead?.id ?? null,
-            MCP_ACTOR,
+            actor,
         );
         return {
             taskId: input.taskId,
@@ -540,7 +564,7 @@ export async function assignTaskCrew(input: {
                 role: assignment.role,
             })),
         };
-    });
+    }, actorLabel);
 }
 
 export async function listCrewAvailability(input: { startDate: string; days: number }) {
@@ -606,7 +630,8 @@ export async function setProjectStartDateWithConfirmation(input: {
     startDate: string | null;
     shiftJobTasks?: boolean;
     confirmToken?: string;
-}) {
+}, actorLabel: McpActorLabel = DEFAULT_MCP_ACTOR_LABEL) {
+    const actor = scheduleActor(actorLabel);
     if (input.startDate !== null) parseStartDateInput(input.startDate);
     const args = {
         projectId: input.projectId,
@@ -623,6 +648,7 @@ export async function setProjectStartDateWithConfirmation(input: {
             "set_project_start_date",
             args,
             `Set "${project.name}" start date from ${project.startDate?.toISOString().slice(0, 10) ?? "unset"} to ${input.startDate ?? "unset"}${args.shiftJobTasks ? `; up to ${project._count.scheduleTasks} schedule tasks may shift with the job` : "; tasks will stay in place"}.`,
+            actorLabel,
         );
     }
     return executeConfirmed("set_project_start_date", args, input.confirmToken, async tx => {
@@ -630,7 +656,7 @@ export async function setProjectStartDateWithConfirmation(input: {
             projectId: input.projectId,
             startDate: input.startDate === null ? null : parseStartDateInput(input.startDate),
             shiftJobTasks: args.shiftJobTasks,
-            actor: MCP_ACTOR,
+            actor,
         });
         if (input.startDate !== null) {
             const taskCount = await tx.scheduleTask.count({ where: { projectId: input.projectId } });
@@ -643,20 +669,21 @@ export async function setProjectStartDateWithConfirmation(input: {
                     estimateId: qualifying.id,
                     mode: "merge",
                     requireEmptyProject: true,
-                    actor: MCP_ACTOR,
+                    actor,
                 });
                 result.notes.push(`Schedule auto-generated from estimate ${qualifying.code} (${generated.created.length} tasks).`);
             }
         }
         return result as unknown as Record<string, unknown>;
-    });
+    }, actorLabel);
 }
 
 export async function generateProjectScheduleWithConfirmation(input: {
     estimateId: string;
     mode?: "merge" | "regenerate";
     confirmToken?: string;
-}) {
+}, actorLabel: McpActorLabel = DEFAULT_MCP_ACTOR_LABEL) {
+    const actor = scheduleActor(actorLabel);
     const args = { estimateId: input.estimateId, mode: input.mode ?? "merge" };
     if (!input.confirmToken) {
         const estimate = await prisma.estimate.findUnique({
@@ -674,14 +701,16 @@ export async function generateProjectScheduleWithConfirmation(input: {
             "generate_project_schedule",
             args,
             `${args.mode === "regenerate" ? "Regenerate" : "Merge"} the schedule for "${estimate.project.name}" from estimate ${estimate.code}: ${estimate._count.items} estimate lines and ${estimate._count.paymentSchedules} payment milestones; ${estimate.project._count.scheduleTasks} tasks currently exist.`,
+            actorLabel,
         );
     }
     return executeConfirmed("generate_project_schedule", args, input.confirmToken, async tx =>
         generateScheduleFromEstimateInTransaction(tx, {
             estimateId: input.estimateId,
             mode: args.mode,
-            actor: MCP_ACTOR,
+            actor,
         }) as unknown as Promise<Record<string, unknown>>,
+        actorLabel,
     );
 }
 
@@ -689,7 +718,8 @@ export async function assignProjectCrewWithConfirmation(input: {
     projectId: string;
     userIds: string[];
     confirmToken?: string;
-}) {
+}, actorLabel: McpActorLabel = DEFAULT_MCP_ACTOR_LABEL) {
+    const actor = scheduleActor(actorLabel);
     const userIds = [...new Set(input.userIds)];
     const args = { projectId: input.projectId, userIds };
     if (!input.confirmToken) {
@@ -711,10 +741,12 @@ export async function assignProjectCrewWithConfirmation(input: {
             "assign_project_crew",
             args,
             `Replace project crew on "${project.name}" with ${users.map(user => user.name || user.email).join(", ") || "nobody"}.`,
+            actorLabel,
         );
     }
     return executeConfirmed("assign_project_crew", args, input.confirmToken, async tx =>
-        setProjectCrewInTransaction(tx, { projectId: input.projectId, userIds, actor: MCP_ACTOR }) as unknown as Promise<Record<string, unknown>>,
+        setProjectCrewInTransaction(tx, { projectId: input.projectId, userIds, actor }) as unknown as Promise<Record<string, unknown>>,
+        actorLabel,
     );
 }
 
@@ -722,7 +754,8 @@ export async function applyChangeOrderToScheduleWithConfirmation(input: {
     changeOrderId: string;
     mode?: "merge" | "regenerate";
     confirmToken?: string;
-}) {
+}, actorLabel: McpActorLabel = DEFAULT_MCP_ACTOR_LABEL) {
+    const actor = scheduleActor(actorLabel);
     const args = { changeOrderId: input.changeOrderId, mode: input.mode ?? "merge" };
     if (!input.confirmToken) {
         const changeOrder = await prisma.changeOrder.findUnique({
@@ -740,13 +773,15 @@ export async function applyChangeOrderToScheduleWithConfirmation(input: {
             "apply_change_order_to_schedule",
             args,
             `${args.mode === "regenerate" ? "Regenerate" : "Apply"} ${changeOrder.code} "${changeOrder.title}" on "${changeOrder.project.name}" to the schedule: ${changeOrder._count.items} items and ${changeOrder._count.paymentSchedules} milestones.`,
+            actorLabel,
         );
     }
     return executeConfirmed("apply_change_order_to_schedule", args, input.confirmToken, async tx =>
         applyChangeOrderToScheduleInTransaction(tx, {
             changeOrderId: input.changeOrderId,
             mode: args.mode,
-            actor: MCP_ACTOR,
+            actor,
         }) as unknown as Promise<Record<string, unknown>>,
+        actorLabel,
     );
 }

--- a/src/lib/project-file-core.ts
+++ b/src/lib/project-file-core.ts
@@ -1,0 +1,385 @@
+import { prisma } from "./prisma";
+import {
+    ALLOWED_FILE_EXTENSIONS,
+    fileExtension,
+    mimeTypeForFileName,
+    saveProjectFile,
+    type SaveProjectFileInput,
+    type SaveProjectFileResult,
+} from "./project-files";
+import { ensureStandardFolders } from "./project-folders";
+import {
+    mcpActivityActorName,
+    type McpActorContext,
+} from "./mcp-actor";
+
+export const MAX_UPLOAD_BYTES = 3_300_000;
+export const MAX_UPLOAD_BASE64_CHARS = 4_400_000;
+
+export type ProjectFileVisibility = "team" | "shared";
+
+export type UploadProjectFileInput = {
+    projectId?: string;
+    leadId?: string;
+    fileName: string;
+    contentBase64: string;
+    folder?: string;
+    visibility?: ProjectFileVisibility;
+    actor: McpActorContext;
+};
+
+export type UploadProjectFileSuccess = {
+    fileId: string;
+    name: string;
+    sizeBytes: number;
+    folder: string | null;
+    visibility: ProjectFileVisibility;
+    url: string;
+    movedToProject?: string;
+    note: string;
+};
+
+export type UploadProjectFileResult =
+    | { ok: true; data: UploadProjectFileSuccess }
+    | { ok: false; error: string };
+
+export type UploadFilesItem = {
+    fileName: string;
+    contentBase64: string;
+    folder?: string;
+    visibility?: ProjectFileVisibility;
+};
+
+export type UploadProjectFilesInput = {
+    projectId?: string;
+    leadId?: string;
+    defaultFolder?: string;
+    files: UploadFilesItem[];
+    actor: McpActorContext;
+};
+
+type UploadDependencies = {
+    saveProjectFile?: (input: SaveProjectFileInput) => Promise<SaveProjectFileResult>;
+};
+
+type ValidatedUpload = {
+    buffer: Buffer;
+    fileName: string;
+    folder?: string;
+    visibility?: ProjectFileVisibility;
+};
+
+type ResolvedTarget = {
+    projectId: string | null;
+    leadId: string | null;
+    movedToProjectNote: string | null;
+};
+
+function invalidTargetError(): string {
+    return "Provide exactly one of projectId or leadId (use find_job / list_projects / list_leads to resolve the target).";
+}
+
+function validateFileExtension(fileName: string): void {
+    const ext = fileExtension(fileName);
+    if (!ALLOWED_FILE_EXTENSIONS.has(ext)) {
+        throw new Error(`File type "${ext || "(no extension)"}" not allowed. Allowed: ${[...ALLOWED_FILE_EXTENSIONS].join(", ")}.`);
+    }
+}
+
+function decodeUploadFile(input: UploadFilesItem): ValidatedUpload {
+    const b64 = input.contentBase64.replace(/\s+/g, "");
+    if (b64.length % 4 !== 0 || !/^[A-Za-z0-9+/]*={0,2}$/.test(b64)) {
+        throw new Error("contentBase64 is not valid base64 — send the file's raw bytes standard-base64-encoded, without a data: URL prefix.");
+    }
+    const buffer = Buffer.from(b64, "base64");
+    if (buffer.length === 0) {
+        throw new Error("contentBase64 decoded to 0 bytes.");
+    }
+    if (buffer.length > MAX_UPLOAD_BYTES) {
+        throw new Error(`File is ${(buffer.length / 1_000_000).toFixed(1)} MB — the connector accepts up to ~3 MB. Upload larger files in ProBuild directly.`);
+    }
+    return {
+        buffer,
+        fileName: input.fileName,
+        folder: input.folder,
+        visibility: input.visibility,
+    };
+}
+
+function validateOneFile(input: UploadFilesItem): ValidatedUpload {
+    validateFileExtension(input.fileName);
+    return decodeUploadFile(input);
+}
+
+export function validateUploadFilesBatch(files: UploadFilesItem[]): ValidatedUpload[] {
+    if (files.length < 1 || files.length > 8) {
+        throw new Error("upload_files accepts between 1 and 8 files.");
+    }
+    const normalizedBase64Length = files.reduce(
+        (total, file) => total + file.contentBase64.replace(/\s+/g, "").length,
+        0,
+    );
+    if (normalizedBase64Length > MAX_UPLOAD_BASE64_CHARS) {
+        throw new Error("Combined files exceed the connector's ~3 MB total upload limit. Split them into smaller calls or upload larger files in ProBuild directly.");
+    }
+    const validated = files.map(validateOneFile);
+    const totalBytes = validated.reduce((total, file) => total + file.buffer.length, 0);
+    if (totalBytes > MAX_UPLOAD_BYTES) {
+        throw new Error(`Combined files are ${(totalBytes / 1_000_000).toFixed(1)} MB — the connector accepts up to ~3 MB total. Split them into smaller calls.`);
+    }
+    return validated;
+}
+
+async function resolveTarget(projectId?: string, leadId?: string): Promise<ResolvedTarget> {
+    if ((projectId ? 1 : 0) + (leadId ? 1 : 0) !== 1) {
+        throw new Error(invalidTargetError());
+    }
+    let targetProjectId: string | null = projectId ?? null;
+    let targetLeadId: string | null = leadId ?? null;
+    let movedToProjectNote: string | null = null;
+    if (targetProjectId) {
+        const project = await prisma.project.findUnique({
+            where: { id: targetProjectId },
+            select: { id: true },
+        });
+        if (!project) {
+            throw new Error(`No project with id ${targetProjectId}. Use find_job or list_projects.`);
+        }
+    } else {
+        const lead = await prisma.lead.findUnique({
+            where: { id: targetLeadId! },
+            select: { id: true },
+        });
+        if (!lead) {
+            throw new Error(`No lead with id ${targetLeadId}. Use find_job or list_leads.`);
+        }
+        const linkedProject = await prisma.project.findFirst({
+            where: { leadId: targetLeadId! },
+            select: { id: true, name: true },
+        });
+        if (linkedProject) {
+            movedToProjectNote = `This lead was already converted to project "${linkedProject.name}" — the file was filed on the project.`;
+            targetProjectId = linkedProject.id;
+            targetLeadId = null;
+        }
+    }
+    return {
+        projectId: targetProjectId,
+        leadId: targetLeadId,
+        movedToProjectNote,
+    };
+}
+
+async function ensureProjectScaffoldIfEmpty(projectId: string): Promise<void> {
+    const folderCount = await prisma.fileFolder.count({
+        where: { projectId, parentId: null },
+    });
+    if (folderCount === 0) await ensureStandardFolders(projectId);
+}
+
+async function prepareBatchFolders(
+    target: ResolvedTarget,
+    files: ValidatedUpload[],
+): Promise<string | null> {
+    const requested = new Map<string, { name: string; hasShared: boolean }>();
+    for (const file of files) {
+        const folderName = file.folder?.trim();
+        if (!folderName) continue;
+        const key = folderName.toLocaleLowerCase();
+        const current = requested.get(key);
+        requested.set(key, {
+            name: current?.name ?? folderName,
+            hasShared: current?.hasShared === true || file.visibility === "shared",
+        });
+    }
+    if (requested.size === 0) return null;
+
+    const existing = await prisma.fileFolder.findMany({
+        where: {
+            projectId: target.projectId,
+            leadId: target.leadId,
+            parentId: null,
+        },
+        select: { id: true, name: true, visibility: true },
+    });
+    const byName = new Map(existing.map(folder => [folder.name.trim().toLocaleLowerCase(), folder]));
+
+    // Validate every requested folder before creating any of them. A later
+    // team-folder conflict must not leave earlier shared folders behind after
+    // the whole batch is rejected.
+    for (const [key, request] of requested) {
+        const folder = byName.get(key);
+        if (folder && request.hasShared && folder.visibility !== "shared") {
+            return `Folder "${folder.name}" is not a shared folder, so the customer could never see a shared file inside it. Upload the shared file without a folder, use a folder that is already shared, or drop visibility to keep it internal.`;
+        }
+    }
+    for (const [key, request] of requested) {
+        const folder = byName.get(key);
+        if (!folder && request.hasShared) {
+            await prisma.fileFolder.create({
+                data: {
+                    name: request.name,
+                    projectId: target.projectId,
+                    leadId: target.leadId,
+                    parentId: null,
+                    visibility: "shared",
+                },
+                select: { id: true },
+            });
+        }
+    }
+    return null;
+}
+
+export async function uploadProjectFileCore(
+    input: UploadProjectFileInput,
+    dependencies: UploadDependencies = {},
+): Promise<UploadProjectFileResult> {
+    if ((input.projectId ? 1 : 0) + (input.leadId ? 1 : 0) !== 1) {
+        return { ok: false, error: invalidTargetError() };
+    }
+
+    try {
+        validateFileExtension(input.fileName);
+    } catch (error) {
+        return { ok: false, error: (error as Error).message };
+    }
+
+    let target: ResolvedTarget;
+    try {
+        target = await resolveTarget(input.projectId, input.leadId);
+    } catch (error) {
+        return { ok: false, error: (error as Error).message };
+    }
+
+    let validated: ValidatedUpload;
+    try {
+        validated = decodeUploadFile(input);
+    } catch (error) {
+        return { ok: false, error: (error as Error).message };
+    }
+
+    // Always store an EXPLICIT visibility (never null/inherit): the portal
+    // shows null-visibility files inside shared folders.
+    const fileVisibility = input.visibility ?? "team";
+    let folderId: string | null = null;
+    const folderName = input.folder?.trim();
+    if (folderName) {
+        const scope = {
+            projectId: target.projectId,
+            leadId: target.leadId,
+            parentId: null,
+        };
+        const existing = await prisma.fileFolder.findFirst({
+            where: {
+                ...scope,
+                name: { equals: folderName, mode: "insensitive" },
+            },
+            select: { id: true, name: true, visibility: true },
+        });
+        if (existing && fileVisibility === "shared" && existing.visibility !== "shared") {
+            return {
+                ok: false,
+                error: `Folder "${existing.name}" is not a shared folder, so the customer could never see a shared file inside it. Upload the shared file without a folder, use a folder that is already shared, or drop visibility to keep it internal.`,
+            };
+        }
+        folderId = existing
+            ? existing.id
+            : (await prisma.fileFolder.create({
+                data: {
+                    name: folderName,
+                    ...scope,
+                    visibility: fileVisibility === "shared" ? "shared" : "team",
+                },
+                select: { id: true },
+            })).id;
+    }
+
+    const save = dependencies.saveProjectFile ?? saveProjectFile;
+    const saved = await save({
+        buffer: validated.buffer,
+        fileName: input.fileName,
+        mimeType: mimeTypeForFileName(input.fileName),
+        projectId: target.projectId,
+        leadId: target.leadId,
+        folderId,
+        visibility: fileVisibility,
+        uploadedById: input.actor.actorUserId,
+        activity: {
+            actorName: mcpActivityActorName(input.actor.actorLabel),
+            action: "uploaded_file",
+            entityType: "project_file",
+            entityName: input.fileName,
+            metadata: {
+                folderId,
+                visibility: fileVisibility,
+                sizeBytes: validated.buffer.length,
+            },
+        },
+    });
+    if (!saved.ok) return { ok: false, error: saved.error };
+
+    const filesUrl = target.projectId
+        ? `https://probuild.goldentouchremodeling.com/projects/${target.projectId}/files`
+        : `https://probuild.goldentouchremodeling.com/leads/${target.leadId}/files`;
+    return {
+        ok: true,
+        data: {
+            fileId: saved.file.id,
+            name: saved.file.name,
+            sizeBytes: saved.file.size,
+            folder: folderName ?? null,
+            visibility: fileVisibility,
+            url: filesUrl,
+            ...(target.movedToProjectNote ? { movedToProject: target.movedToProjectNote } : {}),
+            note: fileVisibility === "shared"
+                ? "This file IS visible to the customer (in the client portal, once the job has a project with the portal's Files section enabled)."
+                : "Internal file — the customer cannot see it.",
+        },
+    };
+}
+
+export async function uploadProjectFilesCore(
+    input: UploadProjectFilesInput,
+    dependencies: UploadDependencies = {},
+): Promise<
+    | { ok: false; error: string }
+    | { ok: true; results: Array<{ fileName: string; ok: boolean; fileId?: string; error?: string }> }
+> {
+    let validated: ValidatedUpload[];
+    try {
+        validated = validateUploadFilesBatch(input.files.map(file => ({
+            ...file,
+            folder: file.folder ?? input.defaultFolder,
+        })));
+    } catch (error) {
+        return { ok: false, error: (error as Error).message };
+    }
+
+    let target: ResolvedTarget;
+    try {
+        target = await resolveTarget(input.projectId, input.leadId);
+        if (target.projectId) await ensureProjectScaffoldIfEmpty(target.projectId);
+        const folderError = await prepareBatchFolders(target, validated);
+        if (folderError) return { ok: false, error: folderError };
+    } catch (error) {
+        return { ok: false, error: (error as Error).message };
+    }
+
+    const results = [];
+    for (const file of validated) {
+        const result = await uploadProjectFileCore({
+            projectId: target.projectId ?? undefined,
+            leadId: target.leadId ?? undefined,
+            fileName: file.fileName,
+            contentBase64: file.buffer.toString("base64"),
+            folder: file.folder,
+            visibility: file.visibility,
+            actor: input.actor,
+        }, dependencies);
+        results.push(result.ok
+            ? { fileName: file.fileName, ok: true, fileId: result.data.fileId }
+            : { fileName: file.fileName, ok: false, error: result.error });
+    }
+    return { ok: true, results };
+}

--- a/src/lib/project-files.ts
+++ b/src/lib/project-files.ts
@@ -56,6 +56,13 @@ export type SaveProjectFileInput = {
     // null = inherit from the folder (default "team"), matching /api/files.
     visibility?: string | null;
     uploadedById?: string | null;
+    activity?: {
+        actorName: string;
+        action: string;
+        entityType: string;
+        entityName: string;
+        metadata?: Record<string, unknown>;
+    };
 };
 
 export type SaveProjectFileResult =
@@ -86,7 +93,7 @@ export async function saveProjectFile(input: SaveProjectFileInput): Promise<Save
 
     const { data: urlData } = supabase.storage.from(STORAGE_BUCKET).getPublicUrl(storagePath);
     try {
-        const record = await prisma.projectFile.create({
+        const createFile = (tx: Pick<typeof prisma, "projectFile">) => tx.projectFile.create({
             data: {
                 name: input.fileName,
                 url: urlData?.publicUrl || storagePath,
@@ -100,6 +107,27 @@ export async function saveProjectFile(input: SaveProjectFileInput): Promise<Save
             },
             select: { id: true, name: true, size: true, url: true },
         });
+        const record = input.activity
+            ? await prisma.$transaction(async tx => {
+                const file = await createFile(tx as typeof prisma);
+                await tx.activityLog.create({
+                    data: {
+                        projectId: input.projectId ?? null,
+                        leadId: input.leadId ?? null,
+                        actorType: "SYSTEM",
+                        actorName: input.activity!.actorName,
+                        action: input.activity!.action,
+                        entityType: input.activity!.entityType,
+                        entityId: file.id,
+                        entityName: input.activity!.entityName,
+                        metadata: input.activity!.metadata
+                            ? JSON.stringify(input.activity!.metadata)
+                            : null,
+                    },
+                });
+                return file;
+            })
+            : await createFile(prisma);
         return { ok: true, file: record };
     } catch (err: any) {
         // The object is already in storage; without the DB row it would be

--- a/src/lib/project-folders.ts
+++ b/src/lib/project-folders.ts
@@ -1,0 +1,52 @@
+import type { Prisma } from "@prisma/client";
+
+import { prisma } from "./prisma";
+
+export const STANDARD_PROJECT_FOLDERS = [
+    "01 Plans & Specs",
+    "02 Permits & Inspections",
+    "03 Contracts & Estimates",
+    "04 RFIs & RFQs",
+    "05 Daily Logs & Field Notes",
+    "06 Photos",
+    "07 Meeting Notes",
+    "08 Closeout",
+] as const;
+
+type FolderDb = Pick<Prisma.TransactionClient, "fileFolder">;
+
+function folderKey(name: string): string {
+    return name.trim().toLocaleLowerCase();
+}
+
+export async function ensureStandardFolders(
+    projectId: string,
+    tx: FolderDb = prisma,
+): Promise<{ created: string[]; existing: string[] }> {
+    const current = await tx.fileFolder.findMany({
+        where: { projectId, parentId: null },
+        select: { name: true },
+    });
+    const existingKeys = new Set(current.map(folder => folderKey(folder.name)));
+    const missing = STANDARD_PROJECT_FOLDERS.filter(name => !existingKeys.has(folderKey(name)));
+
+    const created: string[] = [];
+    for (const name of missing) {
+        await tx.fileFolder.create({
+            data: {
+                projectId,
+                parentId: null,
+                name,
+                visibility: "team",
+            },
+            select: { id: true },
+        });
+        created.push(name);
+        existingKeys.add(folderKey(name));
+    }
+
+    return {
+        created,
+        existing: current.map(folder => folder.name),
+    };
+}


### PR DESCRIPTION
## Why

Richard asked (2026-07-28) for the ProBuild connector to become a real PM assistant. Audit first: his loudest complaint — document upload — **already shipped** (`upload_file`), and the schedule suite landed in PR-F #244. This PR closes the rest of the cheap gaps and gives his ChatGPT its own identity.

**Stacked on #253** (PR-1 evidence layer) — punch reads use `TaskPunchItem.completedAt` from that branch. Merge #253 first; this diff then shows only Phase 1.

## What lands

- **Dual-key auth** — `MCP_SECRET_RICHARD` alongside `MCP_SECRET`. Timing-safe, both candidates always compared, empty/unset never match. The matched key becomes an actor label threaded into **every** writer: audit strings become `SYSTEM:justin-ai` / `SYSTEM:richard-ai` (previously an anonymous "ChatGPT connector"), and confirmation tokens are key-scoped — a preview minted under one key cannot be confirmed under the other, checked inside the consume transaction with single-use semantics unchanged.
- **"Richard's AI" attribution account** — idempotent seed, role `FINANCE` (the one role crew pickers already exclude, so it can never be scheduled). No credentials; it never signs in.
- **Standard project folders** — 8-folder scaffold (`01 Plans & Specs` … `08 Closeout`), idempotent + case-insensitive, wired into project creation non-fatally and lazily into the file tools; dry-run backfill script for existing jobs.
- **`upload_files`** — up to 8 files/call, shared 3.3 MB total cap (Vercel's 4.5 MB request limit), whole-batch validation up front, per-file results so ChatGPT retries only failures. Single-file `upload_file` body extracted verbatim into `project-file-core.ts`; all portal-safety invariants (explicit visibility, shared-in-team-folder refusal, shared-folder creation rule) live in the core once.
- **`list_project_files`** (metadata only — **no URLs by design**; download is deliberately Phase 2, needs signed-URL design not bytes-through-MCP), **`create_folder`**, **`move_file`** (confirmation-gated; refuses cross-project moves and any team→shared exposure unless `visibility: "shared"` is explicit).
- **Daily logs** — `list_daily_logs` + `create_daily_log` (confirmation-gated; `sharedToPortal` not exposed — portal sharing stays human; photos attach by referencing already-uploaded `ProjectFile` ids). Every connector-dictated log becomes project-level evidence in #253's coverage readout.
- **Punch** — `list_punch_items` + `add_punch_items` (bulk, confirmation-gated). `complete_punch_item` **deliberately not registered**: completion is direct field evidence and a model must not fabricate it.
- **`get_project_contacts`** — read-only, PII-bounded (no rates, no financials).
- MCP **v1.13.0**; instructions teach the PM workflow and state download is unavailable.

## Schema (additive — run `scripts/apply-mcp-pm-schema.mjs` against prod BEFORE deploying)

`McpConfirmation.actorLabel TEXT NOT NULL DEFAULT 'justin-ai'` (old build's inserts stay valid mid-deploy), `TaskPunchItem.createdById` + guarded FK + index.

## Deploy order

1. `node scripts/apply-mcp-pm-schema.mjs`
2. `node scripts/seed-richard-ai-user.mjs`
3. Add `MCP_SECRET_RICHARD` to Vercel (all envs)
4. Deploy
5. `node scripts/backfill-standard-folders.mjs` (dry-run, review, then `--write`)
6. Send Richard his connector URL

## Verification

- `tsc --noEmit` clean · `npm run build` clean · `verify-task-evidence.ts` passes
- `verify-mcp-pm-tools.ts` static + auth contracts pass locally; its DB-backed behavioral matrix is prod-guarded and runs in CI's disposable Postgres
- Hands-on review of sol's implementation; one fix applied: the verifier's prod guard originally sat at the top of `main()` and silently skipped every static check on Supabase-pointed machines — moved so only the fixture-writing phase is fenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)