### PR TITLE
refactor(popovers): share one portal primitive, unclip popovers in scroll containers

### DIFF
--- a/src/app/company-dashboard/schedule-board/FloatingPopover.tsx
+++ b/src/app/company-dashboard/schedule-board/FloatingPopover.tsx
@@ -1,15 +1,9 @@
 "use client";
 
-import { createPortal } from "react-dom";
-import { useEffect, useLayoutEffect, useRef, useState, type ReactNode, type RefObject } from "react";
+import { type ReactNode, type RefObject } from "react";
+import { FloatingLayer, type FloatingAnchorPoint } from "@/components/FloatingLayer";
 
-const VIEWPORT_MARGIN_PX = 8;
-const ANCHOR_GAP_PX = 4;
-
-export interface FloatingPopoverAnchorPoint {
-    x: number;
-    y: number;
-}
+export type FloatingPopoverAnchorPoint = FloatingAnchorPoint;
 
 export interface FloatingPopoverProps {
     open: boolean;
@@ -19,152 +13,35 @@ export interface FloatingPopoverProps {
     anchorPoint?: FloatingPopoverAnchorPoint | null;
     onClose: () => void;
     children: ReactNode;
-    /** Panel width in px — the panel right-aligns to the trigger by default (matching the prior `absolute right-0` menus), then clamps into the viewport. */
+    /** Panel width in px — the panel right-aligns to the trigger by default, then clamps into the viewport. */
     width?: number;
     /** Non-interactive hover card mode (schedule-board task hover notes): the panel never captures pointer events, so it can never trap the mouse mid-hover. Default false (normal click/context menu). */
     pointerEventsNone?: boolean;
 }
 
 /**
- * A portal-rendered dropdown/menu anchored to a trigger element OR an
- * explicit point (right-click / ContextMenu-key position). Fixes the
- * schedule board's popover clipping: rendered to document.body (escapes any
- * clipping/overflow ancestor and any CSS containment from a drag/scroll
- * container), positioned from the trigger's live bounding rect (or the given
- * point), flipped above the trigger when there isn't room below, and clamped
- * horizontally with an 8px viewport margin. Escape closes and returns focus
- * to the trigger; a pointerdown outside the panel and trigger also closes it.
+ * The schedule board's card-styled popover: chrome (border, white panel,
+ * padding, shadow, close button) over the shared `FloatingLayer`.
+ *
+ * All positioning and dismissal behaviour — portal to document.body, anchor
+ * measurement, flip-above, viewport clamping, height capping with internal
+ * scroll, re-place on scroll/resize/content-resize, Escape, outside
+ * pointerdown — now lives in FloatingLayer, which the project schedule page's
+ * popovers share. This component's public API is unchanged.
+ *
+ * FloatingLayer's wrapper is `position: fixed`, which is a containing block, so
+ * the absolutely-positioned close button still anchors to the panel.
  */
 export function FloatingPopover({ open, anchorRef, anchorPoint, onClose, children, width = 224, pointerEventsNone = false }: FloatingPopoverProps) {
-    const panelRef = useRef<HTMLDivElement | null>(null);
-    const contentRef = useRef<HTMLDivElement | null>(null);
-    const [position, setPosition] = useState<{ top: number; left: number; maxHeight: number } | null>(null);
-
-    useLayoutEffect(() => {
-        if (!open) {
-            setPosition(null);
-            return;
-        }
-        const anchor = anchorRef?.current ?? null;
-        if (!anchorPoint && !anchor) return;
-
-        function place() {
-            const rect = anchorPoint
-                ? { left: anchorPoint.x, right: anchorPoint.x, top: anchorPoint.y, bottom: anchorPoint.y }
-                : anchor!.getBoundingClientRect();
-            const viewportWidth = window.innerWidth;
-            const viewportHeight = window.innerHeight;
-            const panelWidth = panelRef.current?.offsetWidth ?? width;
-            // scrollHeight, not offsetHeight: once a maxHeight is applied the
-            // box stops growing, so a menu switching to taller content (the
-            // inline crew checklist) would keep measuring the SHORT view and
-            // never re-place. scrollHeight always reflects the content.
-            const panelHeight = Math.max(panelRef.current?.scrollHeight ?? 0, panelRef.current?.offsetHeight ?? 0);
-
-            // Clamp order matters: the left-edge floor is applied LAST so a
-            // viewport narrower than the panel pins to the margin instead of
-            // going negative off-screen. A point anchor opens its LEFT edge at
-            // the point (native context-menu convention) instead of
-            // right-aligning to it.
-            let left = anchorPoint ? rect.left : rect.right - panelWidth;
-            left = Math.max(Math.min(left, viewportWidth - panelWidth - VIEWPORT_MARGIN_PX), VIEWPORT_MARGIN_PX);
-
-            const spaceBelow = viewportHeight - rect.bottom - ANCHOR_GAP_PX - VIEWPORT_MARGIN_PX;
-            const spaceAbove = rect.top - ANCHOR_GAP_PX - VIEWPORT_MARGIN_PX;
-            // Fit below if possible, else above if possible, else whichever
-            // side has more room — capped to that room and scrollable inside.
-            const fitsBelow = spaceBelow >= panelHeight;
-            const fitsAbove = spaceAbove >= panelHeight;
-            const openAbove = !fitsBelow && (fitsAbove || spaceAbove > spaceBelow);
-            const available = Math.max(openAbove ? spaceAbove : spaceBelow, 0);
-            let top: number;
-            let effectiveHeight: number;
-            if (available >= 40) {
-                // Anchor-attached: capped to the chosen side's real room (no
-                // artificial floor — a floor larger than the room overflows).
-                effectiveHeight = Math.min(panelHeight, available);
-                top = openAbove
-                    ? Math.max(rect.top - effectiveHeight - ANCHOR_GAP_PX, VIEWPORT_MARGIN_PX)
-                    : rect.bottom + ANCHOR_GAP_PX;
-            } else {
-                // Degenerate viewport (anchor pinned to an edge, no room either
-                // side): detach from the anchor and use the full viewport.
-                effectiveHeight = Math.min(panelHeight, viewportHeight - 2 * VIEWPORT_MARGIN_PX);
-                top = VIEWPORT_MARGIN_PX;
-            }
-
-            setPosition({ top, left, maxHeight: effectiveHeight });
-        }
-        place();
-        window.addEventListener("resize", place);
-        window.addEventListener("scroll", place, true);
-        // Re-measure when the PANEL's content changes size (e.g. a menu view
-        // switching to the taller inline crew checklist) — placement computed
-        // for the short view would otherwise keep constraining the tall one.
-        // Observe the CONTENT wrapper, not the panel: a maxHeight-capped panel
-        // box never changes size when its content grows, so panel observation
-        // misses the menu→taller-checklist switch entirely.
-        const observed = contentRef.current ?? panelRef.current;
-        const panelObserver = typeof ResizeObserver !== "undefined" && observed
-            ? new ResizeObserver(() => place())
-            : null;
-        if (panelObserver && observed) panelObserver.observe(observed);
-        return () => {
-            window.removeEventListener("resize", place);
-            window.removeEventListener("scroll", place, true);
-            panelObserver?.disconnect();
-        };
-    }, [open, anchorRef, anchorPoint, width]);
-
-    useEffect(() => {
-        if (!open) return;
-        function onKeyDown(event: KeyboardEvent) {
-            if (event.key !== "Escape") return;
-            event.preventDefault();
-            onClose();
-            // Hover cards open on focus — restoring focus to the anchor would
-            // immediately reopen the card Escape just dismissed.
-            if (!pointerEventsNone) anchorRef?.current?.focus();
-        }
-        function onPointerDownOutside(event: PointerEvent) {
-            const target = event.target as Node;
-            if (panelRef.current?.contains(target)) return;
-            if (anchorRef?.current?.contains(target)) return;
-            onClose();
-        }
-        window.addEventListener("keydown", onKeyDown);
-        window.addEventListener("pointerdown", onPointerDownOutside, true);
-        return () => {
-            window.removeEventListener("keydown", onKeyDown);
-            window.removeEventListener("pointerdown", onPointerDownOutside, true);
-        };
-    }, [open, onClose, anchorRef, pointerEventsNone]);
-
-    if (!open || typeof document === "undefined") return null;
-
-    return createPortal(
-        <div
-            ref={panelRef}
-            style={{
-                position: "fixed",
-                top: position?.top ?? -9999,
-                left: position?.left ?? -9999,
-                maxHeight: position?.maxHeight,
-                overflowY: "auto",
-                width,
-                // Crew-picker rebuild (item 5): FloatingPopover is now the ONLY
-                // scroll owner any schedule-board menu ever nests — content
-                // (e.g. CrewChecklist) must never bring its own w-*/max-h-*
-                // scroller, and a viewport narrower than `width` must clip
-                // horizontally rather than overflow the screen.
-                maxWidth: `calc(100vw - ${2 * VIEWPORT_MARGIN_PX}px)`,
-                boxSizing: "border-box",
-                overflowX: "hidden",
-                overscrollBehaviorY: "contain",
-                visibility: position ? "visible" : "hidden",
-            }}
-            className={`relative z-[200] rounded-md border border-hui-border bg-white p-3 text-left text-hui-textMain shadow-xl ${pointerEventsNone ? "pointer-events-none" : ""}`}
-            onPointerDown={pointerEventsNone ? undefined : event => event.stopPropagation()}
+    return (
+        <FloatingLayer
+            open={open}
+            anchorRef={anchorRef}
+            anchorPoint={anchorPoint}
+            onClose={onClose}
+            width={width}
+            pointerEventsNone={pointerEventsNone}
+            className="rounded-md border border-hui-border bg-white p-3 text-left text-hui-textMain shadow-xl"
         >
             {!pointerEventsNone && (
                 <button
@@ -176,11 +53,9 @@ export function FloatingPopover({ open, anchorRef, anchorPoint, onClose, childre
                     ×
                 </button>
             )}
-            {/* Content wrapper: observed for size changes — the panel box
-                itself stops growing once maxHeight caps it, so observing the
-                panel alone misses menu→taller-view switches. */}
-            <div ref={contentRef} className={pointerEventsNone ? undefined : "pr-6"}>{children}</div>
-        </div>,
-        document.body,
+            {/* Content must never bring its own width or max-height scroller —
+                the FloatingLayer panel is the only scroll owner in this stack. */}
+            <div className={pointerEventsNone ? undefined : "pr-6"}>{children}</div>
+        </FloatingLayer>
     );
 }

--- a/src/app/projects/[id]/schedule/CalendarView.tsx
+++ b/src/app/projects/[id]/schedule/CalendarView.tsx
@@ -503,6 +503,7 @@ function QuickEditPopover({
     useEffect(() => { setNameDraft(task.name); }, [task.id, task.name]);
 
     const [showColorPicker, setShowColorPicker] = useState(false);
+    const colorAnchorRef = useRef<HTMLButtonElement | null>(null);
     const [punchItems, setPunchItems] = useState<PunchItem[]>([]);
     const [punchLoading, setPunchLoading] = useState(true);
     const [newPunch, setNewPunch] = useState("");
@@ -621,6 +622,7 @@ function QuickEditPopover({
                     <div className="relative">
                         <button
                             type="button"
+                            ref={colorAnchorRef}
                             onClick={() => setShowColorPicker(v => !v)}
                             className={`w-5 h-5 rounded-full border border-white shadow-sm ring-1 ${task.color?.toLowerCase() === "#ffffff" ? "ring-slate-400" : "ring-slate-200"} hover:scale-110 transition`}
                             style={{ backgroundColor: task.color }}
@@ -631,7 +633,8 @@ function QuickEditPopover({
                                 selected={task.color}
                                 onPick={c => onPatch({ color: c })}
                                 onClose={() => setShowColorPicker(false)}
-                                className="absolute left-0 top-7 z-50 min-w-[200px]"
+                                anchorRef={colorAnchorRef}
+                                align="left"
                             />
                         )}
                     </div>

--- a/src/app/projects/[id]/schedule/ColorPicker.tsx
+++ b/src/app/projects/[id]/schedule/ColorPicker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type RefObject } from "react";
+import { FloatingLayer } from "@/components/FloatingLayer";
 import { PRESET_COLORS } from "./schedule-utils";
 
 const RECENT_KEY = "probuild:scheduleRecentColors";
@@ -36,28 +37,18 @@ export type ColorPickerProps = {
     selected: string;
     onPick: (hex: string) => void;
     onClose: () => void;
-    className?: string;
+    /** Trigger element the panel is anchored to. Every caller sits inside a scroll container, so the panel is portalled rather than absolutely positioned. */
+    anchorRef: RefObject<HTMLElement | null>;
+    align?: "left" | "right";
 };
 
-export default function ColorPicker({ selected, onPick, onClose, className }: ColorPickerProps) {
+export default function ColorPicker({ selected, onPick, onClose, anchorRef, align = "left" }: ColorPickerProps) {
     const [recent, setRecent] = useState<string[]>([]);
     const colorInputRef = useRef<HTMLInputElement>(null);
-    const containerRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => { setRecent(getRecentColors()); }, []);
 
-    useEffect(() => {
-        function handleClickOutside(e: MouseEvent) {
-            if (containerRef.current && !containerRef.current.contains(e.target as Node)) onClose();
-        }
-        function handleEsc(e: KeyboardEvent) { if (e.key === "Escape") onClose(); }
-        document.addEventListener("mousedown", handleClickOutside);
-        document.addEventListener("keydown", handleEsc);
-        return () => {
-            document.removeEventListener("mousedown", handleClickOutside);
-            document.removeEventListener("keydown", handleEsc);
-        };
-    }, [onClose]);
+    // Escape and outside-pointerdown dismissal live in FloatingLayer.
 
     const selectedNorm = normalizeHex(selected);
 
@@ -73,10 +64,12 @@ export default function ColorPicker({ selected, onPick, onClose, className }: Co
     }
 
     return (
-        <div
-            ref={containerRef}
-            className={`bg-white border border-hui-border rounded-lg shadow-xl p-2.5 animate-in fade-in ${className ?? ""}`}
-            onClick={e => e.stopPropagation()}
+        <FloatingLayer
+            open
+            anchorRef={anchorRef}
+            onClose={onClose}
+            align={align}
+            className="min-w-[200px] bg-white border border-hui-border rounded-lg shadow-xl p-2.5 animate-in fade-in"
         >
             <div className="text-[9px] font-bold text-slate-400 uppercase tracking-wider mb-1.5">Presets</div>
             <div className="grid grid-cols-8 gap-1.5">
@@ -139,6 +132,6 @@ export default function ColorPicker({ selected, onPick, onClose, className }: Co
             >
                 Done
             </button>
-        </div>
+        </FloatingLayer>
     );
 }

--- a/src/app/projects/[id]/schedule/DependencyPicker.tsx
+++ b/src/app/projects/[id]/schedule/DependencyPicker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState, type RefObject } from "react";
+import { FloatingLayer } from "@/components/FloatingLayer";
 import type { Task } from "./schedule-types";
 
 export type DependencyPickerProps = {
@@ -8,6 +9,8 @@ export type DependencyPickerProps = {
     allTasks: Task[];
     onPick: (predecessorId: string) => void;
     onClose: () => void;
+    /** Trigger element the panel is anchored to. Callers sit inside scroll containers, so the panel is portalled rather than absolutely positioned. */
+    anchorRef: RefObject<HTMLElement | null>;
     align?: "left" | "right";
 };
 
@@ -31,9 +34,8 @@ function getReachableSuccessors(taskId: string, tasks: Task[]): Set<string> {
     return reachable;
 }
 
-export default function DependencyPicker({ task, allTasks, onPick, onClose, align = "right" }: DependencyPickerProps) {
+export default function DependencyPicker({ task, allTasks, onPick, onClose, anchorRef, align = "right" }: DependencyPickerProps) {
     const [query, setQuery] = useState("");
-    const ref = useRef<HTMLDivElement>(null);
 
     const candidates = useMemo(() => {
         const existing = new Set(task.dependencies.map(d => d.predecessorId));
@@ -47,24 +49,15 @@ export default function DependencyPicker({ task, allTasks, onPick, onClose, alig
         );
     }, [task.id, task.dependencies, allTasks, query]);
 
-    useEffect(() => {
-        function handleClickOutside(e: MouseEvent) {
-            if (ref.current && !ref.current.contains(e.target as Node)) onClose();
-        }
-        function handleKey(e: KeyboardEvent) { if (e.key === "Escape") onClose(); }
-        document.addEventListener("mousedown", handleClickOutside);
-        document.addEventListener("keydown", handleKey);
-        return () => {
-            document.removeEventListener("mousedown", handleClickOutside);
-            document.removeEventListener("keydown", handleKey);
-        };
-    }, [onClose]);
+    // Escape and outside-pointerdown dismissal live in FloatingLayer.
 
     return (
-        <div
-            ref={ref}
-            className={`absolute ${align === "right" ? "right-0" : "left-0"} top-full mt-1 bg-white border border-hui-border rounded-lg shadow-xl z-50 min-w-[260px] max-h-72 overflow-hidden flex flex-col animate-in fade-in`}
-            onClick={e => e.stopPropagation()}
+        <FloatingLayer
+            open
+            anchorRef={anchorRef}
+            onClose={onClose}
+            align={align}
+            className="min-w-[260px] bg-white border border-hui-border rounded-lg shadow-xl flex flex-col animate-in fade-in"
         >
             <div className="p-2 border-b border-slate-100">
                 <input
@@ -76,7 +69,8 @@ export default function DependencyPicker({ task, allTasks, onPick, onClose, alig
                     className="hui-input text-xs w-full py-1"
                 />
             </div>
-            <div className="overflow-y-auto py-1">
+            {/* No scroller here — FloatingLayer caps the panel height and owns the scroll. */}
+            <div className="py-1">
                 {candidates.length === 0 ? (
                     <div className="px-3 py-2 text-xs text-slate-400 italic">
                         {allTasks.length <= 1
@@ -103,6 +97,6 @@ export default function DependencyPicker({ task, allTasks, onPick, onClose, alig
                     ))
                 )}
             </div>
-        </div>
+        </FloatingLayer>
     );
 }

--- a/src/app/projects/[id]/schedule/GanttChart.tsx
+++ b/src/app/projects/[id]/schedule/GanttChart.tsx
@@ -32,6 +32,11 @@ export default function GanttChart({ projectId, projectName, tasks, setTasks, es
     const [editingId, setEditingId] = useState<string | null>(null);
     const [editName, setEditName] = useState("");
     const [colorPickerId, setColorPickerId] = useState<string | null>(null);
+    // Anchor for the portalled color picker. The task list is a scroll pane
+    // nested in an overflow-hidden shell, so an absolutely-positioned panel is
+    // clipped for rows near the bottom. Only one picker is open at a time, so
+    // the ref attaches to the open row's swatch and is null otherwise.
+    const colorAnchorRef = useRef<HTMLButtonElement | null>(null);
     const [editingHoursId, setEditingHoursId] = useState<string | null>(null);
     const [editHoursVal, setEditHoursVal] = useState("");
     const [hoveredTaskId, setHoveredTaskId] = useState<string | null>(null);
@@ -348,14 +353,14 @@ export default function GanttChart({ projectId, projectName, tasks, setTasks, es
                                 >
                                     <div className="relative mr-2">
                                         {task.type === "milestone" ? (
-                                            <button onClick={e => { e.stopPropagation(); setColorPickerId(colorPickerId === task.id ? null : task.id); }} className="w-4 h-4 flex items-center justify-center" title="Milestone">
+                                            <button ref={colorPickerId === task.id ? colorAnchorRef : undefined} onClick={e => { e.stopPropagation(); setColorPickerId(colorPickerId === task.id ? null : task.id); }} className="w-4 h-4 flex items-center justify-center" title="Milestone">
                                                 <div className="w-3 h-3 rotate-45 border-2" style={{ backgroundColor: task.color, borderColor: task.color }} />
                                             </button>
                                         ) : (
-                                            <button onClick={e => { e.stopPropagation(); setColorPickerId(colorPickerId === task.id ? null : task.id); }} className={`w-3 h-3 rounded-full border-2 border-white shadow-sm ring-1 ${task.color?.toLowerCase() === "#ffffff" ? "ring-slate-400" : "ring-slate-200"}`} style={{ backgroundColor: task.color }} />
+                                            <button ref={colorPickerId === task.id ? colorAnchorRef : undefined} onClick={e => { e.stopPropagation(); setColorPickerId(colorPickerId === task.id ? null : task.id); }} className={`w-3 h-3 rounded-full border-2 border-white shadow-sm ring-1 ${task.color?.toLowerCase() === "#ffffff" ? "ring-slate-400" : "ring-slate-200"}`} style={{ backgroundColor: task.color }} />
                                         )}
                                         {colorPickerId === task.id && (
-                                            <ColorPicker selected={task.color} onPick={c => actions.handleColorChange(task.id, c)} onClose={() => setColorPickerId(null)} className="absolute top-5 left-0 z-50 min-w-[200px]" />
+                                            <ColorPicker selected={task.color} onPick={c => actions.handleColorChange(task.id, c)} onClose={() => setColorPickerId(null)} anchorRef={colorAnchorRef} align="left" />
                                         )}
                                     </div>
                                     <div className="flex-1 min-w-0">

--- a/src/app/projects/[id]/schedule/ProgressPopover.tsx
+++ b/src/app/projects/[id]/schedule/ProgressPopover.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useMemo, type RefObject } from "react";
 import Link from "next/link";
+import { FloatingLayer } from "@/components/FloatingLayer";
 import { getTaskTimeEntries } from "@/lib/actions";
 import type { TimeEntryDetail } from "./schedule-types";
 
@@ -17,6 +18,8 @@ export type ProgressPopoverProps = {
     actualHours: number;
     projectId: string;
     onClose: () => void;
+    /** Trigger element the panel is anchored to. The table body scrolls, so the panel is portalled rather than absolutely positioned. */
+    anchorRef: RefObject<HTMLElement | null>;
 };
 
 function formatDate(d: string | Date): string {
@@ -47,8 +50,7 @@ function fmt(n: number): string {
     return n % 1 === 0 ? String(n) : n.toFixed(1);
 }
 
-export default function ProgressPopover({ taskId, taskColor, progress, estimatedHours, actualHours, projectId, onClose }: ProgressPopoverProps) {
-    const containerRef = useRef<HTMLDivElement>(null);
+export default function ProgressPopover({ taskId, taskColor, progress, estimatedHours, actualHours, projectId, onClose, anchorRef }: ProgressPopoverProps) {
     const [entries, setEntries] = useState<TimeEntryDetail[]>([]);
     const [total, setTotal] = useState(0);
     const [loading, setLoading] = useState(true);
@@ -69,18 +71,7 @@ export default function ProgressPopover({ taskId, taskColor, progress, estimated
         return () => { cancelled = true; };
     }, [taskId]);
 
-    useEffect(() => {
-        function handleClickOutside(e: MouseEvent) {
-            if (containerRef.current && !containerRef.current.contains(e.target as Node)) onClose();
-        }
-        function handleEsc(e: KeyboardEvent) { if (e.key === "Escape") onClose(); }
-        document.addEventListener("mousedown", handleClickOutside);
-        document.addEventListener("keydown", handleEsc);
-        return () => {
-            document.removeEventListener("mousedown", handleClickOutside);
-            document.removeEventListener("keydown", handleEsc);
-        };
-    }, [onClose]);
+    // Escape and outside-pointerdown dismissal live in FloatingLayer.
 
     function toggleSort(field: SortField) {
         if (sortField === field) setSortAsc(!sortAsc);
@@ -140,7 +131,17 @@ export default function ProgressPopover({ taskId, taskColor, progress, estimated
     const arrow = (field: SortField) => sortField === field ? (sortAsc ? " ↑" : " ↓") : "";
 
     return (
-        <div ref={containerRef} className="absolute right-0 top-full mt-1 bg-white border border-hui-border rounded-lg shadow-xl z-50 w-[360px] animate-in fade-in" onClick={e => e.stopPropagation()}>
+        // constrainHeight is off: this panel keeps its own inner scroller so the
+        // sticky column headers and the footer stay put while only rows scroll.
+        <FloatingLayer
+            open
+            anchorRef={anchorRef}
+            onClose={onClose}
+            align="right"
+            width={360}
+            constrainHeight={false}
+            className="bg-white border border-hui-border rounded-lg shadow-xl animate-in fade-in"
+        >
             {/* Header */}
             <div className="px-3 py-2 flex items-center justify-between border-b border-slate-100">
                 <span className="text-[11px] font-bold text-slate-500 uppercase tracking-wider">Time Entries</span>
@@ -241,6 +242,6 @@ export default function ProgressPopover({ taskId, taskColor, progress, estimated
                     View all →
                 </Link>
             </div>
-        </div>
+        </FloatingLayer>
     );
 }

--- a/src/app/projects/[id]/schedule/TableView.tsx
+++ b/src/app/projects/[id]/schedule/TableView.tsx
@@ -7,6 +7,7 @@ import {
     updateScheduleTask, linkTasks, unlinkTasks, reorderScheduleTasks,
 } from "@/lib/actions";
 import { toast } from "sonner";
+import { FloatingLayer } from "@/components/FloatingLayer";
 import type { Task, EstimateSummary, TeamMember, Subcontractor, SortKey, SortDir, FilterState } from "./schedule-types";
 import { STATUS_OPTIONS, STATUS_COLORS, getDaysBetween, addDays, formatDate, getInitials, formatCurrency } from "./schedule-utils";
 import { useScheduleActions } from "./useScheduleActions";
@@ -81,6 +82,14 @@ export default function TableView({ projectId, projectName, tasks, setTasks, est
     const [depsPopoverId, setDepsPopoverId] = useState<string | null>(null);
     const [progressPopoverId, setProgressPopoverId] = useState<string | null>(null);
     const [depsPickerId, setDepsPickerId] = useState<string | null>(null);
+    // Anchors for the portalled popovers. Only one row's popover is open at a
+    // time, so each ref is attached to the open row's trigger and is null
+    // otherwise — refs attach before layout effects, so the panel measures the
+    // correct trigger on the same commit that opens it.
+    const colorAnchorRef = useRef<HTMLButtonElement | null>(null);
+    const progressAnchorRef = useRef<HTMLButtonElement | null>(null);
+    const depsPopoverAnchorRef = useRef<HTMLButtonElement | null>(null);
+    const depsPickerAnchorRef = useRef<HTMLButtonElement | null>(null);
     const editRef = useRef<HTMLInputElement | HTMLSelectElement>(null);
 
     useEffect(() => { if (editRef.current) editRef.current.focus(); }, [editingCell]);
@@ -558,9 +567,9 @@ export default function TableView({ projectId, projectName, tasks, setTasks, est
                                                             </div>
                                                             <div className="px-2 py-2 flex items-center">
                                                                 <div className="relative">
-                                                                    <button onClick={e => { e.stopPropagation(); setColorPickerId(colorPickerId === task.id ? null : task.id); setProgressPopoverId(null); }} className={`w-4 h-4 rounded-full border border-white shadow-sm ring-1 ${task.color?.toLowerCase() === "#ffffff" ? "ring-slate-400" : "ring-slate-200"}`} style={{ backgroundColor: task.color }} />
+                                                                    <button ref={colorPickerId === task.id ? colorAnchorRef : undefined} onClick={e => { e.stopPropagation(); setColorPickerId(colorPickerId === task.id ? null : task.id); setProgressPopoverId(null); }} className={`w-4 h-4 rounded-full border border-white shadow-sm ring-1 ${task.color?.toLowerCase() === "#ffffff" ? "ring-slate-400" : "ring-slate-200"}`} style={{ backgroundColor: task.color }} />
                                                                     {colorPickerId === task.id && (
-                                                                        <ColorPicker selected={task.color} onPick={c => actions.handleColorChange(task.id, c)} onClose={() => setColorPickerId(null)} className="absolute left-0 top-full mt-1 z-50 min-w-[200px]" />
+                                                                        <ColorPicker selected={task.color} onPick={c => actions.handleColorChange(task.id, c)} onClose={() => setColorPickerId(null)} anchorRef={colorAnchorRef} align="left" />
                                                                     )}
                                                                 </div>
                                                             </div>
@@ -599,6 +608,7 @@ export default function TableView({ projectId, projectName, tasks, setTasks, est
                                                             <div className="px-3 py-2">
                                                                 <div className="relative inline-block" onClick={e => e.stopPropagation()}>
                                                                     <button
+                                                                        ref={progressPopoverId === task.id ? progressAnchorRef : undefined}
                                                                         onClick={() => {
                                                                             setProgressPopoverId(progressPopoverId === task.id ? null : task.id);
                                                                             setDepsPopoverId(null);
@@ -622,6 +632,7 @@ export default function TableView({ projectId, projectName, tasks, setTasks, est
                                                                             actualHours={task.actualHours}
                                                                             projectId={projectId}
                                                                             onClose={() => setProgressPopoverId(null)}
+                                                                            anchorRef={progressAnchorRef}
                                                                         />
                                                                     )}
                                                                 </div>
@@ -652,6 +663,7 @@ export default function TableView({ projectId, projectName, tasks, setTasks, est
                                                             <div className="px-3 py-2">
                                                                 <div className="relative inline-block" onClick={e => e.stopPropagation()}>
                                                                     <button
+                                                                        ref={depsPopoverId === task.id ? depsPopoverAnchorRef : undefined}
                                                                         onClick={() => { setDepsPopoverId(depsPopoverId === task.id ? null : task.id); setDepsPickerId(null); setProgressPopoverId(null); }}
                                                                         className={`text-[10px] px-1.5 py-0.5 rounded font-medium transition ${task.dependencies.length > 0 ? "bg-slate-100 text-slate-600 hover:bg-indigo-100 hover:text-indigo-700" : "text-slate-300 hover:text-indigo-600 hover:bg-indigo-50"}`}
                                                                         title={task.dependencies.length > 0 ? "View / edit predecessors" : "Add a predecessor"}
@@ -659,7 +671,17 @@ export default function TableView({ projectId, projectName, tasks, setTasks, est
                                                                         {task.dependencies.length > 0 ? `${task.dependencies.length} dep${task.dependencies.length !== 1 ? "s" : ""}` : "+ Link"}
                                                                     </button>
                                                                     {depsPopoverId === task.id && (
-                                                                        <div className="absolute left-0 top-full mt-1 bg-white border border-hui-border rounded-lg shadow-xl z-50 min-w-[240px] py-1 animate-in fade-in">
+                                                                        // dismissOnOutsidePointerDown is off: this panel hosts the
+                                                                        // DependencyPicker as a sibling portal, and it never had
+                                                                        // outside-close before — the × and the other row toggles close it.
+                                                                        <FloatingLayer
+                                                                            open
+                                                                            anchorRef={depsPopoverAnchorRef}
+                                                                            onClose={() => setDepsPopoverId(null)}
+                                                                            align="left"
+                                                                            dismissOnOutsidePointerDown={false}
+                                                                            className="min-w-[240px] bg-white border border-hui-border rounded-lg shadow-xl py-1 animate-in fade-in"
+                                                                        >
                                                                             <div className="px-3 py-1.5 text-[10px] font-bold text-slate-400 uppercase tracking-wider bg-slate-50 flex items-center justify-between">
                                                                                 <span>Predecessors</span>
                                                                                 <button onClick={() => setDepsPopoverId(null)} className="text-slate-400 hover:text-slate-700">
@@ -690,14 +712,14 @@ export default function TableView({ projectId, projectName, tasks, setTasks, est
                                                                             )}
                                                                             <div className="border-t border-slate-100 my-1" />
                                                                             <div className="px-1 relative">
-                                                                                <button onClick={() => setDepsPickerId(depsPickerId === task.id ? null : task.id)} className="w-full text-left px-2 py-1.5 hover:bg-indigo-50 transition text-xs text-indigo-600 font-semibold rounded">
+                                                                                <button ref={depsPickerId === task.id ? depsPickerAnchorRef : undefined} onClick={() => setDepsPickerId(depsPickerId === task.id ? null : task.id)} className="w-full text-left px-2 py-1.5 hover:bg-indigo-50 transition text-xs text-indigo-600 font-semibold rounded">
                                                                                     + Add predecessor
                                                                                 </button>
                                                                                 {depsPickerId === task.id && (
-                                                                                    <DependencyPicker task={task} allTasks={tasks} onPick={(predId) => addPredecessor(task.id, predId)} onClose={() => setDepsPickerId(null)} align="left" />
+                                                                                    <DependencyPicker task={task} allTasks={tasks} onPick={(predId) => addPredecessor(task.id, predId)} onClose={() => setDepsPickerId(null)} anchorRef={depsPickerAnchorRef} align="left" />
                                                                                 )}
                                                                             </div>
-                                                                        </div>
+                                                                        </FloatingLayer>
                                                                     )}
                                                                 </div>
                                                             </div>

--- a/src/app/projects/[id]/schedule/TaskDetailPanel.tsx
+++ b/src/app/projects/[id]/schedule/TaskDetailPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Task, PunchItem, Comment, TeamMember, Subcontractor, EstimateItemSummary } from "./schedule-types";
 import { STATUS_OPTIONS, getInitials, formatCurrency } from "./schedule-utils";
 import DependencyPicker from "./DependencyPicker";
@@ -77,6 +77,10 @@ export default function TaskDetailPanel({
     const [estimateQuery, setEstimateQuery] = useState("");
     const [showPredecessorMenu, setShowPredecessorMenu] = useState(false);
     const [showColorPicker, setShowColorPicker] = useState(false);
+    // Anchors for the portalled popovers — this panel is a scroll container, so
+    // an absolutely-positioned panel would be clipped at its edge.
+    const colorAnchorRef = useRef<HTMLButtonElement | null>(null);
+    const predecessorAnchorRef = useRef<HTMLButtonElement | null>(null);
     const [newPunchName, setNewPunchName] = useState("");
     const [newComment, setNewComment] = useState("");
     const [nameDraft, setNameDraft] = useState(task.name);
@@ -174,6 +178,7 @@ export default function TaskDetailPanel({
                     <div className="relative shrink-0">
                         <button
                             type="button"
+                            ref={colorAnchorRef}
                             onClick={() => setShowColorPicker(v => !v)}
                             title="Change color"
                             className="block hover:scale-110 transition"
@@ -194,7 +199,8 @@ export default function TaskDetailPanel({
                                 selected={task.color}
                                 onPick={c => onColorChange(task.id, c)}
                                 onClose={() => setShowColorPicker(false)}
-                                className="absolute left-0 top-7 z-50 min-w-[200px]"
+                                anchorRef={colorAnchorRef}
+                                align="left"
                             />
                         )}
                     </div>
@@ -485,13 +491,14 @@ export default function TaskDetailPanel({
                                     <div className="flex items-center justify-between mb-2">
                                         <label className={SECTION_LABEL}>Predecessors</label>
                                         <div className="relative">
-                                            <button onClick={() => setShowPredecessorMenu(v => !v)} className="text-xs text-indigo-600 font-semibold hover:text-indigo-800 transition">+ Add</button>
+                                            <button ref={predecessorAnchorRef} onClick={() => setShowPredecessorMenu(v => !v)} className="text-xs text-indigo-600 font-semibold hover:text-indigo-800 transition">+ Add</button>
                                             {showPredecessorMenu && (
                                                 <DependencyPicker
                                                     task={task}
                                                     allTasks={allTasks}
                                                     onPick={(predId) => onLinkPredecessor(predId)}
                                                     onClose={() => setShowPredecessorMenu(false)}
+                                                    anchorRef={predecessorAnchorRef}
                                                 />
                                             )}
                                         </div>

--- a/src/components/FloatingLayer.tsx
+++ b/src/components/FloatingLayer.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { createPortal } from "react-dom";
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode, type RefObject } from "react";
+
+export const FLOATING_VIEWPORT_MARGIN_PX = 8;
+export const FLOATING_ANCHOR_GAP_PX = 4;
+
+export interface FloatingAnchorPoint {
+    x: number;
+    y: number;
+}
+
+export interface FloatingLayerProps {
+    open: boolean;
+    /** Anchor to a trigger element's live bounding rect. Ignored when `anchorPoint` is also given. */
+    anchorRef?: RefObject<HTMLElement | null>;
+    /** Anchor to an explicit viewport point (e.g. a `contextmenu` event's clientX/clientY). Takes precedence over `anchorRef`. */
+    anchorPoint?: FloatingAnchorPoint | null;
+    onClose: () => void;
+    children: ReactNode;
+    /** Which panel edge lines up with the anchor. Default "right" (matches the `absolute right-0` menus this replaced). A point anchor always opens its left edge at the point. */
+    align?: "left" | "right";
+    /** Fixed panel width in px. Omit to size to content — the panel still clamps into the viewport. */
+    width?: number;
+    /** Cap the panel to the room available on its side and scroll inside. Default true. */
+    constrainHeight?: boolean;
+    /** Non-interactive hover-card mode: the panel never captures pointer events, so it can't trap the mouse mid-hover. */
+    pointerEventsNone?: boolean;
+    /**
+     * Close on a pointerdown outside the panel and anchor. Default true.
+     *
+     * Set false when this panel hosts another FloatingLayer: the nested panel
+     * is a sibling portal on document.body, so a pointerdown inside it reads as
+     * "outside" here and would dismiss the parent out from under it.
+     */
+    dismissOnOutsidePointerDown?: boolean;
+    /** Classes for the positioned wrapper. Children supply their own chrome (border, background, padding). */
+    className?: string;
+    /** Stacking order within the portal root. Default 200. */
+    zIndex?: number;
+}
+
+/**
+ * Headless portal-positioned layer: renders `children` to document.body,
+ * anchored to a trigger element or an explicit point.
+ *
+ * This exists because a popover nested in the page can be hidden two different
+ * ways, and only portalling fixes both:
+ *   1. Painted under — an ancestor with its own z-index caps the popover's
+ *      z-index to the ancestor's rank, so a later equal-z sibling covers it.
+ *   2. Clipped — an ancestor with `overflow: hidden/auto` cuts the popover off
+ *      at its edge, which no z-index change can fix.
+ *
+ * Positioning: measured from the anchor's live rect, flipped above when there
+ * isn't room below, clamped into the viewport with an 8px margin, and (by
+ * default) capped to the room on its side with internal scroll. Escape closes
+ * and returns focus to the anchor; a pointerdown outside the panel and anchor
+ * also closes.
+ *
+ * Chrome is deliberately NOT included — callers keep their own panel styling.
+ * `FloatingPopover` (schedule board) wraps this with its own chrome.
+ */
+export function FloatingLayer({
+    open,
+    anchorRef,
+    anchorPoint,
+    onClose,
+    children,
+    align = "right",
+    width,
+    constrainHeight = true,
+    pointerEventsNone = false,
+    dismissOnOutsidePointerDown = true,
+    className,
+    zIndex = 200,
+}: FloatingLayerProps) {
+    const panelRef = useRef<HTMLDivElement | null>(null);
+    const contentRef = useRef<HTMLDivElement | null>(null);
+    const [position, setPosition] = useState<{ top: number; left: number; maxHeight?: number } | null>(null);
+
+    useLayoutEffect(() => {
+        if (!open) {
+            setPosition(null);
+            return;
+        }
+        const anchor = anchorRef?.current ?? null;
+        if (!anchorPoint && !anchor) return;
+
+        function place() {
+            const rect = anchorPoint
+                ? { left: anchorPoint.x, right: anchorPoint.x, top: anchorPoint.y, bottom: anchorPoint.y }
+                : anchor!.getBoundingClientRect();
+            const viewportWidth = window.innerWidth;
+            const viewportHeight = window.innerHeight;
+            const panelWidth = panelRef.current?.offsetWidth ?? width ?? 0;
+            // scrollHeight, not offsetHeight: once a maxHeight is applied the box
+            // stops growing, so a panel switching to taller content would keep
+            // measuring the SHORT view and never re-place.
+            const panelHeight = Math.max(panelRef.current?.scrollHeight ?? 0, panelRef.current?.offsetHeight ?? 0);
+
+            // Clamp order matters: the left-edge floor is applied LAST so a
+            // viewport narrower than the panel pins to the margin instead of
+            // going negative off-screen.
+            let left = anchorPoint
+                ? rect.left
+                : align === "left"
+                    ? rect.left
+                    : rect.right - panelWidth;
+            left = Math.max(
+                Math.min(left, viewportWidth - panelWidth - FLOATING_VIEWPORT_MARGIN_PX),
+                FLOATING_VIEWPORT_MARGIN_PX,
+            );
+
+            const spaceBelow = viewportHeight - rect.bottom - FLOATING_ANCHOR_GAP_PX - FLOATING_VIEWPORT_MARGIN_PX;
+            const spaceAbove = rect.top - FLOATING_ANCHOR_GAP_PX - FLOATING_VIEWPORT_MARGIN_PX;
+            // Fit below if possible, else above if possible, else whichever side
+            // has more room — capped to that room and scrollable inside.
+            const fitsBelow = spaceBelow >= panelHeight;
+            const fitsAbove = spaceAbove >= panelHeight;
+            const openAbove = !fitsBelow && (fitsAbove || spaceAbove > spaceBelow);
+            const available = Math.max(openAbove ? spaceAbove : spaceBelow, 0);
+            let top: number;
+            let effectiveHeight: number;
+            if (available >= 40) {
+                // Anchor-attached: capped to the chosen side's real room (no
+                // artificial floor — a floor larger than the room overflows).
+                effectiveHeight = Math.min(panelHeight, available);
+                top = openAbove
+                    ? Math.max(rect.top - effectiveHeight - FLOATING_ANCHOR_GAP_PX, FLOATING_VIEWPORT_MARGIN_PX)
+                    : rect.bottom + FLOATING_ANCHOR_GAP_PX;
+            } else {
+                // Degenerate viewport (anchor pinned to an edge, no room either
+                // side): detach from the anchor and use the full viewport.
+                effectiveHeight = Math.min(panelHeight, viewportHeight - 2 * FLOATING_VIEWPORT_MARGIN_PX);
+                top = FLOATING_VIEWPORT_MARGIN_PX;
+            }
+
+            setPosition({ top, left, maxHeight: constrainHeight ? effectiveHeight : undefined });
+        }
+        place();
+        window.addEventListener("resize", place);
+        window.addEventListener("scroll", place, true);
+        // Re-measure when the PANEL's content changes size. Observe the CONTENT
+        // wrapper, not the panel: a maxHeight-capped panel box never changes
+        // size when its content grows, so panel observation misses the switch.
+        const observed = contentRef.current ?? panelRef.current;
+        const panelObserver = typeof ResizeObserver !== "undefined" && observed
+            ? new ResizeObserver(() => place())
+            : null;
+        if (panelObserver && observed) panelObserver.observe(observed);
+        return () => {
+            window.removeEventListener("resize", place);
+            window.removeEventListener("scroll", place, true);
+            panelObserver?.disconnect();
+        };
+    }, [open, anchorRef, anchorPoint, align, width, constrainHeight]);
+
+    useEffect(() => {
+        if (!open) return;
+        function onKeyDown(event: KeyboardEvent) {
+            if (event.key !== "Escape") return;
+            event.preventDefault();
+            onClose();
+            // Hover cards open on focus — restoring focus to the anchor would
+            // immediately reopen the card Escape just dismissed.
+            if (!pointerEventsNone) anchorRef?.current?.focus();
+        }
+        function onPointerDownOutside(event: PointerEvent) {
+            const target = event.target as Node;
+            if (panelRef.current?.contains(target)) return;
+            if (anchorRef?.current?.contains(target)) return;
+            onClose();
+        }
+        window.addEventListener("keydown", onKeyDown);
+        if (dismissOnOutsidePointerDown) window.addEventListener("pointerdown", onPointerDownOutside, true);
+        return () => {
+            window.removeEventListener("keydown", onKeyDown);
+            window.removeEventListener("pointerdown", onPointerDownOutside, true);
+        };
+    }, [open, onClose, anchorRef, pointerEventsNone, dismissOnOutsidePointerDown]);
+
+    if (!open || typeof document === "undefined") return null;
+
+    return createPortal(
+        <div
+            ref={panelRef}
+            style={{
+                position: "fixed",
+                top: position?.top ?? -9999,
+                left: position?.left ?? -9999,
+                maxHeight: position?.maxHeight,
+                overflowY: constrainHeight ? "auto" : undefined,
+                width,
+                maxWidth: `calc(100vw - ${2 * FLOATING_VIEWPORT_MARGIN_PX}px)`,
+                boxSizing: "border-box",
+                overflowX: "hidden",
+                overscrollBehaviorY: "contain",
+                zIndex,
+                // Hidden until measured so the panel never flashes at -9999.
+                visibility: position ? "visible" : "hidden",
+            }}
+            className={`${pointerEventsNone ? "pointer-events-none " : ""}${className ?? ""}`}
+            onPointerDown={pointerEventsNone ? undefined : event => event.stopPropagation()}
+        >
+            <div ref={contentRef}>{children}</div>
+        </div>,
+        document.body,
+    );
+}


### PR DESCRIPTION
Follow-up to #268, acting on the stacking-context audit it triggered.

## Two failure modes, one fix

The schedule page had popovers failing in two different ways. Only portalling fixes both:

1. **Painted under** — an ancestor with its own z-index caps the popover's `z-50` to the ancestor's rank, so a later equal-z sibling covers it. That was #268 (the toolbar menus).
2. **Clipped** — an ancestor with `overflow: hidden/auto` cuts the popover off at its edge. **No z-index change fixes this.**

The audit found four sites still broken by (2), all real today:

| Site | Clipped by |
|---|---|
| Gantt colour picker | `overflow-y-auto` task list inside an `overflow-hidden` shell — rows near the bottom open into dead space |
| TableView dependency popover | table body `overflow-auto` |
| TableView progress popover | table body `overflow-auto` |
| TaskDetailPanel colour + predecessor pickers | panel scroll body |

## No third implementation

The audit also found the schedule board had **already** solved this months ago with `FloatingPopover` — portal, anchor measurement, flip-above, viewport clamping, height capping, ResizeObserver — with a header comment citing this exact problem. The `MenuPortal` I added in #268 was a thinner reinvention of it.

So rather than add a third one, this extracts `FloatingPopover`'s positioning and dismissal logic into a shared headless **`FloatingLayer`**:

- `FloatingPopover` becomes a thin chrome wrapper over it. **Public API unchanged** — all 8 schedule-board consumers are untouched.
- `ColorPicker`, `DependencyPicker`, `ProgressPopover` portal through it and drop their duplicated `mousedown`/Escape listeners. All 7 call sites pass an `anchorRef`.
- Chrome is deliberately *not* in the primitive, so callers keep their own panel styling.

## One subtlety worth review

TableView's predecessors popover hosts `DependencyPicker` as a **nested** portal. Once both are on `document.body` they are siblings, so a pointerdown inside the child reads as "outside" to the parent and would dismiss it out from under the child.

Hence the new `dismissOnOutsidePointerDown` prop, set `false` there. That popover never had outside-close to begin with (its `×` and the sibling row toggles close it), so its dismissal behaviour is unchanged.

## Not in this PR

- **Retiring `MenuPortal`** (migrating `ScheduleToolbar` / `SchedulePublishButton` onto `FloatingLayer`) — deliberately deferred: another session is editing `ScheduleToolbar.tsx` right now for the split-button sizing fix, and this would conflict.
- **Hardening the 5 fragile sites** the audit flagged (capped `z-50` menus that work today only because nothing currently overlaps them) — no visible bug, separate pass.

## Verification

`npm run typecheck` and `npm run build` both pass. Behaviour verified on prod after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
