### PR TITLE
feat(mcp): two-way file access, per-person connector keys, audit trail

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,6 +41,20 @@ model User {
   clippedProducts    ProductLibraryItem[]
   addedFavorites     ProjectProductFavorite[]
   decidedProposals   SelectionProposal[]
+  mcpKeys            McpKey[]
+}
+
+model McpKey {
+  id         String    @id @default(cuid())
+  label      String                     // e.g. "Richard — ChatGPT"
+  keyHash    String    @unique           // sha256 hex of the raw key; raw key never stored
+  userId     String
+  user       User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt  DateTime  @default(now())
+  lastUsedAt DateTime?
+  revokedAt  DateTime?
+
+  @@index([userId])
 }
 
 model Client {
@@ -1918,6 +1932,7 @@ model ActivityLog {
   leadId     String?  // lead-stage events (estimate sent/viewed before conversion); no FK — log survives lead deletion
   actorType  String   // "CLIENT", "TEAM", "SUBCONTRACTOR", "SYSTEM"
   actorName  String
+  actorUserId String? // User.id of the acting team member, when known (e.g. per-person MCP key); no FK — log survives user deletion
   action     String   // "viewed_estimate", "signed_contract", "paid_invoice", "sent_message", "viewed_portal"
   entityType String?  // "estimate", "invoice", "contract", "change_order", "message"
   entityId   String?
@@ -1928,6 +1943,7 @@ model ActivityLog {
   @@index([projectId, createdAt])
   @@index([entityType, entityId])
   @@index([leadId, createdAt])
+  @@index([actorUserId, createdAt])
 }
 
 model DispatchPublication {

--- a/scripts/apply-mcp-audit-schema.mjs
+++ b/scripts/apply-mcp-audit-schema.mjs
@@ -1,0 +1,84 @@
+// One-off additive migration for per-person MCP connector keys + the
+// actorUserId audit column on ActivityLog. Safe to re-run while the previous
+// build is live.
+//
+// Run only through the release orchestrator:
+//   node scripts/apply-mcp-audit-schema.mjs
+//
+// Do not run this during implementation handoff. Deploy this schema BEFORE
+// the build that reads/writes McpKey or ActivityLog.actorUserId goes live.
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+function resolveDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const file of [".env", ".env.local"]) {
+    if (!fs.existsSync(file)) continue;
+    const match = fs.readFileSync(file, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+    if (match) return match[1];
+  }
+  throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const prisma = new PrismaClient({
+  datasources: { db: { url: resolveDatabaseUrl() } },
+});
+
+const statements = [
+  `CREATE TABLE IF NOT EXISTS "McpKey" (
+     "id" TEXT NOT NULL,
+     "label" TEXT NOT NULL,
+     "keyHash" TEXT NOT NULL,
+     "userId" TEXT NOT NULL,
+     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+     "lastUsedAt" TIMESTAMP(3),
+     "revokedAt" TIMESTAMP(3),
+     CONSTRAINT "McpKey_pkey" PRIMARY KEY ("id")
+   )`,
+
+  `CREATE UNIQUE INDEX IF NOT EXISTS "McpKey_keyHash_key" ON "McpKey" ("keyHash")`,
+  `CREATE INDEX IF NOT EXISTS "McpKey_userId_idx" ON "McpKey" ("userId")`,
+
+  // Guarded FK: only add it if it isn't already present (idempotent re-run).
+  `DO $$ BEGIN
+     IF NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'McpKey_userId_fkey'
+         AND conrelid = '"McpKey"'::regclass
+     ) THEN
+       ALTER TABLE "McpKey"
+         ADD CONSTRAINT "McpKey_userId_fkey"
+         FOREIGN KEY ("userId") REFERENCES "User"("id")
+         ON DELETE CASCADE ON UPDATE CASCADE;
+     END IF;
+   END $$`,
+
+  // Metadata-only default-null add: brief ACCESS EXCLUSIVE lock, no rewrite.
+  // The lock_timeout keeps it from queueing behind a long read and stalling
+  // every writer on a live table.
+  `SET lock_timeout = '5s'`,
+  `ALTER TABLE "ActivityLog" ADD COLUMN IF NOT EXISTS "actorUserId" TEXT`,
+  // Plain (non-CONCURRENT) build is correct here: ActivityLog is ~200 rows /
+  // 216 kB, so the build is sub-millisecond, and CREATE INDEX CONCURRENTLY is
+  // unreliable through the pgbouncer transaction pooler this URL uses.
+  `CREATE INDEX IF NOT EXISTS "ActivityLog_actorUserId_createdAt_idx" ON "ActivityLog" ("actorUserId", "createdAt")`,
+  `SET lock_timeout = '0'`,
+
+  // Server-only table. RLS with no policies denies anon/authenticated access
+  // through Supabase's exposed Data API. Prisma uses the database-owner
+  // server connection, and this script intentionally does not FORCE RLS.
+  `ALTER TABLE "McpKey" ENABLE ROW LEVEL SECURITY`,
+];
+
+try {
+  for (const sql of statements) {
+    await prisma.$executeRawUnsafe(sql);
+    console.log("applied:", sql.split("\n")[0]);
+  }
+  console.log("MCP audit schema (McpKey + ActivityLog.actorUserId) applied successfully.");
+} catch (error) {
+  console.error("Migration failed:", error);
+  process.exitCode = 1;
+} finally {
+  await prisma.$disconnect();
+}

--- a/scripts/mint-mcp-key.mjs
+++ b/scripts/mint-mcp-key.mjs
@@ -1,0 +1,132 @@
+// Mints a per-person MCP connector key (McpKey) for a ProBuild user.
+// The raw key is generated here and printed once — only its sha256 hash is
+// stored, so it can never be recovered after this run.
+//
+// Usage:
+//   node scripts/mint-mcp-key.mjs <user-email> "<label>"
+//   node scripts/mint-mcp-key.mjs --revoke <keyId>
+//   node scripts/mint-mcp-key.mjs --list
+//
+// DO NOT RUN as part of implementation handoff — this writes to the live
+// database. Run it only when actually issuing/revoking a connector key.
+import { PrismaClient } from "@prisma/client";
+import { randomBytes, createHash } from "node:crypto";
+import fs from "node:fs";
+
+function resolveDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const file of [".env", ".env.local"]) {
+    if (!fs.existsSync(file)) continue;
+    const match = fs.readFileSync(file, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+    if (match) return match[1];
+  }
+  throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const prisma = new PrismaClient({
+  datasources: { db: { url: resolveDatabaseUrl() } },
+});
+
+function usage() {
+  console.error(
+    "Usage:\n" +
+      '  node scripts/mint-mcp-key.mjs <user-email> "<label>"\n' +
+      "  node scripts/mint-mcp-key.mjs --revoke <keyId>\n" +
+      "  node scripts/mint-mcp-key.mjs --list"
+  );
+}
+
+async function listKeys() {
+  const keys = await prisma.mcpKey.findMany({
+    orderBy: { createdAt: "desc" },
+    include: { user: { select: { email: true, name: true } } },
+  });
+  if (keys.length === 0) {
+    console.log("No MCP keys minted yet.");
+    return;
+  }
+  for (const k of keys) {
+    console.log(
+      `${k.id}  ${k.label}  user=${k.user.name ?? k.user.email} <${k.user.email}>  ` +
+        `created=${k.createdAt.toISOString()}  lastUsed=${k.lastUsedAt ? k.lastUsedAt.toISOString() : "never"}  ` +
+        `revoked=${k.revokedAt ? k.revokedAt.toISOString() : "no"}`
+    );
+  }
+}
+
+async function revokeKey(keyId) {
+  const existing = await prisma.mcpKey.findUnique({ where: { id: keyId } });
+  if (!existing) {
+    console.error(`No McpKey with id ${keyId}`);
+    process.exitCode = 1;
+    return;
+  }
+  if (existing.revokedAt) {
+    console.log(`Key ${keyId} (${existing.label}) is already revoked as of ${existing.revokedAt.toISOString()}.`);
+    return;
+  }
+  await prisma.mcpKey.update({ where: { id: keyId }, data: { revokedAt: new Date() } });
+  console.log(`Revoked key ${keyId} (${existing.label}).`);
+}
+
+async function mintKey(email, label) {
+  const user = await prisma.user.findFirst({
+    where: { email: { equals: email, mode: "insensitive" } },
+  });
+  if (!user) {
+    console.error(`No user found with email ${email}`);
+    process.exitCode = 1;
+    return;
+  }
+  if (user.status === "DISABLED") {
+    console.error(`User ${email} is DISABLED — cannot mint a connector key for a disabled user.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const rawKey = randomBytes(32).toString("hex");
+  const keyHash = createHash("sha256").update(rawKey).digest("hex");
+  await prisma.mcpKey.create({
+    data: { label, keyHash, userId: user.id },
+  });
+
+  const url = `https://probuild.goldentouchremodeling.com/api/mcp/mcp?key=${rawKey}`;
+  console.log(`Label: ${label}`);
+  console.log(`User:  ${user.name ?? user.email} <${user.email}>`);
+  console.log(`Connector URL: ${url}`);
+  console.log("This raw key is NOT recoverable — send it to the user over a private channel.");
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  try {
+    if (args[0] === "--list") {
+      await listKeys();
+      return;
+    }
+    if (args[0] === "--revoke") {
+      const keyId = args[1];
+      if (!keyId) {
+        usage();
+        process.exitCode = 1;
+        return;
+      }
+      await revokeKey(keyId);
+      return;
+    }
+    const [email, label] = args;
+    if (!email || !label) {
+      usage();
+      process.exitCode = 1;
+      return;
+    }
+    await mintKey(email, label);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exitCode = 1;
+});

--- a/src/app/api/help-chat/route.ts
+++ b/src/app/api/help-chat/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth/next";
-import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { getCurrentUserWithPermissions } from "@/lib/permissions";
+import { runHelpAgent } from "@/lib/help-agent";
+
+export const maxDuration = 300;
 
 type StructuredHelpResponse =
   | {
@@ -70,16 +72,14 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const session = await getServerSession(authOptions);
-  const sessionUserId = (session?.user as any)?.id;
-  const sessionUserRole = (session?.user as any)?.role;
+  const user = await getCurrentUserWithPermissions();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
-  const { question, currentPage, userId, userRole, conversationId } =
-    await req.json();
-  const effectiveUserId = sessionUserId || userId;
-  const effectiveUserRole = sessionUserRole || userRole || "USER";
+  const { question, currentPage, conversationId } = await req.json();
 
-  if (!question || !effectiveUserId) {
+  if (!question) {
     return NextResponse.json(
       { error: "Missing required fields" },
       { status: 400 }
@@ -90,7 +90,7 @@ export async function POST(req: NextRequest) {
     let convoId = conversationId;
     if (convoId) {
       const existing = await prisma.chatConversation.findFirst({
-        where: { id: convoId, userId: effectiveUserId },
+        where: { id: convoId, userId: user.id },
       });
       if (!existing) convoId = null;
     }
@@ -98,12 +98,21 @@ export async function POST(req: NextRequest) {
     if (!convoId) {
       const convo = await prisma.chatConversation.create({
         data: {
-          userId: effectiveUserId,
+          userId: user.id,
           title: question.slice(0, 80),
         },
       });
       convoId = convo.id;
     }
+
+    // Load prior messages BEFORE persisting the current question, so it
+    // doesn't end up duplicated (once in priorMessages, once appended below).
+    const priorMessages = await prisma.chatMessage.findMany({
+      where: { conversationId: convoId },
+      orderBy: { createdAt: "asc" },
+      take: 20,
+      select: { role: true, content: true },
+    });
 
     await prisma.chatMessage.create({
       data: {
@@ -113,43 +122,16 @@ export async function POST(req: NextRequest) {
       },
     });
 
-    const priorMessages = await prisma.chatMessage.findMany({
-      where: { conversationId: convoId },
-      orderBy: { createdAt: "asc" },
-      take: 20,
-      select: { role: true, content: true },
+    const { text, activity } = await runHelpAgent({
+      user,
+      question,
+      priorMessages: priorMessages.map((m) => ({
+        role: m.role as "user" | "assistant",
+        content: m.content,
+      })),
+      currentPage,
     });
 
-    const response = await fetch("https://api.anthropic.com/v1/messages", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": process.env.ANTHROPIC_API_KEY,
-        "anthropic-version": "2023-06-01",
-      },
-      body: JSON.stringify({
-        model: "claude-sonnet-4-6",
-        max_tokens: 1024,
-        system: `You are a ProBuild help assistant. ProBuild is a construction/remodeling management platform with features for projects, estimates, invoices, leads, time tracking, daily logs, schedules, and reports. The user is on page "${currentPage || "unknown"}". Their role is ${effectiveUserRole}. Answer their question about how to use ProBuild concisely. If the question is about a feature that does not exist yet, respond with ONLY a valid JSON object: {"type":"feature_request","title":"short title","description":"detailed description"} If the user is describing a product bug or broken behavior, respond with ONLY a valid JSON object: {"type":"bug_report","title":"short title","description":"what is broken","steps":"how to reproduce"}. Return only JSON for those two cases, with no markdown wrapping.`,
-        messages: priorMessages.map((m) => ({
-          role: m.role as "user" | "assistant",
-          content: m.content,
-        })),
-      }),
-    });
-
-    if (!response.ok) {
-      const err = await response.text();
-      console.error("Anthropic API error:", err);
-      return NextResponse.json(
-        { error: "AI service error" },
-        { status: 502 }
-      );
-    }
-
-    const data = await response.json();
-    const text =
-      data.content?.[0]?.type === "text" ? data.content[0].text : "";
     const structuredResponse = parseStructuredResponse(text);
 
     await prisma.chatMessage.create({
@@ -167,6 +149,7 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({
       ...structuredResponse,
+      activity,
       conversationId: convoId,
     });
   } catch (error) {

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -3,11 +3,16 @@ import { createMcpHandler } from "mcp-handler";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
+import { logActivity } from "@/lib/actions";
+import { resolveMcpActor, mcpActorStore, currentMcpActor, type McpActor } from "@/lib/mcp-actor";
 import { createEstimateFromPhases, updateEstimateFromPhases, templateToPhases, estimateToPhases, CLOSED_PROJECT_STATUSES, CLOSED_LEAD_STAGES } from "@/lib/gpt-estimate";
 import { getProjectBilling, sendMilestoneInvoicesCore, resendInvoiceCore, createChangeOrderDraft, billChangeOrderCore, sendChangeOrderToClientCore, listReceivables, createInvoiceFromEstimateGuarded, previewCostPlusChangeOrderCore, billCostPlusChangeOrderCore } from "@/lib/billing-core";
 import { getCompanyPipeline, getStartCalendar, getUnappliedChangeOrders, getCrewConflicts } from "@/lib/schedule-core";
 import { coTaxRate, coTaxLabel } from "@/lib/co-tax";
 import { ALLOWED_FILE_EXTENSIONS, fileExtension, mimeTypeForFileName, saveProjectFile } from "@/lib/project-files";
+import { isAncestorFinancial } from "@/lib/file-auth";
+import { downloadDocBytes, resolveDocUrl } from "@/lib/secure-storage";
+import { canAccessProject, hasPermission } from "@/lib/permissions";
 import { calculateCrewTimeCosts, createExpenseCore, createTimeEntryCore, findCrewMatches } from "@/lib/time-expense-core";
 import {
     applyChangeOrderToScheduleWithConfirmation,
@@ -37,6 +42,16 @@ export const maxDuration = 60;
 
 function textResult(data: unknown) {
     return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+// Same convention as FileBrowser.tsx's formatBytes — human-readable size for
+// list_files / read_file output and error messages.
+function formatBytes(bytes: number): string {
+    if (bytes === 0) return "0 B";
+    const k = 1024;
+    const sizes = ["B", "KB", "MB", "GB"];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i];
 }
 
 // Two-step confirmation for customer-facing sends: the preview returns an HMAC
@@ -85,8 +100,194 @@ const milestoneSchema = z.object({
     percentage: z.number().positive().max(100).describe("Percent of the estimate total; all milestones together must sum to exactly 100"),
 });
 
+// ── Audit trail for connector writes ────────────────────────────────────────
+// Every write tool call gets an ActivityLog row (actorName/actorUserId identify
+// who — see src/lib/mcp-actor.ts), read back via get_activity_log below.
+const WRITE_TOOLS = new Set([
+    "create_estimate", "update_estimate", "send_estimate",
+    "send_milestone_invoice", "resend_invoice", "create_invoice_from_estimate",
+    "create_change_order", "send_change_order", "bill_change_order",
+    "create_lead", "log_time", "log_expense", "upload_file",
+    "create_contract", "update_contract", "send_contract",
+    "plan_schedule", "update_task_dates", "set_task_status", "assign_task_crew",
+    "set_project_start_date", "generate_project_schedule", "assign_project_crew",
+    "apply_change_order_to_schedule", "read_file", "get_file_link",
+]);
+const SEND_TOOLS = new Set([
+    "send_estimate", "send_contract", "send_change_order",
+    "send_milestone_invoice", "resend_invoice", "bill_change_order",
+]);
+const ENTITY_TYPE_BY_TOOL: Record<string, string> = {
+    create_contract: "contract", update_contract: "contract", send_contract: "contract",
+    create_estimate: "estimate", update_estimate: "estimate", send_estimate: "estimate",
+    create_invoice_from_estimate: "invoice", send_milestone_invoice: "invoice", resend_invoice: "invoice",
+    create_change_order: "change_order", send_change_order: "change_order", bill_change_order: "change_order",
+    apply_change_order_to_schedule: "change_order",
+    create_lead: "lead",
+    plan_schedule: "task", update_task_dates: "task", set_task_status: "task", assign_task_crew: "task",
+    upload_file: "file", read_file: "file", list_files: "file", get_file_link: "file",
+};
+
+// Args whose VALUE is payload rather than intent — recording even a prefix
+// would turn the activity log into a document store readable by anyone with
+// ADMIN/MANAGER via get_activity_log. Logged as a marker, never the content.
+const AUDIT_REDACTED_ARGS = new Set(["contentBase64", "fileBase64", "bodyHtml", "body", "customMessage"]);
+
+// Shallow sanitize: drop anything that looks like a confirmation token, redact
+// payload-bearing args outright, and cap remaining string values so a huge
+// line-item dump can't blow up the log row.
+function sanitizeMcpArgs(args: Record<string, unknown> | undefined): Record<string, unknown> {
+    const clean: Record<string, unknown> = {};
+    if (!args || typeof args !== "object") return clean;
+    for (const [key, value] of Object.entries(args)) {
+        if (/token/i.test(key)) continue;
+        if (AUDIT_REDACTED_ARGS.has(key)) {
+            clean[key] = typeof value === "string" ? `[redacted: ${value.length} chars]` : "[redacted]";
+            continue;
+        }
+        clean[key] = typeof value === "string" && value.length > 200 ? `${value.slice(0, 200)}…` : value;
+    }
+    return clean;
+}
+
+// The two-step send tools answer a preview call with { preview: true, ... }.
+// Reading the RESULT is the only honest way to label the row: a junk or expired
+// confirmToken still returns a preview (nothing was emailed), and fixed-price
+// bill_change_order executes with no token at all.
+function resultIsPreview(result: unknown): boolean {
+    const content = (result as { content?: Array<{ type?: string; text?: string }> } | undefined)?.content;
+    const text = content?.find(c => c?.type === "text")?.text;
+    if (!text) return false;
+    try {
+        return (JSON.parse(text) as { preview?: unknown })?.preview === true;
+    } catch {
+        return false;
+    }
+}
+
+function buildMcpAuditMetadata(toolName: string, actor: McpActor, args: Record<string, unknown> | undefined, errorText: string | undefined) {
+    const metadata: Record<string, unknown> = {
+        tool: toolName,
+        keyId: actor.keyId,
+        args: sanitizeMcpArgs(args),
+        ...(errorText ? { error: errorText.slice(0, 500) } : {}),
+    };
+    if (JSON.stringify(metadata).length > 4000) {
+        metadata.args = "[omitted: too large]";
+    }
+    return metadata;
+}
+
+async function logMcpAudit(toolName: string, args: Record<string, unknown> | undefined, actor: McpActor, result: unknown, thrown: unknown) {
+    const a = (args ?? {}) as Record<string, unknown>;
+    const resultIsError = !!result && typeof result === "object" && (result as { isError?: boolean }).isError === true;
+    const failed = thrown !== undefined || resultIsError;
+
+    let action: string;
+    if (!SEND_TOOLS.has(toolName)) {
+        action = `mcp_${toolName}`;
+    } else if (!failed && resultIsPreview(result)) {
+        action = `mcp_preview_${toolName}`;
+    } else {
+        // Not a preview: the send actually executed (or attempted and failed).
+        action = `mcp_send_${toolName}`;
+    }
+    if (failed) action += "_failed";
+
+    let projectId = typeof a.projectId === "string" && a.projectId ? a.projectId : null;
+    let leadId = typeof a.leadId === "string" && a.leadId ? a.leadId : null;
+    const entityId =
+        (typeof a.contractId === "string" && a.contractId) ||
+        (typeof a.estimateId === "string" && a.estimateId) ||
+        (typeof a.invoiceId === "string" && a.invoiceId) ||
+        (typeof a.changeOrderId === "string" && a.changeOrderId) ||
+        (typeof a.leadId === "string" && a.leadId) ||
+        (typeof a.taskId === "string" && a.taskId) ||
+        undefined;
+    let entityName: string | undefined;
+
+    // read_file/get_file_link's only arg is fileId — projectId/leadId above are
+    // always null for them, which would otherwise make every row unattributable
+    // to a job. Look the file up once to recover them. A failed lookup must
+    // degrade to nulls, never break the audit write or the tool itself.
+    if ((toolName === "read_file" || toolName === "get_file_link") && typeof a.fileId === "string" && a.fileId) {
+        try {
+            const file = await prisma.projectFile.findUnique({
+                where: { id: a.fileId },
+                select: { projectId: true, leadId: true, name: true },
+            });
+            if (file) {
+                projectId = file.projectId ?? null;
+                leadId = file.leadId ?? null;
+                entityName = file.name;
+            }
+        } catch (err) {
+            console.error("[MCP AUDIT] read_file lookup for audit attribution failed:", err);
+        }
+    }
+
+    let errorText: string | undefined;
+    if (thrown !== undefined) {
+        errorText = thrown instanceof Error ? thrown.message : String(thrown);
+    } else if (resultIsError) {
+        const content = (result as { content?: Array<{ type?: string; text?: string }> }).content;
+        errorText = content?.find(c => c?.type === "text")?.text ?? "Tool reported an error";
+    }
+
+    await logActivity({
+        projectId,
+        leadId,
+        actorType: "TEAM",
+        actorName: actor.name,
+        actorUserId: actor.userId ?? undefined,
+        action,
+        entityType: ENTITY_TYPE_BY_TOOL[toolName],
+        entityId: entityId || undefined,
+        entityName,
+        metadata: buildMcpAuditMetadata(toolName, actor, a, errorText),
+    });
+}
+
+// Monkeypatches registerTool so WRITE_TOOLS get an audit-log wrapper without
+// touching any of the 40 tool bodies below. Must run before the first
+// registerTool call in the initializer.
+function wrapWriteTools(server: { registerTool: (...args: any[]) => unknown }) {
+    const originalRegisterTool = server.registerTool.bind(server);
+    server.registerTool = (name: string, config: unknown, cb: (...cbArgs: any[]) => unknown) => {
+        if (!WRITE_TOOLS.has(name)) {
+            return originalRegisterTool(name, config, cb);
+        }
+        const wrapped = async (args: Record<string, unknown>, extra?: unknown) => {
+            const actor = currentMcpActor();
+            let result: unknown;
+            let thrown: unknown;
+            try {
+                result = await cb(args, extra);
+            } catch (err) {
+                thrown = err;
+            }
+            try {
+                await logMcpAudit(name, args, actor, result, thrown);
+            } catch (auditErr) {
+                // Logging must never break a tool call — but an audit trail
+                // that fails silently is worse than none, so make the gap
+                // loud enough to find in Vercel/Sentry logs.
+                console.error(
+                    `[MCP AUDIT FAILURE] tool=${name} actor=${actor.name} userId=${actor.userId ?? "shared"} — the action ran but was NOT recorded:`,
+                    auditErr
+                );
+            }
+            if (thrown !== undefined) throw thrown;
+            return result;
+        };
+        return originalRegisterTool(name, config, wrapped);
+    };
+}
+
 const handler = createMcpHandler(
     server => {
+        wrapWriteTools(server);
+
         server.registerTool(
             "list_projects",
             {
@@ -1019,6 +1220,339 @@ const handler = createMcpHandler(
             },
         );
 
+        // Shared notion of an "elevated" caller for list_files/read_file. ADMIN
+        // and MANAGER roles are elevated, as is a null actor.userId — that's
+        // the legacy SHARED connector key, which authenticates as the company
+        // and has always had unrestricted access to all 40 tools; making the
+        // file tools uniquely restrictive for it would break the connector
+        // people are using right now. Only a personal key belonging to a
+        // non-admin user gets scoped to what they can actually see in ProBuild.
+        function isElevatedFileActor(actor: McpActor): boolean {
+            return actor.role === "ADMIN" || actor.role === "MANAGER" || actor.userId === null;
+        }
+
+        async function loadActorForFileScope(actor: McpActor) {
+            if (isElevatedFileActor(actor)) return null;
+            return prisma.user.findUnique({
+                where: { id: actor.userId! },
+                select: {
+                    id: true,
+                    role: true,
+                    permissions: true,
+                    projectAccess: { select: { projectId: true } },
+                    assignedProjects: { select: { id: true } },
+                },
+            });
+        }
+
+        async function fileScopeDenial(
+            actor: McpActor,
+            user: Awaited<ReturnType<typeof loadActorForFileScope>>,
+            scope: { projectId?: string | null; leadId?: string | null }
+        ): Promise<string | null> {
+            if (isElevatedFileActor(actor)) return null;
+            if (!user) return "Your connector key isn't linked to an active ProBuild user.";
+            if (!hasPermission(user, "files")) return "Your account doesn't have the Files permission.";
+            if (scope.projectId && !canAccessProject(user, scope.projectId)) {
+                return "You don't have access to that project's files.";
+            }
+            if (scope.leadId) {
+                // Mirrors authorizeFileScope in src/lib/file-auth.ts.
+                if (user.role !== "ADMIN") {
+                    const lead = await prisma.lead.findFirst({
+                        where: { id: scope.leadId, managerId: user.id },
+                        select: { id: true },
+                    });
+                    if (!lead) return "You don't have access to that lead's files.";
+                }
+            }
+            return null;
+        }
+
+        server.registerTool(
+            "list_files",
+            {
+                title: "List a job's files",
+                annotations: { readOnlyHint: true },
+                description:
+                    "Lists the documents and photos on a project's or lead's Files tab (id, name, type, size, folder, uploader). " +
+                    "Pass a file's id to read_file to get its actual contents. Files in a financial folder are hidden from non-admin callers.",
+                inputSchema: {
+                    projectId: z.string().max(50).optional().describe("Project id from find_job (use exactly one of projectId/leadId)"),
+                    leadId: z.string().max(50).optional().describe("Lead id from find_job (use exactly one of projectId/leadId)"),
+                    nameContains: z.string().max(120).optional().describe("Case-insensitive filename filter"),
+                    limit: z.number().int().min(1).max(200).optional().describe("Max rows to return (default 50)"),
+                },
+            },
+            async ({ projectId, leadId, nameContains, limit }) => {
+                if ((projectId ? 1 : 0) + (leadId ? 1 : 0) !== 1) {
+                    return { ...textResult({ error: "Provide exactly one of projectId or leadId (use find_job / list_projects / list_leads to resolve the target)." }), isError: true };
+                }
+
+                const actor = currentMcpActor();
+                const isElevated = isElevatedFileActor(actor);
+                const scopeUser = await loadActorForFileScope(actor);
+                const denial = await fileScopeDenial(actor, scopeUser, { projectId, leadId });
+                if (denial) return { ...textResult({ error: denial }), isError: true };
+
+                const effectiveLimit = limit ?? 50;
+                // Over-fetch, then apply the financial filter, then slice to the
+                // requested limit — otherwise a page of results skewed toward
+                // financial files could come back empty or short for a
+                // non-elevated caller even though more visible files exist further
+                // down the table.
+                const takeCeiling = Math.min(effectiveLimit * 4, 400);
+                const files = await prisma.projectFile.findMany({
+                    where: {
+                        ...(projectId ? { projectId } : { leadId }),
+                        ...(nameContains ? { name: { contains: nameContains, mode: "insensitive" as const } } : {}),
+                    },
+                    orderBy: { createdAt: "desc" },
+                    take: takeCeiling,
+                    include: {
+                        folder: { select: { id: true, name: true, visibility: true } },
+                        uploadedBy: { select: { name: true, email: true } },
+                    },
+                });
+
+                let visibleFiles = files;
+                let hiddenByPermission = 0;
+                if (!isElevated) {
+                    // Distinct folderIds only — one ancestor walk per folder, not per file.
+                    const folderIds = [...new Set(files.map(f => f.folderId).filter((id): id is string => !!id))];
+                    const financialByFolder = new Map<string, boolean>(
+                        await Promise.all(folderIds.map(async (id): Promise<[string, boolean]> => [id, await isAncestorFinancial(id)]))
+                    );
+                    visibleFiles = files.filter(f => {
+                        const hidden = f.visibility === "financial" || (f.folderId ? (financialByFolder.get(f.folderId) ?? false) : false);
+                        if (hidden) hiddenByPermission++;
+                        return !hidden;
+                    });
+                }
+
+                const mayHaveMore = files.length === takeCeiling;
+                const slicedFiles = visibleFiles.slice(0, effectiveLimit);
+
+                return textResult({
+                    count: slicedFiles.length,
+                    // Only elevated callers get this — for a scoped caller, a
+                    // nonzero count would confirm the existence of financial
+                    // files they can't see, which is its own info leak.
+                    ...(isElevated ? { hiddenByPermission } : {}),
+                    ...(mayHaveMore ? { mayHaveMore: true } : {}),
+                    files: slicedFiles.map(f => ({
+                        id: f.id,
+                        name: f.name,
+                        mimeType: f.mimeType,
+                        sizeBytes: f.size,
+                        size: formatBytes(f.size),
+                        folder: f.folder?.name ?? null,
+                        visibility: f.visibility ?? f.folder?.visibility ?? "team",
+                        uploadedBy: f.uploadedBy?.name ?? (f.uploadedByClient ? "client" : null),
+                        uploadedByClient: f.uploadedByClient,
+                        createdAt: f.createdAt,
+                    })),
+                });
+            },
+        );
+
+        const READ_FILE_MAX_BYTES = 25_000_000;
+
+        function extractedTextResult(rawText: string, maxChars: number, sizeBytes?: number) {
+            const normalized = rawText.replace(/\n{3,}/g, "\n\n").trim();
+            const totalChars = normalized.length;
+            const truncated = totalChars > maxChars;
+            // A big PDF that yields almost no text is a drawing or a scan, not a
+            // document — the page content is vector/raster with no text layer.
+            // Verified: a 495 KB architectural foundation plan extracts 36 chars
+            // (just the title block). Say so, or the caller reports the tool as
+            // broken when it worked exactly as designed.
+            const looksLikeNoTextLayer = !!sizeBytes && sizeBytes > 100_000 && totalChars < 200;
+            return {
+                readable: true as const,
+                truncated,
+                totalChars,
+                ...(looksLikeNoTextLayer
+                    ? {
+                          likelyNoTextLayer: true,
+                          note:
+                              "Almost no text came out of a large file — this is very likely a drawing, plan sheet, or scanned page with no embedded text layer. What's below is all there is; the visual content can't be read this way. Open it in ProBuild to view it.",
+                      }
+                    : {}),
+                text: truncated ? normalized.slice(0, maxChars) : normalized,
+            };
+        }
+
+        server.registerTool(
+            "read_file",
+            {
+                title: "Read a file's contents",
+                annotations: { readOnlyHint: true },
+                description:
+                    "Returns extracted text for PDFs, Word docs (.docx) and plain-text/CSV/JSON files on a job's Files tab, so the assistant can actually read a spec, scope sheet, or signed document. " +
+                    "Images and other binary formats return a description instead of content, plus a viewUrl link. Use the id from list_files.",
+                inputSchema: {
+                    fileId: z.string().max(50).describe("File id from list_files"),
+                    maxChars: z.number().int().min(500).max(50_000).optional().describe("Max characters of extracted text to return (default 20000)"),
+                    linkMinutes: z.number().int().min(1).max(120).optional().describe("How long the returned viewUrl stays valid, minutes (default 30)"),
+                },
+            },
+            async ({ fileId, maxChars, linkMinutes }) => {
+                const file = await prisma.projectFile.findUnique({
+                    where: { id: fileId },
+                    select: {
+                        id: true, name: true, url: true, size: true, mimeType: true, visibility: true,
+                        folderId: true, projectId: true, leadId: true,
+                        folder: { select: { id: true, name: true, visibility: true } },
+                    },
+                });
+                if (!file) return { ...textResult({ error: `No file with id ${fileId}. Use list_files.` }), isError: true };
+
+                const actor = currentMcpActor();
+                const isElevated = isElevatedFileActor(actor);
+
+                if (!isElevated) {
+                    const financiallyGated = file.visibility === "financial" || (await isAncestorFinancial(file.folderId));
+                    if (financiallyGated) {
+                        return { ...textResult({ error: "This file is in a financial folder and your account can't read it." }), isError: true };
+                    }
+                    // Use the RESOLVED file's own projectId/leadId, not any
+                    // caller-supplied scope — read_file only takes a fileId, so
+                    // this is the only trustworthy source of what job the file
+                    // belongs to. This also closes the lead-file hole: the old
+                    // check here only ever validated project access.
+                    const scopeUser = await loadActorForFileScope(actor);
+                    const denial = await fileScopeDenial(actor, scopeUser, { projectId: file.projectId, leadId: file.leadId });
+                    if (denial) return { ...textResult({ error: denial }), isError: true };
+                }
+
+                const ext = fileExtension(file.name);
+                const mime = file.mimeType || "";
+                const isGenericMime = mime === "application/octet-stream" || !mime;
+                const effectiveMaxChars = maxChars ?? 20_000;
+                const effectiveLinkMinutes = linkMinutes ?? 30;
+                const viewUrl = await resolveDocUrl(file.url, effectiveLinkMinutes * 60);
+                const base = {
+                    id: file.id, name: file.name, mimeType: file.mimeType, size: file.size, folder: file.folder?.name ?? null,
+                    viewUrl,
+                    ...(viewUrl ? {} : { viewUrlNote: "Could not generate a link for this file." }),
+                };
+
+                const isPdf = mime === "application/pdf" || (isGenericMime && ext === ".pdf");
+                const isDocx = mime.includes("wordprocessingml.document") || (isGenericMime && ext === ".docx");
+                const isPlainText = mime.startsWith("text/") || mime === "application/json" || [".txt", ".md", ".csv", ".json"].includes(ext);
+
+                // Decide readability from mimeType/extension BEFORE downloading
+                // anything — a 20MB photo should never be fetched just to be
+                // told "it's an image". Both branches still carry viewUrl — for
+                // an image or an unsupported type, the link IS the useful output.
+                if (!isPdf && !isDocx && !isPlainText) {
+                    if (mime.startsWith("image/")) {
+                        return textResult({ ...base, readable: false, kind: "image", note: "Images can't be converted to text. Open the link in viewUrl to view the photo." });
+                    }
+                    return textResult({ ...base, readable: false, kind: mime || ext || "unknown", note: "No text extractor for this type — use viewUrl to open it." });
+                }
+
+                // DB `size` ceiling check. This is now the ONLY size guard: the
+                // download below goes through downloadDocBytes against our own
+                // bucket, not an attacker-controlled endpoint, so there's no
+                // untrusted content-length header to double-check against.
+                if (file.size > READ_FILE_MAX_BYTES) {
+                    return { ...textResult({ error: `File is ${formatBytes(file.size)} — too large to read inline (max ${formatBytes(READ_FILE_MAX_BYTES)}).` }), isError: true };
+                }
+
+                const buffer = await downloadDocBytes(file.url);
+                if (!buffer) {
+                    return { ...textResult({ error: "Could not read the file's bytes from storage." }), isError: true };
+                }
+
+                try {
+                    if (isPdf) {
+                        const pdfParseMod: any = await import("pdf-parse");
+                        const PDFParseCtor = pdfParseMod.PDFParse ?? pdfParseMod.default?.PDFParse;
+                        const parser = new PDFParseCtor({ data: buffer });
+                        let text: string;
+                        try {
+                            const result = await parser.getText();
+                            text = result?.text ?? "";
+                        } finally {
+                            await parser.destroy?.();
+                        }
+                        return textResult({ ...base, ...extractedTextResult(text, effectiveMaxChars, file.size) });
+                    }
+                    if (isDocx) {
+                        const mammothMod: any = await import("mammoth");
+                        const extractRawText = mammothMod.extractRawText ?? mammothMod.default?.extractRawText;
+                        const result = await extractRawText({ buffer });
+                        return textResult({ ...base, ...extractedTextResult(result?.value ?? "", effectiveMaxChars, file.size) });
+                    }
+                    // isPlainText is the only remaining possibility — isPdf,
+                    // isDocx and isPlainText are the sole gates past the early
+                    // return above.
+                    return textResult({ ...base, ...extractedTextResult(buffer.toString("utf-8"), effectiveMaxChars) });
+                } catch (err: any) {
+                    return { ...textResult({ error: `Could not extract text: ${err?.message || "unknown error"}` }), isError: true };
+                }
+            },
+        );
+
+        server.registerTool(
+            "get_file_link",
+            {
+                title: "Get a viewable link to a file",
+                annotations: { readOnlyHint: true },
+                description:
+                    "Returns a time-limited link to open or download any file on a job's Files tab — use this for photos, drawings, and scans that read_file can't turn into text, " +
+                    "or whenever the user wants the actual document rather than its extracted text. The link expires after linkMinutes (default 30). Use the id from list_files.",
+                inputSchema: {
+                    fileId: z.string().max(50).describe("File id from list_files"),
+                    linkMinutes: z.number().int().min(1).max(120).optional().describe("How long the returned link stays valid, minutes (default 30)"),
+                },
+            },
+            async ({ fileId, linkMinutes }) => {
+                const file = await prisma.projectFile.findUnique({
+                    where: { id: fileId },
+                    select: {
+                        id: true, name: true, url: true, size: true, mimeType: true, visibility: true,
+                        folderId: true, projectId: true, leadId: true,
+                        folder: { select: { id: true, name: true, visibility: true } },
+                    },
+                });
+                if (!file) return { ...textResult({ error: `No file with id ${fileId}. Use list_files.` }), isError: true };
+
+                const actor = currentMcpActor();
+                const isElevated = isElevatedFileActor(actor);
+
+                if (!isElevated) {
+                    const financiallyGated = file.visibility === "financial" || (await isAncestorFinancial(file.folderId));
+                    if (financiallyGated) {
+                        return { ...textResult({ error: "This file is in a financial folder and your account can't read it." }), isError: true };
+                    }
+                    // Use the RESOLVED file's own projectId/leadId, same as
+                    // read_file — this tool only takes a fileId, so this is the
+                    // only trustworthy source of what job the file belongs to.
+                    const scopeUser = await loadActorForFileScope(actor);
+                    const denial = await fileScopeDenial(actor, scopeUser, { projectId: file.projectId, leadId: file.leadId });
+                    if (denial) return { ...textResult({ error: denial }), isError: true };
+                }
+
+                const effectiveLinkMinutes = linkMinutes ?? 30;
+                const viewUrl = await resolveDocUrl(file.url, effectiveLinkMinutes * 60);
+                if (!viewUrl) {
+                    return { ...textResult({ error: "Could not generate a viewable link for this file." }), isError: true };
+                }
+                return textResult({
+                    id: file.id,
+                    name: file.name,
+                    mimeType: file.mimeType,
+                    size: formatBytes(file.size),
+                    folder: file.folder?.name ?? null,
+                    viewUrl,
+                    expiresInMinutes: effectiveLinkMinutes,
+                });
+            },
+        );
+
         // ── Contracts ──────────────────────────────────────────────────────
         // Standalone legal documents (separate from estimates): HTML body with
         // {{merge_field}} placeholders, client e-sign via portal magic link,
@@ -1629,9 +2163,77 @@ const handler = createMcpHandler(
                 }
             },
         );
+
+        server.registerTool(
+            "get_activity_log",
+            {
+                title: "Review recent ProBuild activity",
+                annotations: { readOnlyHint: true },
+                description:
+                    "Returns the audit trail of actions taken through connectors and the app — newest first: who did what, on which project/lead, and whether a customer-facing send " +
+                    "actually went out or was only previewed. Use to answer 'what did I just do?' or 'what changed on this project recently?'. " +
+                    "Non-admins (anyone without the ADMIN or MANAGER role) only ever see their own actions, scoped to their own connector key.",
+                inputSchema: {
+                    limit: z.number().int().min(1).max(100).optional().describe("Max rows to return (default 25)"),
+                    projectId: z.string().max(50).optional().describe("Restrict to one project's activity"),
+                    actionContains: z.string().max(60).optional().describe("Case-insensitive substring filter on the action, e.g. 'send'"),
+                    sinceDays: z.number().int().min(1).max(90).optional().describe("How many days back to look (default 7)"),
+                },
+            },
+            async ({ limit, projectId, actionContains, sinceDays }) => {
+                const actor = currentMcpActor();
+                const isElevated = actor.role === "ADMIN" || actor.role === "MANAGER";
+                if (!isElevated && !actor.userId) {
+                    return {
+                        ...textResult({ error: "Use a personal connector key to review activity — the shared connector key isn't tied to a person, so it can't be scoped to what's theirs." }),
+                        isError: true,
+                    };
+                }
+
+                const effectiveSinceDays = sinceDays ?? 7;
+                const where: Record<string, unknown> = {
+                    createdAt: { gte: new Date(Date.now() - effectiveSinceDays * 24 * 60 * 60 * 1000) },
+                };
+                if (projectId) where.projectId = projectId;
+                if (actionContains) where.action = { contains: actionContains, mode: "insensitive" };
+                if (!isElevated) where.actorUserId = actor.userId;
+
+                const logs = await prisma.activityLog.findMany({
+                    where,
+                    orderBy: { createdAt: "desc" },
+                    take: limit ?? 25,
+                    select: {
+                        createdAt: true,
+                        actorName: true,
+                        action: true,
+                        entityType: true,
+                        entityName: true,
+                        projectId: true,
+                        metadata: true,
+                    },
+                });
+
+                const projectIds = [...new Set(logs.map(l => l.projectId).filter((id): id is string => !!id))];
+                const projects = projectIds.length
+                    ? await prisma.project.findMany({ where: { id: { in: projectIds } }, select: { id: true, name: true } })
+                    : [];
+                const projectNameById = new Map(projects.map(p => [p.id, p.name]));
+
+                return textResult(logs.map(l => ({
+                    createdAt: l.createdAt,
+                    actorName: l.actorName,
+                    action: l.action,
+                    entityType: l.entityType,
+                    entityName: l.entityName,
+                    projectId: l.projectId,
+                    projectName: l.projectId ? (projectNameById.get(l.projectId) ?? null) : null,
+                    metadata: l.metadata ? JSON.parse(l.metadata) : null,
+                })));
+            },
+        );
     },
     {
-        serverInfo: { name: "probuild", version: "1.12.0" },
+        serverInfo: { name: "probuild", version: "1.14.0" },
         capabilities: { tools: {} },
         instructions:
             "ProBuild is Golden Touch Remodeling's construction management system. " +
@@ -1653,6 +2255,8 @@ const handler = createMcpHandler(
             "once Approved, log_time/log_expense record cost-plus actuals and bill_change_order previews then bills them; fixed orders bill directly → send_milestone_invoice emails the payment link and T&M backup. " +
             "FILES: upload_file parks documents (RFQs, RFIs, spec sheets, generated spreadsheets) on a project's or lead's Files tab — base64 content, ~3 MB max, optional folder. " +
             "Uploads default to internal visibility; only pass visibility 'shared' (customer-visible in the portal) when the user explicitly asks. " +
+            "list_files and read_file let you inspect a job's existing documents — list a project's or lead's Files tab, then pull a PDF/Word/text file's actual contents to read a spec, scope sheet, or signed document. " +
+            "Photos and scans have no text to extract, so read_file returns a viewUrl link for them instead — get_file_link returns that same kind of time-limited link on demand for any file, which is the right tool whenever the user wants to actually view a photo or drawing rather than read its text. " +
             "SCHEDULING: get_company_schedule answers 'what jobs are waiting to start?' and lists upcoming project starts (plus lead expected starts) " +
             "for the next N days, with each project's crew and a crewConflicts block (double-bookings across overlapping project windows). " +
             "get_project_schedule returns one job's task-level plan; list_crew_availability returns only field-crew bookings/free days and never rates or financials. " +
@@ -1670,25 +2274,27 @@ const handler = createMcpHandler(
     { basePath: "/api/mcp", maxDuration: 60 },
 );
 
-// Shared-secret gate. Hash both sides to a fixed length before the timing-safe
-// compare so neither content nor secret length leaks through timing.
-function authorized(req: Request): boolean {
-    const secret = process.env.MCP_SECRET;
-    if (!secret) return false;
-    const key = new URL(req.url).searchParams.get("key") ?? "";
-    const a = createHash("sha256").update(key).digest();
-    const b = createHash("sha256").update(secret).digest();
-    return timingSafeEqual(a, b);
-}
-
-function guarded(req: Request) {
+// Auth: per-person McpKey first, falling back to the legacy shared MCP_SECRET
+// (see src/lib/mcp-actor.ts). The resolved actor rides an AsyncLocalStorage
+// for the life of the request so tool handlers (and the audit wrapper above)
+// can read who's calling without threading it through every function.
+async function guarded(req: Request) {
     if (!process.env.MCP_SECRET) {
         return Response.json({ error: "MCP connector not configured" }, { status: 503 });
     }
-    if (!authorized(req)) {
+    // Every transport mcp-handler serves stays open — ChatGPT negotiates SSE as
+    // well as streamable HTTP, and refusing one silently breaks whichever
+    // connectors chose it. Audit attribution on SSE is handled by keeping the
+    // actor honest rather than by closing the door: each connector URL carries
+    // one person's key and opens its own session, so the session opener IS the
+    // sender; if a message ever escapes this AsyncLocalStorage scope,
+    // currentMcpActor() degrades to "unknown" and the row says so instead of
+    // naming the wrong person.
+    const actor = await resolveMcpActor(req);
+    if (!actor) {
         return Response.json({ error: "unauthorized" }, { status: 401 });
     }
-    return handler(req);
+    return mcpActorStore.run(actor, () => handler(req));
 }
 
 export { guarded as GET, guarded as POST, guarded as DELETE };

--- a/src/components/HelpChatWidget.tsx
+++ b/src/components/HelpChatWidget.tsx
@@ -9,6 +9,7 @@ interface Message {
   content: string;
   featureRequest?: { title: string; description: string };
   bugReport?: { title: string; description: string; steps: string };
+  activity?: { tool: string; ok: boolean }[];
 }
 
 interface ConversationSummary {
@@ -29,8 +30,7 @@ interface HelpRequest {
 }
 
 export default function HelpChatWidget({ userRole }: { userId?: string; userRole?: string }) {
-  const { isAdmin, role, loaded } = usePermissions();
-  const effectiveRole = userRole || role;
+  const { isAdmin, loaded } = usePermissions();
   const effectiveIsAdmin = userRole === "ADMIN" || isAdmin;
 
   const [open, setOpen] = useState(false);
@@ -161,12 +161,13 @@ export default function HelpChatWidget({ userRole }: { userId?: string; userRole
     const data = await apiFetch("/api/help-chat", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ question: userMsg.content, currentPage: pathname, userRole: effectiveRole, conversationId }),
+      body: JSON.stringify({ question: userMsg.content, currentPage: pathname, conversationId }),
     });
 
     if (data) {
       if (data.conversationId) setConversationId(data.conversationId);
       const assistantMsg: Message = { role: "assistant", content: data.answer };
+      if (data.activity?.length) assistantMsg.activity = data.activity;
       if (data.type === "feature_request" && data.title) {
         assistantMsg.featureRequest = { title: data.title, description: data.description };
       }
@@ -265,12 +266,21 @@ export default function HelpChatWidget({ userRole }: { userId?: string; userRole
                 {messages.length === 0 && (
                   <div className="text-center text-sm text-hui-textMuted mt-8">
                     <p className="font-medium text-hui-textMain mb-1">Hi! How can I help?</p>
-                    <p>Ask me anything about using ProBuild.</p>
+                    <p>Ask me anything — or ask me to do it, like &quot;build a contract for the Hoppe job&quot;.</p>
                   </div>
                 )}
                 {messages.map((msg, i) => (
                   <div key={i} className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}>
                     <div className={`max-w-[85%] rounded-lg px-3 py-2 text-sm ${msg.role === "user" ? "text-white" : "bg-white border border-hui-border text-hui-textMain"}`} style={msg.role === "user" ? { backgroundColor: "#4c9a2a" } : undefined}>
+                      {msg.activity && msg.activity.length > 0 && (
+                        <div className="mb-1.5 space-y-0.5">
+                          {msg.activity.map((a, ai) => (
+                            <p key={ai} className="text-[10px] text-hui-textMuted">
+                              {a.ok ? "✓" : "✗"} {a.tool.replace(/_/g, " ")}
+                            </p>
+                          ))}
+                        </div>
+                      )}
                       <p className="whitespace-pre-wrap">{msg.content}</p>
                       {msg.featureRequest && effectiveIsAdmin && (
                         <button onClick={() => submitFeatureRequest(msg.featureRequest!.title, msg.featureRequest!.description)} className="mt-2 text-xs hui-btn-green px-2 py-1 rounded">Submit as feature request?</button>
@@ -281,7 +291,7 @@ export default function HelpChatWidget({ userRole }: { userId?: string; userRole
                     </div>
                   </div>
                 ))}
-                {loading && <div className="flex justify-start"><div className="bg-white border border-hui-border rounded-lg px-3 py-2 text-sm text-hui-textMuted font-medium animate-pulse">Thinking...</div></div>}
+                {loading && <div className="flex justify-start"><div className="bg-white border border-hui-border rounded-lg px-3 py-2 text-sm text-hui-textMuted font-medium animate-pulse">Working on it...</div></div>}
                 <div ref={messagesEndRef} />
               </div>
               <div className="border-t border-hui-border px-3 py-2 bg-white">

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1871,6 +1871,7 @@ export async function logActivity({
     leadId,
     actorType,
     actorName,
+    actorUserId,
     action,
     entityType,
     entityId,
@@ -1881,6 +1882,7 @@ export async function logActivity({
     leadId?: string | null;
     actorType: string;
     actorName: string;
+    actorUserId?: string | null;
     action: string;
     entityType?: string;
     entityId?: string;
@@ -1894,6 +1896,7 @@ export async function logActivity({
                 leadId: leadId ?? null,
                 actorType,
                 actorName,
+                actorUserId: actorUserId ?? null,
                 action,
                 entityType: entityType ?? null,
                 entityId: entityId ?? null,

--- a/src/lib/help-agent.ts
+++ b/src/lib/help-agent.ts
@@ -1,0 +1,505 @@
+import { PermissionKey, hasPermission, canAccessProject } from "@/lib/permissions";
+import { prisma } from "@/lib/prisma";
+
+// Agent runtime for the in-app help chat: gives the assistant live access to
+// ProBuild's own MCP server (src/app/api/mcp/[transport]/route.ts) so it can
+// act on the user's behalf (find jobs, draft estimates/contracts/COs, log
+// time, etc.) instead of only describing UI steps.
+
+const MCP_PROTOCOL_VERSION = "2025-03-26";
+const ADMIN_ROLES = ["ADMIN", "MANAGER"];
+
+export interface McpTool {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+}
+
+interface McpClient {
+  listTools(): Promise<McpTool[]>;
+  callTool(name: string, args: Record<string, unknown>): Promise<unknown>;
+}
+
+function mcpEndpoint(): string | null {
+  const secret = process.env.MCP_SECRET;
+  if (!secret) return null;
+  const baseUrl =
+    process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+  return `${baseUrl}/api/mcp/mcp?key=${encodeURIComponent(secret)}`;
+}
+
+// tools/list and tools/call responses may arrive as SSE ("data: {...}" lines)
+// or as a plain JSON body, depending on how mcp-handler decides to respond.
+function parseMcpBody(text: string): any {
+  const dataLines = text.split("\n").filter((line) => line.startsWith("data: "));
+  if (dataLines.length > 0) {
+    return JSON.parse(dataLines[dataLines.length - 1].slice("data: ".length));
+  }
+  return JSON.parse(text);
+}
+
+let rpcId = 1;
+function nextRpcId() {
+  return rpcId++;
+}
+
+async function mcpRequest(
+  endpoint: string,
+  sessionId: string | null,
+  body: Record<string, unknown>
+): Promise<{ data: any; sessionId: string | null }> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+  };
+  if (sessionId) headers["mcp-session-id"] = sessionId;
+
+  let res: Response;
+  try {
+    res = await fetch(endpoint, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(45_000),
+    });
+  } catch (err) {
+    // Never rethrow the raw fetch error — its message can embed the URL,
+    // which carries the MCP secret in the query string.
+    throw new Error(`MCP request failed: ${err instanceof Error ? err.name : "network error"}`);
+  }
+
+  if (!res.ok) {
+    // Never include the URL in the error — it embeds the MCP secret.
+    throw new Error(`MCP request failed with status ${res.status}`);
+  }
+
+  const newSessionId = res.headers.get("mcp-session-id") || sessionId;
+  const text = await res.text();
+  if (!text.trim()) return { data: null, sessionId: newSessionId };
+  return { data: parseMcpBody(text), sessionId: newSessionId };
+}
+
+export async function mcpClient(): Promise<McpClient> {
+  const rawEndpoint = mcpEndpoint();
+  if (!rawEndpoint) {
+    return {
+      async listTools() {
+        return [];
+      },
+      async callTool() {
+        throw new Error("MCP is not configured (missing MCP_SECRET)");
+      },
+    };
+  }
+  const endpoint: string = rawEndpoint;
+
+  let sessionPromise: Promise<string | null> | null = null;
+
+  function ensureSession(): Promise<string | null> {
+    if (!sessionPromise) {
+      sessionPromise = (async () => {
+        const init = await mcpRequest(endpoint, null, {
+          jsonrpc: "2.0",
+          id: nextRpcId(),
+          method: "initialize",
+          params: {
+            protocolVersion: MCP_PROTOCOL_VERSION,
+            capabilities: {},
+            clientInfo: { name: "probuild-help-agent", version: "1.0.0" },
+          },
+        });
+        const sessionId = init.sessionId;
+        await mcpRequest(endpoint, sessionId, {
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+        });
+        return sessionId;
+      })();
+    }
+    return sessionPromise;
+  }
+
+  return {
+    async listTools() {
+      const sessionId = await ensureSession();
+      const { data } = await mcpRequest(endpoint, sessionId, {
+        jsonrpc: "2.0",
+        id: nextRpcId(),
+        method: "tools/list",
+      });
+      return data?.result?.tools ?? [];
+    },
+    async callTool(name: string, args: Record<string, unknown>) {
+      const sessionId = await ensureSession();
+      const { data } = await mcpRequest(endpoint, sessionId, {
+        jsonrpc: "2.0",
+        id: nextRpcId(),
+        method: "tools/call",
+        params: { name, arguments: args },
+      });
+      if (data?.error) {
+        throw new Error(data.error.message || "MCP tool call failed");
+      }
+      if (data?.result?.isError) {
+        const msg =
+          data.result.content?.map((c: any) => c.text).filter(Boolean).join("\n") ||
+          "Tool reported an error";
+        throw new Error(msg);
+      }
+      return data?.result?.content ?? data?.result ?? null;
+    },
+  };
+}
+
+// Every tool the MCP server exposes must be mapped to the permission that
+// gates it in the UI. null = any authenticated team member. Tools that are
+// NOT in this map (including any added to the MCP server later) default to
+// ADMIN/MANAGER only — see isToolAllowedForUser below.
+export const TOOL_PERMISSIONS: Record<string, PermissionKey | null> = {
+  find_job: null,
+  list_projects: null,
+
+  list_leads: "leadAccess",
+  create_lead: "createLead",
+
+  get_estimating_codes: "estimates",
+  list_templates: "estimates",
+  get_template: "estimates",
+  get_estimate: "estimates",
+  create_estimate: "estimates",
+  update_estimate: "estimates",
+  send_estimate: "estimates",
+
+  list_project_billing: "invoices",
+  send_milestone_invoice: "invoices",
+  resend_invoice: "invoices",
+  create_invoice_from_estimate: "invoices",
+  list_receivables: "invoices",
+
+  create_change_order: "changeOrders",
+  send_change_order: "changeOrders",
+  list_change_orders: "changeOrders",
+  bill_change_order: "changeOrders",
+
+  list_contract_templates: "contracts",
+  list_contracts: "contracts",
+  get_contract: "contracts",
+  create_contract: "contracts",
+  update_contract: "contracts",
+  send_contract: "contracts",
+
+  get_company_schedule: "schedules",
+  get_project_schedule: "schedules",
+  plan_schedule: "schedules",
+  update_task_dates: "schedules",
+  set_task_status: "schedules",
+  assign_task_crew: "schedules",
+  list_crew_availability: "schedules",
+  // set_project_start_date, generate_project_schedule, assign_project_crew,
+  // and apply_change_order_to_schedule are deliberately left OUT of this map.
+  // Unmapped tools fall through to ADMIN/MANAGER-only in isToolAllowedForUser
+  // below, matching the ADMIN-gated UI actions these mirror in actions.ts.
+
+  log_time: "timeClock",
+  log_expense: "timeClock",
+
+  upload_file: "files",
+  list_files: "files",
+  read_file: "files",
+  get_file_link: "files",
+};
+
+function isToolAllowedForUser(
+  user: { role: string; permissions?: any | null },
+  toolName: string
+): boolean {
+  if (!(toolName in TOOL_PERMISSIONS)) {
+    // Unmapped tool (e.g. new tool added to the MCP server): safe default.
+    return ADMIN_ROLES.includes(user.role);
+  }
+  const key = TOOL_PERMISSIONS[toolName];
+  if (key === null) return true;
+  return hasPermission(user, key);
+}
+
+export interface HelpAgentUser {
+  id: string;
+  name?: string | null;
+  role: string;
+  permissions?: any | null;
+  projectAccess?: { projectId: string }[];
+  assignedProjects?: { id: string }[];
+}
+
+export interface HelpAgentMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface HelpAgentResult {
+  text: string;
+  activity: { tool: string; ok: boolean }[];
+}
+
+const MAX_ITERATIONS = 12;
+// Total tool_use blocks executed across the whole request, not just loop
+// iterations — a single model turn can contain many tool_use blocks at once.
+const MAX_TOOL_CALLS = 30;
+
+// Tools whose confirm step actually sends something to a client (email/etc).
+// The in-app help chat may only ever generate a preview for these — the send
+// itself must be completed from the ProBuild page, never from chat.
+const UI_SEND_TOOLS = new Set([
+  "send_estimate",
+  "send_contract",
+  "send_change_order",
+  "send_milestone_invoice",
+  "resend_invoice",
+  "bill_change_order",
+]);
+
+// Recursively redacts any object key that looks like a confirm/send token so
+// a send preview returned to the model can never carry a usable token back
+// to it — structural prevention of self-confirmed sends, not just a prompt
+// instruction.
+function redactTokens(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactTokens);
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = /token/i.test(key) ? "WITHHELD_COMPLETE_SEND_IN_PROBUILD_UI" : redactTokens(v);
+    }
+    return out;
+  }
+  if (typeof value === "string") {
+    // Result parts can carry stringified JSON of their own — scrub token
+    // keys inside nested string values too.
+    return value.replace(
+      /("[\w]*token[\w]*"\s*:\s*")(?:\\.|[^"\\])*(")/gi,
+      "$1WITHHELD_COMPLETE_SEND_IN_PROBUILD_UI$2"
+    );
+  }
+  return value;
+}
+
+// Final sweep over the exact string handed to the model for a send-tool
+// result: the preview confirm tokens are 20-char lowercase-hex HMAC slices
+// (see mintPreviewToken in the MCP route), so removing every 20-char hex run
+// guarantees no usable token survives — regardless of result shape, error
+// path, or how deeply the JSON was string-nested.
+function redactSendTokenText(text: string): string {
+  return text
+    .replace(
+      /(\\*"[\w]*token[\w]*\\*"\s*:\s*\\*")(?:\\.|[^"\\])*?(\\*")/gi,
+      "$1WITHHELD_COMPLETE_SEND_IN_PROBUILD_UI$2"
+    )
+    .replace(/\b[0-9a-f]{20}\b/g, "WITHHELD_COMPLETE_SEND_IN_PROBUILD_UI");
+}
+
+// Args that name an entity whose project must be access-checked for
+// project-scoped (non-ADMIN/MANAGER) users. A bare projectId arg is checked
+// directly; these resolve the parent project first. A null projectId (a
+// lead-scoped estimate/contract/task) is allowed through — lead access is
+// gated by the leadAccess permission, not per-project assignment.
+const ENTITY_PROJECT_LOOKUPS: Record<string, (id: string) => Promise<string | null>> = {
+  estimateId: async (id) =>
+    (await prisma.estimate.findUnique({ where: { id }, select: { projectId: true } }))?.projectId ?? null,
+  invoiceId: async (id) =>
+    (await prisma.invoice.findUnique({ where: { id }, select: { projectId: true } }))?.projectId ?? null,
+  contractId: async (id) =>
+    (await prisma.contract.findUnique({ where: { id }, select: { projectId: true } }))?.projectId ?? null,
+  changeOrderId: async (id) =>
+    (await prisma.changeOrder.findUnique({ where: { id }, select: { projectId: true } }))?.projectId ?? null,
+  taskId: async (id) =>
+    (await prisma.scheduleTask.findUnique({ where: { id }, select: { projectId: true } }))?.projectId ?? null,
+};
+
+// Returns null when allowed, or a denial message for a project the user
+// can't access (directly via args.projectId or implied via an entity id).
+async function projectScopeDenial(
+  user: HelpAgentUser,
+  args: Record<string, unknown>
+): Promise<string | null> {
+  if (ADMIN_ROLES.includes(user.role)) return null;
+  if (typeof args.projectId === "string" && args.projectId && !canAccessProject(user, args.projectId)) {
+    return "Permission denied: you don't have access to that project.";
+  }
+  for (const [argName, lookup] of Object.entries(ENTITY_PROJECT_LOOKUPS)) {
+    const id = args[argName];
+    if (typeof id !== "string" || !id) continue;
+    const projectId = await lookup(id);
+    if (projectId && !canAccessProject(user, projectId)) {
+      return "Permission denied: you don't have access to that project.";
+    }
+  }
+  return null;
+}
+
+export async function runHelpAgent({
+  user,
+  question,
+  priorMessages,
+  currentPage,
+}: {
+  user: HelpAgentUser;
+  question: string;
+  priorMessages: HelpAgentMessage[];
+  currentPage?: string | null;
+}): Promise<HelpAgentResult> {
+  const client = await mcpClient();
+  const allTools = await client.listTools();
+  const allowedTools = allTools.filter((t) => isToolAllowedForUser(user, t.name));
+  // The only names execution will accept — covers both "not permitted" and
+  // "not a real tool on the server" (a hallucinated name must not reach MCP).
+  const allowedToolNames = new Set(allowedTools.map((t) => t.name));
+
+  const anthropicTools = allowedTools.map((t) => ({
+    name: t.name,
+    description: t.description ?? "",
+    input_schema: t.inputSchema,
+  }));
+
+  // currentPage is client-controlled and gets interpolated straight into the
+  // system prompt — only trust it when it looks like a route/path.
+  const safeCurrentPage =
+    typeof currentPage === "string" && /^[a-zA-Z0-9\/\[\]._-]{1,100}$/.test(currentPage)
+      ? currentPage
+      : null;
+  const pageContext = safeCurrentPage ? `, currently on the "${safeCurrentPage}" page` : "";
+
+  const systemPrompt = `You are ProBuild's operations assistant for a remodeling company. You have live tools that can act on the user's behalf inside ProBuild — use them rather than describing UI steps.
+
+The user is ${user.name || "a team member"} (${user.role})${pageContext}.
+
+Rules:
+1. Everything you create lands as a Draft. A send_* tool only ever produces a preview (recipient + amounts) — the in-app chat cannot and will not complete the actual send, even if asked; that step is structurally blocked and always finishes from the ProBuild page (or via the user's connected ChatGPT/Claude). If asked to send something, show the preview and say plainly that they need to finish it from the ProBuild page.
+2. When asked to build something (an estimate, contract, change order, etc.), find the job with find_job first, create the draft, then summarize what you made and where to find it.
+3. If the user reports a bug or asks for a feature that doesn't exist, respond with ONLY the JSON object {"type":"bug_report","title":...,"description":...,"steps":...} or {"type":"feature_request","title":...,"description":...} exactly as this contract — no markdown fences, no other text.
+4. Keep answers short and concrete.`;
+
+  const messages: any[] = priorMessages.map((m) => ({ role: m.role, content: m.content }));
+  messages.push({ role: "user", content: question });
+
+  const activity: { tool: string; ok: boolean }[] = [];
+  let totalToolCalls = 0;
+
+  for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+    const response = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": process.env.ANTHROPIC_API_KEY!,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-6",
+        max_tokens: 2048,
+        system: systemPrompt,
+        messages,
+        ...(anthropicTools.length > 0 ? { tools: anthropicTools } : {}),
+      }),
+      signal: AbortSignal.timeout(120_000),
+    });
+
+    if (!response.ok) {
+      const err = await response.text();
+      throw new Error(`Anthropic API error: ${err}`);
+    }
+
+    const data = await response.json();
+    const content = data.content ?? [];
+    messages.push({ role: "assistant", content });
+
+    if (data.stop_reason !== "tool_use") {
+      const text = content
+        .filter((block: any) => block.type === "text")
+        .map((block: any) => block.text)
+        .join("\n");
+      return { text, activity };
+    }
+
+    const toolResults: any[] = [];
+    for (const block of content) {
+      if (block.type !== "tool_use") continue;
+
+      const args = (block.input ?? {}) as Record<string, unknown>;
+      let ok = true;
+      let denied = false;
+      let resultContent: unknown;
+
+      totalToolCalls++;
+      if (totalToolCalls > MAX_TOOL_CALLS) {
+        ok = false;
+        denied = true;
+        resultContent = "Tool budget for this request is exhausted — summarize progress so far.";
+      } else if (!allowedToolNames.has(block.name) || !isToolAllowedForUser(user, block.name)) {
+        // Defense in depth: the tools array sent to the model is already
+        // pre-filtered, but re-check at execution time so a denied,
+        // unmapped, or hallucinated tool name can never reach MCP.
+        ok = false;
+        denied = true;
+        resultContent = "Permission denied: your account does not have access to this tool.";
+      } else if (UI_SEND_TOOLS.has(block.name) && args.confirmToken) {
+        // Structural send gate: even if the model was handed a confirmToken
+        // from an earlier preview, in-app chat may never use it to send.
+        ok = false;
+        denied = true;
+        resultContent =
+          "In-app chat cannot execute sends. The preview is ready — the user completes the send from the ProBuild page (or via their connected ChatGPT/Claude).";
+      } else {
+        const scopeDenial = await projectScopeDenial(user, args);
+        if (scopeDenial) {
+          ok = false;
+          denied = true;
+          resultContent = scopeDenial;
+        }
+      }
+
+      if (!denied) {
+        try {
+          resultContent = await client.callTool(block.name, args);
+        } catch (err) {
+          ok = false;
+          resultContent = err instanceof Error ? err.message : "Tool call failed";
+        }
+
+        // Redact any confirm/send token in a send-preview result so it can
+        // never be handed back to the model and replayed as a confirmation.
+        if (ok && UI_SEND_TOOLS.has(block.name) && Array.isArray(resultContent)) {
+          resultContent = resultContent.map((part: any) => {
+            if (part && typeof part === "object" && typeof part.text === "string") {
+              try {
+                const parsed = JSON.parse(part.text);
+                return { ...part, text: JSON.stringify(redactTokens(parsed)) };
+              } catch {
+                return part;
+              }
+            }
+            return part;
+          });
+        }
+      }
+
+      activity.push({ tool: block.name, ok });
+      let contentStr =
+        typeof resultContent === "string" ? resultContent : JSON.stringify(resultContent);
+      // Belt and braces on the EXACT string the model will see: whatever the
+      // result shape or error path, no send-preview confirm token survives.
+      if (UI_SEND_TOOLS.has(block.name)) contentStr = redactSendTokenText(contentStr);
+      toolResults.push({
+        type: "tool_result",
+        tool_use_id: block.id,
+        content: contentStr,
+        ...(ok ? {} : { is_error: true }),
+      });
+    }
+    messages.push({ role: "user", content: toolResults });
+  }
+
+  return {
+    text: "I wasn't able to finish that within the allotted number of steps — could you narrow the request?",
+    activity,
+  };
+}

--- a/src/lib/mcp-actor.ts
+++ b/src/lib/mcp-actor.ts
@@ -1,0 +1,91 @@
+import { createHash, timingSafeEqual } from "crypto";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { prisma } from "@/lib/prisma";
+
+// Per-request identity for the MCP connector. A presented `?key=` is looked
+// up against McpKey first (per-person keys minted via scripts/mint-mcp-key.mjs);
+// if that misses, it falls back to the legacy shared MCP_SECRET so the
+// existing ChatGPT connector URL keeps working unchanged.
+
+export interface McpActor {
+    userId: string | null;
+    name: string;
+    role: string | null;
+    keyId: string | null;
+}
+
+// Same semantics as route.ts's `authorized()`: hash both sides to a fixed
+// length before the timing-safe compare so neither content nor length leaks.
+function timingSafeKeyMatches(key: string, secret: string): boolean {
+    const a = createHash("sha256").update(key).digest();
+    const b = createHash("sha256").update(secret).digest();
+    return timingSafeEqual(a, b);
+}
+
+function lookupMcpKey(keyHash: string) {
+    return prisma.mcpKey.findFirst({
+        where: { keyHash, revokedAt: null },
+        include: { user: { select: { id: true, name: true, email: true, role: true, status: true } } },
+    });
+}
+
+export async function resolveMcpActor(req: Request): Promise<McpActor | null> {
+    const key = new URL(req.url).searchParams.get("key") ?? "";
+    if (!key) return null;
+
+    const keyHash = createHash("sha256").update(key).digest("hex");
+    // Fail SOFT: this lookup runs on every request, including ones using the
+    // legacy shared secret. If the McpKey table isn't there yet (build deployed
+    // ahead of scripts/apply-mcp-audit-schema.mjs) or the DB hiccups, fall
+    // through to the shared-secret compare rather than 401-ing the whole
+    // connector. A personal key that can't be looked up simply won't match the
+    // shared secret either, so this doesn't weaken the gate.
+    let mcpKey: Awaited<ReturnType<typeof lookupMcpKey>> = null;
+    try {
+        mcpKey = await lookupMcpKey(keyHash);
+    } catch (err) {
+        console.error("[resolveMcpActor] McpKey lookup failed, falling back to shared secret:", err);
+    }
+
+    // ACTIVATED only — a PENDING invite must not carry connector access.
+    if (mcpKey && mcpKey.user.status === "ACTIVATED") {
+        // Fire-and-forget — never let a lastUsedAt bump fail or slow the request.
+        try {
+            void prisma.mcpKey
+                .update({ where: { id: mcpKey.id }, data: { lastUsedAt: new Date() } })
+                .catch(() => {});
+        } catch {
+            // ignore
+        }
+        return {
+            userId: mcpKey.user.id,
+            name: mcpKey.user.name ?? mcpKey.user.email,
+            role: mcpKey.user.role,
+            keyId: mcpKey.id,
+        };
+    }
+
+    // The shared secret authenticates anonymously and predates per-person keys,
+    // so while it is live nobody's access can truly be revoked — revoking a
+    // personal key still leaves the shared URL working. Once everyone is moved
+    // onto personal keys, set MCP_DISABLE_SHARED_KEY=1 in Vercel to retire it;
+    // MCP_SECRET itself must stay set because it also signs the two-step send
+    // confirmation tokens (mintPreviewToken in the MCP route).
+    if (process.env.MCP_DISABLE_SHARED_KEY === "1") return null;
+
+    const secret = process.env.MCP_SECRET;
+    if (secret && timingSafeKeyMatches(key, secret)) {
+        return { userId: null, name: "ChatGPT connector (shared key)", role: null, keyId: null };
+    }
+
+    return null;
+}
+
+// Request-scoped actor, set once per request in route.ts's `guarded()` via
+// mcpActorStore.run(...) so any tool handler (or the wrapper around it) can
+// read who is calling without threading the actor through every function.
+export const mcpActorStore = new AsyncLocalStorage<McpActor>();
+
+export function currentMcpActor(): McpActor {
+    return mcpActorStore.getStore() ?? { userId: null, name: "unknown", role: null, keyId: null };
+}


### PR DESCRIPTION
## Why

Richard asked whether chat could look at files in ProBuild. It couldn't: the connector only had `upload_file`, and his ChatGPT tool list was a frozen snapshot from before contract tools shipped (ChatGPT caches tools at add-time and never re-discovers them). He refreshed his connector, which fixed the stale list — this PR adds the missing file read side and the attribution needed to audit what gets done through a connector.

## Files — completes the round trip (MCP v1.14.0)

- **`list_files`** — what's on a job's Files tab
- **`read_file`** — text out of PDFs (`pdf-parse` v2 class API), `.docx` (mammoth), and text/CSV/JSON
- **`get_file_link`** — time-limited link to open or download a file
- `upload_file` already covered inbound

Two constraints that shaped this, both measured rather than assumed:

1. **ChatGPT connectors do not render MCP `type:"image"` content blocks** — the response arrives as empty `{}`. So images/drawings go out as links, not embedded content.
2. **Most ProBuild PDFs have no text layer.** A 495 KB architectural plan extracts 36 chars (title block); a signed estimate extracts 27 ("Page 1 of 1"). `read_file` detects this (`likelyNoTextLayer`) and points at the link rather than returning a near-empty string that reads as a bug.

Reads go through `secure-storage`'s `downloadDocBytes` instead of fetching a stored URL — that removes the SSRF surface entirely (no URL is ever dereferenced) and makes private-bucket files readable. Verified live: private download works, a 30-min signed URL serves 200, and the same object unsigned returns 400.

## Attribution + audit

- **`McpKey`** maps a connector key to a ProBuild user, so actions log a name instead of an anonymous shared secret. The shared `MCP_SECRET` keeps working; `MCP_DISABLE_SHARED_KEY=1` retires it once everyone is migrated (until then, per-person revocation is not meaningful — that URL still authenticates).
- A **`registerTool` wrapper** audits every write/send/denial to `ActivityLog` without touching any of the 40 tool bodies.
- Send rows are labelled from the **result**, not from the presence of a `confirmToken` — a junk token still returns a preview, and fixed-price `bill_change_order` sends with no token, so token-presence would mislabel both. 7 cases tested against real prod response shapes.
- **`get_activity_log`** reads the trail back through the connector so it can be reviewed from the field. Non-admins are scoped to their own rows; a shared-key caller is refused.

## In-app help chat

Was a tool-less FAQ bot that also trusted a client-supplied `userId`/`userRole`. Now an agent over the same MCP endpoint, requiring a real session, permission-filtered per user, and structurally barred from completing sends (confirm tokens are redacted before the model sees them).

## Review

Codex reviewed three times; every blocker fixed and re-verified. Notably it caught that `list_files` had no project authorization at all, and that the size ceiling trusted a DB column while reading the body unbounded.

## Deploy note

`scripts/apply-mcp-audit-schema.mjs` **has already been applied to production** (additive: `McpKey` + `ActivityLog.actorUserId`; verified present). Actor resolution also fails soft, falling back to the shared secret if the table is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)