### PR TITLE
fix(mcp): ship @napi-rs/canvas to the lambda; in-app financial/lead file gates

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,7 +10,18 @@ const nextConfig: NextConfig = {
   // Bundling them produced "DOMMatrix is not defined" in production while a
   // direct node import of the same package worked, so keep them external and
   // let the server require() them at runtime. Verified against read_file.
-  serverExternalPackages: ["pdf-parse", "mammoth"],
+  serverExternalPackages: ["pdf-parse", "mammoth", "@napi-rs/canvas"],
+  // pdf-parse's pdfjs loads @napi-rs/canvas via a runtime createRequire, which
+  // Next's file tracing can't see — the deployed lambda otherwise ships with
+  // zero @napi-rs/canvas files, causing "Setting up fake worker failed" in
+  // production. Force-include the package (+ its Linux prebuilt binary, the
+  // only platform Vercel's lambda runs) for the MCP route specifically.
+  outputFileTracingIncludes: {
+    "/api/mcp/[transport]": [
+      "./node_modules/@napi-rs/canvas/**",
+      "./node_modules/@napi-rs/canvas-linux-x64-gnu/**",
+    ],
+  },
   turbopack: { root: path.resolve(__dirname) },
   experimental: {
     workerThreads: false,

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -291,49 +291,6 @@ type AuditOwner = { projectId: string | null; leadId: string | null; entityId?: 
 // only the owner columns it actually has (Invoice/ChangeOrder: projectId only;
 // Estimate/Contract/ScheduleTask/ProjectFile: both). Never throws — a failed
 // lookup degrades to nulls rather than breaking the tool call or the audit write.
-// pdfjs (under pdf-parse) touches browser globals at MODULE LOAD time. Vercel's
-// server runtime resolves a build that needs DOMMatrix/Path2D/ImageData, which
-// a bare local `node` import does not — hence "DOMMatrix is not defined" only
-// once deployed, after passing locally and in CI. These stubs exist purely so
-// the module can load; pure text extraction never exercises them, and each is
-// installed only when genuinely absent so a real implementation always wins.
-function ensurePdfDomGlobals() {
-    const g = globalThis as any;
-    if (typeof g.DOMMatrix === "undefined") {
-        g.DOMMatrix = class DOMMatrix {
-            a = 1; b = 0; c = 0; d = 1; e = 0; f = 0;
-            m11 = 1; m12 = 0; m21 = 0; m22 = 1; m41 = 0; m42 = 0;
-            constructor(init?: number[] | string) {
-                if (Array.isArray(init) && init.length >= 6) {
-                    [this.a, this.b, this.c, this.d, this.e, this.f] = init as number[];
-                    this.m11 = this.a; this.m12 = this.b;
-                    this.m21 = this.c; this.m22 = this.d;
-                    this.m41 = this.e; this.m42 = this.f;
-                }
-            }
-            multiply() { return this; }
-            translate() { return this; }
-            scale() { return this; }
-            inverse() { return this; }
-        };
-    }
-    if (typeof g.Path2D === "undefined") {
-        g.Path2D = class Path2D {
-            addPath() {} moveTo() {} lineTo() {} bezierCurveTo() {}
-            quadraticCurveTo() {} closePath() {} rect() {} arc() {}
-        };
-    }
-    if (typeof g.ImageData === "undefined") {
-        g.ImageData = class ImageData {
-            data: Uint8ClampedArray; width: number; height: number;
-            constructor(width: number, height: number) {
-                this.width = width; this.height = height;
-                this.data = new Uint8ClampedArray(Math.max(0, width * height * 4));
-            }
-        };
-    }
-}
-
 async function resolveAuditOwner(toolName: string, args: Record<string, unknown>): Promise<AuditOwner> {
     const projectIdArg = typeof args.projectId === "string" && args.projectId ? args.projectId : null;
     const leadIdArg = typeof args.leadId === "string" && args.leadId ? args.leadId : null;
@@ -1519,7 +1476,15 @@ function createHandler(actor: RouteMcpActor) {
 
                 try {
                     if (isPdf) {
-                        ensurePdfDomGlobals();
+                        // pdfjs (inside pdf-parse) loads @napi-rs/canvas through a
+                        // runtime createRequire, which no bundler's file tracing can
+                        // see — the deployed lambda shipped ZERO canvas files, which
+                        // is exactly the production "Setting up fake worker failed".
+                        // This literal import exists so Turbopack traces the package
+                        // (outputFileTracingIncludes is silently SKIPPED under
+                        // Turbopack, so that config alone cannot fix it); pdfjs then
+                        // installs the real DOMMatrix/Path2D/ImageData from it.
+                        await import("@napi-rs/canvas").catch(() => null);
                         const pdfParseMod: any = await import("pdf-parse");
                         const PDFParseCtor = pdfParseMod.PDFParse ?? pdfParseMod.default?.PDFParse;
                         const parser = new PDFParseCtor({ data: buffer });
@@ -1542,18 +1507,22 @@ function createHandler(actor: RouteMcpActor) {
                     // isDocx and isPlainText are the sole gates past the early
                     // return above.
                     return textResult({ ...base, ...extractedTextResult(buffer.toString("utf-8"), effectiveMaxChars) });
-                } catch (err: any) {
+                } catch (err) {
                     // Degrade usefully rather than surfacing an internal error:
                     // the link still works even when the text extractor can't
                     // load or the PDF is malformed, and for drawings/scans the
-                    // link was always the answer anyway.
+                    // link was always the answer anyway. Log the raw error
+                    // server-side only — err?.message can leak /var/task paths
+                    // and module layout, so the caller only ever sees a stable,
+                    // generic message.
+                    console.error("[read_file] extraction failed:", err);
                     return {
                         ...textResult({
-                            error: `Could not extract text from "${file.name}": ${err?.message || "unknown error"}`,
+                            error: `Could not extract text from "${file.name}" — the file may be malformed, encrypted, or of an unsupported PDF type.`,
                             readable: false,
                             viewUrl: base.viewUrl ?? null,
                             note: base.viewUrl
-                                ? "Text extraction failed, but the file itself is fine — open viewUrl to view or download it."
+                                ? "The file itself may still open fine — use viewUrl to view or download it."
                                 : "Text extraction failed. Use get_file_link to get a link to the file.",
                         }),
                         isError: true,

--- a/src/lib/help-agent.ts
+++ b/src/lib/help-agent.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 
 import { PermissionKey, hasPermission, canAccessProject } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
+import { isAncestorFinancial } from "@/lib/file-auth";
 
 // Agent runtime for the in-app help chat: gives the assistant live access to
 // ProBuild's own MCP server (src/app/api/mcp/[transport]/route.ts) so it can
@@ -343,40 +344,89 @@ function redactSendTokenText(text: string): string {
 
 // Args that name an entity whose project must be access-checked for
 // project-scoped (non-ADMIN/MANAGER) users. A bare projectId arg is checked
-// directly; these resolve the parent project first. A null projectId (a
-// lead-scoped estimate/contract/task) is allowed through — lead access is
-// gated by the leadAccess permission, not per-project assignment.
-const ENTITY_PROJECT_LOOKUPS: Record<string, (id: string) => Promise<string | null>> = {
+// directly; these resolve the parent project (and, for lead-owned entities,
+// the parent lead) first. fileId additionally carries visibility/folderId so
+// callers can apply the financial-folder gate (see projectScopeDenial below)
+// without a second round-trip. invoice/changeOrder have no leadId column, so
+// their lookups always report leadId: null.
+type EntityOwner = {
+  projectId: string | null;
+  leadId: string | null;
+  visibility?: string | null;
+  folderId?: string | null;
+};
+const ENTITY_PROJECT_LOOKUPS: Record<string, (id: string) => Promise<EntityOwner | null>> = {
   estimateId: async (id) =>
-    (await prisma.estimate.findUnique({ where: { id }, select: { projectId: true } }))?.projectId ?? null,
-  invoiceId: async (id) =>
-    (await prisma.invoice.findUnique({ where: { id }, select: { projectId: true } }))?.projectId ?? null,
+    prisma.estimate.findUnique({ where: { id }, select: { projectId: true, leadId: true } }),
+  invoiceId: async (id) => {
+    const invoice = await prisma.invoice.findUnique({ where: { id }, select: { projectId: true } });
+    return invoice ? { projectId: invoice.projectId, leadId: null } : null;
+  },
   contractId: async (id) =>
-    (await prisma.contract.findUnique({ where: { id }, select: { projectId: true } }))?.projectId ?? null,
-  changeOrderId: async (id) =>
-    (await prisma.changeOrder.findUnique({ where: { id }, select: { projectId: true } }))?.projectId ?? null,
+    prisma.contract.findUnique({ where: { id }, select: { projectId: true, leadId: true } }),
+  changeOrderId: async (id) => {
+    const co = await prisma.changeOrder.findUnique({ where: { id }, select: { projectId: true } });
+    return co ? { projectId: co.projectId, leadId: null } : null;
+  },
   taskId: async (id) =>
-    (await prisma.scheduleTask.findUnique({ where: { id }, select: { projectId: true } }))?.projectId ?? null,
+    prisma.scheduleTask.findUnique({ where: { id }, select: { projectId: true, leadId: true } }),
   fileId: async (id) =>
-    (await prisma.projectFile.findUnique({ where: { id }, select: { projectId: true } }))?.projectId ?? null,
+    prisma.projectFile.findUnique({
+      where: { id },
+      select: { projectId: true, leadId: true, visibility: true, folderId: true },
+    }),
 };
 
-// Returns null when allowed, or a denial message for a project the user
-// can't access (directly via args.projectId or implied via an entity id).
+// Returns null when allowed, or a denial message for:
+// - a project the user can't access (directly via args.projectId or implied
+//   via an entity id)
+// - an entity owned by a lead (no project) when the user lacks leadAccess
+// - a file in a financial folder, read via read_file/get_file_link, when the
+//   user lacks financialReports
 async function projectScopeDenial(
   user: HelpAgentUser,
+  toolName: string,
   args: Record<string, unknown>
 ): Promise<string | null> {
   if (ADMIN_ROLES.includes(user.role)) return null;
-  if (typeof args.projectId === "string" && args.projectId && !canAccessProject(user, args.projectId)) {
+
+  const hasProjectIdArg = typeof args.projectId === "string" && !!args.projectId;
+  if (hasProjectIdArg && !canAccessProject(user, args.projectId as string)) {
     return "Permission denied: you don't have access to that project.";
   }
+  // A tool called directly with a leadId (no projectId) targets a lead-owned
+  // entity — gated by leadAccess, not per-project assignment.
+  if (
+    !hasProjectIdArg &&
+    typeof args.leadId === "string" &&
+    args.leadId &&
+    !hasPermission(user, "leadAccess")
+  ) {
+    return "Permission denied: you don't have lead access.";
+  }
+
   for (const [argName, lookup] of Object.entries(ENTITY_PROJECT_LOOKUPS)) {
     const id = args[argName];
     if (typeof id !== "string" || !id) continue;
-    const projectId = await lookup(id);
-    if (projectId && !canAccessProject(user, projectId)) {
-      return "Permission denied: you don't have access to that project.";
+    const owner = await lookup(id);
+    if (!owner) continue;
+    if (owner.projectId) {
+      if (!canAccessProject(user, owner.projectId)) {
+        return "Permission denied: you don't have access to that project.";
+      }
+    } else if (owner.leadId && !hasPermission(user, "leadAccess")) {
+      return "Permission denied: you don't have lead access.";
+    }
+    if (
+      argName === "fileId" &&
+      (toolName === "read_file" || toolName === "get_file_link") &&
+      !hasPermission(user, "financialReports")
+    ) {
+      const isFinancial =
+        owner.visibility === "financial" || (await isAncestorFinancial(owner.folderId ?? null));
+      if (isFinancial) {
+        return "Permission denied: that file is in a financial folder.";
+      }
     }
   }
   return null;
@@ -504,7 +554,7 @@ Rules:
         resultContent =
           "In-app chat cannot execute sends. The preview is ready — the user completes the send from the ProBuild page (or via their connected ChatGPT/Claude).";
       } else {
-        const scopeDenial = await projectScopeDenial(user, args);
+        const scopeDenial = await projectScopeDenial(user, block.name, args);
         if (scopeDenial) {
           ok = false;
           denied = true;


### PR DESCRIPTION
Post-ship Codex review of the #280/#281 hotfixes found the actual root cause of the PDF extraction failure, plus an authorization gap in the in-app chat. Both fixed here.

## The PDF root cause, finally

pdfjs loads `@napi-rs/canvas` through a runtime `createRequire` that no file tracer can see — **the deployed lambda contained zero canvas files**, which is precisely the "Setting up fake worker failed" error. Worse, the DOM stubs from #281 were actively harmful: pdfjs installs its *real* `DOMMatrix`/`Path2D`/`ImageData` from `@napi-rs/canvas` only when those globals are absent, and the stubs got there first — permanently, in a warm lambda.

Fixes:
- `ensurePdfDomGlobals` deleted outright.
- A literal `await import("@napi-rs/canvas")` right before the pdf-parse import, so the tracer sees the package. `outputFileTracingIncludes` alone **cannot** fix this: Next 16 builds with Turbopack, and that config is silently skipped under Turbopack (`build/index.js` guards `collectBuildTraces` with `bundler !== Turbopack`). The config stays in place for a future webpack build.
- Verified: the route's `.nft.json` now contains the canvas JS files and the platform binary (zero entries before).

## Error hygiene

`read_file`'s catch no longer interpolates raw `err.message` into the tool result (module-resolution errors leak `/var/task` paths). Raw error goes to server logs; the caller gets a stable message, still with the `viewUrl` fallback, minus the earlier over-promising "the file itself is fine" wording.

## In-app chat authorization (external connector keys unchanged, still full-trust)

- Files in **financial folders** (direct visibility or inherited via `isAncestorFinancial`) now require the `financialReports` permission for `read_file`/`get_file_link`.
- **Lead-owned entities** (leadId set, no projectId) now require `leadAccess` — entity lookups return `{projectId, leadId}`, so lead-only ownership no longer sails through the project-assignment check.

Rebased over #282/#283 (no overlap). `verify-mcp-pm-tools` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)