### PR TITLE
fix(files): close the three ways client file visibility could change unguarded

### DIFF
--- a/e2e/file-move.spec.ts
+++ b/e2e/file-move.spec.ts
@@ -194,6 +194,87 @@ test.describe("Project files — move into folders", () => {
         await request.dispose();
     });
 
+    test("refuses a visibility-only change that un-shares a client-visible file", async ({ playwright, baseURL, storageState }) => {
+        const request = await ctx(playwright, baseURL, storageState);
+        const res = await request.post("/api/files/register", {
+            data: {
+                files: [{
+                    name: `${RUN}-visonly.pdf`,
+                    url: `https://example.invalid/${RUN}-visonly.pdf`,
+                    projectId: PROJECT_ID,
+                    size: 1024,
+                    mimeType: "application/pdf",
+                    visibility: "shared",
+                }],
+            },
+        });
+        expect(res.ok()).toBeTruthy();
+        const fileId: string = (await res.json()).files[0].id;
+        createdFileIds.add(fileId);
+
+        // No folderId at all. The guard used to be gated on folderId being present,
+        // so this PATCH walked straight past it and hid the file from the client.
+        const blocked = await request.patch("/api/files", { data: { fileId, visibility: "team" } });
+        expect(blocked.status(), "a visibility-only un-share must be refused").toBe(409);
+        expect(await blocked.text()).toContain("would remove their access");
+
+        const allowed = await request.patch("/api/files", {
+            data: { fileId, visibility: "team", allowClientVisibilityLoss: true },
+        });
+        expect(allowed.ok(), `deliberate un-share must be allowed: ${await allowed.text()}`).toBeTruthy();
+        await request.dispose();
+    });
+
+    test("refuses un-sharing a folder that the client can currently see files in", async ({ playwright, baseURL, storageState }) => {
+        const request = await ctx(playwright, baseURL, storageState);
+
+        // A shared folder holding a client-visible file. Flipping the FOLDER to team
+        // hides the file even though the file itself stays "shared", because the
+        // portal requires the whole ancestor chain to be shared — and the folder
+        // endpoint had no guard at all, so this was the way around the file one.
+        const mk = await request.post("/api/files/folders", {
+            data: { name: `${RUN}-shared-folder`, projectId: PROJECT_ID, visibility: "shared" },
+        });
+        expect(mk.ok(), `folder seed failed: ${await mk.text()}`).toBeTruthy();
+        const sharedFolderId: string = (await mk.json()).id;
+
+        const res = await request.post("/api/files/register", {
+            data: {
+                files: [{
+                    name: `${RUN}-infolder.pdf`,
+                    url: `https://example.invalid/${RUN}-infolder.pdf`,
+                    projectId: PROJECT_ID,
+                    folderId: sharedFolderId,
+                    size: 1024,
+                    mimeType: "application/pdf",
+                    visibility: "shared",
+                }],
+            },
+        });
+        expect(res.ok()).toBeTruthy();
+        createdFileIds.add((await res.json()).files[0].id);
+
+        const blocked = await request.patch("/api/files/folders", {
+            data: { id: sharedFolderId, visibility: "team" },
+        });
+        expect(blocked.status(), "un-sharing a folder with client-visible files must be refused").toBe(409);
+        expect(await blocked.text()).toContain("would remove their access");
+
+        const allowed = await request.patch("/api/files/folders", {
+            data: { id: sharedFolderId, visibility: "team", allowClientVisibilityLoss: true },
+        });
+        expect(allowed.ok(), `deliberate folder un-share must be allowed: ${await allowed.text()}`).toBeTruthy();
+
+        // Renaming must stay unaffected — the guard only fires on a visibility drop.
+        const renamed = await request.patch("/api/files/folders", {
+            data: { id: sharedFolderId, name: `${RUN}-renamed-folder` },
+        });
+        expect(renamed.ok(), `rename must not trip the guard: ${await renamed.text()}`).toBeTruthy();
+
+        await request.delete(`/api/files?folderId=${sharedFolderId}`).catch(() => {});
+        await request.dispose();
+    });
+
     test("declines an OS file drag so upload still works", async ({ page, playwright, baseURL, storageState }) => {
         const request = await ctx(playwright, baseURL, storageState);
         const name = `${RUN}-osdrag.pdf`;

--- a/src/app/api/files/folders/route.ts
+++ b/src/app/api/files/folders/route.ts
@@ -3,7 +3,12 @@ import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { hasPermission } from "@/lib/permissions";
-import { authorizeFileScope, isAncestorFinancial } from "@/lib/file-auth";
+import {
+    authorizeFileScope,
+    folderSubtreeExposesFiles,
+    isAncestorChainShared,
+    isAncestorFinancial,
+} from "@/lib/file-auth";
 
 // GET: list all folders for a project or lead
 export async function GET(req: NextRequest) {
@@ -122,6 +127,27 @@ export async function PATCH(req: NextRequest) {
     }
     if (visibility === "financial" && !hasPermission(user, "financialReports")) {
         return NextResponse.json({ error: "No permission to set financial visibility" }, { status: 403 });
+    }
+
+    // Un-sharing a folder hides everything the chain below it exposes, including
+    // files explicitly marked "shared", because the portal requires the WHOLE
+    // ancestor chain to be shared. The single-file endpoint refuses that; without
+    // the same gate here, flipping "Signed Documents" to team silently takes back
+    // every signed estimate the client could see — the exact regression the
+    // signed-documents fix was written to stop.
+    if (
+        visibility
+        && visibility !== "shared"
+        && existing.visibility === "shared"
+        && existing.projectId
+        && body.allowClientVisibilityLoss !== true
+    ) {
+        const reachable = await isAncestorChainShared(id, existing.projectId);
+        if (reachable && await folderSubtreeExposesFiles(id, existing.projectId)) {
+            return NextResponse.json({
+                error: `The client can currently see files in this folder, and changing it to "${visibility}" would remove their access. Move those files somewhere shared first, or pass allowClientVisibilityLoss: true to do it deliberately.`,
+            }, { status: 409 });
+        }
     }
 
     const updateData: any = {};

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -271,7 +271,10 @@ export async function PATCH(req: NextRequest) {
         // isAncestorChainShared). Any shorthand that just compares the file's own
         // visibility gets this wrong — an explicitly-shared file dropped into a team
         // folder keeps visibility "shared" while becoming completely unreachable.
-        if (folderId !== undefined) {
+        // Runs for a move OR a visibility-only change. Gating this on folderId
+        // alone let a plain { visibility: "team" } PATCH flip a file the client
+        // could see straight to internal without ever meeting the guard below.
+        if (folderId !== undefined || visibility !== undefined) {
             const targetFolder = folderId
                 ? await prisma.fileFolder.findUnique({
                     where: { id: folderId },
@@ -287,8 +290,13 @@ export async function PATCH(req: NextRequest) {
             // so NEITHER portal can reach it and the document silently disappears.
             // mcp-pm-tools.ts already enforces this on its own move tool.
             if (targetFolder) {
-                const sameOwner = (existing.projectId && targetFolder.projectId === existing.projectId)
-                    || (existing.leadId && targetFolder.leadId === existing.leadId);
+                // Exact owner tuple, not project-OR-lead. A row may carry BOTH ids,
+                // and matching on either one alone let a file owned by
+                // {project A, lead L} move into a folder owned by {project B, lead L}
+                // on the strength of the shared lead — after which the file keeps
+                // project A's projectId inside project B's folder.
+                const sameOwner = targetFolder.projectId === existing.projectId
+                    && targetFolder.leadId === existing.leadId;
                 if (!sameOwner) {
                     return NextResponse.json(
                         { error: "That folder belongs to a different project or lead" },
@@ -305,18 +313,25 @@ export async function PATCH(req: NextRequest) {
             };
 
             const nextVisibility = visibility !== undefined ? visibility : existing.visibility;
+            // Only a supplied folderId moves the file. Collapsing an absent folderId
+            // to null would treat every visibility-only change as a move to the
+            // project root and misjudge whether the client keeps access.
+            const nextFolderId = folderId !== undefined ? (folderId || null) : existing.folderId;
             const before = await clientCanSee(existing.visibility, existing.folderId);
-            const after = await clientCanSee(nextVisibility, folderId || null);
+            const after = await clientCanSee(nextVisibility, nextFolderId);
 
             // Refused only when the client LOSES access as a side effect. Passing an
             // explicit visibility is not a licence to hide the file — the caller has
             // to reach a destination the client can still see, or say so via
             // allowClientVisibilityLoss.
             if (before && !after && body.allowClientVisibilityLoss !== true) {
+                const moving = folderId !== undefined;
                 return NextResponse.json({
                     error: targetFolder
                         ? `The client can currently see "${existing.name}" in their portal, and "${targetFolder.name}" is not shared with them — this move would remove their access. Share that folder first, or pass allowClientVisibilityLoss: true to do it deliberately.`
-                        : `The client can currently see "${existing.name}" in their portal; moving it to the project root would remove their access unless it is explicitly shared. Pass visibility "shared", or allowClientVisibilityLoss: true to do it deliberately.`,
+                        : moving
+                            ? `The client can currently see "${existing.name}" in their portal; moving it to the project root would remove their access unless it is explicitly shared. Pass visibility "shared", or allowClientVisibilityLoss: true to do it deliberately.`
+                            : `The client can currently see "${existing.name}" in their portal; changing its visibility to "${nextVisibility ?? "inherited"}" would remove their access. Pass allowClientVisibilityLoss: true to do it deliberately.`,
                 }, { status: 409 });
             }
         }

--- a/src/lib/file-auth.ts
+++ b/src/lib/file-auth.ts
@@ -73,3 +73,44 @@ export async function isAncestorChainShared(folderId: string, projectId: string)
     }
     return true;
 }
+
+/**
+ * Would un-sharing this folder take away files the client can currently see?
+ *
+ * The portal shows a file inside a folder when the file's own visibility is
+ * "shared" or null AND every folder above it is "shared" (see api/portal/files +
+ * isAncestorChainShared). So flipping ONE folder off can hide files several
+ * levels down, including files explicitly marked "shared" — which is exactly the
+ * silent un-sharing the signed-documents work exists to prevent.
+ *
+ * Only descends through children that are themselves currently "shared": an
+ * already-unshared subtree is unreachable either way, so it cannot lose access.
+ * Bounded so a deep or cyclic tree cannot run away.
+ */
+export async function folderSubtreeExposesFiles(
+    folderId: string,
+    projectId: string,
+): Promise<boolean> {
+    const MAX_FOLDERS = 500;
+    const seen = new Set<string>([folderId]);
+    let frontier: string[] = [folderId];
+
+    while (frontier.length > 0 && seen.size <= MAX_FOLDERS) {
+        const exposed = await prisma.projectFile.count({
+            where: {
+                projectId,
+                folderId: { in: frontier },
+                OR: [{ visibility: "shared" }, { visibility: null }],
+            },
+        });
+        if (exposed > 0) return true;
+
+        const children = await prisma.fileFolder.findMany({
+            where: { parentId: { in: frontier }, visibility: "shared", projectId },
+            select: { id: true },
+        });
+        frontier = children.map(child => child.id).filter(id => !seen.has(id));
+        frontier.forEach(id => seen.add(id));
+    }
+    return false;
+}


### PR DESCRIPTION
Follow-up to #275. Codex review of that PR raised five findings; two were addressed already (the pre-existing `OR`-key collision, fixed in `8f950fb`, and the backfill which dry-runs to zero rows on prod and was deliberately not run). These are the remaining three.

## What was wrong

**1. Visibility-only PATCH skipped the un-share guard.** The guard sat inside `if (folderId !== undefined)`, so `{ fileId, visibility: "team" }` walked straight past it and hid a client-visible file with no override required.

Also fixed while in there: `after` was computed with `folderId || null`, which would treat every visibility-only change as a move to the project root and misjudge whether the client keeps access. It now falls back to the file's existing folder.

**2. The folder endpoint had no guard at all.** Flipping `Signed Documents` to `team` took back every signed estimate — including files explicitly marked `shared`, because the portal requires the *whole ancestor chain* to be shared. This was the way around the file-level guard, and it defeated the exact regression #275 exists to prevent.

New `folderSubtreeExposesFiles` in `file-auth.ts` walks the currently-shared subtree (bounded, cycle-safe) and the endpoint refuses without `allowClientVisibilityLoss: true`. Renames are unaffected.

**3. Owner matching was project-OR-lead.** A file owned by `{project A, lead L}` could move into a folder owned by `{project B, lead L}` on the strength of the shared lead, leaving the row carrying project A's `projectId` inside project B's folder. Now exact owner-tuple equality.

## Why the tightening is safe

Checked prod before changing it:

```
ProjectFile  both ids: 0 | project-only: 81 | lead-only: 1
FileFolder   both ids: 0 | project-only: 78 | lead-only: 0
Already-placed files whose tuple != their folder's: 0 of 14
```

No row carries both ids and no existing pair mismatches, so tuple equality refuses nothing that works today.

## Deliberately not changed

Moving a **null-visibility** file into a shared folder still publishes it. That is what dragging something into a shared folder means, and requiring a flag would break the normal share flow in `FileBrowser`. Files deliberately marked `team`/`financial` are already excluded by the portal predicate, so the case that actually risks exposure is covered.

## Verification

- `npx tsc --noEmit` and `npm run build` clean
- New e2e tests in `file-move.spec.ts` for both guards, including that a rename still passes
- No schema change, no migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)