### PR TITLE
fix(schedule): normalize toolbar control heights to a single 30px box

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 | Vercel project ID | `prj_sd7R3WIYZCRMnu5IhAudBdc4vuIL` |
 | Supabase project ref | `ghzdbzdnwjxazvmcefbh` |
 | Sentry org | `golden-touch-remodeling` (us.sentry.io) |
-| Known prod DB project ID | `cmn7tlgiv0001phwqjzwk75or` |
+| Prod test project ("Shop") | `cmpd6xca1009x1iizdf4suln3` |
 
 ## Vercel env vars (already configured)
 `STRIPE_PUBLISHABLE_KEY`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`,
@@ -127,7 +127,7 @@ python compare.py --local --page "Page Name"   # single page local test
 - Do not run compare.py as part of normal development — use ProbuildTodo.md as the roadmap instead
 
 ## Production data
-- Known prod project ID: `cmn7tlgiv0001phwqjzwk75or`
+- Prod test project ("Shop"): `cmpd6xca1009x1iizdf4suln3` — the sanctioned job for clicking through prod
 - Do NOT try psql, prisma direct connect, or supabase CLI to query prod — use the API
 
 ## Messaging component

--- a/compare.py
+++ b/compare.py
@@ -92,7 +92,7 @@ URL_MAP = {
 
     "Project Overview":
         ("https://pro.houzz.com/manage/projects/2340349/overview",
-         "/projects/cmn7tlgiv0001phwqjzwk75or/overview"),
+         "/projects/cmpd6x38x007a1iiz5zsp62m6/overview"),
 
     # ── Leads ─────────────────────────────────────────────────────────────────
     "Leads List":
@@ -112,7 +112,7 @@ URL_MAP = {
     # ── Schedule ──────────────────────────────────────────────────────────────
     "Schedule":
         ("https://pro.houzz.com/manage/schedule/projects/2942703",
-         "/projects/cmn7tlgiv0001phwqjzwk75or/schedule"),
+         "/projects/cmpd6x38x007a1iiz5zsp62m6/schedule"),
 
     # ── Time & Expenses ───────────────────────────────────────────────────────
     "Time & Expenses":
@@ -136,17 +136,17 @@ URL_MAP = {
     # ── Daily Logs ────────────────────────────────────────────────────────────
     "Daily Logs":
         ("https://pro.houzz.com/manage/projects/2942703/daily-logs",
-         "/projects/cmn7tlgiv0001phwqjzwk75or/dailylogs"),
+         "/projects/cmpd6x38x007a1iiz5zsp62m6/dailylogs"),
 
     # ── Client Portal Config ──────────────────────────────────────────────────
     "Client Portal Config":
         ("https://pro.houzz.com/manage/cd/client-dash-edit/2942703",
-         "/projects/cmn7tlgiv0001phwqjzwk75or/client-portal"),
+         "/projects/cmpd6x38x007a1iiz5zsp62m6/client-portal"),
 
     # ── Project Tasks ─────────────────────────────────────────────────────────
     "Project Tasks":
         ("https://pro.houzz.com/manage/tasks/projects/2942703",
-         "/projects/cmn7tlgiv0001phwqjzwk75or/tasks"),
+         "/projects/cmpd6x38x007a1iiz5zsp62m6/tasks"),
 
     # ── Reports ───────────────────────────────────────────────────────────────
     "Report: Open Invoices":

--- a/src/app/projects/[id]/schedule/ScheduleToolbar.tsx
+++ b/src/app/projects/[id]/schedule/ScheduleToolbar.tsx
@@ -61,7 +61,7 @@ function AddTaskDropdown({ isAdding, onAddTask, onAddMilestone }: { isAdding: bo
     return (
         <div className="relative">
             <div className="inline-flex items-center rounded-lg shadow-sm">
-                <button onClick={onAddTask} disabled={isAdding} className="inline-flex items-center justify-center px-4 py-2 text-sm font-medium bg-slate-900 text-white hover:bg-slate-800 transition-colors rounded-l-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-slate-900 focus:z-10">+ Task</button>
+                <button onClick={onAddTask} disabled={isAdding} className="inline-flex items-center justify-center h-[30px] px-4 text-sm font-medium bg-slate-900 text-white hover:bg-slate-800 transition-colors rounded-l-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-slate-900 focus:z-10">+ Task</button>
                 <button
                     ref={btnRef}
                     onClick={() => {
@@ -72,7 +72,7 @@ function AddTaskDropdown({ isAdding, onAddTask, onAddMilestone }: { isAdding: bo
                         setOpen(v => !v);
                     }}
                     disabled={isAdding}
-                    className="inline-flex items-center justify-center px-2.5 py-2 text-sm font-medium bg-slate-900 text-white hover:bg-slate-800 transition-colors rounded-r-lg border-l border-indigo-400/40 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-slate-900 focus:z-10"
+                    className="inline-flex items-center justify-center h-[30px] px-2.5 text-sm font-medium bg-slate-900 text-white hover:bg-slate-800 transition-colors rounded-r-lg border-l border-indigo-400/40 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-slate-900 focus:z-10"
                 >
                     <svg width="8" height="8" viewBox="0 0 12 12" fill="currentColor"><path d="M6 8.5L1.5 4h9z"/></svg>
                 </button>


### PR DESCRIPTION
## Problem

The five right-hand controls on the project Schedule toolbar rendered at **three different heights**. Measured at 1920px:

| Control | top | bottom | height |
|---|---|---|---|
| ✨ AI Schedule | 88 | 118 | 30px |
| Published | 88 | 118 | 30px |
| ⋮ Tools | 88 | 118 | 30px |
| `+ Task` (label half) | 85 | 121 | **36px** |
| caret toggle (right half) | 91 | 115 | **24px** |

The split button overhung its neighbours by 3px top and bottom, and its own two halves disagreed by 12px — leaving a visible notch at the right end of the pill and putting the `rounded-r-lg` corners off the button's real edges.

## Cause

Both halves of `AddTaskDropdown` used `py-2 text-sm`, so each derived its height from its own content:

- the label half holds a text node → 20px line-height → `8 + 20 + 8 = 36px`
- the caret half holds only an 8px SVG → `8 + 8 + 8 = 24px`

The wrapper is `inline-flex items-center`, which centers the shorter half rather than stretching it.

## Fix

Explicit `h-[30px]` on both halves.

Matching the neighbours' `py-1.5` recipe would not work: those three only reach 30px because they carry a 1px border, and the split button is borderless, so the same padding lands at 28px. Stating the height directly also removes the content-dependence that caused the bug in the first place.

`text-sm` is kept on the label so the primary CTA retains its larger type — only the box changed. No menu or portal logic is touched.

## Verification

`getBoundingClientRect` on all five controls, on two projects (Shop and Hoppe):

| Control | top | bottom | height |
|---|---|---|---|
| ✨ AI Schedule | 88 | 118 | 30 |
| Published | 88 | 118 | 30 |
| `+ Task` | 88 | 118 | 30 |
| caret | 88 | 118 | 30 |
| ⋮ Tools | 88 | 118 | 30 |

`allTopsEqual: true`, `allBottomsEqual: true`, `distinctHeights: [30]`, split-button `seamGap: 0`.

`npm run build` passes — exit 0 with a complete route table.

## Second commit: dead prod project ID

Unrelated to the toolbar, kept as a separate commit. `cmn7tlgiv0001phwqjzwk75or` no longer exists in production — it is absent from all 8 projects and loads as "Project not found".

- **CLAUDE.md** referenced it twice → repointed at the Shop test job, relabelled "Prod test project" to match actual usage.
- **compare.py** hardcoded it in 5 page comparisons, so each loaded a not-found page instead of the screen under comparison → repointed at Hoppe Bathroom Remodel, a job with real data. All 5 routes verified rendering.

## Notes for the reviewer

- Per the project Code Review Protocol this is styling/layout-only, so Codex review was deliberately skipped.
- **This branch is not deploy-ready on its own.** It sits on top of `d804df5`, which carries PR #253's `prisma/schema.prisma` change. That schema needs applying to prod before any deploy, per the pre-deploy checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
