### PR TITLE
fix(ci): hermetic e2e storage + engage selection AI mocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,22 @@ jobs:
       NEXT_PUBLIC_APP_URL: http://localhost:3000
       NEXT_PUBLIC_SUPABASE_URL: https://ghzdbzdnwjxazvmcefbh.supabase.co
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+      # SUPABASE_URL stays (it's non-secret TRUST config — the SSRF hostname
+      # allowlist in secure-storage.ts and the attachment gate in
+      # client-messages both key off its presence) but the service key is
+      # deliberately gone: storage is hermetic here, like the DB.
+      # E2E_STORAGE_MOCK routes getSupabase() to an in-memory stub
+      # (src/lib/supabase-storage-mock.ts), so e2e never talks to the live
+      # bucket and can't write objects into it. (The prod service key this
+      # job used to get went stale when the key was rotated 2026-07-23, which
+      # broke every storage-dependent spec with "signature verification
+      # failed".)
       SUPABASE_URL: https://ghzdbzdnwjxazvmcefbh.supabase.co
-      SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+      E2E_STORAGE_MOCK: "1"
+      # Routes the selection AI features (ai-sort, decision-schedule-link) to
+      # their deterministic mocks. Without it the specs hit the real Anthropic
+      # API on every PR and the forced-failure test marker is inert prose.
+      SELECTION_AI_MOCK: "1"
       GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
       GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
       STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -22,6 +22,19 @@ Three safeguards now exist — keep all three intact:
    `DATABASE_URL`/`DIRECT_URL` at it. No Supabase secret is exposed to the
    e2e job. The DB dies with the runner.
 
+   **Storage is hermetic too (July 2026).** The job sets `E2E_STORAGE_MOCK=1`,
+   which makes `getSupabase()` return an in-memory stub
+   (`src/lib/supabase-storage-mock.ts`) instead of a real client — so
+   attachment/PDF/signature paths work in e2e without a storage service key
+   and can never write objects into the live bucket. (`SUPABASE_URL` itself
+   stays set: it's non-secret trust config for the SSRF hostname allowlist
+   and attachment gating.) The job also sets `SELECTION_AI_MOCK=1` so the
+   selection AI features use their deterministic mocks instead of calling the
+   real Anthropic API. Both flags are inert on Vercel; the storage mock
+   additionally requires `PLAYWRIGHT_TEST_SECRET` to be set (see
+   `isE2eStorageMockEnabled()` in `src/lib/supabase.ts`), since it fakes
+   successful writes and must never engage outside a test environment.
+
 2. **`e2e/data.setup.ts` refuses to run against the live DB.**
    It aborts if `DATABASE_URL` (env or `.env`) looks like Supabase, unless
    `ALLOW_PROD_E2E=1` is explicitly set. Local `.env` points at prod, so a
@@ -59,6 +72,8 @@ docker run --rm -d --name probuild-e2e -p 5433:5432 -e POSTGRES_PASSWORD=probuil
 $env:DATABASE_URL = "postgresql://postgres:probuild@localhost:5433/postgres?pgbouncer=true"
 $env:DIRECT_URL   = "postgresql://postgres:probuild@localhost:5433/postgres"
 $env:PLAYWRIGHT_TEST_SECRET = "any-local-secret"
+$env:E2E_STORAGE_MOCK = "1"     # in-memory storage stub — never the live bucket
+$env:SELECTION_AI_MOCK = "1"    # deterministic AI mocks — no real Anthropic calls
 npx prisma db push --skip-generate
 npx playwright test
 ```

--- a/e2e/selections-item-threads.spec.ts
+++ b/e2e/selections-item-threads.spec.ts
@@ -4,6 +4,7 @@ import { signClientPortalToken } from "../src/lib/client-portal-auth";
 import { canAccessProject } from "../src/lib/permissions";
 import { postSelectionItemComment } from "../src/lib/selection-item-thread-core";
 import { createComment, getUnreadSelectionThreadCountForStaff } from "../src/lib/selection-item-thread-dependencies";
+import { isE2eStorageMockEnabled } from "../src/lib/supabase";
 
 const prisma = new PrismaClient();
 const run = `selection-threads-${process.pid}-${Date.now()}`;
@@ -312,17 +313,22 @@ test.describe.serial("selection item discussion threads", () => {
   });
 
   // Attachment round-trip. A real multipart upload through saveProjectFile()
-  // needs real Supabase Storage credentials (SUPABASE_URL +
-  // SUPABASE_SERVICE_KEY) — present in CI's Playwright job, but this sandbox
-  // has neither, and per docs/TESTING.md must never be pointed at
-  // production's. The test below runs for real wherever those creds exist
-  // (CI, or a manually configured environment) and is skipped otherwise;
-  // meanwhile denied/invalid-extension posts and the canonical-shape DB
-  // write are provable without Storage at all (both below, always run).
-  const hasRealStorage = !!process.env.SUPABASE_URL && !!process.env.SUPABASE_SERVICE_KEY;
+  // needs working Supabase Storage — either the hermetic in-memory stub
+  // (isE2eStorageMockEnabled(), which is what CI's Playwright job turns on —
+  // see src/lib/supabase-storage-mock.ts) or real credentials (SUPABASE_URL
+  // + SUPABASE_SERVICE_KEY) in a manually configured environment. Per
+  // docs/TESTING.md, never production's. The gate imports the runtime's own
+  // predicate rather than re-deriving it so skip conditions can't drift from
+  // what getSupabase() actually does. The test below is skipped when neither
+  // is available; meanwhile denied/invalid-extension posts and the
+  // canonical-shape DB write are provable without Storage at all (both
+  // below, always run).
+  const hasWorkingStorage =
+    isE2eStorageMockEnabled() ||
+    (!!process.env.SUPABASE_URL && !!process.env.SUPABASE_SERVICE_KEY);
 
   test("client posts a real file through the route: shared ProjectFile, provenance, canonical shape, chip renders", async ({ browser }) => {
-    test.skip(!hasRealStorage, "requires real Supabase Storage credentials (SUPABASE_URL + SUPABASE_SERVICE_KEY) — see CI's Playwright job");
+    test.skip(!hasWorkingStorage, "requires working Supabase Storage (E2E_STORAGE_MOCK=1 or SUPABASE_URL + SUPABASE_SERVICE_KEY) — see CI's Playwright job");
 
     const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
     const page = await context.newPage();
@@ -367,10 +373,11 @@ test.describe.serial("selection item discussion threads", () => {
       await card.getByTestId("selection-thread-toggle").click();
       await expect(card.getByTestId(`selection-thread-attachment-${fileId}`)).toContainText("swatch.png");
     } finally {
-      // This test is the only one in the suite that touches real Supabase
-      // Storage (CI's Playwright job has real credentials) — clean up
-      // exactly what it created, by exact id, so nothing accumulates in the
-      // live bucket across runs.
+      // This test is the only one in the suite that writes to Storage (the
+      // in-memory stub in CI, a real bucket where real credentials are
+      // configured) — clean up exactly what it created, by exact id, so
+      // nothing accumulates in a live bucket across runs. Against the stub
+      // the remove is a harmless no-op.
       if (fileId) {
         const file = await prisma.projectFile.findUnique({ where: { id: fileId }, select: { url: true } });
         await prisma.projectFile.delete({ where: { id: fileId } }).catch(() => {});

--- a/src/lib/supabase-storage-mock.ts
+++ b/src/lib/supabase-storage-mock.ts
@@ -1,0 +1,128 @@
+// In-memory Supabase Storage stand-in for e2e runs (E2E_STORAGE_MOCK=1) —
+// see the production guard in supabase.ts's getSupabase(), which mirrors the
+// SELECTION_AI_MOCK gate (flag && !process.env.VERCEL, so it can never engage
+// on a real deploy). CI's Playwright job runs against a throwaway Postgres
+// with no Supabase credentials at all; this stub makes the storage-dependent
+// paths (comment attachments, signed-PDF filing, signature persistence) work
+// hermetically instead of either failing or writing junk objects into the
+// live production bucket.
+//
+// Only the `storage` surface is implemented — Supabase is storage-only on the
+// server (data access is Prisma, auth is NextAuth), so nothing else should be
+// reached in a test run. Objects live in a Map cached on globalThis so state
+// survives Next.js instantiating this module once per route bundle.
+//
+// KNOWN LIMITATION: the URLs this mock returns (public, signed, signed-upload)
+// have the right shape but point at a non-serving host — server-side storage
+// I/O (upload/download/remove) works, but flows where the BROWSER fetches or
+// PUTs to a storage URL directly (FileBrowser signed uploads, takeoff/receipt
+// direct uploads, rendering a public object URL) cannot round-trip under this
+// mock. No current e2e spec exercises those; a spec that needs them requires
+// real credentials in a non-production bucket, not this stub.
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+type StoredObject = { bytes: Buffer; contentType: string };
+
+// Host is deliberately fake but the URL keeps Supabase's real object-URL path
+// shape (`/storage/v1/object/public/<bucket>/<path>`): cleanup code locates
+// the storage path by slicing stored URLs at the `/<bucket>/` marker, and
+// that must keep working on rows the stub created.
+const MOCK_PUBLIC_HOST = "http://supabase-storage-mock.e2e.invalid";
+
+const globalCache = globalThis as unknown as {
+    __e2eStorageMockObjects?: Map<string, StoredObject>;
+};
+
+function objects(): Map<string, StoredObject> {
+    globalCache.__e2eStorageMockObjects ??= new Map();
+    return globalCache.__e2eStorageMockObjects;
+}
+
+function key(bucket: string, path: string): string {
+    return `${bucket}/${path}`;
+}
+
+async function toBuffer(body: unknown): Promise<Buffer> {
+    if (Buffer.isBuffer(body)) return body;
+    if (body instanceof Uint8Array) return Buffer.from(body);
+    if (body instanceof ArrayBuffer) return Buffer.from(body);
+    if (typeof body === "string") return Buffer.from(body);
+    if (body instanceof Blob) return Buffer.from(await body.arrayBuffer());
+    throw new Error(`E2E storage mock: unsupported upload body type (${typeof body})`);
+}
+
+function bucketApi(bucket: string) {
+    return {
+        async upload(
+            path: string,
+            body: unknown,
+            options?: { contentType?: string; upsert?: boolean },
+        ) {
+            const k = key(bucket, path);
+            if (objects().has(k) && !options?.upsert) {
+                // Same message a real duplicate upload returns.
+                return { data: null, error: { message: "The resource already exists" } };
+            }
+            objects().set(k, {
+                bytes: await toBuffer(body),
+                contentType: options?.contentType ?? "application/octet-stream",
+            });
+            return { data: { path }, error: null };
+        },
+
+        getPublicUrl(path: string) {
+            return {
+                data: {
+                    publicUrl: `${MOCK_PUBLIC_HOST}/storage/v1/object/public/${bucket}/${path}`,
+                },
+            };
+        },
+
+        async remove(paths: string[]) {
+            for (const path of paths) objects().delete(key(bucket, path));
+            return { data: [], error: null };
+        },
+
+        async download(path: string) {
+            const stored = objects().get(key(bucket, path));
+            if (!stored) return { data: null, error: { message: "Object not found" } };
+            return {
+                data: new Blob([new Uint8Array(stored.bytes)], { type: stored.contentType }),
+                error: null,
+            };
+        },
+
+        async createSignedUrl(path: string, _ttlSeconds: number) {
+            if (!objects().has(key(bucket, path))) {
+                return { data: null, error: { message: "Object not found" } };
+            }
+            return {
+                data: {
+                    signedUrl: `${MOCK_PUBLIC_HOST}/storage/v1/object/sign/${bucket}/${path}?token=e2e-mock`,
+                },
+                error: null,
+            };
+        },
+
+        async createSignedUploadUrl(path: string) {
+            return {
+                data: {
+                    signedUrl: `${MOCK_PUBLIC_HOST}/storage/v1/object/upload/sign/${bucket}/${path}?token=e2e-mock`,
+                    token: "e2e-mock",
+                    path,
+                },
+                error: null,
+            };
+        },
+    };
+}
+
+export function createStorageMockClient(): SupabaseClient {
+    const client = {
+        storage: {
+            from: (bucket: string) => bucketApi(bucket),
+        },
+    };
+    return client as unknown as SupabaseClient;
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,4 +1,5 @@
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import { createStorageMockClient } from "./supabase-storage-mock";
 
 export const STORAGE_BUCKET = "project-files";
 
@@ -6,9 +7,34 @@ export const STORAGE_BUCKET = "project-files";
 let _supabase: SupabaseClient | null = null;
 let _initialized = false;
 
+/**
+ * True only in a test environment: the explicit opt-in flag, off Vercel, AND
+ * the Playwright test-auth secret present. The third condition exists because
+ * this mock is more dangerous than SELECTION_AI_MOCK if it ever engaged in a
+ * real deployment — uploads would "succeed" into process memory and the data
+ * would be silently lost — so the gate requires an independent marker that
+ * only test environments set (the same secret that enables the e2e
+ * credentials login in src/lib/auth.ts). e2e specs must use this exact
+ * predicate (not re-derive it) so skip conditions can't drift from runtime.
+ */
+export function isE2eStorageMockEnabled(): boolean {
+    return (
+        process.env.E2E_STORAGE_MOCK === "1" &&
+        !process.env.VERCEL &&
+        !!process.env.PLAYWRIGHT_TEST_SECRET
+    );
+}
+
 export function getSupabase(): SupabaseClient | null {
     if (_initialized) return _supabase;
     _initialized = true;
+
+    // Hermetic in-memory storage for e2e (CI's Playwright job) — see
+    // supabase-storage-mock.ts and the gate's own doc comment above.
+    if (isE2eStorageMockEnabled()) {
+        _supabase = createStorageMockClient();
+        return _supabase;
+    }
 
     const supabaseUrl = process.env.SUPABASE_URL || "";
     const supabaseKey = process.env.SUPABASE_SERVICE_KEY || "";


### PR DESCRIPTION
## Why every PR's Playwright job is red

The two failing specs (`selections-ai-sort`, `selections-item-threads`) landed 2026-07-30 with the selections phase-3 work, which was merged to main directly — the Playwright job only runs on `pull_request`, so unrelated PRs were the first time CI ever executed them. Two independent gaps, both proven from run 30661401342's logs:

1. **item-threads (500 at line 350):** comment attachments upload to prod Supabase storage, and the CI secret still holds the service key rotated 2026-07-23 → `signature verification failed`. (The `[approveEstimate] Failed to file signed PDF` errors in the logs are the same stale key, caught and logged.)
2. **ai-sort (`failedItemIds` empty at line 240):** the deterministic mock requires `SELECTION_AI_MOCK=1`, which the job never set — so CI has been calling the **real Anthropic API on every PR run**, and the forced-failure marker is inert prose to a real model.

## Fix (hermetic — no prod service key in CI)

- New `src/lib/supabase-storage-mock.ts`: in-memory Supabase Storage stand-in (upload/getPublicUrl/remove/download/createSignedUrl/createSignedUploadUrl). State lives on `globalThis` to survive per-route-bundle module instantiation. Known limitation (documented in the header): browser-direct PUT/fetch of storage URLs can't round-trip — no current spec exercises that.
- `getSupabase()` returns the stub only when `isE2eStorageMockEnabled()`: `E2E_STORAGE_MOCK=1 && !VERCEL && PLAYWRIGHT_TEST_SECRET` — three independent conditions, since this mock fakes successful writes and must never engage outside a test environment.
- `ci.yml` playwright job: **`SUPABASE_SERVICE_KEY` removed entirely**; `SUPABASE_URL` kept (non-secret trust config — SSRF hostname allowlist, attachment gating); `E2E_STORAGE_MOCK=1` + `SELECTION_AI_MOCK=1` added.
- The item-threads attachment test's skip gate now imports `isE2eStorageMockEnabled()` instead of re-deriving env checks, so it can't drift from runtime.
- `docs/TESTING.md` updated (storage hermeticity + local-run flags).

## Verification

- Local prod build + throwaway Postgres, both flags set: the two failing specs **31/31**, `money-pipeline` **32/32** (no assertion flips from storage starting to work — its signature tests use injected fake buckets), verify suites **12/12**.
- Codex peer review, two rounds: round-1 blocker (guard strength) fixed via the triple-condition predicate; round-1 catch (keep `SUPABASE_URL` as trust config) applied; round 2 clean — no blockers, no real issues, no nits.

Follow-ups worth noting (not in this PR): the stale `SUPABASE_SERVICE_KEY` GitHub secret can now be deleted outright, and `NEXT_PUBLIC_SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_ANON_KEY` appear unused in `src/` (dead env in both CI jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)