### PR TITLE
feat(portal): collaborative client mood boards + selection board guards

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1740,6 +1740,7 @@ model MoodBoardItem {
   width       Float     @default(200)
   height      Float     @default(200)
   zIndex      Int       @default(1)
+  addedByClient Boolean @default(false)
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
 }

--- a/scripts/apply-moodboard-client-collab.mjs
+++ b/scripts/apply-moodboard-client-collab.mjs
@@ -1,0 +1,41 @@
+// One-off additive migration for the collaborative client mood board feature
+// (portal add/move/delete mood-board items). Adds MoodBoardItem.addedByClient
+// so client-added items can be told apart from staff-added ones and protected
+// from being clobbered by a stale staff full-save.
+// Safe to run against the live DB while the deployed (old) client is in use:
+// the column uses IF NOT EXISTS. Mirrors scripts/apply-cost-plus-change-orders.mjs.
+//
+// Run:  node scripts/apply-moodboard-client-collab.mjs
+// (DDL via $executeRawUnsafe over the Supabase transaction pooler — the working
+//  path in this project; psql / prisma db push / migrate dev do not work here.)
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+function resolveDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const f of [".env", ".env.local"]) {
+    if (!fs.existsSync(f)) continue;
+    const m = fs.readFileSync(f, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+    if (m) return m[1];
+  }
+  throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const prisma = new PrismaClient({ datasources: { db: { url: resolveDatabaseUrl() } } });
+
+const statements = [
+  `ALTER TABLE "MoodBoardItem" ADD COLUMN IF NOT EXISTS "addedByClient" BOOLEAN NOT NULL DEFAULT false;`,
+];
+
+try {
+  for (const sql of statements) {
+    await prisma.$executeRawUnsafe(sql);
+    console.log("✔ applied:", sql.split("\n")[0].slice(0, 90));
+  }
+  console.log(`Done. ${statements.length} statements applied.`);
+} catch (e) {
+  console.error("Migration failed:", e);
+  process.exitCode = 1;
+} finally {
+  await prisma.$disconnect();
+}

--- a/src/app/portal/projects/[id]/mood-boards/PortalStartMoodBoardButton.tsx
+++ b/src/app/portal/projects/[id]/mood-boards/PortalStartMoodBoardButton.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { portalCreateMoodBoard } from "@/lib/actions";
+
+export default function PortalStartMoodBoardButton({ projectId }: { projectId: string }) {
+    const router = useRouter();
+    const [open, setOpen] = useState(false);
+    const [title, setTitle] = useState("");
+    const [creating, setCreating] = useState(false);
+
+    const handleCreate = async () => {
+        const trimmed = title.trim();
+        if (!trimmed) {
+            toast.error("Give your board a title first");
+            return;
+        }
+        setCreating(true);
+        try {
+            const board = await portalCreateMoodBoard(projectId, trimmed);
+            toast.success("Board created!");
+            router.push(`/portal/projects/${projectId}/mood-boards/${board.id}`);
+        } catch (e: any) {
+            toast.error(e.message || "Failed to create board");
+        } finally {
+            setCreating(false);
+        }
+    };
+
+    if (!open) {
+        return (
+            <button onClick={() => setOpen(true)} className="hui-btn hui-btn-primary flex items-center gap-1.5">
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+                Start a board
+            </button>
+        );
+    }
+
+    return (
+        <div className="hui-card p-4 flex flex-col sm:flex-row items-stretch sm:items-center gap-2 w-full sm:w-auto">
+            <input
+                autoFocus
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Enter") handleCreate(); if (e.key === "Escape") setOpen(false); }}
+                placeholder="Board title (e.g. Kitchen Ideas)"
+                maxLength={120}
+                className="hui-input"
+            />
+            <div className="flex items-center gap-2 shrink-0">
+                <button onClick={handleCreate} disabled={creating} className="hui-btn hui-btn-primary text-sm">
+                    {creating ? "Creating..." : "Create"}
+                </button>
+                <button onClick={() => { setOpen(false); setTitle(""); }} className="hui-btn hui-btn-secondary text-sm">
+                    Cancel
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/app/portal/projects/[id]/mood-boards/[boardId]/PortalMoodBoardViewer.tsx
+++ b/src/app/portal/projects/[id]/mood-boards/[boardId]/PortalMoodBoardViewer.tsx
@@ -1,5 +1,14 @@
 "use client";
 
+import { useRef, useState } from "react";
+import { toast } from "sonner";
+import {
+    portalAddMoodBoardItem,
+    portalMoveMoodBoardItem,
+    portalDeleteMoodBoardItem,
+} from "@/lib/actions";
+import { isHttpUrl } from "@/lib/url-safety";
+
 interface Item {
     id: string;
     type: string;
@@ -9,54 +18,439 @@ interface Item {
     width: number;
     height: number;
     zIndex: number;
+    addedByClient?: boolean;
 }
 
-export default function PortalMoodBoardViewer({ items }: { items: Item[] }) {
-    if (items.length === 0) {
-        return (
-            <div className="w-full h-full flex flex-col items-center justify-center text-slate-400 p-8">
-                <svg className="w-16 h-16 mb-4 text-slate-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                </svg>
-                <p>This board is currently empty.</p>
-            </div>
-        );
-    }
+interface TrayEntry {
+    key: string;
+    name: string;
+    imageUrl: string;
+}
+
+export default function PortalMoodBoardViewer({
+    boardId,
+    projectId,
+    items: initialItems,
+    isStaff,
+    canUpload,
+    tray,
+}: {
+    boardId: string;
+    projectId: string;
+    items: Item[];
+    isStaff: boolean;
+    canUpload: boolean;
+    tray: TrayEntry[];
+}) {
+    const canvasRef = useRef<HTMLDivElement>(null);
+    const photoInputRef = useRef<HTMLInputElement>(null);
+    const [items, setItems] = useState<Item[]>(initialItems);
+    const [selectedId, setSelectedId] = useState<string | null>(null);
+    const [trayOpen, setTrayOpen] = useState(initialItems.length === 0);
+    const [busy, setBusy] = useState(false);
+    const [uploadingPhoto, setUploadingPhoto] = useState(false);
+    const [swatchColor, setSwatchColor] = useState("#3b82f6");
+    const [noteText, setNoteText] = useState("");
+
+    const updateLocal = (id: string, updates: Partial<Item>) => {
+        setItems(prev => prev.map(i => (i.id === id ? { ...i, ...updates } : i)));
+    };
+
+    const getNextZIndex = () => Math.max(0, ...items.map(i => i.zIndex)) + 1;
+
+    const centerPosition = (size: number) => {
+        const w = canvasRef.current?.clientWidth ?? 500;
+        const h = canvasRef.current?.clientHeight ?? 400;
+        return { x: Math.max(0, w / 2 - size / 2), y: Math.max(0, h / 2 - size / 2) };
+    };
+
+    const commitMove = async (item: Item) => {
+        try {
+            await portalMoveMoodBoardItem(boardId, item.id, {
+                x: Math.round(item.x),
+                y: Math.round(item.y),
+                width: Math.round(item.width),
+                height: Math.round(item.height),
+                zIndex: item.zIndex,
+            });
+        } catch (e: any) {
+            toast.error(e.message || "Failed to save position");
+        }
+    };
+
+    const handleAddFromTray = async (entry: TrayEntry) => {
+        setBusy(true);
+        try {
+            const { x, y } = centerPosition(240);
+            const item = await portalAddMoodBoardItem(boardId, {
+                type: "IMAGE",
+                content: entry.imageUrl,
+                x, y, width: 240, height: 240,
+            });
+            setItems(prev => [...prev, item]);
+            toast.success("Added to board");
+        } catch (e: any) {
+            toast.error(e.message || "Failed to add item");
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleAddSwatch = async () => {
+        setBusy(true);
+        try {
+            const { x, y } = centerPosition(150);
+            const item = await portalAddMoodBoardItem(boardId, {
+                type: "SWATCH",
+                content: swatchColor,
+                x, y, width: 150, height: 150,
+            });
+            setItems(prev => [...prev, item]);
+            toast.success("Swatch added");
+        } catch (e: any) {
+            toast.error(e.message || "Failed to add swatch");
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleAddNote = async () => {
+        const trimmed = noteText.trim();
+        if (!trimmed) {
+            toast.error("Write a note first");
+            return;
+        }
+        setBusy(true);
+        try {
+            const { x, y } = centerPosition(250);
+            const item = await portalAddMoodBoardItem(boardId, {
+                type: "TEXT",
+                content: trimmed,
+                x, y, width: 250, height: 100,
+            });
+            setItems(prev => [...prev, item]);
+            setNoteText("");
+            toast.success("Note added");
+        } catch (e: any) {
+            toast.error(e.message || "Failed to add note");
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handlePhotoChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        setUploadingPhoto(true);
+        try {
+            const formData = new FormData();
+            formData.append("file", file);
+            formData.append("projectId", projectId);
+            const res = await fetch("/api/portal/files", { method: "POST", body: formData });
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.error || "Upload failed");
+            const url = data.file?.url;
+            if (!url) throw new Error("Upload did not return a file URL");
+            const { x, y } = centerPosition(240);
+            const item = await portalAddMoodBoardItem(boardId, {
+                type: "IMAGE",
+                content: url,
+                x, y, width: 240, height: 240,
+            });
+            setItems(prev => [...prev, item]);
+            toast.success("Photo added");
+        } catch (e: any) {
+            toast.error(e.message || "Failed to upload photo");
+        } finally {
+            setUploadingPhoto(false);
+            if (photoInputRef.current) photoInputRef.current.value = "";
+        }
+    };
+
+    const handleDelete = async (itemId: string) => {
+        try {
+            await portalDeleteMoodBoardItem(boardId, itemId);
+            setItems(prev => prev.filter(i => i.id !== itemId));
+            if (selectedId === itemId) setSelectedId(null);
+        } catch (e: any) {
+            toast.error(e.message || "Failed to remove item");
+        }
+    };
 
     return (
-        <div className="w-full h-full relative overflow-auto custom-scrollbar" style={{ backgroundImage: 'radial-gradient(#CBD5E1 1px, transparent 1px)', backgroundSize: '20px 20px' }}>
-            {items.map(item => (
+        <div className="w-full h-full flex flex-col">
+            <div className="px-4 py-2 text-xs text-slate-500 border-b border-slate-200 bg-white flex items-center justify-between gap-3 shrink-0">
+                <span>Drag things around until it feels right — your project team sees this same board.</span>
+                <button onClick={() => setTrayOpen(o => !o)} className="hui-btn hui-btn-secondary text-xs shrink-0">
+                    {trayOpen ? "Hide tray" : "Add ideas"}
+                </button>
+            </div>
+
+            <div className="flex-1 flex flex-col md:flex-row overflow-hidden">
                 <div
-                    key={item.id}
-                    style={{
-                        position: "absolute",
-                        left: item.x,
-                        top: item.y,
-                        width: item.width,
-                        height: item.height,
-                        zIndex: item.zIndex,
-                    }}
+                    ref={canvasRef}
+                    className="flex-1 relative overflow-auto custom-scrollbar"
+                    style={{ backgroundImage: 'radial-gradient(#CBD5E1 1px, transparent 1px)', backgroundSize: '20px 20px' }}
+                    onPointerDown={(e) => { if (e.target === canvasRef.current) setSelectedId(null); }}
                 >
-                    {item.type === "IMAGE" && (
-                        <img src={item.content} alt="Mood Board Content" className="w-full h-full object-contain pointer-events-none" />
-                    )}
-                    
-                    {item.type === "TEXT" && (
-                        <div className="w-full h-full p-4 bg-white/80 backdrop-blur shadow-sm border border-slate-200 text-slate-800 text-lg flex items-center justify-center text-center overflow-hidden break-words pointer-events-none rounded-lg">
-                            {item.content}
+                    {items.length === 0 && (
+                        <div className="absolute inset-0 flex flex-col items-center justify-center text-slate-400 p-8 text-center pointer-events-none">
+                            <svg className="w-16 h-16 mb-4 text-slate-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                            </svg>
+                            <p>This board is empty — add your first idea from the tray.</p>
                         </div>
                     )}
-                    
-                    {item.type === "SWATCH" && (
-                        <div className="w-full h-full shadow-sm rounded-lg flex flex-col overflow-hidden pointer-events-none border border-slate-200">
-                            <div className="flex-1" style={{ backgroundColor: item.content }} />
-                            <div className="h-8 bg-white flex items-center justify-center text-xs font-mono text-slate-600">
-                                {item.content}
-                            </div>
-                        </div>
-                    )}
+
+                    {items.map(item => (
+                        <MoodBoardNode
+                            key={item.id}
+                            item={item}
+                            isSelected={selectedId === item.id}
+                            canDelete={isStaff || !!item.addedByClient}
+                            onSelect={() => setSelectedId(item.id)}
+                            onLocalChange={(updates) => updateLocal(item.id, updates)}
+                            onCommit={(updates) => commitMove({ ...item, ...updates })}
+                            getNextZIndex={getNextZIndex}
+                            onDelete={() => handleDelete(item.id)}
+                        />
+                    ))}
                 </div>
-            ))}
+
+                {trayOpen && (
+                    <div className="w-full md:w-72 border-t md:border-t-0 md:border-l border-slate-200 bg-white overflow-y-auto p-4 space-y-6 shrink-0 max-h-[45vh] md:max-h-none">
+                        <div>
+                            <h3 className="text-sm font-semibold text-slate-700 mb-2">From your project</h3>
+                            {tray.length === 0 ? (
+                                <p className="text-xs text-slate-400">Nothing here yet — favorites, suggestions, and selection photos will show up as they're added.</p>
+                            ) : (
+                                <div className="grid grid-cols-3 gap-2">
+                                    {tray.map(entry => (
+                                        <button
+                                            key={entry.key}
+                                            onClick={() => handleAddFromTray(entry)}
+                                            disabled={busy}
+                                            title={entry.name}
+                                            className="aspect-square rounded-md overflow-hidden border border-slate-200 hover:border-hui-primary transition disabled:opacity-50"
+                                        >
+                                            <img src={entry.imageUrl} alt={entry.name} className="w-full h-full object-cover" />
+                                        </button>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+
+                        <div>
+                            <h3 className="text-sm font-semibold text-slate-700 mb-2">Color swatch</h3>
+                            <div className="flex items-center gap-2">
+                                <input
+                                    type="color"
+                                    value={swatchColor}
+                                    onChange={(e) => setSwatchColor(e.target.value)}
+                                    className="w-10 h-10 rounded border border-slate-200 cursor-pointer"
+                                />
+                                <span className="text-xs font-mono text-slate-500">{swatchColor}</span>
+                            </div>
+                            <button onClick={handleAddSwatch} disabled={busy} className="hui-btn hui-btn-secondary text-xs mt-2 w-full">
+                                Add swatch
+                            </button>
+                        </div>
+
+                        <div>
+                            <h3 className="text-sm font-semibold text-slate-700 mb-2">Note</h3>
+                            <textarea
+                                value={noteText}
+                                onChange={(e) => setNoteText(e.target.value)}
+                                maxLength={500}
+                                rows={3}
+                                placeholder="Jot down an idea..."
+                                className="hui-input w-full text-sm resize-none"
+                            />
+                            <button onClick={handleAddNote} disabled={busy} className="hui-btn hui-btn-secondary text-xs mt-2 w-full">
+                                Add note
+                            </button>
+                        </div>
+
+                        {canUpload && (
+                            <div>
+                                <h3 className="text-sm font-semibold text-slate-700 mb-2">Photo</h3>
+                                <input
+                                    ref={photoInputRef}
+                                    type="file"
+                                    accept="image/*"
+                                    className="hidden"
+                                    onChange={handlePhotoChange}
+                                />
+                                <button
+                                    onClick={() => photoInputRef.current?.click()}
+                                    disabled={uploadingPhoto}
+                                    className="hui-btn hui-btn-secondary text-xs w-full"
+                                >
+                                    {uploadingPhoto ? "Uploading..." : "Upload a photo"}
+                                </button>
+                            </div>
+                        )}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+function MoodBoardNode({
+    item,
+    isSelected,
+    canDelete,
+    onSelect,
+    onLocalChange,
+    onCommit,
+    getNextZIndex,
+    onDelete,
+}: {
+    item: Item;
+    isSelected: boolean;
+    canDelete: boolean;
+    onSelect: () => void;
+    onLocalChange: (updates: Partial<Item>) => void;
+    onCommit: (updates: Partial<Item>) => void;
+    getNextZIndex: () => number;
+    onDelete: () => void;
+}) {
+    // Final values are tracked in a local variable (not read back from React
+    // state) so the eventual onCommit always reflects exactly what the user
+    // dragged/resized to — the pointerdown handler's closure over `item` is
+    // fixed at drag-start and would otherwise go stale across the many
+    // re-renders a drag triggers.
+    const handlePointerDownMove = (e: React.PointerEvent) => {
+        e.stopPropagation();
+        onSelect();
+        const el = e.currentTarget as HTMLElement;
+        el.setPointerCapture(e.pointerId);
+        const startX = e.clientX;
+        const startY = e.clientY;
+        const origX = item.x;
+        const origY = item.y;
+        const newZ = getNextZIndex();
+        let latest: Partial<Item> = { x: origX, y: origY, width: item.width, height: item.height, zIndex: newZ };
+
+        const onMove = (moveEvent: PointerEvent) => {
+            const dx = moveEvent.clientX - startX;
+            const dy = moveEvent.clientY - startY;
+            latest = { ...latest, x: Math.max(0, origX + dx), y: Math.max(0, origY + dy) };
+            onLocalChange(latest);
+        };
+        const onUp = (upEvent: PointerEvent) => {
+            el.releasePointerCapture(upEvent.pointerId);
+            el.removeEventListener("pointermove", onMove);
+            el.removeEventListener("pointerup", onUp);
+            el.removeEventListener("pointercancel", onUp);
+            onCommit(latest);
+        };
+        el.addEventListener("pointermove", onMove);
+        el.addEventListener("pointerup", onUp);
+        // pointercancel fires instead of pointerup when the browser aborts the
+        // gesture mid-drag (e.g. an OS gesture takes over, or a touch is
+        // interrupted) — without handling it the drag state (and pointer
+        // capture) is left dangling and the item never gets its commit.
+        el.addEventListener("pointercancel", onUp);
+    };
+
+    const handlePointerDownResize = (e: React.PointerEvent) => {
+        e.stopPropagation();
+        const el = e.currentTarget as HTMLElement;
+        el.setPointerCapture(e.pointerId);
+        const startX = e.clientX;
+        const startY = e.clientY;
+        const origWidth = item.width;
+        const origHeight = item.height;
+        let latest: Partial<Item> = { x: item.x, y: item.y, width: origWidth, height: origHeight, zIndex: item.zIndex };
+
+        const onMove = (moveEvent: PointerEvent) => {
+            const dx = moveEvent.clientX - startX;
+            const dy = moveEvent.clientY - startY;
+            latest = { ...latest, width: Math.max(40, origWidth + dx), height: Math.max(40, origHeight + dy) };
+            onLocalChange(latest);
+        };
+        const onUp = (upEvent: PointerEvent) => {
+            el.releasePointerCapture(upEvent.pointerId);
+            el.removeEventListener("pointermove", onMove);
+            el.removeEventListener("pointerup", onUp);
+            el.removeEventListener("pointercancel", onUp);
+            onCommit(latest);
+        };
+        el.addEventListener("pointermove", onMove);
+        el.addEventListener("pointerup", onUp);
+        // See handlePointerDownMove above — pointercancel must be treated the
+        // same as pointerup so an aborted resize gesture doesn't leave drag
+        // state dangling.
+        el.addEventListener("pointercancel", onUp);
+    };
+
+    return (
+        <div
+            onPointerDown={handlePointerDownMove}
+            onClick={(e) => { e.stopPropagation(); onSelect(); }}
+            style={{
+                position: "absolute",
+                left: item.x,
+                top: item.y,
+                width: item.width,
+                height: item.height,
+                zIndex: item.zIndex,
+                touchAction: "none",
+                cursor: "move",
+            }}
+            className={`group ${isSelected ? "ring-2 ring-hui-primary ring-offset-2" : ""}`}
+        >
+            {item.type === "IMAGE" && (
+                isHttpUrl(item.content) ? (
+                    <img src={item.content} alt="Mood board item" className="w-full h-full object-contain pointer-events-none" draggable={false} />
+                ) : (
+                    // Defense in depth for legacy rows that predate the
+                    // server-side isHttpUrl validation in
+                    // portalAddMoodBoardItem — never hand a non-http(s)
+                    // string straight to <img src>.
+                    <div className="w-full h-full flex items-center justify-center bg-slate-100 border border-slate-200 rounded-lg pointer-events-none text-slate-300">
+                        <svg className="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                        </svg>
+                    </div>
+                )
+            )}
+
+            {item.type === "TEXT" && (
+                <div className="w-full h-full p-4 bg-white/80 backdrop-blur shadow-sm border border-slate-200 text-slate-800 text-lg flex items-center justify-center text-center overflow-hidden break-words pointer-events-none rounded-lg">
+                    {item.content}
+                </div>
+            )}
+
+            {item.type === "SWATCH" && (
+                <div className="w-full h-full shadow-sm rounded-lg flex flex-col overflow-hidden pointer-events-none border border-slate-200">
+                    <div className="flex-1" style={{ backgroundColor: item.content }} />
+                    <div className="h-8 bg-white flex items-center justify-center text-xs font-mono text-slate-600">
+                        {item.content}
+                    </div>
+                </div>
+            )}
+
+            {isSelected && (
+                <div
+                    onPointerDown={handlePointerDownResize}
+                    style={{ touchAction: "none" }}
+                    className="absolute -bottom-2 -right-2 w-5 h-5 bg-hui-primary border-2 border-white rounded-full cursor-nwse-resize z-50 shadow-md"
+                />
+            )}
+
+            {isSelected && canDelete && (
+                <button
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => { e.stopPropagation(); onDelete(); }}
+                    title="Remove"
+                    className="absolute -top-2 -right-2 w-5 h-5 bg-white border border-slate-300 rounded-full flex items-center justify-center text-slate-500 hover:text-red-600 hover:border-red-300 shadow-sm z-50 text-xs leading-none"
+                >
+                    ✕
+                </button>
+            )}
         </div>
     );
 }

--- a/src/app/portal/projects/[id]/mood-boards/[boardId]/page.tsx
+++ b/src/app/portal/projects/[id]/mood-boards/[boardId]/page.tsx
@@ -1,7 +1,13 @@
-import { getServerSession } from "next-auth/next";
-import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
-import { getPortalVisibility, getMoodBoard } from "@/lib/actions";
+import {
+    getPortalVisibility,
+    getMoodBoard,
+    getProjectFavoritesForPortal,
+    getSelectionProposalsForPortal,
+    getPortalMoodBoardAccess,
+} from "@/lib/actions";
+import { isHttpUrl } from "@/lib/url-safety";
 import Link from "next/link";
 import PortalMoodBoardViewer from "./PortalMoodBoardViewer";
 
@@ -15,6 +21,51 @@ export default async function PortalMoodBoardCanvasPage(props: { params: Promise
 
     const board = await getMoodBoard(boardId);
     if (!board || board.projectId !== id) return notFound();
+
+    // Ownership check: PortalVisibility only gates whether mood boards are
+    // enabled for the project, not whether this session may see THIS
+    // project's boards — without this a client authenticated on a different
+    // project could read another project's board by id.
+    let isStaff: boolean;
+    try {
+        ({ isStaff } = await getPortalMoodBoardAccess(id));
+    } catch (e) {
+        if (e instanceof Error && e.message === "Unauthorized") return notFound();
+        throw e;
+    }
+
+    // Staff add images from their own editor (MoodBoardEditor.tsx) — the
+    // portal photo-upload tray posts to /api/portal/files, which always marks
+    // uploads as client-originated, so staff must not see that upload option
+    // here.
+    const canUpload = visibility.showFiles && !isStaff;
+
+    // Tray content the client can drop onto the board: project selection
+    // option images, plus their own favorites/suggestions — but favorites and
+    // proposals are gated on showSelections, which can be off while mood
+    // boards stay on, so both are best-effort and fall back to [] rather than
+    // taking the whole page down.
+    const [selectionImages, favorites, proposals] = await Promise.all([
+        prisma.selectionOption.findMany({
+            where: { category: { board: { projectId: id } }, imageUrl: { not: null } },
+            select: { id: true, name: true, imageUrl: true },
+        }),
+        getProjectFavoritesForPortal(id).catch(() => [] as Awaited<ReturnType<typeof getProjectFavoritesForPortal>>),
+        getSelectionProposalsForPortal(id).catch(() => [] as Awaited<ReturnType<typeof getSelectionProposalsForPortal>>),
+    ]);
+
+    const trayByKey = new Map<string, { key: string; name: string; imageUrl: string }>();
+    for (const opt of selectionImages) {
+        if (isHttpUrl(opt.imageUrl)) trayByKey.set(`selection-${opt.id}`, { key: `selection-${opt.id}`, name: opt.name, imageUrl: opt.imageUrl });
+    }
+    for (const fav of favorites) {
+        const imageUrl = (fav as any).product?.imageUrl;
+        if (isHttpUrl(imageUrl)) trayByKey.set(`favorite-${fav.id}`, { key: `favorite-${fav.id}`, name: (fav as any).product?.name || "Favorite", imageUrl });
+    }
+    for (const prop of proposals) {
+        if (isHttpUrl((prop as any).imageUrl)) trayByKey.set(`proposal-${prop.id}`, { key: `proposal-${prop.id}`, name: (prop as any).name || "Suggestion", imageUrl: (prop as any).imageUrl });
+    }
+    const tray = Array.from(trayByKey.values());
 
     return (
         <div className="h-[calc(100vh-8rem)] flex flex-col p-4">
@@ -30,7 +81,14 @@ export default async function PortalMoodBoardCanvasPage(props: { params: Promise
             </div>
 
             <div className="flex-1 bg-slate-50 border border-slate-200 rounded-xl overflow-hidden shadow-inner relative">
-                <PortalMoodBoardViewer items={board.items} />
+                <PortalMoodBoardViewer
+                    boardId={boardId}
+                    projectId={id}
+                    items={JSON.parse(JSON.stringify(board.items))}
+                    isStaff={isStaff}
+                    canUpload={canUpload}
+                    tray={tray}
+                />
             </div>
         </div>
     );

--- a/src/app/portal/projects/[id]/mood-boards/page.tsx
+++ b/src/app/portal/projects/[id]/mood-boards/page.tsx
@@ -1,9 +1,8 @@
-import { getServerSession } from "next-auth/next";
-import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
-import { getPortalVisibility, getMoodBoards } from "@/lib/actions";
+import { getPortalVisibility, getMoodBoards, getPortalMoodBoardAccess } from "@/lib/actions";
 import Link from "next/link";
+import PortalStartMoodBoardButton from "./PortalStartMoodBoardButton";
 
 export default async function PortalMoodBoardsPage(props: { params: Promise<{ id: string }> }) {
     const { id } = await props.params;
@@ -23,6 +22,18 @@ export default async function PortalMoodBoardsPage(props: { params: Promise<{ id
         );
     }
 
+    // Ownership check: PortalVisibility alone only gates whether mood boards
+    // are enabled for the project, not whether the current session may see
+    // THIS project's boards — a client on a different project could
+    // otherwise browse boards that aren't theirs.
+    let isStaff: boolean;
+    try {
+        ({ isStaff } = await getPortalMoodBoardAccess(id));
+    } catch (e) {
+        if (e instanceof Error && e.message === "Unauthorized") return notFound();
+        throw e;
+    }
+
     const boards = await getMoodBoards(id);
 
     return (
@@ -39,11 +50,14 @@ export default async function PortalMoodBoardsPage(props: { params: Promise<{ id
                 </Link>
             </div>
 
-            <div className="mb-8">
-                <h1 className="text-3xl font-bold text-hui-textMain mb-2">Visual Mood Boards</h1>
-                <p className="text-sm text-hui-textMuted">
-                    Explore design concepts and material presentations.
-                </p>
+            <div className="mb-8 flex items-start justify-between gap-4 flex-wrap">
+                <div>
+                    <h1 className="text-3xl font-bold text-hui-textMain mb-2">Visual Mood Boards</h1>
+                    <p className="text-sm text-hui-textMuted">
+                        Explore design concepts and material presentations — drag, drop, and arrange them together with your project team.
+                    </p>
+                </div>
+                {!isStaff && <PortalStartMoodBoardButton projectId={id} />}
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/src/app/portal/projects/[id]/selections/PortalSelectionsClient.tsx
+++ b/src/app/portal/projects/[id]/selections/PortalSelectionsClient.tsx
@@ -66,7 +66,7 @@ export default function PortalSelectionsClient({ boards }: { boards: Board[] }) 
         const board = boards.find(b => b.id === boardId);
         if (!board) return;
         
-        const missingCats = board.categories.filter(c => !selections[c.id]);
+        const missingCats = board.categories.filter(c => c.options.length > 0 && !selections[c.id]);
         if (missingCats.length > 0) {
             toast.error(`Please select an option for: ${missingCats.map(c => c.name).join(", ")}`);
             return;
@@ -107,13 +107,17 @@ export default function PortalSelectionsClient({ boards }: { boards: Board[] }) 
                                 )}
                             </div>
                             {!isSubmitted && (
-                                <button
-                                    onClick={() => handleSubmit(board.id)}
-                                    disabled={submitting[board.id]}
-                                    className="hui-btn hui-btn-green"
-                                >
-                                    {submitting[board.id] ? "Submitting..." : "Submit Selections"}
-                                </button>
+                                board.categories.some(c => c.options.length > 0) ? (
+                                    <button
+                                        onClick={() => handleSubmit(board.id)}
+                                        disabled={submitting[board.id]}
+                                        className="hui-btn hui-btn-green"
+                                    >
+                                        {submitting[board.id] ? "Submitting..." : "Submit Selections"}
+                                    </button>
+                                ) : (
+                                    <span className="text-sm text-hui-textMuted font-medium">Waiting on options</span>
+                                )
                             )}
                         </div>
 
@@ -122,13 +126,18 @@ export default function PortalSelectionsClient({ boards }: { boards: Board[] }) 
                                 <div key={cat.id}>
                                     <div className="flex items-center justify-between mb-4 border-b border-slate-200 pb-2">
                                         <h3 className="text-lg font-semibold text-slate-800">{cat.name}</h3>
-                                        {!isSubmitted && (
+                                        {!isSubmitted && cat.options.length > 0 && (
                                             <span className={`text-sm font-medium ${boardSelections[cat.id] ? 'text-green-600' : 'text-slate-400'}`}>
                                                 {boardSelections[cat.id] ? '✓ Option Selected' : 'Not Selected'}
                                             </span>
                                         )}
                                     </div>
-                                    
+
+                                    {cat.options.length === 0 ? (
+                                        <p className="text-sm text-slate-400 italic">
+                                            Your project manager is still adding options for this category — nothing to pick yet.
+                                        </p>
+                                    ) : (
                                     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
                                         {cat.options.map(opt => {
                                             const isSelected = boardSelections[cat.id] === opt.id;
@@ -204,6 +213,7 @@ export default function PortalSelectionsClient({ boards }: { boards: Board[] }) 
                                             );
                                         })}
                                     </div>
+                                    )}
                                 </div>
                             ))}
                         </div>

--- a/src/app/projects/[id]/mood-boards/[boardId]/MoodBoardEditor.tsx
+++ b/src/app/projects/[id]/mood-boards/[boardId]/MoodBoardEditor.tsx
@@ -23,6 +23,11 @@ export default function MoodBoardEditor({ board }: { board: any }) {
     const [saving, setSaving] = useState(false);
     const [uploading, setUploading] = useState(false);
     const [selectedId, setSelectedId] = useState<string | null>(null);
+    // Ids present when this editor last loaded/saved — used to compute which
+    // items were removed locally (including ones a client added via the
+    // portal since this ref was last updated) so the server only deletes
+    // those, instead of wiping every id not in the current submitted array.
+    const initialIds = useRef<string[]>((board.items || []).map((i: Item) => i.id));
 
     // Click outside to deselect
     useEffect(() => {
@@ -38,8 +43,20 @@ export default function MoodBoardEditor({ board }: { board: any }) {
     const handleSave = async () => {
         setSaving(true);
         try {
-            await saveMoodBoardItems(board.id, items);
-            toast.success("Mood board saved!");
+            const currentIds = items.filter(i => !i.id.startsWith("temp-")).map(i => i.id);
+            const deletedIds = initialIds.current.filter(id => !currentIds.includes(id));
+            const result = await saveMoodBoardItems(board.id, items, deletedIds);
+            // Replace local state with the persisted items (real DB ids) so
+            // "temp-*" ids from this save don't get re-sent (and duplicated)
+            // on the next save.
+            setItems(result.items);
+            initialIds.current = result.items.map((i: Item) => i.id);
+            setSelectedId(null);
+            if (result.skippedIds && result.skippedIds.length > 0) {
+                toast.info("Some items changed elsewhere and were refreshed.");
+            } else {
+                toast.success("Mood board saved!");
+            }
         } catch (e: any) {
             toast.error(e.message || "Failed to save");
         } finally {

--- a/src/app/projects/[id]/selections/SelectionsClient.tsx
+++ b/src/app/projects/[id]/selections/SelectionsClient.tsx
@@ -290,16 +290,23 @@ export default function SelectionsClient({
                                     {/* Board Actions */}
                                     <div className="flex items-center gap-2 px-5 py-3 bg-slate-50 border-b border-hui-border">
                                         {board.status === "Draft" && (
-                                            <button
-                                                onClick={() => handleSendToClient(board.id)}
-                                                className="hui-btn hui-btn-green text-sm flex items-center gap-1.5"
-                                                disabled={board.categories.length === 0}
-                                            >
-                                                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
-                                                </svg>
-                                                Send to Client
-                                            </button>
+                                            <>
+                                                <button
+                                                    onClick={() => handleSendToClient(board.id)}
+                                                    className="hui-btn hui-btn-green text-sm flex items-center gap-1.5"
+                                                    disabled={board.categories.length === 0 || board.categories.some(c => c.options.length === 0)}
+                                                >
+                                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
+                                                    </svg>
+                                                    Send to Client
+                                                </button>
+                                                {(board.categories.length === 0 || board.categories.some(c => c.options.length === 0)) && (
+                                                    <span className="text-xs text-hui-textMuted">
+                                                        Add at least one option to every category before sending.
+                                                    </span>
+                                                )}
+                                            </>
                                         )}
                                         {board.status !== "Draft" && (
                                             <button

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -9419,11 +9419,24 @@ export async function deleteSelectionOption(id: string) {
 }
 
 export async function sendSelectionBoardToClient(boardId: string) {
+    await assertActiveStaff();
+
     const board = await prisma.selectionBoard.findUnique({
         where: { id: boardId },
-        include: { project: { include: { client: true } } },
+        include: {
+            project: { include: { client: true } },
+            categories: { include: { options: true } },
+        },
     });
     if (!board) throw new Error("Board not found");
+
+    if (board.categories.length === 0) {
+        throw new Error("Add at least one category before sending.");
+    }
+    const emptyCategories = board.categories.filter((c) => c.options.length === 0);
+    if (emptyCategories.length > 0) {
+        throw new Error(`Every category needs at least one option before sending. Missing options: ${emptyCategories.map((c) => c.name).join(", ")}`);
+    }
 
     await prisma.selectionBoard.update({
         where: { id: boardId },
@@ -9468,26 +9481,80 @@ export async function submitClientSelections(boardId: string, selections: Record
     });
     if (!board) throw new Error("Board not found");
 
-    // Reset all options then set selected ones
+    await assertPortalProjectOwnership(board.projectId);
+
+    if (board.status !== "Sent") {
+        throw new Error("This board is not open for selections.");
+    }
+
+    // Cheap pre-check against the snapshot read above, for a fast error
+    // before touching the transaction. This snapshot can go stale if staff
+    // edit the board's categories/options between this read and the claim
+    // below, so it is re-validated against fresh in-tx data after the claim
+    // succeeds — this pass is purely an early-exit convenience.
     for (const cat of board.categories) {
+        if (cat.options.length === 0) continue;
         const selectedOptionId = selections[cat.id];
-        for (const opt of cat.options) {
-            await prisma.selectionOption.update({
-                where: { id: opt.id },
-                data: { selected: opt.id === selectedOptionId },
-            });
+        if (!selectedOptionId || !cat.options.some((o) => o.id === selectedOptionId)) {
+            throw new Error("Please select an option for every category.");
         }
     }
 
-    await prisma.selectionBoard.update({
-        where: { id: boardId },
-        data: { status: "Selections Made" },
+    // Claim the board first, inside the transaction: updateMany only flips
+    // status if it's still "Sent", so two concurrent submits (or a resubmit
+    // racing a re-send) can't both write option selections — the loser gets
+    // count 0 and throws instead of silently double-applying.
+    const freshCategories = await prisma.$transaction(async (tx) => {
+        const claim = await tx.selectionBoard.updateMany({
+            where: { id: boardId, status: "Sent" },
+            data: { status: "Selections Made" },
+        });
+        if (claim.count === 0) {
+            throw new Error("This board is not open for selections.");
+        }
+
+        // Re-read categories+options inside the transaction, after the claim
+        // succeeds, and re-run the same validation against this fresh data —
+        // a staff edit that slipped in between the pre-check above and the
+        // claim (e.g. removing/replacing an option) throws here, which rolls
+        // back the claim instead of recording a selection against stale data.
+        const cats = await tx.selectionCategory.findMany({
+            where: { boardId },
+            include: { options: true },
+        });
+        for (const cat of cats) {
+            if (cat.options.length === 0) continue;
+            const selectedOptionId = selections[cat.id];
+            if (!selectedOptionId || !cat.options.some((o) => o.id === selectedOptionId)) {
+                throw new Error("Please select an option for every category.");
+            }
+        }
+
+        // Reset all options then set selected ones, per category.
+        for (const cat of cats) {
+            const selectedOptionId = selections[cat.id];
+            if (cat.options.length === 0) continue;
+            await tx.selectionOption.updateMany({
+                where: { categoryId: cat.id },
+                data: { selected: false },
+            });
+            const set = await tx.selectionOption.updateMany({
+                where: { id: selectedOptionId, categoryId: cat.id },
+                data: { selected: true },
+            });
+            if (set.count !== 1) {
+                throw new Error("Please select an option for every category.");
+            }
+        }
+
+        return cats;
     });
 
-    // Notify PM
+    // Notify PM — built from the fresh in-tx data captured above, not the
+    // pre-transaction snapshot.
     const settings = await getCachedCompanySettings();
     if (settings.notificationEmail) {
-        const selectedSummary = board.categories.map(cat => {
+        const selectedSummary = freshCategories.map(cat => {
             const selectedOpt = cat.options.find(o => selections[cat.id] === o.id);
             return `<li><strong>${cat.name}:</strong> ${selectedOpt?.name || 'None'}</li>`;
         }).join('');
@@ -9555,6 +9622,35 @@ async function assertPortalProjectOwnership(projectId: string): Promise<{ isStaf
     const project = await prisma.project.findFirst({ where: { id: projectId, clientId }, select: { id: true } });
     if (!project) throw new Error("Unauthorized");
     return { isStaff: false, clientId };
+}
+
+/**
+ * Ownership + visibility assertion for the portal-facing collaborative mood
+ * board actions below. Modeled exactly on assertPortalProjectOwnership above,
+ * gated on showMoodBoards instead of showSelections.
+ */
+async function assertPortalMoodBoardAccess(projectId: string): Promise<{ isStaff: boolean; clientId: string | null }> {
+    const visibility = await getPortalVisibility(projectId);
+    if (!visibility.isPortalEnabled || !visibility.showMoodBoards) throw new Error("Unauthorized");
+
+    const session = await getSessionOrDev();
+    const role = (session?.user as { role?: string } | undefined)?.role;
+    const isStaff = role === "ADMIN" || role === "MANAGER";
+    if (isStaff) return { isStaff: true, clientId: null };
+
+    const clientId = await resolveSessionClientId();
+    if (!clientId) throw new Error("Unauthorized");
+    const project = await prisma.project.findFirst({ where: { id: projectId, clientId }, select: { id: true } });
+    if (!project) throw new Error("Unauthorized");
+    return { isStaff: false, clientId };
+}
+
+// Thin exported wrapper around assertPortalMoodBoardAccess for the portal
+// mood-board pages (server components), which need the same
+// ownership/visibility check the actions above enforce — throws on failure,
+// same as the internal function.
+export async function getPortalMoodBoardAccess(projectId: string): Promise<{ isStaff: boolean; clientId: string | null }> {
+    return assertPortalMoodBoardAccess(projectId);
 }
 
 /** Persist boundary for any stored vendorUrl/imageUrl: only a plain http(s)
@@ -10237,6 +10333,7 @@ export async function getMoodBoard(id: string) {
 }
 
 export async function createMoodBoard(projectId: string, title: string) {
+    await assertActiveStaff();
     const board = await prisma.moodBoard.create({
         data: { projectId, title },
     });
@@ -10245,6 +10342,7 @@ export async function createMoodBoard(projectId: string, title: string) {
 }
 
 export async function deleteMoodBoard(id: string) {
+    await assertActiveStaff();
     const board = await prisma.moodBoard.findUnique({ where: { id } });
     if (!board) return { success: false };
     await prisma.moodBoard.delete({ where: { id } });
@@ -10252,6 +10350,11 @@ export async function deleteMoodBoard(id: string) {
     return { success: true };
 }
 
+// deletedIds: ids the staff editor removed locally since it loaded the board.
+// Only these are deleted server-side (filtered to ids actually belonging to
+// this board) — the old "delete everything not in the submitted array"
+// behavior would silently wipe items a client added via the portal after the
+// staff editor's initial load (see portalAddMoodBoardItem below).
 export async function saveMoodBoardItems(boardId: string, items: Array<{
     id?: string;
     type: string;
@@ -10261,23 +10364,33 @@ export async function saveMoodBoardItems(boardId: string, items: Array<{
     width: number;
     height: number;
     zIndex: number;
-}>) {
+}>, deletedIds?: string[]) {
+    await assertActiveStaff();
+
     const board = await prisma.moodBoard.findUnique({ where: { id: boardId } });
     if (!board) throw new Error("Board not found");
 
+    const skippedIds: string[] = [];
+
     await prisma.$transaction(async (tx) => {
-        const currentItemIds = items.filter(i => i.id && !i.id.startsWith("temp-")).map(i => i.id as string);
-        await tx.moodBoardItem.deleteMany({
-            where: {
-                moodBoardId: boardId,
-                id: { notIn: currentItemIds }
-            }
-        });
+        if (deletedIds && deletedIds.length > 0) {
+            await tx.moodBoardItem.deleteMany({
+                where: {
+                    moodBoardId: boardId,
+                    id: { in: deletedIds },
+                },
+            });
+        }
 
         for (const item of items) {
             if (item.id && !item.id.startsWith("temp-")) {
-                await tx.moodBoardItem.update({
-                    where: { id: item.id },
+                // updateMany (not update) so this is scoped to moodBoardId as
+                // well as id: an item the client deleted concurrently is
+                // silently skipped (matchCount 0) instead of throwing and
+                // rolling back the whole save, and a forged id belonging to
+                // another board is a no-op rather than cross-board writes.
+                const updated = await tx.moodBoardItem.updateMany({
+                    where: { id: item.id, moodBoardId: boardId },
                     data: {
                         type: item.type,
                         content: item.content,
@@ -10288,6 +10401,7 @@ export async function saveMoodBoardItems(boardId: string, items: Array<{
                         zIndex: item.zIndex,
                     }
                 });
+                if (updated.count === 0) skippedIds.push(item.id);
             } else {
                 await tx.moodBoardItem.create({
                     data: {
@@ -10306,7 +10420,157 @@ export async function saveMoodBoardItems(boardId: string, items: Array<{
     });
 
     revalidatePath(`/projects/${board.projectId}/mood-boards/${boardId}`);
+
+    // Return the persisted, ordered item list (real DB ids) so the caller can
+    // replace its local state — the editor re-sends "temp-*" ids on every
+    // save, so without this the client can't tell which temp ids became which
+    // real ids and would recreate them on the next save.
+    const persisted = await prisma.moodBoardItem.findMany({
+        where: { moodBoardId: boardId },
+        orderBy: { createdAt: "asc" },
+    });
+    return { success: true, items: persisted, skippedIds };
+}
+
+// ── Portal collaborative mood board actions ─────────────────────────────────
+// Staff and client share the same board: both can arrange (move/resize) any
+// item, but only the client's own added items (or staff, always) can delete
+// a given item. See assertPortalMoodBoardAccess above.
+
+const MOODBOARD_ITEM_TYPES = ["IMAGE", "TEXT", "SWATCH"] as const;
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+
+function clampMoodBoardCoord(value: number): number {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return 0;
+    return Math.min(5000, Math.max(0, n));
+}
+
+function clampMoodBoardSize(value: number): number {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return 40;
+    return Math.min(2000, Math.max(40, n));
+}
+
+function clampMoodBoardZIndex(value: number): number {
+    const n = Math.round(Number(value));
+    if (!Number.isFinite(n)) return 1;
+    return Math.min(100000, Math.max(1, n));
+}
+
+export async function portalAddMoodBoardItem(boardId: string, data: {
+    type: string;
+    content: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}) {
+    const board = await prisma.moodBoard.findUnique({ where: { id: boardId } });
+    if (!board) throw new Error("Board not found");
+    const { isStaff } = await assertPortalMoodBoardAccess(board.projectId);
+
+    if (!MOODBOARD_ITEM_TYPES.includes(data.type as any)) {
+        throw new Error("Invalid item type");
+    }
+
+    let content: string;
+    if (data.type === "IMAGE") {
+        if (!isHttpUrl(data.content)) throw new Error("Invalid image URL");
+        content = data.content;
+    } else if (data.type === "SWATCH") {
+        if (!HEX_COLOR_RE.test(data.content?.trim() || "")) throw new Error("Invalid color — use a 6-digit hex code like #3b82f6");
+        content = data.content.trim();
+    } else {
+        const trimmed = (data.content || "").trim();
+        if (!trimmed) throw new Error("Note text is required");
+        if (trimmed.length > 500) throw new Error("Note text must be 500 characters or fewer");
+        content = trimmed;
+    }
+
+    const maxZ = await prisma.moodBoardItem.aggregate({
+        where: { moodBoardId: boardId },
+        _max: { zIndex: true },
+    });
+
+    const item = await prisma.moodBoardItem.create({
+        data: {
+            moodBoardId: boardId,
+            type: data.type,
+            content,
+            x: clampMoodBoardCoord(data.x),
+            y: clampMoodBoardCoord(data.y),
+            width: clampMoodBoardSize(data.width),
+            height: clampMoodBoardSize(data.height),
+            zIndex: (maxZ._max.zIndex ?? 0) + 1,
+            addedByClient: !isStaff,
+        },
+    });
+
+    revalidatePath(`/portal/projects/${board.projectId}/mood-boards/${boardId}`);
+    return item;
+}
+
+export async function portalMoveMoodBoardItem(boardId: string, itemId: string, data: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    zIndex?: number;
+}) {
+    const item = await prisma.moodBoardItem.findUnique({ where: { id: itemId } });
+    if (!item || item.moodBoardId !== boardId) throw new Error("Item not found");
+
+    const board = await prisma.moodBoard.findUnique({ where: { id: boardId } });
+    if (!board) throw new Error("Board not found");
+    await assertPortalMoodBoardAccess(board.projectId);
+
+    const updated = await prisma.moodBoardItem.update({
+        where: { id: itemId },
+        data: {
+            x: clampMoodBoardCoord(data.x),
+            y: clampMoodBoardCoord(data.y),
+            width: clampMoodBoardSize(data.width),
+            height: clampMoodBoardSize(data.height),
+            ...(data.zIndex != null ? { zIndex: clampMoodBoardZIndex(data.zIndex) } : {}),
+        },
+    });
+
+    revalidatePath(`/portal/projects/${board.projectId}/mood-boards/${boardId}`);
+    return updated;
+}
+
+export async function portalDeleteMoodBoardItem(boardId: string, itemId: string) {
+    const item = await prisma.moodBoardItem.findUnique({ where: { id: itemId } });
+    if (!item || item.moodBoardId !== boardId) throw new Error("Item not found");
+
+    const board = await prisma.moodBoard.findUnique({ where: { id: boardId } });
+    if (!board) throw new Error("Board not found");
+    const { isStaff } = await assertPortalMoodBoardAccess(board.projectId);
+
+    if (!isStaff && !item.addedByClient) {
+        throw new Error("Only items you added can be removed.");
+    }
+
+    await prisma.moodBoardItem.delete({ where: { id: itemId } });
+    revalidatePath(`/portal/projects/${board.projectId}/mood-boards/${boardId}`);
     return { success: true };
+}
+
+export async function portalCreateMoodBoard(projectId: string, title: string) {
+    await assertPortalMoodBoardAccess(projectId);
+
+    const trimmed = title?.trim();
+    if (!trimmed) throw new Error("Title is required");
+    if (trimmed.length > 120) throw new Error("Title must be 120 characters or fewer");
+
+    const board = await prisma.moodBoard.create({
+        data: { projectId, title: trimmed },
+    });
+
+    revalidatePath(`/portal/projects/${projectId}/mood-boards`);
+    revalidatePath(`/projects/${projectId}/mood-boards`);
+    return board;
 }
 
 // ─── Catalog Items ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

**Selection board guards** (fixes the "can't select anything" report on Shop):
- Staff can no longer send a SelectionBoard whose categories have zero options (server throw + disabled Send button with hint)
- Portal submit skips empty categories, shows a friendly note instead of an empty grid, and disables submit when nothing is selectable
- `submitClientSelections`: added portal auth, atomic status claim (`Sent` → `Selections Made` via updateMany count check), in-transaction revalidation against fresh data, per-option count verification
- `sendSelectionBoardToClient`: added `assertActiveStaff`

**Collaborative client mood boards**:
- Portal mood board is now an interactive shared canvas: clients drag/resize/arrange items, add images from their selection options / project favorites / suggestions, add color swatches and notes, upload photos (via /api/portal/files), and can start their own board
- New `MoodBoardItem.addedByClient` column; client-added items survive staff editor saves
- `saveMoodBoardItems`: full-replace delete → explicit `deletedIds`, per-item writes scoped to the board (`updateMany`), returns persisted items + skipped ids; staff editor reconciles state after save
- Portal mood-board pages now enforce client project ownership (previously any authenticated client could read another project's boards by URL)
- New portal actions gated by `assertPortalMoodBoardAccess` (PortalVisibility.showMoodBoards + ownership), with content validation (http(s) image URLs, 6-digit hex swatches, 500-char notes) and coordinate clamping

## Schema
`scripts/apply-moodboard-client-collab.mjs` — additive, idempotent (`ADD COLUMN IF NOT EXISTS`). **Run against prod before deploying.**

## Review
Codex peer review round 1 (3 blockers, 3 real issues) and round 2 (4 real issues) — all addressed. Independent checker verified all 11 acceptance criteria. `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)