### PR TITLE
fix(mcp): audit attribution needs proof of origin; help chat cannot bill

### DIFF
--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -2547,12 +2547,27 @@ function guarded(req: Request) {
     if (!actorLabel) {
         return Response.json({ error: "unauthorized" }, { status: 401 });
     }
-    // Read ONLY after the key has authenticated — holding a valid key is
-    // already full trust, so this param grants nothing extra. It only lets
-    // help-agent.ts (the sole caller that sets it) credit the signed-in human
-    // in the audit trail instead of just the connector account.
+    // onBehalfOf rewrites the AUDIT attribution — actorUserId and the
+    // "(via <person>)" label — so a bare query param is not enough: an external
+    // connector holding a key could stamp any teammate's id onto its own writes
+    // and the audit trail would swear that person did it. Only help-agent.ts
+    // may set it, and it proves it is server-side code by sending a digest of a
+    // secret that never leaves the server. No proof → the param is ignored and
+    // attribution falls back to the key's own account (fail closed, not fatal).
     const onBehalfOfId = new URL(req.url).searchParams.get("onBehalfOf");
-    return createHandler(createRouteMcpActor(actorLabel, onBehalfOfId))(req);
+    const honoredOnBehalfOf =
+        onBehalfOfId && isInternalOnBehalfProof(req.headers.get("x-probuild-internal"))
+            ? onBehalfOfId
+            : null;
+    return createHandler(createRouteMcpActor(actorLabel, honoredOnBehalfOf))(req);
+}
+
+function isInternalOnBehalfProof(header: string | null): boolean {
+    const secret = process.env.NEXTAUTH_SECRET;
+    if (!secret || !header) return false;
+    const expected = createHash("sha256").update(`mcp-onbehalf:${secret}`).digest();
+    const provided = Buffer.from(header, "hex");
+    return provided.length === expected.length && timingSafeEqual(provided, expected);
 }
 
 export { guarded as GET, guarded as POST, guarded as DELETE };

--- a/src/lib/help-agent.ts
+++ b/src/lib/help-agent.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { PermissionKey, hasPermission, canAccessProject } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 
@@ -20,11 +22,18 @@ interface McpClient {
   callTool(name: string, args: Record<string, unknown>): Promise<unknown>;
 }
 
-// onBehalfOfUserId rides in the query string alongside the shared secret, read
-// by the MCP route's guarded() ONLY after the secret has authenticated the
-// request — holding the secret is already full trust, so this param grants
-// nothing extra. It just lets the route's audit log credit the signed-in
-// human instead of always naming the connector account.
+// onBehalfOfUserId rides in the query string alongside the shared secret, but
+// the route only HONORS it when the x-probuild-internal header proves the call
+// came from this server (see internalOnBehalfProof) — otherwise an external
+// connector could stamp any teammate's id onto its own writes and forge the
+// audit trail. It lets the route's audit log credit the signed-in human
+// instead of always naming the connector account.
+function internalOnBehalfProof(): string | null {
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) return null;
+  return createHash("sha256").update(`mcp-onbehalf:${secret}`).digest("hex");
+}
+
 function mcpEndpoint(onBehalfOfUserId?: string | null): string | null {
   const secret = process.env.MCP_SECRET;
   if (!secret) return null;
@@ -61,6 +70,10 @@ async function mcpRequest(
     Accept: "application/json, text/event-stream",
   };
   if (sessionId) headers["mcp-session-id"] = sessionId;
+  // Proves to guarded() that this call originates from this server, so the
+  // route may honor onBehalfOf. A digest, never the secret itself.
+  const proof = internalOnBehalfProof();
+  if (proof) headers["x-probuild-internal"] = proof;
 
   let res: Response;
   try {
@@ -277,9 +290,16 @@ const UI_SEND_TOOLS = new Set([
   "send_change_order",
   "send_milestone_invoice",
   "resend_invoice",
-  // bill_change_order is deliberately NOT here: it bills, it does not email.
-  // Blocking it would stop the in-app chat completing a non-sending write.
 ]);
+
+// Tools that COMMIT a billing artifact in one call — a fixed-price
+// bill_change_order stages a real invoice milestone with no confirm step.
+// The help chat's tool loop also reads file contents (read_file), which makes
+// its input prompt-injectable: a PDF a client uploaded can carry instructions.
+// An injected "send" is already structurally blocked above; an injected "bill"
+// must be too. This blocks the in-app chat only — connector keys (ChatGPT /
+// Richard's AI) keep full billing power, per the standing full-access decision.
+const MONEY_COMMIT_TOOLS = new Set(["bill_change_order"]);
 
 // Recursively redacts any object key that looks like a confirm/send token so
 // a send preview returned to the model can never carry a usable token back
@@ -375,7 +395,9 @@ export async function runHelpAgent({
 }): Promise<HelpAgentResult> {
   const client = await mcpClient(user.id);
   const allTools = await client.listTools();
-  const allowedTools = allTools.filter((t) => isToolAllowedForUser(user, t.name));
+  const allowedTools = allTools.filter(
+    (t) => isToolAllowedForUser(user, t.name) && !MONEY_COMMIT_TOOLS.has(t.name),
+  );
   // The only names execution will accept — covers both "not permitted" and
   // "not a real tool on the server" (a hallucinated name must not reach MCP).
   const allowedToolNames = new Set(allowedTools.map((t) => t.name));
@@ -459,6 +481,14 @@ Rules:
         ok = false;
         denied = true;
         resultContent = "Tool budget for this request is exhausted — summarize progress so far.";
+      } else if (MONEY_COMMIT_TOOLS.has(block.name)) {
+        // Structural billing gate — see MONEY_COMMIT_TOOLS. Checked before the
+        // allowlist so the model gets the accurate refusal (the tool is also
+        // withheld from its tools array, making this defense in depth).
+        ok = false;
+        denied = true;
+        resultContent =
+          "In-app chat cannot bill a change order. Point the user at the project's Billing page (or their connected ChatGPT/Claude) to run the billing step themselves.";
       } else if (!allowedToolNames.has(block.name) || !isToolAllowedForUser(user, block.name)) {
         // Defense in depth: the tools array sent to the model is already
         // pre-filtered, but re-check at execution time so a denied,


### PR DESCRIPTION
Two pre-deploy fixes from the Codex review of the #279–281 range (the file-guard findings from that same review shipped separately as #282).

**Audit forgery.** `onBehalfOf` rewrites the audit attribution — `actorUserId` and the "(via person)" label — and was honored from a bare query param on the same endpoint external connectors call, so any key holder could stamp any teammate's id onto its own writes. `guarded()` now honors it only when `x-probuild-internal` carries a sha256 digest derived from `NEXTAUTH_SECRET`, which only this server's own help-agent can produce. No proof → the param is ignored and attribution falls back to the key's own account (fail closed, not fatal).

**Prompt-injected billing.** #279's `read_file` puts client-uploaded file contents into the in-app help chat's tool loop, and a fixed-price `bill_change_order` commits a real invoice milestone in one unconfirmed call. It's now withheld from the chat's advertised tools AND refused structurally at execution — the same two-layer shape as the existing send gate. Connector keys (ChatGPT / Richard's AI) keep full billing power, per the standing full-access decision.

Reviewed and accepted as-is (no change): company-wide connector keys (explicit owner decision); `resolveDocUrl` passing through externally-registered URLs (pre-existing, follow-up allowlist candidate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)