### PR TITLE
feat(portal): client-facing clipper — Get the Clipper card + /portal/clip suggestion capture

### DIFF
--- a/src/app/company/product-library/ProductLibraryClient.tsx
+++ b/src/app/company/product-library/ProductLibraryClient.tsx
@@ -9,6 +9,7 @@ import {
     addProjectFavorite,
 } from "@/lib/actions";
 import { isHttpUrl } from "@/lib/url-safety";
+import { buildClipperBookmarklet } from "@/lib/clipper-bookmarklet";
 import {
     Plus,
     Search,
@@ -58,47 +59,6 @@ const EMPTY_FORM = {
 
 export const SITE_BLOCKS_PARSE_MESSAGE =
     "This site blocks automated reading. Tip: use the ProBuild Clip bookmarklet while on the product page — it reads the page directly.";
-
-/**
- * Builds the "Get the Clipper" bookmarklet's javascript: URL. Unlike a plain
- * "open /clip?url=..." link, this extracts product data from the LIVE page
- * DOM (JSON-LD -> OpenGraph/meta fallback) before ever opening /clip — the
- * same trick Houzz's clipper uses to beat bot walls like Lowe's/Home Depot's
- * Akamai block, which returns a 403 to any server-side fetch regardless of
- * User-Agent. The user's own browser already has the rendered page, so this
- * never needs to fetch anything.
- *
- * Kept as one compact (not obfuscated, just short-named) IIFE so it fits
- * comfortably as a draggable bookmark URL. Extraction logic verified against
- * JSON-LD fixtures (array/object image, string/object brand, array offers,
- * AggregateOffer.lowPrice) and a fake-DOM harness in a throwaway script
- * before being embedded here — see the PR description for the harness.
- */
-function buildBookmarkletHref(appUrl: string): string {
-    const js =
-        "(function(){function I(v){if(!v)return'';if(Array.isArray(v))v=v[0];if(v&&typeof v==='object')return v.url||'';return typeof v==='string'?v:''}" +
-        "function B(b){if(!b)return'';return typeof b==='string'?b:(b.name||'')}" +
-        "function O(o){if(!o)return{};if(Array.isArray(o))o=o[0];if(!o)return{};var p=o.price!=null?o.price:o.lowPrice;return{p:p,c:o.priceCurrency||''}}" +
-        "var nm='',im='',pr='',cu='',vd='';" +
-        "var ss=document.querySelectorAll('script[type=\"application/ld+json\"]');" +
-        "F:for(var i=0;i<ss.length;i++){var d;try{d=JSON.parse(ss[i].textContent)}catch(e){continue}" +
-        "var cs=Array.isArray(d)?d:[d];" +
-        "for(var c=0;c<cs.length;c++){var cd=cs[c];var ns=(cd&&cd['@graph'])?cd['@graph']:[cd];" +
-        "for(var n=0;n<ns.length;n++){var nd=ns[n];if(!nd)continue;var t=nd['@type'];var ts=Array.isArray(t)?t:[t];" +
-        "var isP=ts.some(function(x){return typeof x==='string'&&x.toLowerCase()==='product'});if(!isP)continue;" +
-        "nm=nd.name||'';im=I(nd.image);var of=O(nd.offers);pr=(of.p!=null?of.p:'');cu=of.c||'';vd=B(nd.brand);break F}}}" +
-        "function M(s){var e=document.querySelector(s);return e?(e.getAttribute('content')||''):''}" +
-        "if(!nm)nm=M('meta[property=\"og:title\"]')||document.title||'';" +
-        "if(!im)im=M('meta[property=\"og:image\"]');" +
-        "if(!pr)pr=M('meta[property=\"product:price:amount\"]');" +
-        "if(!cu)cu=M('meta[property=\"product:price:currency\"]');" +
-        "nm=String(nm).slice(0,200);im=String(im).slice(0,1000);" +
-        "var ps=[];function A(k,v){if(v)ps.push(k+'='+encodeURIComponent(v))}" +
-        "A('url',location.href);A('name',nm);A('price',pr);A('currency',cu);A('image',im);A('vendor',vd);" +
-        "window.open('" + appUrl + "/clip?'+ps.join('&'),'probuild-clip','width=480,height=720')" +
-        "})();";
-    return "javascript:" + js;
-}
 
 function formatPrice(value: number | string | null | undefined): string | null {
     if (value === null || value === undefined || value === "") return null;
@@ -287,7 +247,7 @@ export default function ProductLibraryClient({ initialProducts, allProjects, app
         }
     }
 
-    const bookmarkletHref = buildBookmarkletHref(appUrl);
+    const bookmarkletHref = buildClipperBookmarklet({ origin: appUrl, targetPath: "/clip" });
 
     return (
         <div className="max-w-6xl mx-auto py-8 px-6">

--- a/src/app/portal/clip/PortalClipClient.tsx
+++ b/src/app/portal/clip/PortalClipClient.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { submitSelectionProposal } from "@/lib/actions";
+import { isHttpUrl } from "@/lib/url-safety";
+import { ImageOff, Check } from "lucide-react";
+
+interface Props {
+    projectId: string;
+    initialUrl: string;
+    initialName: string;
+    initialPrice: string;
+    initialCurrency: string;
+    initialImage: string;
+    // Accepted (the bookmarklet always sends it when found) but not rendered
+    // or persisted — SelectionProposal has no vendor column, and the spec's
+    // form only shows name / photo / note / source link. The source link
+    // still gets the team to the vendor page directly.
+    initialVendor: string;
+}
+
+// The client-facing clipper form. Prefilled entirely from the bookmarklet's
+// in-page DOM extraction (see PortalClipPage / buildClipperBookmarklet) — no
+// re-parse-from-URL step here, unlike the team clipper's ClipClient, since
+// the spec keeps this a straight "review what we found, send it" form. Price
+// is intentionally never shown or editable: the project team prices things
+// out after reviewing the suggestion.
+export default function PortalClipClient({
+    projectId,
+    initialUrl,
+    initialName,
+    initialPrice,
+    initialCurrency,
+    initialImage,
+}: Props) {
+    const [name, setName] = useState((initialName || "").slice(0, 200));
+    const [note, setNote] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+    const [sent, setSent] = useState(false);
+
+    const safeImage = initialImage && isHttpUrl(initialImage) ? initialImage : "";
+
+    // Same non-USD fold as the team clipper (product-parse.ts's
+    // normalizeParsedProduct): a listed price in another currency isn't a USD
+    // number, so it's dropped from listPrice and kept as a note instead. This
+    // never reaches the client's own view either way (price stays hidden
+    // regardless of currency), but it keeps the team from seeing a
+    // mis-scaled price once they approve the suggestion.
+    const currency = (initialCurrency || "").trim().toUpperCase();
+    const priceIsUsd = !!initialPrice && (!currency || currency === "USD");
+    const parsedPrice = priceIsUsd ? parseFloat(initialPrice) : undefined;
+    const listPrice = parsedPrice !== undefined && Number.isFinite(parsedPrice) ? parsedPrice : undefined;
+    const currencyNote =
+        !!initialPrice && currency && currency !== "USD" ? `Listed price: ${initialPrice} ${currency}` : undefined;
+
+    async function handleSubmit() {
+        if (!name.trim()) {
+            toast.error("Give it a name so your team knows what you're pointing at.");
+            return;
+        }
+        setSubmitting(true);
+        try {
+            await submitSelectionProposal(projectId, {
+                url: initialUrl || undefined,
+                name: name.trim(),
+                description: currencyNote,
+                imageUrl: safeImage || undefined,
+                clientNote: note.trim() || undefined,
+                listPrice,
+            });
+            setSent(true);
+        } catch (e: any) {
+            toast.error(e.message || "Couldn't send that suggestion. Please try again.");
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    function clipAnother() {
+        setSent(false);
+        setName((initialName || "").slice(0, 200));
+        setNote("");
+    }
+
+    if (sent) {
+        return (
+            <div className="flex items-center justify-center min-h-[60vh] p-4">
+                <div className="hui-card w-full max-w-sm p-6 text-center">
+                    <div className="w-14 h-14 bg-green-100 rounded-2xl flex items-center justify-center mx-auto mb-4">
+                        <Check className="w-7 h-7 text-green-600" />
+                    </div>
+                    <h1 className="text-base font-bold text-hui-textMain">Sent!</h1>
+                    <p className="text-sm text-hui-textMuted mt-1">
+                        Your project team will take a look and get back to you.
+                    </p>
+                    <div className="flex flex-col gap-2 mt-6">
+                        <button onClick={clipAnother} className="hui-btn hui-btn-secondary w-full">
+                            Clip another item
+                        </button>
+                        <button onClick={() => window.close()} className="hui-btn hui-btn-green w-full">
+                            Close window
+                        </button>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex items-center justify-center min-h-[60vh] p-4">
+            <div className="w-full max-w-sm">
+                <h1 className="text-base font-bold text-hui-textMain mb-1">ProBuild Clip</h1>
+                <p className="text-xs text-hui-textMuted mb-4">Send this to your project team for review.</p>
+
+                <div className="hui-card p-4 space-y-3">
+                    <div className="h-28 bg-slate-50 border border-hui-border rounded-lg flex items-center justify-center overflow-hidden">
+                        {safeImage ? (
+                            <img
+                                src={safeImage}
+                                alt="Preview"
+                                className="h-full object-contain"
+                                onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
+                            />
+                        ) : (
+                            <ImageOff className="w-6 h-6 text-slate-300" />
+                        )}
+                    </div>
+
+                    <div>
+                        <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">Item name *</label>
+                        <input
+                            type="text"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            className="hui-input w-full mt-1 text-sm"
+                            placeholder="Product name"
+                            disabled={submitting}
+                        />
+                    </div>
+
+                    <div>
+                        <label className="text-xs font-semibold text-hui-textMuted uppercase tracking-wider">
+                            Note to your team <span className="normal-case font-normal">(optional)</span>
+                        </label>
+                        <textarea
+                            value={note}
+                            onChange={(e) => setNote(e.target.value)}
+                            className="hui-input w-full mt-1 text-sm"
+                            rows={3}
+                            placeholder="Where it'd go, why you like it..."
+                            disabled={submitting}
+                        />
+                    </div>
+
+                    {isHttpUrl(initialUrl) && (
+                        <div className="text-xs text-hui-textMuted truncate">
+                            Source:{" "}
+                            <a
+                                href={initialUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-blue-600 hover:underline"
+                            >
+                                {initialUrl}
+                            </a>
+                        </div>
+                    )}
+
+                    <p className="text-xs text-hui-textMuted border-t border-hui-border pt-3">
+                        Your project team will price this out.
+                    </p>
+
+                    <button
+                        onClick={handleSubmit}
+                        disabled={submitting || !name.trim()}
+                        className="hui-btn hui-btn-green w-full disabled:opacity-50"
+                    >
+                        {submitting ? "Sending..." : "Send to your project team"}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/app/portal/clip/page.tsx
+++ b/src/app/portal/clip/page.tsx
@@ -1,0 +1,98 @@
+export const dynamic = "force-dynamic";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { redirect } from "next/navigation";
+import { resolveSessionClientId } from "@/lib/portal-auth";
+import { getPortalVisibility } from "@/lib/actions";
+import PortalClipClient from "./PortalClipClient";
+
+// The client-facing clipper capture popup — opened by the per-project
+// "ProBuild Clip" bookmarklet on the portal Selections tab (see the "Get the
+// Clipper" card in PortalSuggestionsSection.tsx, built via
+// buildClipperBookmarklet in src/lib/clipper-bookmarklet.ts). Unlike the team
+// clipper (/clip), a clip here lands in the CLIENT's own suggestion queue —
+// it calls submitSelectionProposal, not createProductLibraryItem.
+//
+// Rendering: this route sits under app/portal/layout.tsx like every other
+// portal page, so it keeps that layout's thin header (title + user menu) —
+// Next.js layouts can't be selectively suppressed for one nested route
+// without restructuring the entire portal route tree into route groups, so
+// this is the "minimal standalone layout" the spec allows as a fallback to
+// /clip's fully bare rendering (AppLayout already treats every
+// /portal-prefixed path as public/chrome-free for the OUTER app shell, i.e.
+// no sidebar — that part matches /clip exactly).
+//
+// Auth gate order (matches assertPortalProjectOwnership's convention, and
+// the staff-bypass style used by /portal/projects/[id]/page.tsx):
+//   1. Portal client session (or staff) — no session/client match redirects
+//      to /portal, the same landing/re-auth gate every other portal page
+//      falls back to (there is no separate /login route for clients).
+//   2. Ownership of ?projectId= — a mismatch renders a friendly "not
+//      available" card instead of notFound()/crashing, since this page opens
+//      in a small popup window with no nav chrome to escape from.
+//   3. Portal visibility (isPortalEnabled + showSelections) — same treatment.
+export default async function PortalClipPage(props: {
+    searchParams: Promise<{
+        projectId?: string;
+        url?: string;
+        name?: string;
+        price?: string;
+        currency?: string;
+        image?: string;
+        vendor?: string;
+    }>;
+}) {
+    const { projectId, url, name, price, currency, image, vendor } = await props.searchParams;
+
+    if (!projectId) {
+        return (
+            <NotAvailable message="This clip link is missing its project. Try the Clipper button again from your Selections tab." />
+        );
+    }
+
+    const session = await getServerSession(authOptions);
+    const isStaff = ["ADMIN", "MANAGER"].includes((session?.user as any)?.role);
+
+    let projectWhere: { id: string; clientId?: string };
+    if (isStaff) {
+        projectWhere = { id: projectId };
+    } else {
+        const clientId = await resolveSessionClientId();
+        if (!clientId) redirect("/portal");
+        projectWhere = { id: projectId, clientId };
+    }
+
+    const project = await prisma.project.findFirst({ where: projectWhere, select: { id: true } });
+    if (!project) {
+        return <NotAvailable message="We couldn't find that project, or you don't have access to it." />;
+    }
+
+    const visibility = await getPortalVisibility(projectId);
+    if (!visibility.isPortalEnabled || !visibility.showSelections) {
+        return <NotAvailable message="Suggestions aren't available for this project right now." />;
+    }
+
+    return (
+        <PortalClipClient
+            projectId={project.id}
+            initialUrl={url || ""}
+            initialName={name || ""}
+            initialPrice={price || ""}
+            initialCurrency={currency || ""}
+            initialImage={image || ""}
+            initialVendor={vendor || ""}
+        />
+    );
+}
+
+function NotAvailable({ message }: { message: string }) {
+    return (
+        <div className="flex items-center justify-center min-h-[60vh] p-4">
+            <div className="hui-card w-full max-w-sm p-6 text-center">
+                <h1 className="text-base font-bold text-hui-textMain">Not available</h1>
+                <p className="text-sm text-hui-textMuted mt-1">{message}</p>
+            </div>
+        </div>
+    );
+}

--- a/src/app/portal/projects/[id]/selections/PortalSuggestionsSection.tsx
+++ b/src/app/portal/projects/[id]/selections/PortalSuggestionsSection.tsx
@@ -5,6 +5,8 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { submitSelectionProposal } from "@/lib/actions";
 import { isHttpUrl } from "@/lib/url-safety";
+import { buildClipperBookmarklet } from "@/lib/clipper-bookmarklet";
+import { Link2 } from "lucide-react";
 
 const COULD_NOT_READ_PAGE_MESSAGE =
     "We couldn't read that page automatically. Just add the name (and a photo link if you have one) and we'll take it from there.";
@@ -222,18 +224,57 @@ function SuggestItemModal({
     );
 }
 
+function GetTheClipperCard({ projectId, appUrl }: { projectId: string; appUrl: string }) {
+    const bookmarkletHref = buildClipperBookmarklet({
+        origin: appUrl,
+        targetPath: "/portal/clip",
+        extraParams: { projectId },
+    });
+
+    return (
+        <div className="hui-card p-5 mb-6 flex items-center justify-between gap-6 flex-wrap">
+            <div className="flex items-center gap-4">
+                <div className="w-11 h-11 bg-hui-primary/10 rounded-xl flex items-center justify-center shrink-0">
+                    <Link2 className="w-5 h-5 text-hui-primary" />
+                </div>
+                <div>
+                    <h2 className="text-base font-semibold text-hui-textMain">Get the Clipper</h2>
+                    <p className="text-sm text-hui-textMuted mt-0.5 max-w-md">
+                        Found something while shopping? Drag the ProBuild Clip button to your bookmarks bar.
+                        <br />
+                        On any product page, click it and the item comes straight here for your team to review.
+                    </p>
+                </div>
+            </div>
+            <a
+                href={bookmarkletHref}
+                onClick={(e) => e.preventDefault()}
+                className="hui-btn hui-btn-secondary flex items-center gap-2 cursor-grab active:cursor-grabbing shrink-0"
+                title="Drag me to your bookmarks bar"
+            >
+                <Link2 className="w-4 h-4" />
+                ProBuild Clip
+            </a>
+        </div>
+    );
+}
+
 export default function PortalSuggestionsSection({
     projectId,
     initialProposals,
+    appUrl,
 }: {
     projectId: string;
     initialProposals: Proposal[];
+    appUrl: string;
 }) {
     const router = useRouter();
     const [modalOpen, setModalOpen] = useState(false);
 
     return (
-        <div className="hui-card p-6">
+        <div>
+            <GetTheClipperCard projectId={projectId} appUrl={appUrl} />
+            <div className="hui-card p-6">
             <div className="flex items-center justify-between mb-4 flex-wrap gap-3">
                 <div>
                     <h2 className="text-xl font-bold text-hui-textMain">Your suggestions</h2>
@@ -300,6 +341,7 @@ export default function PortalSuggestionsSection({
                     })}
                 </div>
             )}
+            </div>
 
             <SuggestItemModal
                 projectId={projectId}

--- a/src/app/portal/projects/[id]/selections/page.tsx
+++ b/src/app/portal/projects/[id]/selections/page.tsx
@@ -50,6 +50,7 @@ export default async function PortalSelectionsPage(props: { params: Promise<{ id
     // the "Your suggestions" section below always renders and covers that case
     // with its own invite-to-suggest empty state.
     const showFavorites = favorites.length > 0 || boards.length > 0 || proposals.length > 0;
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
 
     return (
         <div className="max-w-5xl mx-auto py-8 px-4">
@@ -88,6 +89,7 @@ export default async function PortalSelectionsPage(props: { params: Promise<{ id
                 <PortalSuggestionsSection
                     projectId={id}
                     initialProposals={JSON.parse(JSON.stringify(proposals))}
+                    appUrl={appUrl}
                 />
             </div>
         </div>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -9728,15 +9728,26 @@ export async function submitSelectionProposal(projectId: string, data: {
     const url = data.url?.trim();
     if (!manualName && !url) throw new Error("A name or a product link is required");
 
+    const clampedListPrice = clampListPrice(data.listPrice);
+
     // Parse server-side so price is captured even though it's never returned
     // to the client here. Never throws — degrades to {vendorUrl, name: null}.
+    // Skipped entirely when the caller already supplied a valid listPrice —
+    // the only reason this re-parse exists is to recover the price that the
+    // portal prefill route (/api/portal/projects/[id]/proposals/parse)
+    // strips from its response; the clipper path (submitSelectionProposal's
+    // listPrice caller) already has that price from the bookmarklet's
+    // in-page DOM read, so re-fetching the URL server-side here would just
+    // be a slow (up to the Gemini url_context fallback's ~20s+) no-op for
+    // price, while every other field already prefers the caller-supplied
+    // value over parsed.* below regardless. The manual "Suggest an item"
+    // modal never sends listPrice, so it's unaffected and still gets parsed.
     let parsed: Awaited<ReturnType<typeof parseProductUrl>> | null = null;
-    if (url) {
+    if (url && clampedListPrice === undefined) {
         parsed = await parseProductUrl(url);
     }
 
     const name = (manualName || parsed?.name || "Suggested item").slice(0, 200);
-    const clampedListPrice = clampListPrice(data.listPrice);
 
     const proposal = await prisma.selectionProposal.create({
         data: {

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -14,7 +14,7 @@ import { formatCurrency } from "./utils";
 import { createHash, createHmac, timingSafeEqual } from "crypto";
 import { resolveSessionClientId } from "./portal-auth";
 import { persistSignature } from "./signature-storage";
-import { parseProductUrl } from "./product-parse";
+import { parseProductUrl, MAX_PRICE as PRODUCT_PARSE_MAX_PRICE } from "./product-parse";
 import { isHttpUrl } from "./url-safety";
 import { canUseDevAuthFallback, getCurrentUserWithPermissions, hasPermission, canAccessProject } from "./permissions";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
@@ -9568,6 +9568,19 @@ function safeUrlOrNull(url: string | null | undefined): string | null {
     return isHttpUrl(url) ? url : null;
 }
 
+/** Clamp a client-supplied list price identically to product-parse.ts's own
+ * normalizeParsedProduct() price rule (finite, >0, <=MAX_PRICE) — used by
+ * submitSelectionProposal's optional listPrice param (the portal clipper's
+ * bookmarklet-extracted price) so it's held to the exact same bound as a
+ * server-parsed price instead of a second, driftable check. Returns
+ * undefined (not persisted) for anything out of range. */
+function clampListPrice(value: number | null | undefined): number | undefined {
+    if (typeof value !== "number" || !Number.isFinite(value) || value <= 0 || value > PRODUCT_PARSE_MAX_PRICE) {
+        return undefined;
+    }
+    return value;
+}
+
 // ── Product Library CRUD (team) ─────────────────────────────────────────────
 
 export async function createProductLibraryItem(data: {
@@ -9701,6 +9714,13 @@ export async function submitSelectionProposal(projectId: string, data: {
     description?: string;
     imageUrl?: string;
     clientNote?: string;
+    // Price already known at call time (e.g. the portal clipper bookmarklet
+    // read it straight off the live page DOM, same as the team clipper) — see
+    // clampListPrice() above. Still never returned to the client below; only
+    // ever persisted server-side. Falls back to the server-side parse's price
+    // when not supplied, same as every other field's precedence in this
+    // function (client-supplied value wins, parse fills the gap).
+    listPrice?: number;
 }) {
     await assertPortalProjectOwnership(projectId);
 
@@ -9716,6 +9736,7 @@ export async function submitSelectionProposal(projectId: string, data: {
     }
 
     const name = (manualName || parsed?.name || "Suggested item").slice(0, 200);
+    const clampedListPrice = clampListPrice(data.listPrice);
 
     const proposal = await prisma.selectionProposal.create({
         data: {
@@ -9723,7 +9744,7 @@ export async function submitSelectionProposal(projectId: string, data: {
             name,
             description: data.description?.trim() || parsed?.description || null,
             imageUrl: safeUrlOrNull(data.imageUrl) || safeUrlOrNull(parsed?.imageUrl),
-            price: parsed?.price ?? null,
+            price: clampedListPrice ?? parsed?.price ?? null,
             vendorUrl: safeUrlOrNull(url) || safeUrlOrNull(parsed?.vendorUrl),
             clientNote: data.clientNote?.trim() || null,
             status: "Pending",

--- a/src/lib/clipper-bookmarklet.ts
+++ b/src/lib/clipper-bookmarklet.ts
@@ -1,0 +1,63 @@
+// Shared "ProBuild Clip" bookmarklet builder — the in-page JSON-LD/OpenGraph
+// product extraction script used by both the team clipper
+// (/company/product-library -> /clip) and the client clipper (portal
+// Selections tab -> /portal/clip). Originally lived as buildBookmarkletHref
+// inside ProductLibraryClient.tsx; extracted here so both call sites share
+// one copy instead of drifting.
+//
+// Extraction chain: JSON-LD schema.org/Product -> OpenGraph/meta tags. It
+// reads the LIVE page DOM in the user's own browser before ever opening the
+// target page — the same trick Houzz's clipper uses to beat bot walls like
+// Lowe's/Home Depot's Akamai block, which returns a 403 to any server-side
+// fetch regardless of User-Agent. Since the user's browser already has the
+// rendered page, this never needs to fetch anything itself.
+//
+// Kept as one compact (not obfuscated, just short-named) IIFE so it fits
+// comfortably as a draggable bookmark URL. Extraction logic verified against
+// JSON-LD fixtures (array/object image, string/object brand, array offers,
+// AggregateOffer.lowPrice) and a fake-DOM harness in a throwaway script
+// before being embedded here — see the product-library-clipper PR
+// description for the harness.
+export interface BuildClipperBookmarkletOptions {
+    /** Site origin, e.g. NEXT_PUBLIC_APP_URL. No trailing slash expected. */
+    origin: string;
+    /** Path the popup opens, e.g. "/clip" or "/portal/clip". */
+    targetPath: string;
+    /** Static params baked into the target URL ahead of the page-extracted
+     * ones (e.g. { projectId } for the per-project client clipper). */
+    extraParams?: Record<string, string>;
+}
+
+export function buildClipperBookmarklet({ origin, targetPath, extraParams }: BuildClipperBookmarkletOptions): string {
+    const extraQS = extraParams
+        ? Object.entries(extraParams)
+              .filter(([, v]) => v)
+              .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+              .join("&")
+        : "";
+    const openUrlPrefix = `${origin}${targetPath}?${extraQS ? `${extraQS}&` : ""}`;
+
+    const js =
+        "(function(){function I(v){if(!v)return'';if(Array.isArray(v))v=v[0];if(v&&typeof v==='object')return v.url||'';return typeof v==='string'?v:''}" +
+        "function B(b){if(!b)return'';return typeof b==='string'?b:(b.name||'')}" +
+        "function O(o){if(!o)return{};if(Array.isArray(o))o=o[0];if(!o)return{};var p=o.price!=null?o.price:o.lowPrice;return{p:p,c:o.priceCurrency||''}}" +
+        "var nm='',im='',pr='',cu='',vd='';" +
+        "var ss=document.querySelectorAll('script[type=\"application/ld+json\"]');" +
+        "F:for(var i=0;i<ss.length;i++){var d;try{d=JSON.parse(ss[i].textContent)}catch(e){continue}" +
+        "var cs=Array.isArray(d)?d:[d];" +
+        "for(var c=0;c<cs.length;c++){var cd=cs[c];var ns=(cd&&cd['@graph'])?cd['@graph']:[cd];" +
+        "for(var n=0;n<ns.length;n++){var nd=ns[n];if(!nd)continue;var t=nd['@type'];var ts=Array.isArray(t)?t:[t];" +
+        "var isP=ts.some(function(x){return typeof x==='string'&&x.toLowerCase()==='product'});if(!isP)continue;" +
+        "nm=nd.name||'';im=I(nd.image);var of=O(nd.offers);pr=(of.p!=null?of.p:'');cu=of.c||'';vd=B(nd.brand);break F}}}" +
+        "function M(s){var e=document.querySelector(s);return e?(e.getAttribute('content')||''):''}" +
+        "if(!nm)nm=M('meta[property=\"og:title\"]')||document.title||'';" +
+        "if(!im)im=M('meta[property=\"og:image\"]');" +
+        "if(!pr)pr=M('meta[property=\"product:price:amount\"]');" +
+        "if(!cu)cu=M('meta[property=\"product:price:currency\"]');" +
+        "nm=String(nm).slice(0,200);im=String(im).slice(0,1000);" +
+        "var ps=[];function A(k,v){if(v)ps.push(k+'='+encodeURIComponent(v))}" +
+        "A('url',location.href);A('name',nm);A('price',pr);A('currency',cu);A('image',im);A('vendor',vd);" +
+        "window.open('" + openUrlPrefix + "'+ps.join('&'),'probuild-clip','width=480,height=720')" +
+        "})();";
+    return "javascript:" + js;
+}

--- a/src/lib/product-parse.ts
+++ b/src/lib/product-parse.ts
@@ -491,7 +491,10 @@ type RawExtract = {
 const MAX_NAME_LEN = 200;
 const MAX_VENDOR_LEN = 100;
 const MAX_DESCRIPTION_LEN = 2000;
-const MAX_PRICE = 9_999_999.99;
+// Exported so callers that clamp a price outside this module (e.g.
+// submitSelectionProposal's listPrice param in actions.ts) use the identical
+// bound instead of a second, driftable magic number.
+export const MAX_PRICE = 9_999_999.99;
 
 /**
  * Single normalization point for every extraction path (JSON-LD, OpenGraph,


### PR DESCRIPTION
Follow-up to #250/#256: clients had no path to the Clipper (it lived on the team-only product-library page). This gives portal clients their own — clips land in their suggestion queue (Pending, PM-reviewed), not the company library.

- `src/lib/clipper-bookmarklet.ts`: shared in-page JSON-LD/OG extraction bookmarklet builder; team `/clip` card refactored onto it, behavior unchanged (identical href verified).
- `/portal/clip`: popup capture page. Gate chain: portal session (staff bypass) → project ownership → `isPortalEnabled` + `showSelections`; friendly not-available states, never a crash. Prefills from bookmarklet params, image preview `isHttpUrl`-gated, **no price ever displayed** ("Your project team will price this out"), submits a `SelectionProposal`.
- "Get the Clipper" card in the portal suggestions section — per-project bookmarklet (projectId baked in), client-toned copy.
- `submitSelectionProposal` gains clamped optional `listPrice` (retail list price the bookmarklet saw — persisted for PM context, still stripped from all portal reads until Approved; existing strip paths verified unchanged). When `listPrice` is supplied the server-side URL re-parse is skipped entirely, removing a redundant fetch (and the ~20s Gemini fallback latency on bot-walled vendor sites) from the clip path. The manual suggest-modal path is unchanged.

No schema changes. No money-path files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)