### PR TITLE
fix(schedule): portal toolbar menus out of the header stacking context

### DIFF
--- a/src/app/projects/[id]/schedule/MenuPortal.tsx
+++ b/src/app/projects/[id]/schedule/MenuPortal.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { type ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+/* Renders a toolbar popover on document.body.
+
+   The schedule toolbar lives in a `relative z-20` header, which is its own
+   stacking context — so a `z-50` menu nested inside it still paints at the
+   header's level, and the equally-ranked `z-20` filter row that follows in the
+   DOM covers it. Portalling to the body escapes that context; the menus already
+   position themselves with viewport coordinates, so nothing else changes. */
+export default function MenuPortal({ children }: { children: ReactNode }) {
+    if (typeof document === "undefined") return null;
+    return createPortal(children, document.body);
+}

--- a/src/app/projects/[id]/schedule/SchedulePublishButton.tsx
+++ b/src/app/projects/[id]/schedule/SchedulePublishButton.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useTransition } from "react";
 import { toggleSchedulePublished, emailPortalLinkToClient } from "@/lib/actions";
 import { toast } from "sonner";
+import MenuPortal from "./MenuPortal";
 
 export default function SchedulePublishButton({
     projectId,
@@ -72,7 +73,7 @@ export default function SchedulePublishButton({
             </button>
 
             {showMenu && (
-                <>
+                <MenuPortal>
                     <div className="fixed inset-0 z-40" onClick={() => setShowMenu(false)} />
                     <div className="fixed w-56 bg-white border border-slate-200 rounded-lg shadow-xl z-50 py-1" style={{ top: menuPos.top, right: menuPos.right }}>
                         <button
@@ -115,7 +116,7 @@ export default function SchedulePublishButton({
                                 : "Clients won't see the schedule until published"}
                         </div>
                     </div>
-                </>
+                </MenuPortal>
             )}
         </div>
     );

--- a/src/app/projects/[id]/schedule/ScheduleToolbar.tsx
+++ b/src/app/projects/[id]/schedule/ScheduleToolbar.tsx
@@ -2,6 +2,7 @@
 
 import { type ReactNode, useRef, useState } from "react";
 import type { EstimateSummary } from "./schedule-types";
+import MenuPortal from "./MenuPortal";
 import SchedulePublishButton from "./SchedulePublishButton";
 
 type ViewMode = "gantt" | "table" | "calendar";
@@ -77,7 +78,7 @@ function AddTaskDropdown({ isAdding, onAddTask, onAddMilestone }: { isAdding: bo
                 </button>
             </div>
             {open && (
-                <>
+                <MenuPortal>
                     <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
                     <div className="fixed bg-white border border-hui-border rounded-lg shadow-xl z-50 min-w-[160px] py-1 animate-in fade-in" style={{ top: pos.top, right: pos.right }}>
                         <button onClick={() => { onAddTask(); setOpen(false); }} className="w-full text-left px-3 py-2 hover:bg-slate-50 transition text-sm flex items-center gap-2">
@@ -89,7 +90,7 @@ function AddTaskDropdown({ isAdding, onAddTask, onAddMilestone }: { isAdding: bo
                             Milestone
                         </button>
                     </div>
-                </>
+                </MenuPortal>
             )}
         </div>
     );
@@ -111,6 +112,8 @@ export default function ScheduleToolbar({
     const hasEstimates = estimates.length > 0;
     const moreBtnRef = useRef<HTMLButtonElement>(null);
     const [moreMenuPos, setMoreMenuPos] = useState({ top: 0, right: 0 });
+    const aiBtnRef = useRef<HTMLButtonElement>(null);
+    const [aiMenuPos, setAiMenuPos] = useState({ top: 0, right: 0 });
 
     return (
         <>
@@ -168,19 +171,30 @@ export default function ScheduleToolbar({
                         {/* AI Schedule */}
                         <div className="relative">
                             <button
-                                onClick={() => hasEstimates ? onToggleAiMenu() : onAiSchedule()}
+                                ref={aiBtnRef}
+                                onClick={() => {
+                                    if (!hasEstimates) { onAiSchedule(); return; }
+                                    if (!showAiMenu && aiBtnRef.current) {
+                                        const rect = aiBtnRef.current.getBoundingClientRect();
+                                        setAiMenuPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
+                                    }
+                                    onToggleAiMenu();
+                                }}
                                 disabled={isAiGenerating}
                                 className={`text-xs flex items-center gap-1.5 px-3 py-1.5 rounded-lg font-medium transition border ${isAiGenerating ? "bg-gradient-to-r from-purple-500 to-indigo-500 text-white border-purple-600 animate-pulse" : "bg-gradient-to-r from-purple-50 to-indigo-50 text-purple-700 border-purple-200 hover:shadow-md hover:from-purple-100 hover:to-indigo-100"}`}
                             >
                                 ✨ {isAiGenerating ? "AI thinking..." : "AI Schedule"}
                             </button>
                             {showAiMenu && hasEstimates && (
-                                <div className="absolute right-0 top-full mt-1 bg-white border border-hui-border rounded-lg shadow-xl z-50 min-w-[260px] py-1 animate-in fade-in">
-                                    <button onClick={() => onAiSchedule()} className="w-full text-left px-3 py-2.5 hover:bg-purple-50 transition text-sm flex items-center gap-2"><span>🧠</span> General Schedule</button>
-                                    {estimates.map(est => (
-                                        <button key={est.id} onClick={() => onAiSchedule(est.id)} className="w-full text-left px-3 py-2.5 hover:bg-purple-50 transition text-sm flex items-center gap-2"><span>📋</span> {est.title}</button>
-                                    ))}
-                                </div>
+                                <MenuPortal>
+                                    <div className="fixed inset-0 z-40" onClick={onToggleAiMenu} />
+                                    <div className="fixed bg-white border border-hui-border rounded-lg shadow-xl z-50 min-w-[260px] py-1 animate-in fade-in" style={{ top: aiMenuPos.top, right: aiMenuPos.right }}>
+                                        <button onClick={() => onAiSchedule()} className="w-full text-left px-3 py-2.5 hover:bg-purple-50 transition text-sm flex items-center gap-2"><span>🧠</span> General Schedule</button>
+                                        {estimates.map(est => (
+                                            <button key={est.id} onClick={() => onAiSchedule(est.id)} className="w-full text-left px-3 py-2.5 hover:bg-purple-50 transition text-sm flex items-center gap-2"><span>📋</span> {est.title}</button>
+                                        ))}
+                                    </div>
+                                </MenuPortal>
                             )}
                         </div>
 
@@ -196,7 +210,7 @@ export default function ScheduleToolbar({
                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="12" cy="19" r="1.5"/></svg>
                             </button>
                             {showToolsMenu && (
-                                <>
+                                <MenuPortal>
                                     <div className="fixed inset-0 z-40" onClick={onToggleToolsMenu} />
                                     <div className="fixed bg-white border border-hui-border rounded-lg shadow-xl z-50 min-w-[220px] py-1 animate-in fade-in" style={{ top: moreMenuPos.top, right: moreMenuPos.right }}>
                                         {/* View section */}
@@ -254,7 +268,7 @@ export default function ScheduleToolbar({
                                             Clear All Tasks
                                         </button>
                                     </div>
-                                </>
+                                </MenuPortal>
                             )}
                         </div>
                     </div>


### PR DESCRIPTION
## Problem

Every dropdown in the project Schedule toolbar (AI Schedule, Published, **+ Task**, **⋮ Tools**) rendered as a blank white panel with its items invisible and unclickable.

The toolbar header is `relative z-20`, which makes it its own stacking context. The menus inside declare `z-50`, but that only ranks them *within* the header — against the page the whole subtree is `z-20`. The search/filter row below is also `relative z-20` and comes later in the DOM, so it painted over the open menus.

Measured on prod with the ⋮ menu open:

```
header (relative z-20)      y  64-139
filter row (relative z-20)  y 139-186   <- later sibling, wins
menu item "Critical Path"   y 150       -> elementFromPoint = filter row
```

## Fix

New `MenuPortal` renders the menus on `document.body`, outside the header's stacking context. Three of the four already positioned themselves with `position: fixed` + viewport coords, so this is a drop-in. The AI Schedule menu was `absolute right-0 top-full`, so it moves to the same measured-fixed pattern and gains the click-away backdrop the other three already had.

## Verification

`npm run build` passes. Applying the portal's exact effect on the live page (`document.body.appendChild(panel)`) and re-probing every item with `elementFromPoint`:

| Item | Before | After |
|---|---|---|
| Critical Path | **unreachable** (covered by filter row) | reachable |
| Link Tasks / Sync to Calendar / AI Risk / Clear All | reachable | reachable |

Layout only — no logic, no money-path, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
