### PR TITLE
fix(invoices): milestone-scoped viewed notification + deterministic schedule order

### DIFF
--- a/src/app/portal/invoices/[id]/PortalInvoiceClient.tsx
+++ b/src/app/portal/invoices/[id]/PortalInvoiceClient.tsx
@@ -90,16 +90,23 @@ export default function PortalInvoiceClient({ initialInvoice, companySettings, p
 
     // Milestone focus mode: the payment-request email links here with
     // ?milestone=<ids> so the client sees a clear "amount due now" for exactly
-    // the requested payment(s), with the full-invoice figures hidden. Paid/
-    // Canceled/unknown ids fall out (same predicate as markInvoiceViewed and
-    // the PDF); if nothing valid remains the page renders as the normal full
-    // invoice.
+    // the requested payment(s), with the full-invoice figures hidden. Only
+    // Pending ids stay focused (same predicate as markInvoiceViewed and the
+    // PDF) — Paid, Canceled, and in-flight Processing payments are not an ask.
+    // If nothing valid remains the page renders as the normal full invoice.
     const focusIds = parseFocusIds(focusMilestoneParam);
     const focusedPayments = focusIds.length > 0
-        ? (initialInvoice.payments || []).filter((p: any) => focusIds.includes(p.id) && p.status !== "Paid" && p.status !== "Canceled")
+        ? (initialInvoice.payments || []).filter((p: any) => focusIds.includes(p.id) && p.status === "Pending")
         : [];
     const hasFocus = focusedPayments.length > 0;
     const focusTotal = focusedPayments.reduce((sum: number, p: any) => sum + Number(p.amount), 0);
+
+    // "Due now" = requested (payment-request email sent) and still pending.
+    // The rest of the schedule is context, not an ask — the client should never
+    // see the whole contract balance presented as due.
+    const requestedDueNow = (initialInvoice.payments || [])
+        .filter((p: any) => p.status === "Pending" && p.qbInvoiceSentAt)
+        .reduce((sum: number, p: any) => sum + Number(p.amount), 0);
 
     return (
         <div className="min-h-screen bg-slate-100 font-sans">
@@ -152,9 +159,13 @@ export default function PortalInvoiceClient({ initialInvoice, companySettings, p
                                             <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" /></svg>
                                             Paid
                                         </span>
-                                    ) : (
+                                    ) : (requestedDueNow > 0 || hasFocus) ? (
                                         <span className="inline-flex items-center px-3 py-1 rounded-md text-xs font-bold bg-amber-50 text-amber-700 border border-amber-200 uppercase tracking-wider">
                                             Payment Due
+                                        </span>
+                                    ) : (
+                                        <span className="inline-flex items-center px-3 py-1 rounded-md text-xs font-bold bg-slate-50 text-slate-500 border border-slate-200 uppercase tracking-wider">
+                                            No Payment Due
                                         </span>
                                     )}
                                 </div>
@@ -213,9 +224,12 @@ export default function PortalInvoiceClient({ initialInvoice, companySettings, p
                                 <p className="text-2xl font-bold text-green-600">{formatCurrency(totalPaid)}</p>
                             </div>
                             <div className="text-right">
-                                <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-1">Balance Due</p>
-                                <p className={`text-2xl font-bold ${Number(initialInvoice.balanceDue) > 0 ? 'text-red-600' : 'text-green-600'}`}>
-                                    {formatCurrency(initialInvoice.balanceDue)}
+                                <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-1">Due Now</p>
+                                <p className={`text-2xl font-bold ${requestedDueNow > 0 ? 'text-red-600' : 'text-green-600'}`}>
+                                    {formatCurrency(requestedDueNow)}
+                                </p>
+                                <p className="text-xs text-slate-400 mt-0.5">
+                                    Remaining balance {formatCurrency(initialInvoice.balanceDue)}
                                 </p>
                             </div>
                         </div>
@@ -238,8 +252,10 @@ export default function PortalInvoiceClient({ initialInvoice, companySettings, p
                             <div className="space-y-3">
                                 {initialInvoice.payments.map((payment: any) => {
                                     const isPaidItem = payment.status === "Paid";
-                                    const isPastDue = payment.dueDate && new Date(payment.dueDate) < new Date() && !isPaidItem;
-                                    const isFocused = !isPaidItem && payment.status !== "Canceled" && focusIds.includes(payment.id);
+                                    // Overdue only means something once the payment was actually
+                                    // requested — an unrequested scheduled milestone can't be late.
+                                    const isPastDue = payment.dueDate && new Date(payment.dueDate) < new Date() && payment.status === "Pending" && payment.qbInvoiceSentAt;
+                                    const isFocused = payment.status === "Pending" && focusIds.includes(payment.id);
 
                                     return (
                                         <div
@@ -290,16 +306,24 @@ export default function PortalInvoiceClient({ initialInvoice, companySettings, p
                                                 <span className="font-semibold text-slate-800 text-lg">
                                                     {formatCurrency(payment.amount)}
                                                 </span>
-                                                {!isPaidItem && (
-                                                    <PortalPayButton 
-                                                        invoiceId={initialInvoice.id} 
-                                                        paymentScheduleId={payment.id} 
+                                                {/* Pay only what's been requested AND still pending:
+                                                    qbInvoiceSentAt is stamped when the payment-request email
+                                                    goes out; Processing/Canceled rows must never re-offer
+                                                    checkout. Unrequested rows are schedule context, not an ask. */}
+                                                {!isPaidItem && (payment.status === "Pending" && payment.qbInvoiceSentAt ? (
+                                                    <PortalPayButton
+                                                        invoiceId={initialInvoice.id}
+                                                        paymentScheduleId={payment.id}
                                                         amount={payment.amount}
                                                         label="Pay Now"
                                                         settings={companySettings}
                                                         qbPayLink={payment.status === "Pending" && !payment.qbSyncError ? (payment.qbInvoiceLink || null) : null}
                                                     />
-                                                )}
+                                                ) : (
+                                                    payment.status === "Pending" && (
+                                                        <span className="text-xs text-slate-400 whitespace-nowrap">Not yet due</span>
+                                                    )
+                                                ))}
                                                 {isPaidItem && (
                                                     <div className="w-8 h-8 bg-green-100 rounded-full flex items-center justify-center">
                                                         <svg className="w-4 h-4 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" /></svg>

--- a/src/app/portal/invoices/[id]/PortalInvoiceClient.tsx
+++ b/src/app/portal/invoices/[id]/PortalInvoiceClient.tsx
@@ -30,12 +30,21 @@ class PaymentSectionErrorBoundary extends React.Component<{ children: React.Reac
     }
 }
 
+// Single parser for the ?milestone= focus param — the same list (including the
+// cap, which markInvoiceViewed also enforces server-side) drives both the
+// focused rendering and the viewed notification, so they can never diverge.
+function parseFocusIds(param: string | null | undefined): string[] {
+    return (param || "").split(",").map(s => s.trim()).filter(Boolean).slice(0, 40);
+}
+
 export default function PortalInvoiceClient({ initialInvoice, companySettings, paymentSuccess, focusMilestoneParam }: { initialInvoice: any, companySettings?: any, paymentSuccess?: boolean, focusMilestoneParam?: string | null }) {
     const [isPayingId, setIsPayingId] = useState<string | null>(null);
 
     useEffect(() => {
-        markInvoiceViewed(initialInvoice.id).catch(console.error);
-    }, [initialInvoice.id]);
+        // Pass the focused milestone ids so the internal "Invoice Viewed"
+        // notification reflects the payment request the client actually saw.
+        markInvoiceViewed(initialInvoice.id, parseFocusIds(focusMilestoneParam)).catch(console.error);
+    }, [initialInvoice.id, focusMilestoneParam]);
 
     // Telemetry: log Pay-button DOM state on mount so we can confirm visibility on iPhone customers
     useEffect(() => {
@@ -81,12 +90,13 @@ export default function PortalInvoiceClient({ initialInvoice, companySettings, p
 
     // Milestone focus mode: the payment-request email links here with
     // ?milestone=<ids> so the client sees a clear "amount due now" for exactly
-    // the requested payment(s), with the full-invoice figures demoted to a
-    // secondary reference line. Paid/unknown ids fall out; if nothing valid
-    // remains the page renders as the normal full invoice.
-    const focusIds = (focusMilestoneParam || "").split(",").map(s => s.trim()).filter(Boolean);
+    // the requested payment(s), with the full-invoice figures hidden. Paid/
+    // Canceled/unknown ids fall out (same predicate as markInvoiceViewed and
+    // the PDF); if nothing valid remains the page renders as the normal full
+    // invoice.
+    const focusIds = parseFocusIds(focusMilestoneParam);
     const focusedPayments = focusIds.length > 0
-        ? (initialInvoice.payments || []).filter((p: any) => focusIds.includes(p.id) && p.status !== "Paid")
+        ? (initialInvoice.payments || []).filter((p: any) => focusIds.includes(p.id) && p.status !== "Paid" && p.status !== "Canceled")
         : [];
     const hasFocus = focusedPayments.length > 0;
     const focusTotal = focusedPayments.reduce((sum: number, p: any) => sum + Number(p.amount), 0);
@@ -188,15 +198,10 @@ export default function PortalInvoiceClient({ initialInvoice, companySettings, p
                         </div>
                     )}
 
-                    {/* Amount Summary — full-width when there's no focus; a compact
-                        reference line when a specific payment is being requested */}
-                    {hasFocus ? (
-                        <div className="px-10 py-4 bg-slate-50 border-b border-slate-200">
-                            <p className="text-xs text-slate-500 text-center">
-                                Full invoice {initialInvoice.code}: total {formatCurrency(initialInvoice.totalAmount)} · paid to date {formatCurrency(totalPaid)} · remaining balance {formatCurrency(initialInvoice.balanceDue)}
-                            </p>
-                        </div>
-                    ) : (
+                    {/* Amount Summary — only when there's no milestone focus. A focused
+                        payment request shows just the requested amount above; the full
+                        balance stays out of the client's view until it's asked for. */}
+                    {!hasFocus && (
                     <div className="px-10 py-8 bg-slate-50 border-b border-slate-200">
                         <div className="flex justify-between items-center">
                             <div>
@@ -234,7 +239,7 @@ export default function PortalInvoiceClient({ initialInvoice, companySettings, p
                                 {initialInvoice.payments.map((payment: any) => {
                                     const isPaidItem = payment.status === "Paid";
                                     const isPastDue = payment.dueDate && new Date(payment.dueDate) < new Date() && !isPaidItem;
-                                    const isFocused = !isPaidItem && focusIds.includes(payment.id);
+                                    const isFocused = !isPaidItem && payment.status !== "Canceled" && focusIds.includes(payment.id);
 
                                     return (
                                         <div

--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -23,7 +23,7 @@ export default async function PortalDashboard() {
                 client: { select: { name: true } },
                 invoices: {
                     where: { status: { in: ['Issued', 'Overdue', 'Partially Paid'] } },
-                    select: { id: true, balanceDue: true }
+                    select: { id: true, payments: { select: { amount: true, status: true, qbInvoiceSentAt: true } } }
                 }
             }
         });
@@ -69,7 +69,7 @@ export default async function PortalDashboard() {
                     include: {
                         invoices: {
                             where: { status: { in: ['Issued', 'Overdue', 'Partially Paid'] } },
-                            select: { id: true, balanceDue: true }
+                            select: { id: true, payments: { select: { amount: true, status: true, qbInvoiceSentAt: true } } }
                         }
                     }
                 }
@@ -135,7 +135,13 @@ export default async function PortalDashboard() {
             ) : projects.length > 0 && (
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                     {projects.map(p => {
-                        const activeInvoices = (p.invoices || []).reduce((sum: number, inv: any) => sum + Number(inv.balanceDue), 0);
+                        // "Payment Due" badge only when a REQUESTED milestone is outstanding
+                        // (qbInvoiceSentAt stamps the payment-request email) — never for the
+                        // remaining contract balance.
+                        const activeInvoices = (p.invoices || []).reduce((sum: number, inv: any) =>
+                            sum + (inv.payments || [])
+                                .filter((pm: any) => pm.status === 'Pending' && pm.qbInvoiceSentAt)
+                                .reduce((s: number, pm: any) => s + Number(pm.amount), 0), 0);
 
                         return (
                             <Link href={`/portal/projects/${p.id}`} key={p.id} className="hui-card group overflow-hidden hover:shadow-md transition flex flex-col">

--- a/src/app/portal/projects/[id]/page.tsx
+++ b/src/app/portal/projects/[id]/page.tsx
@@ -76,7 +76,7 @@ export default async function PortalProjectDetail(props: {
                 where: { status: { not: 'Draft' } },
                 orderBy: { issueDate: 'desc' },
                 include: {
-                    payments: { orderBy: { createdAt: 'asc' } }
+                    payments: { orderBy: [{ createdAt: 'asc' }, { id: 'asc' }] }
                 }
             },
             changeOrders: {

--- a/src/app/portal/projects/[id]/page.tsx
+++ b/src/app/portal/projects/[id]/page.tsx
@@ -134,11 +134,15 @@ export default async function PortalProjectDetail(props: {
     const changeOrderCount = (project.changeOrders || []).length;
 
     // All overview-derived data must respect the same visibility flag as the section it surfaces.
+    // "Due" in the portal means REQUESTED and unpaid — qbInvoiceSentAt is stamped
+    // when a milestone payment request is emailed. Unrequested milestones are part
+    // of the schedule, not an ask; they must never roll up into a due amount.
+    const isRequested = (p: any) => p.status === 'Pending' && p.qbInvoiceSentAt;
     const pendingPayments: { invoiceId: string; payment: any }[] = [];
     if (visibility.showInvoices) {
         for (const inv of project.invoices) {
             for (const p of (inv.payments || [])) {
-                if (p.status === 'Pending') pendingPayments.push({ invoiceId: inv.id, payment: p });
+                if (isRequested(p)) pendingPayments.push({ invoiceId: inv.id, payment: p });
             }
         }
     }
@@ -252,8 +256,8 @@ export default async function PortalProjectDetail(props: {
                                         <p className="text-2xl md:text-3xl font-bold text-green-900">{formatCurrency(totalDue)}</p>
                                         <p className="text-sm text-green-700 mt-1">
                                             {pendingPayments.length === 1
-                                                ? `Due ${pendingPayments[0].payment.dueDate ? new Date(pendingPayments[0].payment.dueDate).toLocaleDateString() : 'soon'}`
-                                                : `${pendingPayments.length} payments awaiting your approval`
+                                                ? `${pendingPayments[0].payment.name} · due ${pendingPayments[0].payment.dueDate ? new Date(pendingPayments[0].payment.dueDate).toLocaleDateString() : 'upon receipt'}`
+                                                : `${pendingPayments.length} requested payments`
                                             }
                                         </p>
                                     </div>
@@ -373,7 +377,13 @@ export default async function PortalProjectDetail(props: {
 
                 {activeTab === "invoices" && (
                     <div className="space-y-3">
-                        {project.invoices.map(inv => (
+                        {project.invoices.map(inv => {
+                            // Only requested-and-unpaid milestones are "due now"; the rest
+                            // of the schedule is informational until a request goes out.
+                            const dueNow = (inv.payments || [])
+                                .filter((p: any) => isRequested(p))
+                                .reduce((sum: number, p: any) => sum + Number(p.amount), 0);
+                            return (
                             <div key={inv.id} className="hui-card p-4">
                                 <div className="flex justify-between items-start mb-2 gap-2">
                                     <h3 className="font-semibold text-hui-textMain">Invoice #{inv.code}</h3>
@@ -385,7 +395,9 @@ export default async function PortalProjectDetail(props: {
                                 </div>
                                 <div className="flex justify-between text-sm mb-4">
                                     <span className="text-hui-textMuted">Amount: {formatCurrency(inv.totalAmount)}</span>
-                                    <span className="font-medium text-hui-textMain">Due: {formatCurrency(inv.balanceDue)}</span>
+                                    <span className="font-medium text-hui-textMain">
+                                        {dueNow > 0 ? `Due now: ${formatCurrency(dueNow)}` : 'Nothing due right now'}
+                                    </span>
                                 </div>
 
                                 {inv.payments && inv.payments.length > 0 && (
@@ -412,7 +424,7 @@ export default async function PortalProjectDetail(props: {
                                                     )}
                                                 </div>
                                                 <div className="flex flex-col sm:items-end w-full sm:w-auto mt-2 sm:mt-0">
-                                                    {payment.status === 'Pending' ? (
+                                                    {isRequested(payment) ? (
                                                         <PortalPayButton
                                                             invoiceId={inv.id}
                                                             paymentScheduleId={payment.id}
@@ -422,7 +434,12 @@ export default async function PortalProjectDetail(props: {
                                                             qbPayLink={payment.qbInvoiceLink || null}
                                                         />
                                                     ) : (
-                                                        <span className="text-sm font-medium text-hui-textMain">{formatCurrency(payment.amount)}</span>
+                                                        <div className="flex flex-col sm:items-end">
+                                                            <span className="text-sm font-medium text-hui-textMain">{formatCurrency(payment.amount)}</span>
+                                                            {payment.status === 'Pending' && (
+                                                                <span className="text-xs text-hui-textMuted mt-0.5">Not yet due</span>
+                                                            )}
+                                                        </div>
                                                     )}
                                                 </div>
                                             </div>
@@ -430,7 +447,8 @@ export default async function PortalProjectDetail(props: {
                                     </div>
                                 )}
                             </div>
-                        ))}
+                            );
+                        })}
                     </div>
                 )}
 

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -2747,7 +2747,7 @@ export async function getInvoiceForPortal(id: string) {
                 include: {
                     project: { include: { client: true } },
                     client: true,
-                    payments: { include: { coBilling: { select: { id: true, changeOrderId: true, label: true } } }, orderBy: { createdAt: "asc" } },
+                    payments: { include: { coBilling: { select: { id: true, changeOrderId: true, label: true } } }, orderBy: [{ createdAt: "asc" }, { id: "asc" }] },
                 },
             });
             if (!invoice) return null;
@@ -2769,7 +2769,7 @@ export async function getInvoiceForPortal(id: string) {
             include: {
                 project: { include: { client: true } },
                 client: true,
-                payments: { include: { coBilling: { select: { id: true, changeOrderId: true, label: true } } }, orderBy: { createdAt: "asc" } },
+                payments: { include: { coBilling: { select: { id: true, changeOrderId: true, label: true } } }, orderBy: [{ createdAt: "asc" }, { id: "asc" }] },
             },
         });
         if (!invoice) return null;
@@ -2785,9 +2785,15 @@ export async function getInvoiceForPortal(id: string) {
     }
 }
 
-export async function markInvoiceViewed(invoiceId: string) {
+export async function markInvoiceViewed(invoiceId: string, focusedMilestoneIds?: string[]) {
     const sessionClientId = await assertInvoicePortalAccess();
     if (!sessionClientId) return;
+
+    // Client-supplied (from the portal's ?milestone= param) — validated against
+    // the invoice's own payments below before it influences anything.
+    const claimedFocusIds = Array.isArray(focusedMilestoneIds)
+        ? focusedMilestoneIds.filter((id): id is string => typeof id === "string" && id.length <= 50).slice(0, 40)
+        : [];
 
     const claim = await prisma.invoice.updateMany({
         where: {
@@ -2808,11 +2814,17 @@ export async function markInvoiceViewed(invoiceId: string) {
             viewedAt: true, code: true, projectId: true,
             project: { select: { name: true, client: { select: { name: true } } } },
             client: { select: { name: true } },
+            payments: { select: { id: true, name: true, amount: true, status: true }, orderBy: [{ createdAt: "asc" }, { id: "asc" }] },
         },
     });
     if (invoice) {
         const clientName = invoice.client?.name || invoice.project?.client?.name || "A client";
         const projectName = invoice.project?.name || "";
+        // The milestones the client was actually looking at (focused portal view).
+        const focusedPayments = invoice.payments.filter(
+            p => claimedFocusIds.includes(p.id) && p.status !== "Paid" && p.status !== "Canceled"
+        );
+        const focusedTotal = focusedPayments.reduce((sum, p) => sum + Number(p.amount), 0);
         try {
             const settings = await getCachedCompanySettings();
             if (settings.notificationEmail && isNotificationEnabled(settings, "invoiceViewed")) {
@@ -2822,7 +2834,9 @@ export async function markInvoiceViewed(invoiceId: string) {
                 let attachments: { filename: string; content: Buffer }[] | undefined = undefined;
                 try {
                     const { generateInvoicePdf } = await import("./pdf");
-                    const pdfBuffer = await generateInvoicePdf(invoiceId);
+                    const pdfBuffer = await generateInvoicePdf(invoiceId, {
+                        requestedMilestoneIds: focusedPayments.map(p => p.id),
+                    });
                     if (pdfBuffer) {
                         attachments = [{ filename: `Invoice_${invoice.code}.pdf`, content: pdfBuffer }];
                     }
@@ -2830,6 +2844,9 @@ export async function markInvoiceViewed(invoiceId: string) {
                     console.error("[markInvoiceViewed] PDF generation failed; sending without attachment:", e);
                 }
 
+                const focusedLine = focusedPayments.length > 0
+                    ? `<p style="margin: 0 0 4px; color: #333;">They were viewing the payment request for <strong>${focusedPayments.map(p => p.name).join(" · ")}</strong> (${formatCurrency(focusedTotal)}).</p>`
+                    : "";
                 await sendNotification(
                     settings.notificationEmail,
                     `👁️ Invoice Viewed — ${invoice.code}`,
@@ -2837,13 +2854,14 @@ export async function markInvoiceViewed(invoiceId: string) {
                         <div style="background: #ecfdf5; border: 1px solid #a7f3d0; border-radius: 8px; padding: 20px;">
                             <h3 style="margin: 0 0 8px; color: #065f46;">Invoice Viewed</h3>
                             <p style="margin: 0 0 4px; color: #333;"><strong>${clientName}</strong> opened invoice <strong>${invoice.code}</strong>${projectName ? ` for ${projectName}` : ""}.</p>
+                            ${focusedLine}
                             <p style="margin: 0 0 16px; color: #666; font-size: 13px;">Viewed at: ${new Date().toLocaleString()}</p>
                             <div style="text-align: center; margin: 16px 0;">
                                 <a href="${editorUrl}" style="display: inline-block; background: #059669; color: #fff; text-decoration: none; padding: 12px 24px; border-radius: 8px; font-weight: 600; font-size: 14px;">
                                     View Invoice
                                 </a>
                             </div>
-                            ${attachments ? `<p style="margin: 0; color: #666; font-size: 12px; text-align: center;">A PDF copy of this invoice is attached.</p>` : ""}
+                            ${attachments ? `<p style="margin: 0; color: #666; font-size: 12px; text-align: center;">A PDF copy of the invoice as the client saw it is attached.</p>` : ""}
                         </div>
                     </div>`,
                     attachments

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -2821,8 +2821,9 @@ export async function markInvoiceViewed(invoiceId: string, focusedMilestoneIds?:
         const clientName = invoice.client?.name || invoice.project?.client?.name || "A client";
         const projectName = invoice.project?.name || "";
         // The milestones the client was actually looking at (focused portal view).
+        // Pending-only — same predicate as the portal's focus mode and the PDF.
         const focusedPayments = invoice.payments.filter(
-            p => claimedFocusIds.includes(p.id) && p.status !== "Paid" && p.status !== "Canceled"
+            p => claimedFocusIds.includes(p.id) && p.status === "Pending"
         );
         const focusedTotal = focusedPayments.reduce((sum, p) => sum + Number(p.amount), 0);
         try {

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -459,7 +459,7 @@ export async function sendInvoiceToClientCore(invoiceId: string, overrideEmail?:
 
     const invoiceAdditionalEmail = invoice.client?.additionalEmail || invoice.project?.client?.additionalEmail || null;
     const invoiceCc = buildCc(recipientEmail, invoiceAdditionalEmail);
-    await sendNotification(
+    const emailResult = await sendNotification(
         recipientEmail,
         `${companyName} sent you an invoice — ${invoice.code}`,
         `<!DOCTYPE html>
@@ -496,6 +496,29 @@ export async function sendInvoiceToClientCore(invoiceId: string, overrideEmail?:
         undefined,
         { fromName: companyName, replyTo: settings?.email || undefined, cc: invoiceCc, copyToInternal: true }
     );
+
+    // Requested-marker stamp, gated on the email actually going out — a failed
+    // send must never leave the portal claiming a payment is due.
+    if (!emailResult?.success) {
+        return { success: false as const, error: "The invoice email could not be sent — please try again.", sentTo: undefined };
+    }
+
+    // A whole-invoice email asks the client for everything unpaid, so every
+    // Pending milestone becomes "requested". qbInvoiceSentAt doubles as the
+    // rail-neutral request marker: the portal only shows Pay buttons and due
+    // amounts for requested milestones. (Covers resendInvoiceCore too — it
+    // delegates here after refreshing QBO links.) Delivered-but-not-recorded
+    // must not read as a send failure — the email DID go out, and reporting
+    // failure here would invite a duplicate send — so the stamp is fail-soft
+    // and loud, same pattern as the milestone path.
+    try {
+        await prisma.paymentSchedule.updateMany({
+            where: { invoiceId, status: "Pending" },
+            data: { qbInvoiceSentAt: new Date() },
+        });
+    } catch (stampErr) {
+        console.error(`[sendInvoiceToClientCore] Email sent but the request stamp failed for invoice ${invoice.code} — portal will show nothing due until a resend:`, stampErr);
+    }
 
     // Log to activity feed (project-scoped only)
     if (invoice.projectId) {

--- a/src/lib/pdf.ts
+++ b/src/lib/pdf.ts
@@ -870,17 +870,29 @@ export async function generatePurchaseOrderPdf(poId: string): Promise<Buffer> {
     return Buffer.from(pdfBytes);
 }
 
-export async function generateInvoicePdf(invoiceId: string): Promise<Buffer> {
+export async function generateInvoicePdf(
+    invoiceId: string,
+    // When set, the PDF mirrors the client's milestone-scoped view: the listed
+    // milestones are marked "Requested" and the headline figure is the requested
+    // total, not the full invoice balance.
+    opts?: { requestedMilestoneIds?: string[] },
+): Promise<Buffer> {
     const invoice = await prisma.invoice.findUnique({
         where: { id: invoiceId },
         include: {
-            payments: { orderBy: { name: 'asc' } },
+            // Schedule order (same as the portal and invoice editor), not alphabetical.
+            // id tiebreaker: same-transaction inserts can share createdAt, and cuids
+            // are monotonic within a batch, so this pins insertion order.
+            payments: { orderBy: [{ createdAt: 'asc' }, { id: 'asc' }] },
             project: { include: { client: true } },
             client: true,
         },
     });
 
     if (!invoice) throw new Error('Invoice not found');
+
+    const requestedIds = new Set(opts?.requestedMilestoneIds ?? []);
+    const requestedPayments = invoice.payments.filter(p => requestedIds.has(p.id) && p.status !== 'Paid' && p.status !== 'Canceled');
 
     const company = await prisma.companySettings.findUnique({ where: { id: 'singleton' } });
 
@@ -962,9 +974,11 @@ export async function generateInvoicePdf(invoiceId: string): Promise<Buffer> {
 
         page.drawText(displayName, { x: invCols.name, y, size: 10, font: helvetica, color: colors.textMain });
 
-        const statusStr = payment.status || 'Pending';
-        const statusW = helvetica.widthOfTextAtSize(statusStr, 10);
-        page.drawText(statusStr, { x: invCols.status - statusW, y, size: 10, font: helvetica, color: payment.status === 'Paid' ? colors.primary : colors.textMuted });
+        const isRequested = requestedIds.has(payment.id) && payment.status !== 'Paid' && payment.status !== 'Canceled';
+        const statusStr = isRequested ? 'Requested' : (payment.status || 'Pending');
+        const statusFont = isRequested ? helveticaBold : helvetica;
+        const statusW = statusFont.widthOfTextAtSize(statusStr, 10);
+        page.drawText(statusStr, { x: invCols.status - statusW, y, size: 10, font: statusFont, color: payment.status === 'Paid' || isRequested ? colors.primary : colors.textMuted });
 
         const dueDateStr = payment.dueDate ? new Date(payment.dueDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : '—';
         const dueDateW = helvetica.widthOfTextAtSize(dueDateStr, 10);
@@ -993,8 +1007,13 @@ export async function generateInvoicePdf(invoiceId: string): Promise<Buffer> {
     page.drawText(totalStr, { x: invCols.amount - totalW, y, size: 10, font: helvetica, color: colors.textMain });
     y -= 22;
 
-    page.drawText('Balance Due', { x: invLabelX, y, size: 14, font: helveticaBold, color: colors.primary });
-    const balStr = formatCurrency(balanceDue);
+    // Milestone-scoped view: the headline is what was requested of the client,
+    // not the whole outstanding balance.
+    const requestedTotal = requestedPayments.reduce((sum, p) => sum + (Number(p.amount) || 0), 0);
+    const headlineLabel = requestedPayments.length > 0 ? 'Amount Requested' : 'Balance Due';
+    const headlineAmt = requestedPayments.length > 0 ? requestedTotal : balanceDue;
+    page.drawText(headlineLabel, { x: invLabelX, y, size: 14, font: helveticaBold, color: colors.primary });
+    const balStr = formatCurrency(headlineAmt);
     const balW = helveticaBold.widthOfTextAtSize(balStr, 14);
     page.drawText(balStr, { x: invCols.amount - balW, y, size: 14, font: helveticaBold, color: colors.primary });
 

--- a/src/lib/pdf.ts
+++ b/src/lib/pdf.ts
@@ -892,7 +892,8 @@ export async function generateInvoicePdf(
     if (!invoice) throw new Error('Invoice not found');
 
     const requestedIds = new Set(opts?.requestedMilestoneIds ?? []);
-    const requestedPayments = invoice.payments.filter(p => requestedIds.has(p.id) && p.status !== 'Paid' && p.status !== 'Canceled');
+    // Pending-only — same predicate as the portal's focus mode and markInvoiceViewed.
+    const requestedPayments = invoice.payments.filter(p => requestedIds.has(p.id) && p.status === 'Pending');
 
     const company = await prisma.companySettings.findUnique({ where: { id: 'singleton' } });
 
@@ -974,7 +975,7 @@ export async function generateInvoicePdf(
 
         page.drawText(displayName, { x: invCols.name, y, size: 10, font: helvetica, color: colors.textMain });
 
-        const isRequested = requestedIds.has(payment.id) && payment.status !== 'Paid' && payment.status !== 'Canceled';
+        const isRequested = requestedIds.has(payment.id) && payment.status === 'Pending';
         const statusStr = isRequested ? 'Requested' : (payment.status || 'Pending');
         const statusFont = isRequested ? helveticaBold : helvetica;
         const statusW = statusFont.widthOfTextAtSize(statusStr, 10);

--- a/src/lib/quickbooks-payments.ts
+++ b/src/lib/quickbooks-payments.ts
@@ -80,7 +80,9 @@ export async function claimQBInvoiceUnlink(
         data: {
             qbInvoiceId: null,
             qbInvoiceLink: null,
-            qbInvoiceSentAt: null,
+            // qbInvoiceSentAt deliberately survives the unlink: it records that a
+            // payment request was emailed (the portal's "due" marker), which stays
+            // true even when the QBO invoice behind it is voided and re-staged.
             qbSyncedAt: null,
             qbSyncError: null,
         },


### PR DESCRIPTION
## What

Follow-up to today's first milestone-scoped send on CHRISTENSEN INV-00319. Two commits:

### Commit 1 — internal record matches what the client saw
1. **Invoice PDF milestone order** — was alphabetical, scrambling the schedule. Now creation order with an `id` tiebreak, applied uniformly to the PDF generator, invoice editor/portal queries, portal project page, and the viewed-notification query.
2. **Invoice Viewed notification mirrors the client's view** — the portal passes the `?milestone=` focus ids into `markInvoiceViewed` (validated server-side). The internal email names the requested milestone(s) + total, and the attached PDF marks those rows **Requested** with headline **Amount Requested** instead of the full Balance Due.
3. **Focused portal view hides the full balance** — reference line removed; `parseFocusIds()` shared between rendering and the action.

### Commit 2 — "due" means REQUESTED (Richard's field report)
Sandi's portal overview said **Payment Due $244,800 / 7 payments awaiting your approval** when only one $30,000 milestone had been requested. One predicate now rules every surface: *a milestone is due iff Pending AND a payment request was emailed for it* (`qbInvoiceSentAt`).

- Portal home card badge, project overview callout, Invoices tab ("Due now: $X" / "Nothing due right now"), and the invoice document header ("Due Now" + small-print remaining balance) all show requested amounts only.
- Pay Now buttons only render on requested Pending milestones; unrequested rows show "Not yet due".
- Whole-invoice sends (`sendInvoiceToClientCore`/`resendInvoiceCore`) stamp all Pending milestones as requested — only after the email verifiably sends; failed send returns failure with no stamp; post-delivery stamp is fail-soft + loud (no duplicate-send bait).
- `claimQBInvoiceUnlink` keeps `qbInvoiceSentAt` — a voided/re-staged QBO invoice doesn't un-ask the client.
- Focus/viewed/PDF predicates are Pending-only: Processing ACH and Canceled rows can't focus, re-offer checkout, or show as overdue; overdue requires requested.

Standalone Download PDF / Email-me-a-copy keep the full-invoice view on purpose.

## Review

Codex peer review, 2 rounds per commit (4 total). Round-1 blockers on commit 2 (client-query regression only visible to real clients, whole-invoice-send inconsistency) and round-2 ordering findings (stamp-on-failed-email, uncaught post-delivery stamp, Break-QB-Link erasing the marker) all fixed. Deferred by decision: rail-neutral rename of `qbInvoiceSentAt` → `paymentRequestedAt`; Canceled-row labeling on project detail (pre-existing).

## Testing

- `npm run build` — 0 errors (both commits)
- Known-red CI: the two **selections** e2e specs fail on every PR (pre-existing storage-signature issue in CI, being fixed in a separate session — proven unrelated: PR #290 with a disjoint diff fails identically). `money-pipeline` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)