### PR TITLE
fix(ci): enable SELECTION_AI_MOCK in Playwright e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,13 @@ jobs:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_ORG: golden-touch-remodeling
       PLAYWRIGHT_TEST_SECRET: ${{ secrets.PLAYWRIGHT_TEST_SECRET }}
+      # e2e/selections-ai-sort.spec.ts requires the deterministic AI mock
+      # (selection-ai-sort-mock.ts). Without this flag the route calls the real
+      # Anthropic API: the spec's forced-invalid-batch marker is inert prose to
+      # a real model, so the batch-isolation assertions fail — and every CI run
+      # burns real API tokens. Safe by construction: the mock gate also
+      # requires !process.env.VERCEL, so real deploys ignore this flag.
+      SELECTION_AI_MOCK: "1"
       CI: true
 
     steps:


### PR DESCRIPTION
## Root cause of the repo-wide PR CI failures (every PR since 2026-07-31)

Two independent breakages, both surfaced by the selections specs that landed 2026-07-30/31:

### 1. Missing `SELECTION_AI_MOCK=1` in ci.yml (fixed here)
`e2e/selections-ai-sort.spec.ts` asserts on the deterministic mock (`selection-ai-sort-mock.ts`) — its poison item carries `FORCE_INVALID_BATCH_MARKER` which only the mock recognizes. CI never set the flag, so the route called the **real Anthropic API**: the marker is inert prose to a real model, the poison batch 'succeeds', and `failedItemIds` comes back empty → deterministic failure of the batch-isolation test (plus real API tokens burned on every CI run). Safe by construction: the mock gate in `selection-ai-sort-dependencies.ts` also requires `!process.env.VERCEL`, so real deploys ignore the flag.

### 2. Stale `SUPABASE_SERVICE_KEY` repo secret (admin action required — no code change)
`e2e/selections-item-threads.spec.ts:324` does a real storage round-trip in CI by design (with exact-id cleanup). The Actions secret still holds the service key **revoked in the 2026-07-23 rotation** → `Storage upload failed: signature verification failed`. The current key in `.env.local`/Vercel verifies fine against storage. Fix (admin):

```
grep '^SUPABASE_SERVICE_KEY=' .env.local | cut -d= -f2- | gh secret set SUPABASE_SERVICE_KEY --repo Clarion1631/probuild
```

### Also checked
- `scripts/verify-crew-overlays.ts` "Cannot find module 'server-only'" from the first failing run: already resolved on current main (the verify-suites step passes on reruns).
- Evidence it's repo-wide, not branch-specific: identical failures on `claude/custom-color-wheel-projects-4731b0` (run 30657370382, survives rerun) and `claude/elated-kapitsa-ee9af9` (run 30649809133). Last green PR run was 2026-07-30T17:21Z, before these specs merged.

Once the secret is refreshed, this PR's own CI run should go green and unblock #287 and the dependabot PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)