### PR TITLE
fix(proxy): exempt /api/office-tasks/ingest from session-auth redirect

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -34,10 +34,14 @@ const MOBILE_AUTHENTICATED_ROUTE_PATTERNS = [
 // api/selections/link-schedule is the same shape (staff-only, self-
 // authorizing, must return a clean 403) for the schedule-linking AI
 // suggestion route (docs/superpowers/plans/2026-07-31-selection-templates-due-dates.md).
+// api/office-tasks/ingest is a machine-to-machine endpoint (GTR Automations
+// bot) that self-authenticates with a Bearer secret (OFFICE_TASKS_INGEST_SECRET)
+// and must return a clean 401, not a redirect to /login. Exact-match only —
+// future descendants under /api/office-tasks/ must NOT inherit the bypass.
 // privacy / terms / account-deletion are static legal pages with no data access.
 // The app stores require them to be reachable by a logged-out reviewer, and Google
 // Play specifically requires a public account-deletion URL.
-const PUBLIC_PROXY_BYPASS_PATTERN = /^\/(?:api\/health$|api\/(?:auth|cron|twilio|webhook|payments|portal|integrations|mcp(?:\/|$)|version|pdf\/(?:estimates|invoices)|sub-portal|mobile|selections\/(?:item-comments|ai-sort|link-schedule))(?:\/|$)|login(?:\/|$)|portal(?:\/|$)|sub-portal(?:\/|$)|share(?:\/|$)|privacy(?:\/|$)|terms(?:\/|$)|account-deletion(?:\/|$)|support(?:\/|$)|_next\/(?:static|image)(?:\/|$)|favicon\.ico$|.*\.(?:png|jpg|svg|webmanifest)$)/;
+const PUBLIC_PROXY_BYPASS_PATTERN = /^\/(?:api\/health$|api\/(?:auth|cron|twilio|webhook|payments|portal|integrations|mcp(?:\/|$)|version|pdf\/(?:estimates|invoices)|sub-portal|mobile|selections\/(?:item-comments|ai-sort|link-schedule))(?:\/|$)|api\/office-tasks\/ingest\/?$|login(?:\/|$)|portal(?:\/|$)|sub-portal(?:\/|$)|share(?:\/|$)|privacy(?:\/|$)|terms(?:\/|$)|account-deletion(?:\/|$)|support(?:\/|$)|_next\/(?:static|image)(?:\/|$)|favicon\.ico$|.*\.(?:png|jpg|svg|webmanifest)$)/;
 const CHANGE_ORDER_BILLING_PDF_PATTERN = /^\/api\/pdf\/change-orders\/[^/]+\/billing\/[^/]+\/?$/;
 
 // The legal pages are static server components that define no Server Actions.


### PR DESCRIPTION
## Problem
The GTR Automations bot's `POST /api/office-tasks/ingest` calls return **307 → /login?callbackUrl=/api/office-tasks/ingest** because the auth proxy intercepts the request before the route handler's Bearer-token check runs. Every office to-do the bot filed bounced; it's holding payloads in its state folder until this ships.

## Fix
One-line addition to `PUBLIC_PROXY_BYPASS_PATTERN` in `src/proxy.ts`: an **exact-match** bypass `api\/office-tasks\/ingest\/?$` (same style as `api/health`). The handler already self-authenticates with `Authorization: Bearer <OFFICE_TASKS_INGEST_SECRET>` and fails closed with 401 — the secret is confirmed present in Vercel prod env.

Deliberately NOT subtree-scoped: future routes under `/api/office-tasks/` will not inherit the bypass (Codex review flagged the subtree form as a footgun; addressed).

## Review
Codex peer review: no blockers. Real issue (descendant inheritance via the shared `(?:\/|$)` suffix) fixed by switching to the exact-match alternative. Nits noted: method-agnostic bypass (only POST exists on the route), timing-safe compare optional, pre-existing `mcp` regex oddity untouched.

## Verification
- Regex tested against 16 path cases (exact + trailing slash allowed; descendants, siblings, `ingestx`, `/api/office-tasks` denied; all existing branches unchanged)
- `npm run build` passes with 0 errors
- Post-deploy: curl with wrong Bearer must return 401 JSON (not 307); anonymous `/api/projects` still redirects

🤖 Generated with [Claude Code](https://claude.com/claude-code)