### PR TITLE
fix(clipper): React 19 was blocking the bookmarklet href — clipper never worked

### DIFF
--- a/src/app/company/product-library/ProductLibraryClient.tsx
+++ b/src/app/company/product-library/ProductLibraryClient.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/actions";
 import { isHttpUrl } from "@/lib/url-safety";
 import { buildClipperBookmarklet } from "@/lib/clipper-bookmarklet";
+import ClipperDragLink from "@/components/ClipperDragLink";
 import {
     Plus,
     Search,
@@ -21,6 +22,7 @@ import {
     Link2,
     FolderPlus,
     Clipboard,
+    Copy,
 } from "lucide-react";
 
 interface Product {
@@ -249,6 +251,15 @@ export default function ProductLibraryClient({ initialProducts, allProjects, app
 
     const bookmarkletHref = buildClipperBookmarklet({ origin: appUrl, targetPath: "/clip" });
 
+    async function handleCopyBookmarklet() {
+        try {
+            await navigator.clipboard.writeText(bookmarkletHref);
+            toast.success("Clipper code copied — create a new bookmark and paste this as the URL.");
+        } catch {
+            toast.error("Couldn't copy. Try dragging the button instead.");
+        }
+    }
+
     return (
         <div className="max-w-6xl mx-auto py-8 px-6">
             {/* Header */}
@@ -275,18 +286,29 @@ export default function ProductLibraryClient({ initialProducts, allProjects, app
                         <h2 className="text-base font-semibold text-hui-textMain">Get the Clipper</h2>
                         <p className="text-sm text-hui-textMuted mt-0.5">
                             Drag this to your bookmarks bar. On any product page, click it to clip straight to the library.
+                            Bookmark bar drag not working? Copy the code, make a new bookmark, and paste it as the URL.
                         </p>
                     </div>
                 </div>
-                <a
-                    href={bookmarkletHref}
-                    onClick={(e) => e.preventDefault()}
-                    className="hui-btn hui-btn-secondary flex items-center gap-2 cursor-grab active:cursor-grabbing shrink-0"
-                    title="Drag me to your bookmarks bar"
-                >
-                    <Link2 className="w-4 h-4" />
-                    ProBuild Clip
-                </a>
+                <div className="flex items-center gap-2 shrink-0">
+                    <ClipperDragLink
+                        href={bookmarkletHref}
+                        className="hui-btn hui-btn-secondary flex items-center gap-2 cursor-grab active:cursor-grabbing"
+                        title="Drag me to your bookmarks bar"
+                    >
+                        <Link2 className="w-4 h-4" />
+                        ProBuild Clip
+                    </ClipperDragLink>
+                    <button
+                        type="button"
+                        onClick={handleCopyBookmarklet}
+                        className="hui-btn hui-btn-secondary flex items-center gap-2"
+                        title="Copy the clipper code"
+                    >
+                        <Copy className="w-4 h-4" />
+                        Copy
+                    </button>
+                </div>
             </div>
 
             {/* Search + category filter */}

--- a/src/app/portal/projects/[id]/selections/PortalSuggestionsSection.tsx
+++ b/src/app/portal/projects/[id]/selections/PortalSuggestionsSection.tsx
@@ -6,7 +6,8 @@ import { toast } from "sonner";
 import { submitSelectionProposal } from "@/lib/actions";
 import { isHttpUrl } from "@/lib/url-safety";
 import { buildClipperBookmarklet } from "@/lib/clipper-bookmarklet";
-import { Link2 } from "lucide-react";
+import ClipperDragLink from "@/components/ClipperDragLink";
+import { Link2, Copy } from "lucide-react";
 
 const COULD_NOT_READ_PAGE_MESSAGE =
     "We couldn't read that page automatically. Just add the name (and a photo link if you have one) and we'll take it from there.";
@@ -231,6 +232,15 @@ function GetTheClipperCard({ projectId, appUrl }: { projectId: string; appUrl: s
         extraParams: { projectId },
     });
 
+    async function handleCopyBookmarklet() {
+        try {
+            await navigator.clipboard.writeText(bookmarkletHref);
+            toast.success("Clipper code copied! Create a new bookmark and paste this in as the URL.");
+        } catch {
+            toast.error("Couldn't copy that — try dragging the button instead.");
+        }
+    }
+
     return (
         <div className="hui-card p-5 mb-6 flex items-center justify-between gap-6 flex-wrap">
             <div className="flex items-center gap-4">
@@ -243,18 +253,30 @@ function GetTheClipperCard({ projectId, appUrl }: { projectId: string; appUrl: s
                         Found something while shopping? Drag the ProBuild Clip button to your bookmarks bar.
                         <br />
                         On any product page, click it and the item comes straight here for your team to review.
+                        <br />
+                        Dragging not working on your device? Tap Copy, then make a new bookmark and paste it in as the URL.
                     </p>
                 </div>
             </div>
-            <a
-                href={bookmarkletHref}
-                onClick={(e) => e.preventDefault()}
-                className="hui-btn hui-btn-secondary flex items-center gap-2 cursor-grab active:cursor-grabbing shrink-0"
-                title="Drag me to your bookmarks bar"
-            >
-                <Link2 className="w-4 h-4" />
-                ProBuild Clip
-            </a>
+            <div className="flex items-center gap-2 shrink-0">
+                <ClipperDragLink
+                    href={bookmarkletHref}
+                    className="hui-btn hui-btn-secondary flex items-center gap-2 cursor-grab active:cursor-grabbing"
+                    title="Drag me to your bookmarks bar"
+                >
+                    <Link2 className="w-4 h-4" />
+                    ProBuild Clip
+                </ClipperDragLink>
+                <button
+                    type="button"
+                    onClick={handleCopyBookmarklet}
+                    className="hui-btn hui-btn-secondary flex items-center gap-2"
+                    title="Copy the clipper code"
+                >
+                    <Copy className="w-4 h-4" />
+                    Copy
+                </button>
+            </div>
         </div>
     );
 }

--- a/src/components/ClipperDragLink.tsx
+++ b/src/components/ClipperDragLink.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+// React 19 blocks `javascript:` URLs passed through the `href` prop —
+// renderToStaticMarkup emits a booby-trapped href that throws instead of the
+// real bookmarklet code (see https://react.dev/blog/2024/04/25/react-19#new-feature-support-for-metadata-tags
+// / the "blocked a javascript: URL" security precaution). The ProBuild Clip
+// bookmarklet legitimately needs a javascript: href, so we set it on the DOM
+// node directly in an effect, bypassing React's href sanitizer entirely.
+import { useEffect, useRef, type ReactNode } from "react";
+
+export default function ClipperDragLink({
+    href,
+    className,
+    title,
+    children,
+}: {
+    href: string;
+    className?: string;
+    title?: string;
+    children: ReactNode;
+}) {
+    const ref = useRef<HTMLAnchorElement>(null);
+
+    useEffect(() => {
+        ref.current?.setAttribute("href", href);
+    }, [href]);
+
+    return (
+        <a
+            ref={ref}
+            href="#"
+            onClick={(e) => e.preventDefault()}
+            className={className}
+            title={title}
+            aria-label={title}
+        >
+            {children}
+        </a>
+    );
+}


### PR DESCRIPTION
Field report: "I clicked the ProBuild Clip bookmark, nothing happened."

**Root cause:** React 19 blocks `javascript:` URLs passed as an `href` prop. Verified with `renderToStaticMarkup`:

```
<a href="javascript:throw new Error('React has blocked a javascript: URL as a security precaution.')">
```

Both "Get the Clipper" drag links (team `/company/product-library` and the portal Selections card) rendered that. Dragging it produced a bookmark whose entire payload is a `throw` — clicking silently did nothing. The clipper has never worked since it shipped in #250; the bookmarklet JS itself was always fine.

**Fix:** new shared `ClipperDragLink` client component sets the href via `ref.setAttribute` in an effect instead of passing it as a React prop, bypassing the sanitizer. Both cards now use it.

**Also:** added a "Copy" fallback button (copies the bookmarklet code + toast) and one line of manual-bookmark instructions on both cards, since drag-to-bookmarks-bar is fragile and impossible on mobile.

**Verification** (this shipped once because nobody checked the rendered DOM):
- SSR harness reproduced the bug on a control `<a>`, and confirmed `ClipperDragLink` emits no throw-href.
- Real browser check on a bundled scratch page: post-mount `outerHTML` is `<a href="javascript:(function(){...})();">`, exact string match, clean console.
- Grepped `src/` for other React-rendered `javascript:` URLs — none; remaining hits are the builder itself and the guards that block such URLs from user input.

No schema changes. No money-path files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)