### PR TITLE
fix(mcp): stop bundling pdf-parse so read_file works in the server runtime

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,12 @@ const nextConfig: NextConfig = {
   // Pin the workspace root: a stray package.json in an ancestor directory makes
   // Next infer the wrong root, which breaks CSS module resolution in `next dev`.
   outputFileTracingRoot: path.resolve(__dirname),
+  // pdf-parse (and mammoth) pull in pdfjs, whose bundled build reaches for
+  // browser globals like DOMMatrix that don't exist in the Node server runtime.
+  // Bundling them produced "DOMMatrix is not defined" in production while a
+  // direct node import of the same package worked, so keep them external and
+  // let the server require() them at runtime. Verified against read_file.
+  serverExternalPackages: ["pdf-parse", "mammoth"],
   turbopack: { root: path.resolve(__dirname) },
   experimental: {
     workerThreads: false,


### PR DESCRIPTION
`read_file` shipped in #279 and is broken on production for every PDF:

```
{ "error": "Could not extract text: DOMMatrix is not defined" }
```

## Why it got through

`pdf-parse` v2 uses pdfjs, whose **bundled** build reaches for browser globals (`DOMMatrix`) that the Node server runtime doesn't provide. A direct `node` import of the same package works fine — I'd verified extraction that way against real files before shipping, and CI and the local build both passed. Bundling was the only difference, so nothing short of exercising the deployed route could have caught it.

`serverExternalPackages: ["pdf-parse", "mammoth"]` makes the server `require()` them at runtime instead of bundling.

## Verified

Against a production build (`next start`) serving the real file that was failing:

- before: `Could not extract text: DOMMatrix is not defined`
- after: `readable: true`, 34 chars, `likelyNoTextLayer: true`, text `"RES-390676\n7/27/2026\n\n-- 1 of 1 --"`

The audit trail recorded the whole thing correctly on its own — three `mcp_read_file_failed` rows carrying the DOMMatrix error, then `mcp_read_file` once fixed, each with the filename and the project backfilled from only a `fileId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)