### PR TITLE
fix(security): auth-gate legacy SelectionBoard/Category/Option server actions

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -9309,6 +9309,8 @@ export async function sendPurchaseOrder(id: string, toEmail: string, message: st
 // =============================================
 
 export async function getSelectionBoards(projectId: string) {
+    const user = await assertActiveStaff();
+    if (!canAccessProject(user, projectId)) throw new Error("Forbidden");
     return await prisma.selectionBoard.findMany({
         where: { projectId },
         orderBy: { createdAt: "desc" },
@@ -9324,7 +9326,8 @@ export async function getSelectionBoards(projectId: string) {
 }
 
 export async function getSelectionBoard(id: string) {
-    return await prisma.selectionBoard.findUnique({
+    const user = await assertActiveStaff();
+    const board = await prisma.selectionBoard.findUnique({
         where: { id },
         include: {
             project: { include: { client: true } },
@@ -9336,9 +9339,14 @@ export async function getSelectionBoard(id: string) {
             },
         },
     });
+    if (!board) return null;
+    if (!canAccessProject(user, board.projectId)) throw new Error("Forbidden");
+    return board;
 }
 
 export async function createSelectionBoard(projectId: string, title: string) {
+    const user = await assertActiveStaff();
+    if (!canAccessProject(user, projectId)) throw new Error("Forbidden");
     const board = await prisma.selectionBoard.create({
         data: { projectId, title },
     });
@@ -9347,6 +9355,10 @@ export async function createSelectionBoard(projectId: string, title: string) {
 }
 
 export async function updateSelectionBoard(id: string, data: { title?: string; status?: string }) {
+    const user = await assertActiveStaff();
+    const existing = await prisma.selectionBoard.findUnique({ where: { id }, select: { projectId: true } });
+    if (!existing) throw new Error("Board not found");
+    if (!canAccessProject(user, existing.projectId)) throw new Error("Forbidden");
     const board = await prisma.selectionBoard.update({
         where: { id },
         data,
@@ -9356,14 +9368,20 @@ export async function updateSelectionBoard(id: string, data: { title?: string; s
 }
 
 export async function deleteSelectionBoard(id: string) {
+    const user = await assertActiveStaff();
     const board = await prisma.selectionBoard.findUnique({ where: { id } });
     if (!board) return { success: false };
+    if (!canAccessProject(user, board.projectId)) throw new Error("Forbidden");
     await prisma.selectionBoard.delete({ where: { id } });
     revalidatePath(`/projects/${board.projectId}/selections`);
     return { success: true };
 }
 
 export async function createSelectionCategory(boardId: string, name: string) {
+    const user = await assertActiveStaff();
+    const board = await prisma.selectionBoard.findUnique({ where: { id: boardId } });
+    if (!board) throw new Error("Board not found");
+    if (!canAccessProject(user, board.projectId)) throw new Error("Forbidden");
     const maxOrder = await prisma.selectionCategory.aggregate({
         where: { boardId },
         _max: { order: true },
@@ -9371,18 +9389,23 @@ export async function createSelectionCategory(boardId: string, name: string) {
     const cat = await prisma.selectionCategory.create({
         data: { boardId, name, order: (maxOrder._max.order ?? -1) + 1 },
     });
-    const board = await prisma.selectionBoard.findUnique({ where: { id: boardId } });
-    if (board) revalidatePath(`/projects/${board.projectId}/selections`);
+    revalidatePath(`/projects/${board.projectId}/selections`);
     return cat;
 }
 
 export async function updateSelectionCategory(id: string, data: { name?: string; order?: number }) {
+    const user = await assertActiveStaff();
+    const existing = await prisma.selectionCategory.findUnique({ where: { id }, include: { board: true } });
+    if (!existing) throw new Error("Category not found");
+    if (!canAccessProject(user, existing.board.projectId)) throw new Error("Forbidden");
     return await prisma.selectionCategory.update({ where: { id }, data });
 }
 
 export async function deleteSelectionCategory(id: string) {
+    const user = await assertActiveStaff();
     const cat = await prisma.selectionCategory.findUnique({ where: { id }, include: { board: true } });
     if (!cat) return { success: false };
+    if (!canAccessProject(user, cat.board.projectId)) throw new Error("Forbidden");
     await prisma.selectionCategory.delete({ where: { id } });
     revalidatePath(`/projects/${cat.board.projectId}/selections`);
     return { success: true };
@@ -9395,6 +9418,10 @@ export async function createSelectionOption(categoryId: string, data: {
     price?: number;
     vendorUrl?: string;
 }) {
+    const user = await assertActiveStaff();
+    const cat = await prisma.selectionCategory.findUnique({ where: { id: categoryId }, include: { board: true } });
+    if (!cat) throw new Error("Category not found");
+    if (!canAccessProject(user, cat.board.projectId)) throw new Error("Forbidden");
     const maxOrder = await prisma.selectionOption.aggregate({
         where: { categoryId },
         _max: { order: true },
@@ -9410,8 +9437,7 @@ export async function createSelectionOption(categoryId: string, data: {
             order: (maxOrder._max.order ?? -1) + 1,
         },
     });
-    const cat = await prisma.selectionCategory.findUnique({ where: { id: categoryId }, include: { board: true } });
-    if (cat) revalidatePath(`/projects/${cat.board.projectId}/selections`);
+    revalidatePath(`/projects/${cat.board.projectId}/selections`);
     return option;
 }
 
@@ -9423,22 +9449,31 @@ export async function updateSelectionOption(id: string, data: {
     vendorUrl?: string;
     selected?: boolean;
 }) {
+    const user = await assertActiveStaff();
+    const existing = await prisma.selectionOption.findUnique({
+        where: { id },
+        include: { category: { include: { board: true } } },
+    });
+    if (!existing) throw new Error("Option not found");
+    if (!canAccessProject(user, existing.category.board.projectId)) throw new Error("Forbidden");
     return await prisma.selectionOption.update({ where: { id }, data });
 }
 
 export async function deleteSelectionOption(id: string) {
+    const user = await assertActiveStaff();
     const option = await prisma.selectionOption.findUnique({
         where: { id },
         include: { category: { include: { board: true } } },
     });
     if (!option) return { success: false };
+    if (!canAccessProject(user, option.category.board.projectId)) throw new Error("Forbidden");
     await prisma.selectionOption.delete({ where: { id } });
     revalidatePath(`/projects/${option.category.board.projectId}/selections`);
     return { success: true };
 }
 
 export async function sendSelectionBoardToClient(boardId: string) {
-    await assertActiveStaff();
+    const user = await assertActiveStaff();
 
     const board = await prisma.selectionBoard.findUnique({
         where: { id: boardId },
@@ -9448,6 +9483,7 @@ export async function sendSelectionBoardToClient(boardId: string) {
         },
     });
     if (!board) throw new Error("Board not found");
+    if (!canAccessProject(user, board.projectId)) throw new Error("Forbidden");
 
     if (board.categories.length === 0) {
         throw new Error("Add at least one category before sending.");


### PR DESCRIPTION
## Summary

The legacy SelectionBoard / SelectionCategory / SelectionOption CRUD server actions in `src/lib/actions.ts` had no auth gating. Since `src/lib/actions.ts` is a `"use server"` file, every exported async function is a directly callable server-action endpoint regardless of whether any client code currently references it, so any authenticated request could hit them.

## What was ungated

- `getSelectionBoards(projectId)`
- `getSelectionBoard(id)` — currently unused in the app but still an exported, callable server action
- `createSelectionBoard(projectId, title)`
- `updateSelectionBoard(id, data)`
- `deleteSelectionBoard(id)`
- `createSelectionCategory(boardId, name)`
- `updateSelectionCategory(id, data)` — currently unused, still callable
- `deleteSelectionCategory(id)`
- `createSelectionOption(categoryId, data)`
- `updateSelectionOption(id, data)` — currently unused, still callable
- `deleteSelectionOption(id)`
- `sendSelectionBoardToClient(boardId)` — had `assertActiveStaff()` but was missing the `canAccessProject()` scoping check, so a FIELD_CREW/FINANCE user could email any project's selection board to that project's client even without access to the project.

## Gate applied to each

All of the above now do `assertActiveStaff()` + `canAccessProject(user, projectId)`, matching the idiom already used by sibling actions on the same `/projects/[id]/selections` page (`getSelectionProposals`, `getProjectFavorites`, `decideSelectionProposal`).

Where an action only receives a `boardId`/`categoryId`/`optionId` (not a `projectId` directly), it looks up the parent chain first to resolve `projectId` before gating — the minimum lookup needed for the check, with no other behavior change. For `createSelectionCategory` and `createSelectionOption`, the parent lookup that already existed (previously done *after* the create, only to compute the `revalidatePath` target) was moved earlier and reused for the gate instead of being duplicated.

`submitClientSelections` and `getSelectionBoardsForPortal` (the client/portal-facing actions) were already correctly gated via `assertPortalProjectOwnership` / `assertProjectReadAccess` and were left untouched.

## Call-site audit

Grepped every action name across `src/app`, `src/lib`, `scripts/`, and the rest of the repo:

- Team-side actions (`getSelectionBoards`, `createSelectionBoard`, `updateSelectionBoard`, `deleteSelectionBoard`, `createSelectionCategory`, `deleteSelectionCategory`, `createSelectionOption`, `deleteSelectionOption`, `sendSelectionBoardToClient`) are called only from `src/app/projects/[id]/selections/page.tsx` and `SelectionsClient.tsx` — a route with no independent layout-level access guard, so the action-level gate is the only protection for that page's data today. No caller passes an out-of-scope `projectId`, so nothing breaks.
- `getSelectionBoard`, `updateSelectionCategory`, `updateSelectionOption` have **no call sites anywhere** in the app — dead code from the UI's perspective, but still directly callable server actions, hence still gated.
- Portal-side actions (`submitClientSelections`, `getSelectionBoardsForPortal`) are called only from `src/app/portal/projects/[id]/selections/*` and were already gated for client ownership — untouched.
- No cron jobs, seed scripts, or other system paths call any of these actions.

## Behavior

No behavior, signatures, or return shapes changed beyond the auth gates and the minimal parent lookups needed to resolve `projectId` for those gates. `npm run build` passes with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)