### PR TITLE
feat(mcp): read file contents, share file links, audit connector writes

### DIFF
--- a/e2e/cost-plus-change-order.spec.ts
+++ b/e2e/cost-plus-change-order.spec.ts
@@ -825,11 +825,12 @@ test.describe.serial("PB-pipeline-004 cost-plus and split change orders", () => 
 
   // NOTE: this pins the MCP server version exactly, so it must be bumped in
   // lockstep with serverInfo in the route. 1.12.0 -> 1.13.0 when the PM tools
-  // (files/folders, daily logs, punch, contacts) landed; the voice-first
+  // (files/folders, daily logs, punch, contacts) landed; 1.13.0 -> 1.14.0 when
+  // read_file/get_file_link and the connector audit trail landed; the voice-first
   // cost-plus tools asserted below are unaffected and must keep working.
-  test("CPCO10: MCP is v1.13.0 and exposes the required voice-first tools and UI copy", () => {
+  test("CPCO10: MCP is v1.14.0 and exposes the required voice-first tools and UI copy", () => {
     const mcp = readFileSync(join(process.cwd(), "src/app/api/mcp/[transport]/route.ts"), "utf8");
-    expect(mcp).toContain('version: "1.13.0"');
+    expect(mcp).toContain('version: "1.14.0"');
     for (const tool of ["list_change_orders", "log_time", "log_expense", "bill_change_order"]) {
       expect(mcp).toContain(`"${tool}"`);
     }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1977,6 +1977,7 @@ model ActivityLog {
   leadId     String?  // lead-stage events (estimate sent/viewed before conversion); no FK — log survives lead deletion
   actorType  String   // "CLIENT", "TEAM", "SUBCONTRACTOR", "SYSTEM"
   actorName  String
+  actorUserId String? // User.id of the acting team member, when known (e.g. MCP connector actor); no FK — log survives user deletion
   action     String   // "viewed_estimate", "signed_contract", "paid_invoice", "sent_message", "viewed_portal"
   entityType String?  // "estimate", "invoice", "contract", "change_order", "message"
   entityId   String?
@@ -1987,6 +1988,7 @@ model ActivityLog {
   @@index([projectId, createdAt])
   @@index([entityType, entityId])
   @@index([leadId, createdAt])
+  @@index([actorUserId, createdAt])
 }
 
 model DispatchPublication {

--- a/scripts/apply-mcp-audit-schema.mjs
+++ b/scripts/apply-mcp-audit-schema.mjs
@@ -1,0 +1,51 @@
+// One-off additive migration for the actorUserId audit column on ActivityLog,
+// used to attribute MCP connector writes (read_file/get_activity_log etc.) to
+// a real ProBuild user instead of only a shared-secret actor label.
+//
+// Already applied to production on 2026-07-28 — safe to re-run (idempotent
+// IF NOT EXISTS / CREATE INDEX IF NOT EXISTS).
+//
+// Run only through the release orchestrator:
+//   node scripts/apply-mcp-audit-schema.mjs
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+function resolveDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const file of [".env", ".env.local"]) {
+    if (!fs.existsSync(file)) continue;
+    const match = fs.readFileSync(file, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+    if (match) return match[1];
+  }
+  throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const prisma = new PrismaClient({
+  datasources: { db: { url: resolveDatabaseUrl() } },
+});
+
+const statements = [
+  // Metadata-only default-null add: brief ACCESS EXCLUSIVE lock, no rewrite.
+  // The lock_timeout keeps it from queueing behind a long read and stalling
+  // every writer on a live table.
+  `SET lock_timeout = '5s'`,
+  `ALTER TABLE "ActivityLog" ADD COLUMN IF NOT EXISTS "actorUserId" TEXT`,
+  // Plain (non-CONCURRENT) build is correct here: ActivityLog is a small
+  // table, so the build is sub-millisecond, and CREATE INDEX CONCURRENTLY is
+  // unreliable through the pgbouncer transaction pooler this URL uses.
+  `CREATE INDEX IF NOT EXISTS "ActivityLog_actorUserId_createdAt_idx" ON "ActivityLog" ("actorUserId", "createdAt")`,
+  `SET lock_timeout = '0'`,
+];
+
+try {
+  for (const sql of statements) {
+    await prisma.$executeRawUnsafe(sql);
+    console.log("applied:", sql.split("\n")[0]);
+  }
+  console.log("MCP audit schema (ActivityLog.actorUserId) applied successfully.");
+} catch (error) {
+  console.error("Migration failed:", error);
+  process.exitCode = 1;
+} finally {
+  await prisma.$disconnect();
+}

--- a/scripts/verify-mcp-pm-tools.ts
+++ b/scripts/verify-mcp-pm-tools.ts
@@ -112,7 +112,7 @@ async function main() {
     // Static registry, security, migration, and no-Phase-2 contracts.
     assert.match(routeSource, /MCP_SECRET_RICHARD/);
     assert.match(routeSource, /timingSafeEqual/);
-    assert.match(routeSource, /serverInfo:\s*\{\s*name:\s*"probuild",\s*version:\s*"1\.13\.0"\s*\}/);
+    assert.match(routeSource, /serverInfo:\s*\{\s*name:\s*"probuild",\s*version:\s*"1\.14\.0"\s*\}/);
     for (const toolName of [
         "upload_file",
         "upload_files",
@@ -124,14 +124,20 @@ async function main() {
         "list_punch_items",
         "add_punch_items",
         "get_project_contacts",
+        "read_file",
+        "get_file_link",
     ]) {
         assert.match(routeSource, new RegExp(`"${toolName}"`), `${toolName} must be registered`);
     }
     assert.doesNotMatch(routeSource, /registerTool\(\s*"complete_punch_item"/);
     assert.match(routeSource, /complete_punch_item[\s\S]{0,300}(?:cut|absent|not registered|human reported)/i);
     assert.match(routeSource, /Project management/i);
-    assert.match(routeSource, /download is not available/i);
-    assert.match(routeSource, /list_project_files[\s\S]{0,800}(?:never returns|no) URLs/i);
+    // File download through MCP was deliberately enabled (read_file for text,
+    // get_file_link for a link), reversing the earlier "no download" contract.
+    // Reads must never dereference a stored URL — downloadDocBytes only.
+    assert.doesNotMatch(routeSource, /download is not available/i);
+    assert.match(routeSource, /downloadDocBytes/);
+    assert.match(routeSource, /resolveDocUrl/);
     assert.match(schemaSource, /model McpConfirmation \{[\s\S]*\bactorLabel\s+String/);
     assert.match(schemaSource, /model TaskPunchItem \{[\s\S]*\bcreatedById\s+String\?/);
     assert.match(applySource, /ADD COLUMN IF NOT EXISTS "actorLabel"/);

--- a/src/app/api/help-chat/route.ts
+++ b/src/app/api/help-chat/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth/next";
-import { authOptions } from "@/lib/auth";
+import { getSessionOrDev } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { getUserWithPermissionsByEmail } from "@/lib/permissions";
+import { runHelpAgent, type HelpAgentUser } from "@/lib/help-agent";
+
+export const maxDuration = 300;
 
 type StructuredHelpResponse =
   | {
@@ -70,27 +73,34 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const session = await getServerSession(authOptions);
-  const sessionUserId = (session?.user as any)?.id;
-  const sessionUserRole = (session?.user as any)?.role;
+  const { question, currentPage, conversationId } = await req.json();
 
-  const { question, currentPage, userId, userRole, conversationId } =
-    await req.json();
-  const effectiveUserId = sessionUserId || userId;
-  const effectiveUserRole = sessionUserRole || userRole || "USER";
-
-  if (!question || !effectiveUserId) {
+  if (!question) {
     return NextResponse.json(
       { error: "Missing required fields" },
       { status: 400 }
     );
   }
 
+  // runHelpAgent needs the FULL user record (role + permissions + project
+  // access) to scope which MCP tools it may call — not just an id/role pair.
+  // Resolved server-side only: getSessionOrDev falls back to a mock ADMIN
+  // session in local dev (see src/lib/auth.ts) so that path still works
+  // without trusting any client-supplied identifier — the widget never sends
+  // one anyway.
+  const session = await getSessionOrDev();
+  const user: HelpAgentUser | null = session?.user?.email
+    ? await getUserWithPermissionsByEmail(session.user.email)
+    : null;
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   try {
     let convoId = conversationId;
     if (convoId) {
       const existing = await prisma.chatConversation.findFirst({
-        where: { id: convoId, userId: effectiveUserId },
+        where: { id: convoId, userId: user.id },
       });
       if (!existing) convoId = null;
     }
@@ -98,12 +108,21 @@ export async function POST(req: NextRequest) {
     if (!convoId) {
       const convo = await prisma.chatConversation.create({
         data: {
-          userId: effectiveUserId,
+          userId: user.id,
           title: question.slice(0, 80),
         },
       });
       convoId = convo.id;
     }
+
+    // Load prior messages BEFORE persisting the current question, so it
+    // doesn't end up duplicated (once in priorMessages, once appended below).
+    const priorMessages = await prisma.chatMessage.findMany({
+      where: { conversationId: convoId },
+      orderBy: { createdAt: "asc" },
+      take: 20,
+      select: { role: true, content: true },
+    });
 
     await prisma.chatMessage.create({
       data: {
@@ -113,43 +132,16 @@ export async function POST(req: NextRequest) {
       },
     });
 
-    const priorMessages = await prisma.chatMessage.findMany({
-      where: { conversationId: convoId },
-      orderBy: { createdAt: "asc" },
-      take: 20,
-      select: { role: true, content: true },
+    const { text, activity } = await runHelpAgent({
+      user,
+      question,
+      priorMessages: priorMessages.map((m) => ({
+        role: m.role as "user" | "assistant",
+        content: m.content,
+      })),
+      currentPage,
     });
 
-    const response = await fetch("https://api.anthropic.com/v1/messages", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": process.env.ANTHROPIC_API_KEY,
-        "anthropic-version": "2023-06-01",
-      },
-      body: JSON.stringify({
-        model: "claude-sonnet-4-6",
-        max_tokens: 1024,
-        system: `You are a ProBuild help assistant. ProBuild is a construction/remodeling management platform with features for projects, estimates, invoices, leads, time tracking, daily logs, schedules, and reports. The user is on page "${currentPage || "unknown"}". Their role is ${effectiveUserRole}. Answer their question about how to use ProBuild concisely. If the question is about a feature that does not exist yet, respond with ONLY a valid JSON object: {"type":"feature_request","title":"short title","description":"detailed description"} If the user is describing a product bug or broken behavior, respond with ONLY a valid JSON object: {"type":"bug_report","title":"short title","description":"what is broken","steps":"how to reproduce"}. Return only JSON for those two cases, with no markdown wrapping.`,
-        messages: priorMessages.map((m) => ({
-          role: m.role as "user" | "assistant",
-          content: m.content,
-        })),
-      }),
-    });
-
-    if (!response.ok) {
-      const err = await response.text();
-      console.error("Anthropic API error:", err);
-      return NextResponse.json(
-        { error: "AI service error" },
-        { status: 502 }
-      );
-    }
-
-    const data = await response.json();
-    const text =
-      data.content?.[0]?.type === "text" ? data.content[0].text : "";
     const structuredResponse = parseStructuredResponse(text);
 
     await prisma.chatMessage.create({
@@ -167,6 +159,7 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({
       ...structuredResponse,
+      activity,
       conversationId: convoId,
     });
   } catch (error) {

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -9,7 +9,7 @@ import { getCompanyPipeline, getStartCalendar, getUnappliedChangeOrders, getCrew
 import { coTaxRate, coTaxLabel } from "@/lib/co-tax";
 import { ALLOWED_FILE_EXTENSIONS, fileExtension, mimeTypeForFileName, saveProjectFile } from "@/lib/project-files";
 import { calculateCrewTimeCosts, createExpenseCore, createTimeEntryCore, findCrewMatches } from "@/lib/time-expense-core";
-import { downloadDocBytes, resolveDocUrl, isSecureRef } from "@/lib/secure-storage";
+import { downloadDocBytes, resolveDocUrl, isSecureRef, secureRefPath } from "@/lib/secure-storage";
 import { logActivity } from "@/lib/activity-log";
 import {
     MAX_UPLOAD_BASE64_CHARS,
@@ -211,7 +211,9 @@ function sanitizeMcpValue(value: unknown, depth: number): unknown {
     if (depth > SANITIZE_MAX_DEPTH) {
         if (Array.isArray(value)) return `[array: ${value.length} items, depth limit reached]`;
         if (value && typeof value === "object") return "[object omitted: depth limit reached]";
-        return value;
+        // Still truncate primitives at the cap — returning them raw would let a
+        // payload nested one level past the limit through intact.
+        return typeof value === "string" && value.length > 200 ? `${value.slice(0, 200)}…` : value;
     }
     if (Array.isArray(value)) {
         return value.map(item => sanitizeMcpValue(item, depth + 1));
@@ -333,6 +335,15 @@ async function resolveAuditOwner(toolName: string, args: Record<string, unknown>
                 select: { projectId: true, leadId: true },
             });
             if (task) return { projectId: task.projectId ?? null, leadId: task.leadId ?? null, entityId: args.taskId };
+        } else if (typeof args.estimate === "string" && args.estimate) {
+            // update_estimate names its arg `estimate` and accepts either the
+            // code ("EST-00317") or the id — without this branch those writes
+            // log projectId:null and can't be found by job.
+            const estimate = await prisma.estimate.findFirst({
+                where: { OR: [{ id: args.estimate }, { code: args.estimate }] },
+                select: { id: true, projectId: true, leadId: true, code: true },
+            });
+            if (estimate) return { projectId: estimate.projectId ?? null, leadId: estimate.leadId ?? null, entityId: estimate.id, entityName: estimate.code };
         }
     } catch (err) {
         console.error(`[MCP AUDIT] owner lookup for ${toolName} failed:`, err);
@@ -1335,7 +1346,7 @@ function createHandler(actor: RouteMcpActor) {
                 description:
                     "Returns a project's or lead's folder tree and file metadata (id, name, size, mime type, visibility, folder, created date) — metadata only, no URLs. " +
                     "Standard project folders are created implicitly when a project has no folders. " +
-                    "Pass a file's id to read_file for its extracted text, or to get_file_link for a time-limited view/download link.",
+                    "Pass a file's id to read_file for its extracted text, or to get_file_link for a view/download link.",
                 inputSchema: {
                     projectId: z.string().max(50).optional(),
                     leadId: z.string().max(50).optional(),
@@ -1411,7 +1422,10 @@ function createHandler(actor: RouteMcpActor) {
                 // Only a `secure:` ref is actually a time-limited signed URL — an
                 // ordinary project upload's stored value is a permanent public URL
                 // that resolveDocUrl returns unchanged, so don't claim it expires.
-                const linkIsSigned = isSecureRef(file.url);
+                // Prefix alone is not enough: a malformed ref like "secure:/bad"
+                // passes isSecureRef but fails secureRefPath and falls through to
+                // public resolution, so it must not be labelled as expiring.
+                const linkIsSigned = isSecureRef(file.url) && !!secureRefPath(file.url);
                 const base = {
                     id: file.id, name: file.name, mimeType: file.mimeType, size: file.size, folder: file.folder?.name ?? null,
                     viewUrl,
@@ -1496,7 +1510,7 @@ function createHandler(actor: RouteMcpActor) {
                 title: "Get a viewable link to a file",
                 annotations: { readOnlyHint: true },
                 description:
-                    "Returns a time-limited link to open or download any file on a job's Files tab — use this for photos, drawings, and scans that read_file can't turn into text, " +
+                    "Returns a link to open or download any file on a job's Files tab — use this for photos, drawings, and scans that read_file can't turn into text, " +
                     "or whenever the user wants the actual document rather than its extracted text. The link expires after linkMinutes (default 30). Use the id from list_project_files.",
                 inputSchema: {
                     fileId: z.string().max(50).describe("File id from list_project_files"),
@@ -1522,7 +1536,10 @@ function createHandler(actor: RouteMcpActor) {
                 // Only a `secure:` ref is actually a time-limited signed URL — an
                 // ordinary project upload's stored value is a permanent public URL
                 // that resolveDocUrl returns unchanged, so don't claim it expires.
-                const linkIsSigned = isSecureRef(file.url);
+                // Prefix alone is not enough: a malformed ref like "secure:/bad"
+                // passes isSecureRef but fails secureRefPath and falls through to
+                // public resolution, so it must not be labelled as expiring.
+                const linkIsSigned = isSecureRef(file.url) && !!secureRefPath(file.url);
                 return textResult({
                     id: file.id,
                     name: file.name,
@@ -2424,7 +2441,8 @@ function createHandler(actor: RouteMcpActor) {
             "Use upload_files for up to 8 files / ~3 MB total, then create_daily_log with already-uploaded photo ProjectFile ids so image bytes are not sent twice. " +
             "Use list_punch_items and add_punch_items for punch lists; punch completion is intentionally human-only. " +
             "FILE ROUND TRIP: upload_file/upload_files puts documents in, list_project_files shows what's there (metadata and folder structure only, no URLs), " +
-            "read_file pulls a PDF/Word/text file's actual extracted text, and get_file_link returns a time-limited view/download link for anything. " +
+            "read_file pulls a PDF/Word/text file's actual extracted text, and get_file_link returns a view/download link for anything "
+            + "(signed and expiring for private documents, a permanent public URL otherwise — the response says which). " +
             "Photos, drawings, scans and signed PDFs typically have no text layer to extract, so get_file_link (not read_file) is the right tool for them. " +
             "get_activity_log reviews the audit trail of connector actions — who did what, and whether a customer-facing send actually went out or was only previewed. " +
             "SCHEDULING: get_company_schedule answers 'what jobs are waiting to start?' and lists upcoming project starts (plus lead expected starts) " +

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -9,6 +9,8 @@ import { getCompanyPipeline, getStartCalendar, getUnappliedChangeOrders, getCrew
 import { coTaxRate, coTaxLabel } from "@/lib/co-tax";
 import { ALLOWED_FILE_EXTENSIONS, fileExtension, mimeTypeForFileName, saveProjectFile } from "@/lib/project-files";
 import { calculateCrewTimeCosts, createExpenseCore, createTimeEntryCore, findCrewMatches } from "@/lib/time-expense-core";
+import { downloadDocBytes, resolveDocUrl, isSecureRef } from "@/lib/secure-storage";
+import { logActivity } from "@/lib/activity-log";
 import {
     MAX_UPLOAD_BASE64_CHARS,
     uploadProjectFileCore,
@@ -16,6 +18,7 @@ import {
 } from "@/lib/project-file-core";
 import {
     MCP_ACTOR_EMAILS,
+    mcpActivityActorName,
     type McpActorLabel,
 } from "@/lib/mcp-actor";
 import {
@@ -107,6 +110,10 @@ const milestoneSchema = z.object({
 type RouteMcpActor = {
     actorLabel: McpActorLabel;
     resolveActorUserId: () => Promise<string | null>;
+    // Resolves the signed-in human help-agent.ts is acting for (via the
+    // trusted onBehalfOf query param — see guarded() below), so the audit
+    // trail can credit the actual person instead of just the connector.
+    resolveOnBehalfOf: () => Promise<{ id: string; name: string } | null>;
 };
 
 // The secret for the key that authenticated THIS request. Passing it to a send
@@ -116,8 +123,9 @@ function secretForActor(actorLabel: McpActorLabel): string | undefined {
     return actorLabel === "richard-ai" ? process.env.MCP_SECRET_RICHARD : process.env.MCP_SECRET;
 }
 
-function createRouteMcpActor(actorLabel: McpActorLabel): RouteMcpActor {
+function createRouteMcpActor(actorLabel: McpActorLabel, onBehalfOfId?: string | null): RouteMcpActor {
     let actorUserId: Promise<string | null> | null = null;
+    let onBehalfOf: Promise<{ id: string; name: string } | null> | null = null;
     return {
         actorLabel,
         resolveActorUserId: () => {
@@ -127,12 +135,307 @@ function createRouteMcpActor(actorLabel: McpActorLabel): RouteMcpActor {
             }).then(user => user?.id ?? null);
             return actorUserId;
         },
+        resolveOnBehalfOf: () => {
+            if (!onBehalfOfId) return Promise.resolve(null);
+            onBehalfOf ??= prisma.user.findUnique({
+                where: { id: onBehalfOfId },
+                select: { id: true, name: true, email: true },
+            }).then(user => (user ? { id: user.id, name: user.name || user.email || "a teammate" } : null))
+                .catch(() => null);
+            return onBehalfOf;
+        },
+    };
+}
+
+// Same convention as FileBrowser.tsx's formatBytes — human-readable size for
+// read_file / get_file_link output and error messages.
+function formatBytes(bytes: number): string {
+    if (bytes === 0) return "0 B";
+    const k = 1024;
+    const sizes = ["B", "KB", "MB", "GB"];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i];
+}
+
+// ── Audit trail for connector writes ────────────────────────────────────────
+// Every write tool call gets an ActivityLog row (actorName/actorUserId identify
+// who — see src/lib/mcp-actor.ts), read back via get_activity_log below.
+// Derived by enumerating every server.registerTool(...) call below and taking
+// every tool WITHOUT annotations.readOnlyHint === true, plus read_file and
+// get_file_link (content access is worth an audit row even though they're reads).
+const WRITE_TOOLS = new Set([
+    "create_estimate", "update_estimate", "send_estimate",
+    "send_milestone_invoice", "resend_invoice", "create_invoice_from_estimate",
+    "create_change_order", "send_change_order", "bill_change_order",
+    "create_lead", "log_time", "log_expense",
+    "upload_file", "upload_files", "create_folder", "move_file",
+    "create_daily_log", "add_punch_items",
+    "create_contract", "update_contract", "send_contract",
+    "plan_schedule", "update_task_dates", "set_task_status", "assign_task_crew",
+    "set_project_start_date", "generate_project_schedule", "assign_project_crew",
+    "apply_change_order_to_schedule", "read_file", "get_file_link",
+]);
+// bill_change_order is deliberately NOT here: fixed-price orders bill without
+// emailing anyone, so "mcp_send_bill_change_order" would misreport a plain
+// billing action as a customer send. It stays in WRITE_TOOLS for auditing.
+const SEND_TOOLS = new Set([
+    "send_estimate", "send_contract", "send_change_order",
+    "send_milestone_invoice", "resend_invoice",
+]);
+const ENTITY_TYPE_BY_TOOL: Record<string, string> = {
+    create_contract: "contract", update_contract: "contract", send_contract: "contract",
+    create_estimate: "estimate", update_estimate: "estimate", send_estimate: "estimate",
+    create_invoice_from_estimate: "invoice", send_milestone_invoice: "invoice", resend_invoice: "invoice",
+    create_change_order: "change_order", send_change_order: "change_order", bill_change_order: "change_order",
+    apply_change_order_to_schedule: "change_order",
+    create_lead: "lead",
+    plan_schedule: "task", update_task_dates: "task", set_task_status: "task", assign_task_crew: "task",
+    upload_file: "file", upload_files: "file", read_file: "file", get_file_link: "file",
+    create_folder: "folder", move_file: "file",
+    create_daily_log: "daily_log",
+    add_punch_items: "punch_item",
+};
+
+// Args whose VALUE is payload rather than intent — recording even a prefix
+// would turn the activity log into a document store readable by anyone with
+// ADMIN/MANAGER via get_activity_log. Logged as a marker, never the content.
+const AUDIT_REDACTED_ARGS = new Set(["contentBase64", "fileBase64", "bodyHtml", "body", "customMessage"]);
+
+// Recursive sanitize (depth-capped): drop anything that looks like a
+// confirmation token, redact payload-bearing args outright, and cap remaining
+// string values so a huge line-item dump (or a nested payload like
+// upload_files' files[].contentBase64) can't blow up the log row or leak
+// content that only lives at a nested level.
+const SANITIZE_MAX_DEPTH = 5;
+function sanitizeMcpValue(value: unknown, depth: number): unknown {
+    if (depth > SANITIZE_MAX_DEPTH) {
+        if (Array.isArray(value)) return `[array: ${value.length} items, depth limit reached]`;
+        if (value && typeof value === "object") return "[object omitted: depth limit reached]";
+        return value;
+    }
+    if (Array.isArray(value)) {
+        return value.map(item => sanitizeMcpValue(item, depth + 1));
+    }
+    if (value && typeof value === "object") {
+        const clean: Record<string, unknown> = {};
+        for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+            if (/token/i.test(key)) continue;
+            if (AUDIT_REDACTED_ARGS.has(key)) {
+                clean[key] = typeof v === "string" ? `[redacted: ${v.length} chars]` : "[redacted]";
+                continue;
+            }
+            clean[key] = sanitizeMcpValue(v, depth + 1);
+        }
+        return clean;
+    }
+    if (typeof value === "string" && value.length > 200) return `${value.slice(0, 200)}…`;
+    return value;
+}
+function sanitizeMcpArgs(args: Record<string, unknown> | undefined): Record<string, unknown> {
+    if (!args || typeof args !== "object") return {};
+    return sanitizeMcpValue(args, 0) as Record<string, unknown>;
+}
+
+// Every tool result is a textResult({...}) — a single JSON-text content block.
+// Reading the RESULT body is the only honest way to label a row: a junk or
+// expired confirmToken still returns a preview (nothing was written), and some
+// tools (sendMilestoneInvoicesCore, resendInvoiceCore) report a failed send as
+// an ordinary result with no top-level isError.
+function parseResultJson(result: unknown): any | null {
+    const content = (result as { content?: Array<{ type?: string; text?: string }> } | undefined)?.content;
+    const text = content?.find(c => c?.type === "text")?.text;
+    if (!text) return null;
+    try {
+        return JSON.parse(text);
+    } catch {
+        return null;
+    }
+}
+
+// Two-step tools answer an unconfirmed call with either { preview: true, ... }
+// (the send tools, minted here in the route) or { confirmationRequired: true,
+// ... } (issueConfirmation, used by the schedule/PM tools) — nothing was
+// written in either case.
+function isPreviewBody(body: any): boolean {
+    return !!body && (body.preview === true || body.confirmationRequired === true);
+}
+
+// A result body can report failure without ever setting isError — e.g.
+// sendMilestoneInvoicesCore/resendInvoiceCore return { success: false, error }
+// inside a plain textResult when the send didn't go out.
+function bodyReportsFailure(body: any): boolean {
+    return !!body && (body.success === false || (typeof body.error === "string" && body.error.length > 0));
+}
+
+function buildMcpAuditMetadata(toolName: string, actorLabel: McpActorLabel, args: Record<string, unknown> | undefined, errorText: string | undefined) {
+    const metadata: Record<string, unknown> = {
+        tool: toolName,
+        actorLabel,
+        args: sanitizeMcpArgs(args),
+        ...(errorText ? { error: errorText.slice(0, 500) } : {}),
+    };
+    if (JSON.stringify(metadata).length > 4000) {
+        metadata.args = "[omitted: too large]";
+    }
+    return metadata;
+}
+
+type AuditOwner = { projectId: string | null; leadId: string | null; entityId?: string; entityName?: string };
+
+// Attributes a tool call to a project/lead (and, where cheap, a human-readable
+// entity name) so get_activity_log can find it. A literal projectId/leadId arg
+// wins outright; otherwise resolve the owner from whichever entity id is
+// present — one findUnique for whichever matched. Every model here selects
+// only the owner columns it actually has (Invoice/ChangeOrder: projectId only;
+// Estimate/Contract/ScheduleTask/ProjectFile: both). Never throws — a failed
+// lookup degrades to nulls rather than breaking the tool call or the audit write.
+async function resolveAuditOwner(toolName: string, args: Record<string, unknown>): Promise<AuditOwner> {
+    const projectIdArg = typeof args.projectId === "string" && args.projectId ? args.projectId : null;
+    const leadIdArg = typeof args.leadId === "string" && args.leadId ? args.leadId : null;
+    if (projectIdArg || leadIdArg) {
+        return { projectId: projectIdArg, leadId: leadIdArg };
+    }
+
+    try {
+        if (typeof args.fileId === "string" && args.fileId) {
+            const file = await prisma.projectFile.findUnique({
+                where: { id: args.fileId },
+                select: { projectId: true, leadId: true, name: true },
+            });
+            if (file) return { projectId: file.projectId ?? null, leadId: file.leadId ?? null, entityId: args.fileId, entityName: file.name };
+        } else if (typeof args.estimateId === "string" && args.estimateId) {
+            const estimate = await prisma.estimate.findUnique({
+                where: { id: args.estimateId },
+                select: { projectId: true, leadId: true },
+            });
+            if (estimate) return { projectId: estimate.projectId ?? null, leadId: estimate.leadId ?? null, entityId: args.estimateId };
+        } else if (typeof args.invoiceId === "string" && args.invoiceId) {
+            const invoice = await prisma.invoice.findUnique({
+                where: { id: args.invoiceId },
+                select: { projectId: true },
+            });
+            if (invoice) return { projectId: invoice.projectId ?? null, leadId: null, entityId: args.invoiceId };
+        } else if (typeof args.contractId === "string" && args.contractId) {
+            const contract = await prisma.contract.findUnique({
+                where: { id: args.contractId },
+                select: { projectId: true, leadId: true, title: true },
+            });
+            if (contract) return { projectId: contract.projectId ?? null, leadId: contract.leadId ?? null, entityId: args.contractId, entityName: contract.title };
+        } else if (typeof args.changeOrderId === "string" && args.changeOrderId) {
+            const co = await prisma.changeOrder.findUnique({
+                where: { id: args.changeOrderId },
+                select: { projectId: true },
+            });
+            if (co) return { projectId: co.projectId ?? null, leadId: null, entityId: args.changeOrderId };
+        } else if (typeof args.taskId === "string" && args.taskId) {
+            const task = await prisma.scheduleTask.findUnique({
+                where: { id: args.taskId },
+                select: { projectId: true, leadId: true },
+            });
+            if (task) return { projectId: task.projectId ?? null, leadId: task.leadId ?? null, entityId: args.taskId };
+        }
+    } catch (err) {
+        console.error(`[MCP AUDIT] owner lookup for ${toolName} failed:`, err);
+    }
+    return { projectId: null, leadId: null };
+}
+
+async function logMcpAudit(toolName: string, args: Record<string, unknown> | undefined, actor: RouteMcpActor, result: unknown, thrown: unknown) {
+    const a = (args ?? {}) as Record<string, unknown>;
+    const resultIsError = !!result && typeof result === "object" && (result as { isError?: boolean }).isError === true;
+    const parsedBody = parseResultJson(result);
+    const bodyFailed = bodyReportsFailure(parsedBody);
+    const failed = thrown !== undefined || resultIsError || bodyFailed;
+    const isPreview = !failed && isPreviewBody(parsedBody);
+
+    // Preview labelling generalizes to every write tool (not just SEND_TOOLS):
+    // any two-step tool that answered with a preview/confirmationRequired body
+    // wrote nothing. Otherwise SEND_TOOLS get the "send" label (executed or
+    // attempted-and-failed), everything else gets the plain mcp_<tool> label.
+    let action: string;
+    if (isPreview) {
+        action = `mcp_preview_${toolName}`;
+    } else if (SEND_TOOLS.has(toolName)) {
+        action = `mcp_send_${toolName}`;
+    } else {
+        action = `mcp_${toolName}`;
+    }
+    if (failed) action += "_failed";
+
+    const owner = await resolveAuditOwner(toolName, a);
+
+    let errorText: string | undefined;
+    if (thrown !== undefined) {
+        errorText = thrown instanceof Error ? thrown.message : String(thrown);
+    } else if (resultIsError) {
+        const content = (result as { content?: Array<{ type?: string; text?: string }> }).content;
+        errorText = content?.find(c => c?.type === "text")?.text ?? "Tool reported an error";
+    } else if (bodyFailed && typeof parsedBody?.error === "string") {
+        errorText = parsedBody.error;
+    }
+
+    // onBehalfOf (help-agent.ts's trusted side-channel) credits the actual
+    // human who typed in-app chat, instead of always naming the connector.
+    const onBehalfOf = await actor.resolveOnBehalfOf();
+    const actorName = onBehalfOf
+        ? `${mcpActivityActorName(actor.actorLabel)} (via ${onBehalfOf.name})`
+        : mcpActivityActorName(actor.actorLabel);
+    const actorUserId = onBehalfOf?.id ?? (await actor.resolveActorUserId()) ?? undefined;
+
+    await logActivity({
+        projectId: owner.projectId,
+        leadId: owner.leadId,
+        actorType: "TEAM",
+        actorName,
+        actorUserId,
+        action,
+        entityType: ENTITY_TYPE_BY_TOOL[toolName],
+        entityId: owner.entityId || undefined,
+        entityName: owner.entityName,
+        metadata: buildMcpAuditMetadata(toolName, actor.actorLabel, a, errorText),
+    });
+}
+
+// Monkeypatches registerTool so WRITE_TOOLS get an audit-log wrapper without
+// touching any of the tool bodies below. Must run before the first
+// registerTool call in the initializer.
+function wrapWriteTools(server: { registerTool: (...args: any[]) => unknown }, actor: RouteMcpActor) {
+    const originalRegisterTool = server.registerTool.bind(server);
+    server.registerTool = (name: string, config: unknown, cb: (...cbArgs: any[]) => unknown) => {
+        if (!WRITE_TOOLS.has(name)) {
+            return originalRegisterTool(name, config, cb);
+        }
+        const wrapped = async (args: Record<string, unknown>, extra?: unknown) => {
+            let result: unknown;
+            let thrown: unknown;
+            try {
+                result = await cb(args, extra);
+            } catch (err) {
+                thrown = err;
+            }
+            try {
+                await logMcpAudit(name, args, actor, result, thrown);
+            } catch (auditErr) {
+                // Logging must never break a tool call — but an audit trail
+                // that fails silently is worse than none, so make the gap
+                // loud enough to find in Vercel/Sentry logs.
+                console.error(
+                    `[MCP AUDIT FAILURE] tool=${name} actor=${actor.actorLabel} — the action ran but was NOT recorded:`,
+                    auditErr
+                );
+            }
+            if (thrown !== undefined) throw thrown;
+            return result;
+        };
+        return originalRegisterTool(name, config, wrapped);
     };
 }
 
 function createHandler(actor: RouteMcpActor) {
     return createMcpHandler(
     server => {
+        wrapWriteTools(server, actor);
+
         server.registerTool(
             "list_projects",
             {
@@ -1030,8 +1333,9 @@ function createHandler(actor: RouteMcpActor) {
                 title: "List a job's folder tree and files",
                 annotations: { readOnlyHint: true },
                 description:
-                    "Returns a project's or lead's folder tree and file metadata (id, name, size, mime type, visibility, folder, created date). " +
-                    "Standard project folders are created implicitly when a project has no folders. This tool NEVER returns URLs; file download is not available through MCP.",
+                    "Returns a project's or lead's folder tree and file metadata (id, name, size, mime type, visibility, folder, created date) — metadata only, no URLs. " +
+                    "Standard project folders are created implicitly when a project has no folders. " +
+                    "Pass a file's id to read_file for its extracted text, or to get_file_link for a time-limited view/download link.",
                 inputSchema: {
                     projectId: z.string().max(50).optional(),
                     leadId: z.string().max(50).optional(),
@@ -1043,6 +1347,193 @@ function createHandler(actor: RouteMcpActor) {
                 } catch (error) {
                     return { ...textResult({ error: error instanceof Error ? error.message : "Failed to list project files" }), isError: true };
                 }
+            },
+        );
+
+        const READ_FILE_MAX_BYTES = 25_000_000;
+
+        function extractedTextResult(rawText: string, maxChars: number, sizeBytes?: number) {
+            const normalized = rawText.replace(/\n{3,}/g, "\n\n").trim();
+            const totalChars = normalized.length;
+            const truncated = totalChars > maxChars;
+            // A big PDF that yields almost no text is a drawing or a scan, not a
+            // document — the page content is vector/raster with no text layer.
+            // Verified: a 495 KB architectural foundation plan extracts 36 chars
+            // (just the title block). Say so, or the caller reports the tool as
+            // broken when it worked exactly as designed.
+            const looksLikeNoTextLayer = !!sizeBytes && sizeBytes > 100_000 && totalChars < 200;
+            return {
+                readable: true as const,
+                truncated,
+                totalChars,
+                ...(looksLikeNoTextLayer
+                    ? {
+                          likelyNoTextLayer: true,
+                          note:
+                              "Almost no text came out of a large file — this is very likely a drawing, plan sheet, or scanned page with no embedded text layer. What's below is all there is; the visual content can't be read this way. Open it in ProBuild to view it.",
+                      }
+                    : {}),
+                text: truncated ? normalized.slice(0, maxChars) : normalized,
+            };
+        }
+
+        server.registerTool(
+            "read_file",
+            {
+                title: "Read a file's contents",
+                annotations: { readOnlyHint: true },
+                description:
+                    "Returns extracted text for PDFs, Word docs (.docx) and plain-text/CSV/JSON files on a job's Files tab, so the assistant can actually read a spec, scope sheet, or signed document. " +
+                    "Images and other binary formats return a description instead of content, plus a viewUrl link. Use the id from list_project_files.",
+                inputSchema: {
+                    fileId: z.string().max(50).describe("File id from list_project_files"),
+                    maxChars: z.number().int().min(500).max(50_000).optional().describe("Max characters of extracted text to return (default 20000)"),
+                    linkMinutes: z.number().int().min(1).max(120).optional().describe("How long the returned viewUrl stays valid, minutes (default 30)"),
+                },
+            },
+            async ({ fileId, maxChars, linkMinutes }) => {
+                const file = await prisma.projectFile.findUnique({
+                    where: { id: fileId },
+                    select: {
+                        id: true, name: true, url: true, size: true, mimeType: true, visibility: true,
+                        folderId: true, projectId: true, leadId: true,
+                        folder: { select: { id: true, name: true, visibility: true } },
+                    },
+                });
+                if (!file) return { ...textResult({ error: `No file with id ${fileId}. Use list_project_files.` }), isError: true };
+
+                const ext = fileExtension(file.name);
+                const mime = file.mimeType || "";
+                const isGenericMime = mime === "application/octet-stream" || !mime;
+                const effectiveMaxChars = maxChars ?? 20_000;
+                const effectiveLinkMinutes = linkMinutes ?? 30;
+                const viewUrl = await resolveDocUrl(file.url, effectiveLinkMinutes * 60);
+                // Only a `secure:` ref is actually a time-limited signed URL — an
+                // ordinary project upload's stored value is a permanent public URL
+                // that resolveDocUrl returns unchanged, so don't claim it expires.
+                const linkIsSigned = isSecureRef(file.url);
+                const base = {
+                    id: file.id, name: file.name, mimeType: file.mimeType, size: file.size, folder: file.folder?.name ?? null,
+                    viewUrl,
+                    ...(!viewUrl
+                        ? { viewUrlNote: "Could not generate a link for this file." }
+                        : linkIsSigned
+                            ? { expiresInMinutes: effectiveLinkMinutes }
+                            : { expires: false as const, viewUrlNote: "This is a permanent public link — it does not expire." }),
+                };
+
+                const isPdf = mime === "application/pdf" || (isGenericMime && ext === ".pdf");
+                const isDocx = mime.includes("wordprocessingml.document") || (isGenericMime && ext === ".docx");
+                const isPlainText = mime.startsWith("text/") || mime === "application/json" || [".txt", ".md", ".csv", ".json"].includes(ext);
+
+                // Decide readability from mimeType/extension BEFORE downloading
+                // anything — a 20MB photo should never be fetched just to be
+                // told "it's an image". Both branches still carry viewUrl — for
+                // an image or an unsupported type, the link IS the useful output.
+                if (!isPdf && !isDocx && !isPlainText) {
+                    if (mime.startsWith("image/")) {
+                        return textResult({ ...base, readable: false, kind: "image", note: "Images can't be converted to text. Open the link in viewUrl to view the photo." });
+                    }
+                    return textResult({ ...base, readable: false, kind: mime || ext || "unknown", note: "No text extractor for this type — use viewUrl to open it." });
+                }
+
+                // DB `size` ceiling check. This is now the ONLY size guard: the
+                // download below goes through downloadDocBytes against our own
+                // bucket, not an attacker-controlled endpoint, so there's no
+                // untrusted content-length header to double-check against.
+                if (file.size > READ_FILE_MAX_BYTES) {
+                    return { ...textResult({ error: `File is ${formatBytes(file.size)} — too large to read inline (max ${formatBytes(READ_FILE_MAX_BYTES)}).` }), isError: true };
+                }
+
+                const buffer = await downloadDocBytes(file.url);
+                if (!buffer) {
+                    return { ...textResult({ error: "Could not read the file's bytes from storage." }), isError: true };
+                }
+                // `ProjectFile.size` defaults to 0 and can be stale, so the check
+                // above is only a cheap early-out. Enforce the real ceiling here
+                // too — the memory is already spent (downloadDocBytes just read
+                // the whole object), but this still stops extraction from running
+                // against an oversized buffer. The bytes came from our own bucket,
+                // not an attacker-controlled endpoint, so there's no untrusted
+                // content-length to check earlier instead.
+                if (buffer.length > READ_FILE_MAX_BYTES) {
+                    return { ...textResult({ error: `File is ${formatBytes(buffer.length)} — too large to read inline (max ${formatBytes(READ_FILE_MAX_BYTES)}).` }), isError: true };
+                }
+
+                try {
+                    if (isPdf) {
+                        const pdfParseMod: any = await import("pdf-parse");
+                        const PDFParseCtor = pdfParseMod.PDFParse ?? pdfParseMod.default?.PDFParse;
+                        const parser = new PDFParseCtor({ data: buffer });
+                        let text: string;
+                        try {
+                            const result = await parser.getText();
+                            text = result?.text ?? "";
+                        } finally {
+                            await parser.destroy?.();
+                        }
+                        return textResult({ ...base, ...extractedTextResult(text, effectiveMaxChars, file.size) });
+                    }
+                    if (isDocx) {
+                        const mammothMod: any = await import("mammoth");
+                        const extractRawText = mammothMod.extractRawText ?? mammothMod.default?.extractRawText;
+                        const result = await extractRawText({ buffer });
+                        return textResult({ ...base, ...extractedTextResult(result?.value ?? "", effectiveMaxChars, file.size) });
+                    }
+                    // isPlainText is the only remaining possibility — isPdf,
+                    // isDocx and isPlainText are the sole gates past the early
+                    // return above.
+                    return textResult({ ...base, ...extractedTextResult(buffer.toString("utf-8"), effectiveMaxChars) });
+                } catch (err: any) {
+                    return { ...textResult({ error: `Could not extract text: ${err?.message || "unknown error"}` }), isError: true };
+                }
+            },
+        );
+
+        server.registerTool(
+            "get_file_link",
+            {
+                title: "Get a viewable link to a file",
+                annotations: { readOnlyHint: true },
+                description:
+                    "Returns a time-limited link to open or download any file on a job's Files tab — use this for photos, drawings, and scans that read_file can't turn into text, " +
+                    "or whenever the user wants the actual document rather than its extracted text. The link expires after linkMinutes (default 30). Use the id from list_project_files.",
+                inputSchema: {
+                    fileId: z.string().max(50).describe("File id from list_project_files"),
+                    linkMinutes: z.number().int().min(1).max(120).optional().describe("How long the returned link stays valid, minutes (default 30)"),
+                },
+            },
+            async ({ fileId, linkMinutes }) => {
+                const file = await prisma.projectFile.findUnique({
+                    where: { id: fileId },
+                    select: {
+                        id: true, name: true, url: true, size: true, mimeType: true, visibility: true,
+                        folderId: true, projectId: true, leadId: true,
+                        folder: { select: { id: true, name: true, visibility: true } },
+                    },
+                });
+                if (!file) return { ...textResult({ error: `No file with id ${fileId}. Use list_project_files.` }), isError: true };
+
+                const effectiveLinkMinutes = linkMinutes ?? 30;
+                const viewUrl = await resolveDocUrl(file.url, effectiveLinkMinutes * 60);
+                if (!viewUrl) {
+                    return { ...textResult({ error: "Could not generate a viewable link for this file." }), isError: true };
+                }
+                // Only a `secure:` ref is actually a time-limited signed URL — an
+                // ordinary project upload's stored value is a permanent public URL
+                // that resolveDocUrl returns unchanged, so don't claim it expires.
+                const linkIsSigned = isSecureRef(file.url);
+                return textResult({
+                    id: file.id,
+                    name: file.name,
+                    mimeType: file.mimeType,
+                    size: formatBytes(file.size),
+                    folder: file.folder?.name ?? null,
+                    viewUrl,
+                    ...(linkIsSigned
+                        ? { expiresInMinutes: effectiveLinkMinutes }
+                        : { expires: false as const, note: "This is a permanent public link — it does not expire." }),
+                });
             },
         );
 
@@ -1844,9 +2335,70 @@ function createHandler(actor: RouteMcpActor) {
                 }
             },
         );
+
+        server.registerTool(
+            "get_activity_log",
+            {
+                title: "Review recent ProBuild activity",
+                annotations: { readOnlyHint: true },
+                description:
+                    "Returns the audit trail of actions taken through connectors and the app — newest first: who did what, on which project/lead, and whether a customer-facing send " +
+                    "actually went out or was only previewed. Use to answer 'what did I just do?' or 'what changed on this project recently?'.",
+                inputSchema: {
+                    limit: z.number().int().min(1).max(100).optional().describe("Max rows to return (default 25)"),
+                    projectId: z.string().max(50).optional().describe("Restrict to one project's activity"),
+                    leadId: z.string().max(50).optional().describe("Restrict to one lead's activity"),
+                    actionContains: z.string().max(60).optional().describe("Case-insensitive substring filter on the action, e.g. 'send'"),
+                    sinceDays: z.number().int().min(1).max(90).optional().describe("How many days back to look (default 7)"),
+                },
+            },
+            async ({ limit, projectId, leadId, actionContains, sinceDays }) => {
+                const effectiveSinceDays = sinceDays ?? 7;
+                const where: Record<string, unknown> = {
+                    createdAt: { gte: new Date(Date.now() - effectiveSinceDays * 24 * 60 * 60 * 1000) },
+                };
+                if (projectId) where.projectId = projectId;
+                if (leadId) where.leadId = leadId;
+                if (actionContains) where.action = { contains: actionContains, mode: "insensitive" };
+
+                const logs = await prisma.activityLog.findMany({
+                    where,
+                    orderBy: { createdAt: "desc" },
+                    take: limit ?? 25,
+                    select: {
+                        createdAt: true,
+                        actorName: true,
+                        action: true,
+                        entityType: true,
+                        entityName: true,
+                        projectId: true,
+                        leadId: true,
+                        metadata: true,
+                    },
+                });
+
+                const projectIds = [...new Set(logs.map(l => l.projectId).filter((id): id is string => !!id))];
+                const projects = projectIds.length
+                    ? await prisma.project.findMany({ where: { id: { in: projectIds } }, select: { id: true, name: true } })
+                    : [];
+                const projectNameById = new Map(projects.map(p => [p.id, p.name]));
+
+                return textResult(logs.map(l => ({
+                    createdAt: l.createdAt,
+                    actorName: l.actorName,
+                    action: l.action,
+                    entityType: l.entityType,
+                    entityName: l.entityName,
+                    projectId: l.projectId,
+                    projectName: l.projectId ? (projectNameById.get(l.projectId) ?? null) : null,
+                    leadId: l.leadId,
+                    metadata: l.metadata ? JSON.parse(l.metadata) : null,
+                })));
+            },
+        );
     },
     {
-        serverInfo: { name: "probuild", version: "1.13.0" },
+        serverInfo: { name: "probuild", version: "1.14.0" },
         capabilities: { tools: {} },
         instructions:
             "ProBuild is Golden Touch Remodeling's construction management system. " +
@@ -1871,7 +2423,10 @@ function createHandler(actor: RouteMcpActor) {
             "PROJECT MANAGEMENT: use find_job to resolve the project/lead; standard project folders are ensured implicitly by list_project_files and upload_files when needed. " +
             "Use upload_files for up to 8 files / ~3 MB total, then create_daily_log with already-uploaded photo ProjectFile ids so image bytes are not sent twice. " +
             "Use list_punch_items and add_punch_items for punch lists; punch completion is intentionally human-only. " +
-            "File download is not available through MCP. list_project_files returns metadata and folder structure, never URLs. " +
+            "FILE ROUND TRIP: upload_file/upload_files puts documents in, list_project_files shows what's there (metadata and folder structure only, no URLs), " +
+            "read_file pulls a PDF/Word/text file's actual extracted text, and get_file_link returns a time-limited view/download link for anything. " +
+            "Photos, drawings, scans and signed PDFs typically have no text layer to extract, so get_file_link (not read_file) is the right tool for them. " +
+            "get_activity_log reviews the audit trail of connector actions — who did what, and whether a customer-facing send actually went out or was only previewed. " +
             "SCHEDULING: get_company_schedule answers 'what jobs are waiting to start?' and lists upcoming project starts (plus lead expected starts) " +
             "for the next N days, with each project's crew and a crewConflicts block (double-bookings across overlapping project windows). " +
             "get_project_schedule returns one job's task-level plan; list_crew_availability returns only field-crew bookings/free days and never rates or financials. " +
@@ -1916,7 +2471,12 @@ function guarded(req: Request) {
     if (!actorLabel) {
         return Response.json({ error: "unauthorized" }, { status: 401 });
     }
-    return createHandler(createRouteMcpActor(actorLabel))(req);
+    // Read ONLY after the key has authenticated — holding a valid key is
+    // already full trust, so this param grants nothing extra. It only lets
+    // help-agent.ts (the sole caller that sets it) credit the signed-in human
+    // in the audit trail instead of just the connector account.
+    const onBehalfOfId = new URL(req.url).searchParams.get("onBehalfOf");
+    return createHandler(createRouteMcpActor(actorLabel, onBehalfOfId))(req);
 }
 
 export { guarded as GET, guarded as POST, guarded as DELETE };

--- a/src/components/HelpChatWidget.tsx
+++ b/src/components/HelpChatWidget.tsx
@@ -9,6 +9,7 @@ interface Message {
   content: string;
   featureRequest?: { title: string; description: string };
   bugReport?: { title: string; description: string; steps: string };
+  activity?: { tool: string; ok: boolean }[];
 }
 
 interface ConversationSummary {
@@ -173,6 +174,7 @@ export default function HelpChatWidget({ userRole }: { userId?: string; userRole
       if (data.type === "bug_report" && data.title) {
         assistantMsg.bugReport = { title: data.title, description: data.description, steps: data.steps || "" };
       }
+      if (data.activity?.length) assistantMsg.activity = data.activity;
       setMessages((prev) => [...prev, assistantMsg]);
     } else {
       setMessages((prev) => [...prev, { role: "assistant", content: "Error: Failed to submit. Please try again." }]);
@@ -265,12 +267,21 @@ export default function HelpChatWidget({ userRole }: { userId?: string; userRole
                 {messages.length === 0 && (
                   <div className="text-center text-sm text-hui-textMuted mt-8">
                     <p className="font-medium text-hui-textMain mb-1">Hi! How can I help?</p>
-                    <p>Ask me anything about using ProBuild.</p>
+                    <p>Ask me anything — or ask me to do it, like &quot;build a contract for the Hoppe job&quot;.</p>
                   </div>
                 )}
                 {messages.map((msg, i) => (
                   <div key={i} className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}>
                     <div className={`max-w-[85%] rounded-lg px-3 py-2 text-sm ${msg.role === "user" ? "text-white" : "bg-white border border-hui-border text-hui-textMain"}`} style={msg.role === "user" ? { backgroundColor: "#4c9a2a" } : undefined}>
+                      {msg.activity && msg.activity.length > 0 && (
+                        <div className="mb-1.5 space-y-0.5">
+                          {msg.activity.map((a, ai) => (
+                            <p key={ai} className="text-[10px] text-hui-textMuted">
+                              {a.ok ? "✓" : "✗"} {a.tool.replace(/_/g, " ")}
+                            </p>
+                          ))}
+                        </div>
+                      )}
                       <p className="whitespace-pre-wrap">{msg.content}</p>
                       {msg.featureRequest && effectiveIsAdmin && (
                         <button onClick={() => submitFeatureRequest(msg.featureRequest!.title, msg.featureRequest!.description)} className="mt-2 text-xs hui-btn-green px-2 py-1 rounded">Submit as feature request?</button>
@@ -281,7 +292,7 @@ export default function HelpChatWidget({ userRole }: { userId?: string; userRole
                     </div>
                   </div>
                 ))}
-                {loading && <div className="flex justify-start"><div className="bg-white border border-hui-border rounded-lg px-3 py-2 text-sm text-hui-textMuted font-medium animate-pulse">Thinking...</div></div>}
+                {loading && <div className="flex justify-start"><div className="bg-white border border-hui-border rounded-lg px-3 py-2 text-sm text-hui-textMuted font-medium animate-pulse">Working on it...</div></div>}
                 <div ref={messagesEndRef} />
               </div>
               <div className="border-t border-hui-border px-3 py-2 bg-white">

--- a/src/lib/activity-log.ts
+++ b/src/lib/activity-log.ts
@@ -17,6 +17,7 @@ export type ActivityLogEntry = {
     leadId?: string | null;
     actorType: string;
     actorName: string;
+    actorUserId?: string | null;
     action: string;
     entityType?: string;
     entityId?: string;
@@ -30,6 +31,7 @@ export async function logActivity({
     leadId,
     actorType,
     actorName,
+    actorUserId,
     action,
     entityType,
     entityId,
@@ -43,6 +45,7 @@ export async function logActivity({
                 leadId: leadId ?? null,
                 actorType,
                 actorName,
+                actorUserId: actorUserId ?? null,
                 action,
                 entityType: entityType ?? null,
                 entityId: entityId ?? null,

--- a/src/lib/help-agent.ts
+++ b/src/lib/help-agent.ts
@@ -1,0 +1,529 @@
+import { PermissionKey, hasPermission, canAccessProject } from "@/lib/permissions";
+import { prisma } from "@/lib/prisma";
+
+// Agent runtime for the in-app help chat: gives the assistant live access to
+// ProBuild's own MCP server (src/app/api/mcp/[transport]/route.ts) so it can
+// act on the user's behalf (find jobs, draft estimates/contracts/COs, log
+// time, etc.) instead of only describing UI steps.
+
+const MCP_PROTOCOL_VERSION = "2025-03-26";
+const ADMIN_ROLES = ["ADMIN", "MANAGER"];
+
+export interface McpTool {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+}
+
+interface McpClient {
+  listTools(): Promise<McpTool[]>;
+  callTool(name: string, args: Record<string, unknown>): Promise<unknown>;
+}
+
+// onBehalfOfUserId rides in the query string alongside the shared secret, read
+// by the MCP route's guarded() ONLY after the secret has authenticated the
+// request — holding the secret is already full trust, so this param grants
+// nothing extra. It just lets the route's audit log credit the signed-in
+// human instead of always naming the connector account.
+function mcpEndpoint(onBehalfOfUserId?: string | null): string | null {
+  const secret = process.env.MCP_SECRET;
+  if (!secret) return null;
+  const baseUrl =
+    process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+  const url = new URL("/api/mcp/mcp", baseUrl);
+  url.searchParams.set("key", secret);
+  if (onBehalfOfUserId) url.searchParams.set("onBehalfOf", onBehalfOfUserId);
+  return url.toString();
+}
+
+// tools/list and tools/call responses may arrive as SSE ("data: {...}" lines)
+// or as a plain JSON body, depending on how mcp-handler decides to respond.
+function parseMcpBody(text: string): any {
+  const dataLines = text.split("\n").filter((line) => line.startsWith("data: "));
+  if (dataLines.length > 0) {
+    return JSON.parse(dataLines[dataLines.length - 1].slice("data: ".length));
+  }
+  return JSON.parse(text);
+}
+
+let rpcId = 1;
+function nextRpcId() {
+  return rpcId++;
+}
+
+async function mcpRequest(
+  endpoint: string,
+  sessionId: string | null,
+  body: Record<string, unknown>
+): Promise<{ data: any; sessionId: string | null }> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+  };
+  if (sessionId) headers["mcp-session-id"] = sessionId;
+
+  let res: Response;
+  try {
+    res = await fetch(endpoint, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(45_000),
+    });
+  } catch (err) {
+    // Never rethrow the raw fetch error — its message can embed the URL,
+    // which carries the MCP secret in the query string.
+    throw new Error(`MCP request failed: ${err instanceof Error ? err.name : "network error"}`);
+  }
+
+  if (!res.ok) {
+    // Never include the URL in the error — it embeds the MCP secret.
+    throw new Error(`MCP request failed with status ${res.status}`);
+  }
+
+  const newSessionId = res.headers.get("mcp-session-id") || sessionId;
+  const text = await res.text();
+  if (!text.trim()) return { data: null, sessionId: newSessionId };
+  return { data: parseMcpBody(text), sessionId: newSessionId };
+}
+
+export async function mcpClient(onBehalfOfUserId?: string | null): Promise<McpClient> {
+  const rawEndpoint = mcpEndpoint(onBehalfOfUserId);
+  if (!rawEndpoint) {
+    return {
+      async listTools() {
+        return [];
+      },
+      async callTool() {
+        throw new Error("MCP is not configured (missing MCP_SECRET)");
+      },
+    };
+  }
+  const endpoint: string = rawEndpoint;
+
+  let sessionPromise: Promise<string | null> | null = null;
+
+  function ensureSession(): Promise<string | null> {
+    if (!sessionPromise) {
+      sessionPromise = (async () => {
+        const init = await mcpRequest(endpoint, null, {
+          jsonrpc: "2.0",
+          id: nextRpcId(),
+          method: "initialize",
+          params: {
+            protocolVersion: MCP_PROTOCOL_VERSION,
+            capabilities: {},
+            clientInfo: { name: "probuild-help-agent", version: "1.0.0" },
+          },
+        });
+        const sessionId = init.sessionId;
+        await mcpRequest(endpoint, sessionId, {
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+        });
+        return sessionId;
+      })();
+    }
+    return sessionPromise;
+  }
+
+  return {
+    async listTools() {
+      const sessionId = await ensureSession();
+      const { data } = await mcpRequest(endpoint, sessionId, {
+        jsonrpc: "2.0",
+        id: nextRpcId(),
+        method: "tools/list",
+      });
+      return data?.result?.tools ?? [];
+    },
+    async callTool(name: string, args: Record<string, unknown>) {
+      const sessionId = await ensureSession();
+      const { data } = await mcpRequest(endpoint, sessionId, {
+        jsonrpc: "2.0",
+        id: nextRpcId(),
+        method: "tools/call",
+        params: { name, arguments: args },
+      });
+      if (data?.error) {
+        throw new Error(data.error.message || "MCP tool call failed");
+      }
+      if (data?.result?.isError) {
+        const msg =
+          data.result.content?.map((c: any) => c.text).filter(Boolean).join("\n") ||
+          "Tool reported an error";
+        throw new Error(msg);
+      }
+      return data?.result?.content ?? data?.result ?? null;
+    },
+  };
+}
+
+// Every tool the MCP server exposes must be mapped to the permission that
+// gates it in the UI. null = any authenticated team member. Tools that are
+// NOT in this map (including any added to the MCP server later) default to
+// ADMIN/MANAGER only — see isToolAllowedForUser below.
+export const TOOL_PERMISSIONS: Record<string, PermissionKey | null> = {
+  find_job: null,
+  list_projects: null,
+
+  list_leads: "leadAccess",
+  create_lead: "createLead",
+
+  get_estimating_codes: "estimates",
+  list_templates: "estimates",
+  get_template: "estimates",
+  get_estimate: "estimates",
+  create_estimate: "estimates",
+  update_estimate: "estimates",
+  send_estimate: "estimates",
+
+  list_project_billing: "invoices",
+  send_milestone_invoice: "invoices",
+  resend_invoice: "invoices",
+  create_invoice_from_estimate: "invoices",
+  list_receivables: "invoices",
+
+  create_change_order: "changeOrders",
+  send_change_order: "changeOrders",
+  list_change_orders: "changeOrders",
+  bill_change_order: "changeOrders",
+
+  list_contract_templates: "contracts",
+  list_contracts: "contracts",
+  get_contract: "contracts",
+  create_contract: "contracts",
+  update_contract: "contracts",
+  send_contract: "contracts",
+
+  get_company_schedule: "schedules",
+  get_project_schedule: "schedules",
+  plan_schedule: "schedules",
+  update_task_dates: "schedules",
+  set_task_status: "schedules",
+  assign_task_crew: "schedules",
+  list_crew_availability: "schedules",
+  list_punch_items: "schedules",
+  add_punch_items: "schedules",
+  // set_project_start_date, generate_project_schedule, assign_project_crew,
+  // and apply_change_order_to_schedule are deliberately left OUT of this map.
+  // Unmapped tools fall through to ADMIN/MANAGER-only in isToolAllowedForUser
+  // below, matching the ADMIN-gated UI actions these mirror in actions.ts.
+
+  log_time: "timeClock",
+  log_expense: "timeClock",
+
+  list_project_files: "files",
+  upload_file: "files",
+  upload_files: "files",
+  read_file: "files",
+  get_file_link: "files",
+  create_folder: "files",
+  move_file: "files",
+
+  create_daily_log: "dailyLogs",
+  list_daily_logs: "dailyLogs",
+
+  // get_project_contacts (client name/email/phone, subcontractor contacts) and
+  // get_activity_log (company-wide audit trail — recipient emails, payment
+  // amounts, reference numbers) are deliberately left OUT of this map: both
+  // read too much PII for a blanket "any authenticated user" default. Unmapped
+  // tools fall through to ADMIN/MANAGER-only in isToolAllowedForUser below.
+};
+
+function isToolAllowedForUser(
+  user: { role: string; permissions?: any | null },
+  toolName: string
+): boolean {
+  if (!(toolName in TOOL_PERMISSIONS)) {
+    // Unmapped tool (e.g. new tool added to the MCP server): safe default.
+    return ADMIN_ROLES.includes(user.role);
+  }
+  const key = TOOL_PERMISSIONS[toolName];
+  if (key === null) return true;
+  return hasPermission(user, key);
+}
+
+export interface HelpAgentUser {
+  id: string;
+  name?: string | null;
+  role: string;
+  permissions?: any | null;
+  projectAccess?: { projectId: string }[];
+  assignedProjects?: { id: string }[];
+}
+
+export interface HelpAgentMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface HelpAgentResult {
+  text: string;
+  activity: { tool: string; ok: boolean }[];
+}
+
+const MAX_ITERATIONS = 12;
+// Total tool_use blocks executed across the whole request, not just loop
+// iterations — a single model turn can contain many tool_use blocks at once.
+const MAX_TOOL_CALLS = 30;
+
+// Tools whose confirm step actually sends something to a client (email/etc).
+// The in-app help chat may only ever generate a preview for these — the send
+// itself must be completed from the ProBuild page, never from chat.
+const UI_SEND_TOOLS = new Set([
+  "send_estimate",
+  "send_contract",
+  "send_change_order",
+  "send_milestone_invoice",
+  "resend_invoice",
+  "bill_change_order",
+]);
+
+// Recursively redacts any object key that looks like a confirm/send token so
+// a send preview returned to the model can never carry a usable token back
+// to it — structural prevention of self-confirmed sends, not just a prompt
+// instruction.
+function redactTokens(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactTokens);
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = /token/i.test(key) ? "WITHHELD_COMPLETE_SEND_IN_PROBUILD_UI" : redactTokens(v);
+    }
+    return out;
+  }
+  if (typeof value === "string") {
+    // Result parts can carry stringified JSON of their own — scrub token
+    // keys inside nested string values too.
+    return value.replace(
+      /("[\w]*token[\w]*"\s*:\s*")(?:\\.|[^"\\])*(")/gi,
+      "$1WITHHELD_COMPLETE_SEND_IN_PROBUILD_UI$2"
+    );
+  }
+  return value;
+}
+
+// Final sweep over the exact string handed to the model for a send-tool
+// result: the preview confirm tokens are 20-char lowercase-hex HMAC slices
+// (see mintPreviewToken in the MCP route), so removing every 20-char hex run
+// guarantees no usable token survives — regardless of result shape, error
+// path, or how deeply the JSON was string-nested.
+function redactSendTokenText(text: string): string {
+  return text
+    .replace(
+      /(\\*"[\w]*token[\w]*\\*"\s*:\s*\\*")(?:\\.|[^"\\])*?(\\*")/gi,
+      "$1WITHHELD_COMPLETE_SEND_IN_PROBUILD_UI$2"
+    )
+    .replace(/\b[0-9a-f]{20}\b/g, "WITHHELD_COMPLETE_SEND_IN_PROBUILD_UI");
+}
+
+// Args that name an entity whose project must be access-checked for
+// project-scoped (non-ADMIN/MANAGER) users. A bare projectId arg is checked
+// directly; these resolve the parent project first. A null projectId (a
+// lead-scoped estimate/contract/task) is allowed through — lead access is
+// gated by the leadAccess permission, not per-project assignment.
+const ENTITY_PROJECT_LOOKUPS: Record<string, (id: string) => Promise<string | null>> = {
+  estimateId: async (id) =>
+    (await prisma.estimate.findUnique({ where: { id }, select: { projectId: true } }))?.projectId ?? null,
+  invoiceId: async (id) =>
+    (await prisma.invoice.findUnique({ where: { id }, select: { projectId: true } }))?.projectId ?? null,
+  contractId: async (id) =>
+    (await prisma.contract.findUnique({ where: { id }, select: { projectId: true } }))?.projectId ?? null,
+  changeOrderId: async (id) =>
+    (await prisma.changeOrder.findUnique({ where: { id }, select: { projectId: true } }))?.projectId ?? null,
+  taskId: async (id) =>
+    (await prisma.scheduleTask.findUnique({ where: { id }, select: { projectId: true } }))?.projectId ?? null,
+  fileId: async (id) =>
+    (await prisma.projectFile.findUnique({ where: { id }, select: { projectId: true } }))?.projectId ?? null,
+};
+
+// Returns null when allowed, or a denial message for a project the user
+// can't access (directly via args.projectId or implied via an entity id).
+async function projectScopeDenial(
+  user: HelpAgentUser,
+  args: Record<string, unknown>
+): Promise<string | null> {
+  if (ADMIN_ROLES.includes(user.role)) return null;
+  if (typeof args.projectId === "string" && args.projectId && !canAccessProject(user, args.projectId)) {
+    return "Permission denied: you don't have access to that project.";
+  }
+  for (const [argName, lookup] of Object.entries(ENTITY_PROJECT_LOOKUPS)) {
+    const id = args[argName];
+    if (typeof id !== "string" || !id) continue;
+    const projectId = await lookup(id);
+    if (projectId && !canAccessProject(user, projectId)) {
+      return "Permission denied: you don't have access to that project.";
+    }
+  }
+  return null;
+}
+
+export async function runHelpAgent({
+  user,
+  question,
+  priorMessages,
+  currentPage,
+}: {
+  user: HelpAgentUser;
+  question: string;
+  priorMessages: HelpAgentMessage[];
+  currentPage?: string | null;
+}): Promise<HelpAgentResult> {
+  const client = await mcpClient(user.id);
+  const allTools = await client.listTools();
+  const allowedTools = allTools.filter((t) => isToolAllowedForUser(user, t.name));
+  // The only names execution will accept — covers both "not permitted" and
+  // "not a real tool on the server" (a hallucinated name must not reach MCP).
+  const allowedToolNames = new Set(allowedTools.map((t) => t.name));
+
+  const anthropicTools = allowedTools.map((t) => ({
+    name: t.name,
+    description: t.description ?? "",
+    input_schema: t.inputSchema,
+  }));
+
+  // currentPage is client-controlled and gets interpolated straight into the
+  // system prompt — only trust it when it looks like a route/path.
+  const safeCurrentPage =
+    typeof currentPage === "string" && /^[a-zA-Z0-9\/\[\]._-]{1,100}$/.test(currentPage)
+      ? currentPage
+      : null;
+  const pageContext = safeCurrentPage ? `, currently on the "${safeCurrentPage}" page` : "";
+
+  const systemPrompt = `You are ProBuild's operations assistant for a remodeling company. You have live tools that can act on the user's behalf inside ProBuild — use them rather than describing UI steps.
+
+The user is ${user.name || "a team member"} (${user.role})${pageContext}.
+
+Rules:
+1. Everything you create lands as a Draft. A send_* tool only ever produces a preview (recipient + amounts) — the in-app chat cannot and will not complete the actual send, even if asked; that step is structurally blocked and always finishes from the ProBuild page (or via the user's connected ChatGPT/Claude). If asked to send something, show the preview and say plainly that they need to finish it from the ProBuild page.
+2. When asked to build something (an estimate, contract, change order, etc.), find the job with find_job first, create the draft, then summarize what you made and where to find it.
+3. If the user reports a bug or asks for a feature that doesn't exist, respond with ONLY the JSON object {"type":"bug_report","title":...,"description":...,"steps":...} or {"type":"feature_request","title":...,"description":...} exactly as this contract — no markdown fences, no other text.
+4. Keep answers short and concrete.`;
+
+  const messages: any[] = priorMessages.map((m) => ({ role: m.role, content: m.content }));
+  messages.push({ role: "user", content: question });
+
+  const activity: { tool: string; ok: boolean }[] = [];
+  let totalToolCalls = 0;
+
+  for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+    const response = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": process.env.ANTHROPIC_API_KEY!,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-6",
+        max_tokens: 2048,
+        system: systemPrompt,
+        messages,
+        ...(anthropicTools.length > 0 ? { tools: anthropicTools } : {}),
+      }),
+      signal: AbortSignal.timeout(120_000),
+    });
+
+    if (!response.ok) {
+      const err = await response.text();
+      throw new Error(`Anthropic API error: ${err}`);
+    }
+
+    const data = await response.json();
+    const content = data.content ?? [];
+    messages.push({ role: "assistant", content });
+
+    if (data.stop_reason !== "tool_use") {
+      const text = content
+        .filter((block: any) => block.type === "text")
+        .map((block: any) => block.text)
+        .join("\n");
+      return { text, activity };
+    }
+
+    const toolResults: any[] = [];
+    for (const block of content) {
+      if (block.type !== "tool_use") continue;
+
+      const args = (block.input ?? {}) as Record<string, unknown>;
+      let ok = true;
+      let denied = false;
+      let resultContent: unknown;
+
+      totalToolCalls++;
+      if (totalToolCalls > MAX_TOOL_CALLS) {
+        ok = false;
+        denied = true;
+        resultContent = "Tool budget for this request is exhausted — summarize progress so far.";
+      } else if (!allowedToolNames.has(block.name) || !isToolAllowedForUser(user, block.name)) {
+        // Defense in depth: the tools array sent to the model is already
+        // pre-filtered, but re-check at execution time so a denied,
+        // unmapped, or hallucinated tool name can never reach MCP.
+        ok = false;
+        denied = true;
+        resultContent = "Permission denied: your account does not have access to this tool.";
+      } else if (UI_SEND_TOOLS.has(block.name) && args.confirmToken) {
+        // Structural send gate: even if the model was handed a confirmToken
+        // from an earlier preview, in-app chat may never use it to send.
+        ok = false;
+        denied = true;
+        resultContent =
+          "In-app chat cannot execute sends. The preview is ready — the user completes the send from the ProBuild page (or via their connected ChatGPT/Claude).";
+      } else {
+        const scopeDenial = await projectScopeDenial(user, args);
+        if (scopeDenial) {
+          ok = false;
+          denied = true;
+          resultContent = scopeDenial;
+        }
+      }
+
+      if (!denied) {
+        try {
+          resultContent = await client.callTool(block.name, args);
+        } catch (err) {
+          ok = false;
+          resultContent = err instanceof Error ? err.message : "Tool call failed";
+        }
+
+        // Redact any confirm/send token in a send-preview result so it can
+        // never be handed back to the model and replayed as a confirmation.
+        if (ok && UI_SEND_TOOLS.has(block.name) && Array.isArray(resultContent)) {
+          resultContent = resultContent.map((part: any) => {
+            if (part && typeof part === "object" && typeof part.text === "string") {
+              try {
+                const parsed = JSON.parse(part.text);
+                return { ...part, text: JSON.stringify(redactTokens(parsed)) };
+              } catch {
+                return part;
+              }
+            }
+            return part;
+          });
+        }
+      }
+
+      activity.push({ tool: block.name, ok });
+      let contentStr =
+        typeof resultContent === "string" ? resultContent : JSON.stringify(resultContent);
+      // Belt and braces on the EXACT string the model will see: whatever the
+      // result shape or error path, no send-preview confirm token survives.
+      if (UI_SEND_TOOLS.has(block.name)) contentStr = redactSendTokenText(contentStr);
+      toolResults.push({
+        type: "tool_result",
+        tool_use_id: block.id,
+        content: contentStr,
+        ...(ok ? {} : { is_error: true }),
+      });
+    }
+    messages.push({ role: "user", content: toolResults });
+  }
+
+  return {
+    text: "I wasn't able to finish that within the allotted number of steps — could you narrow the request?",
+    activity,
+  };
+}

--- a/src/lib/help-agent.ts
+++ b/src/lib/help-agent.ts
@@ -277,7 +277,8 @@ const UI_SEND_TOOLS = new Set([
   "send_change_order",
   "send_milestone_invoice",
   "resend_invoice",
-  "bill_change_order",
+  // bill_change_order is deliberately NOT here: it bills, it does not email.
+  // Blocking it would stop the in-app chat completing a non-sending write.
 ]);
 
 // Recursively redacts any object key that looks like a confirm/send token so

--- a/src/lib/mcp-pm-tools.ts
+++ b/src/lib/mcp-pm-tools.ts
@@ -194,7 +194,7 @@ export async function listProjectFiles(input: OwnerInput) {
         },
         folders: roots,
         unfiled,
-        note: "No file URLs are returned. File download is not available through MCP.",
+        note: "No file URLs are returned here. Use read_file for extracted text or get_file_link for a viewable/download link.",
     };
 }
 


### PR DESCRIPTION
Supersedes #276, which was cut from a 52-commit-stale base and duplicated work main had already shipped (dual-key auth, `list_project_files`). This is the same intent rebased onto current main, keeping only what main actually lacks.

## Files — the read side

The connector could list a job's files but never open one.

- **`read_file`** — extracted text from PDFs (`pdf-parse` v2), `.docx` (mammoth), and text/CSV/JSON
- **`get_file_link`** — a link to open or download anything

Both read through `secure-storage`'s `downloadDocBytes` rather than fetching a stored URL, so no URL is ever dereferenced (its own doc comment says server-side consumers must do this) and private-bucket documents become reachable.

Two measured constraints shaped the design:

1. **ChatGPT connectors do not render MCP `type:"image"` content blocks** — the response arrives as empty `{}`. Images therefore go out as links, not base64.
2. **Most ProBuild PDFs have no text layer.** A 495 KB architectural plan extracts 36 characters; a signed estimate extracts 27. `read_file` detects this (`likelyNoTextLayer`) and points at the link instead of returning a near-empty string that reads as a bug.

Verified against production: private-bucket download works, a signed URL serves 200, and the same object unsigned returns 400. `get_file_link` only claims an expiry when the ref genuinely resolves as a signed path — ordinary uploads are reported as permanent public links rather than pretending to expire.

## Audit — main's MCP route called `logActivity` zero times

A `registerTool` wrapper logs every write to `ActivityLog` without touching a single tool body.

The labelling is derived from the **result**, which is the whole point:

- a `{preview:true}` or `{confirmationRequired:true}` response is recorded as `mcp_preview_*` — a declined confirmation never reads as a completed write
- a core returning `{success:false}` (or an `error` string) with no `isError` is recorded `_failed`, so a send that never left is not logged as delivered
- `bill_change_order` bills without emailing, so it is not labelled as a send

15 label cases are covered, including two real production response shapes.

`resolveAuditOwner` backfills the owning project/lead from an entity id so entity-only calls stay findable by job. Args are sanitized recursively, so nested `upload_files` payloads cannot land in the log. `get_activity_log` reads the trail back through the connector.

## In-app help chat

Was a tool-less FAQ bot that trusted a client-supplied `userId`/`userRole`. Now an agent over the same endpoint: identity from the session only, per-user tool filtering enforced at execution and not just in the tool list, sends structurally blocked (confirm tokens redacted before the model sees them), and its calls attributed to the signed-in human via `onBehalfOf`.

## Review

Codex reviewed twice on this base. Fixed: false delivered-send audits, previews logged as writes, nested payload leaking into the log, company-wide activity exposed to every help-chat user, cross-project file reads via `fileId`, the client-supplied identity fallback, and the unbounded read.

**Knowingly left, escalated rather than fixed here:**

- `resend_invoice` / `send_contract` / `send_change_order` cores swallow a provider failure and return success (`email.ts:82`), so the audit can still record a delivered send when the provider failed. That is pre-existing in main's money-path cores, not introduced here, and fixing it means touching send cores — separate PR with the money-pipeline suite.
- In-app chat scoping is not fail-closed for every read: `find_job` / `list_projects` are company-wide, and `get_project_schedule` takes a `jobName` alias. A product decision about what FIELD_CREW should see.
- `list_project_files` creates standard folders on first call, so it is technically a write, but auditing every file listing to catch that is a bad trade.

## Deploy

`scripts/apply-mcp-audit-schema.mjs` (adds `ActivityLog.actorUserId`) **is already applied to production** — verified present. Idempotent and safe to re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)