### PR TITLE
fix(security): require auth on all PDF document routes

### DIFF
--- a/src/app/api/daily-logs/[projectId]/pdf/route.ts
+++ b/src/app/api/daily-logs/[projectId]/pdf/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { isStaffRequest } from "@/lib/pdf-route-auth";
 import { prisma } from "@/lib/prisma";
 import { PDFDocument, rgb, StandardFonts } from "pdf-lib";
 
@@ -19,6 +20,11 @@ export async function GET(
     { params }: { params: Promise<{ projectId: string }> }
 ) {
     const { projectId } = await params;
+
+    // Internal field report — staff only.
+    if (!await isStaffRequest()) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
 
     const project = await prisma.project.findUnique({
         where: { id: projectId },
@@ -242,6 +248,7 @@ export async function GET(
     return new NextResponse(buffer, {
         headers: {
             "Content-Type": "application/pdf",
+            "Cache-Control": "private, no-store",
             "Content-Disposition": `attachment; filename="daily-logs-${project.name.replace(/\s+/g, "-")}.pdf"`,
         },
     });

--- a/src/app/api/pdf/[id]/route.ts
+++ b/src/app/api/pdf/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { generateEstimatePdf } from "@/lib/pdf";
+import { isStaffRequest } from "@/lib/pdf-route-auth";
 
 export async function GET(
     req: NextRequest,
@@ -12,6 +13,11 @@ export async function GET(
         return NextResponse.json({ error: "Missing ID" }, { status: 400 });
     }
 
+    // Legacy staff-facing estimate PDF; clients get theirs via /portal/estimates.
+    if (!await isStaffRequest()) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
     try {
         const pdfBuffer = await generateEstimatePdf(id);
 
@@ -21,6 +27,7 @@ export async function GET(
             status: 200,
             headers: {
                 "Content-Type": "application/pdf",
+                "Cache-Control": "private, no-store",
                 "Content-Disposition": inline
                     ? `inline; filename="Estimate_${id}.pdf"`
                     : `attachment; filename="Estimate_${id}.pdf"`,

--- a/src/app/api/pdf/change-orders/[id]/billing/[billingId]/route.ts
+++ b/src/app/api/pdf/change-orders/[id]/billing/[billingId]/route.ts
@@ -1,10 +1,7 @@
-import { getServerSession } from "next-auth";
 import { NextRequest, NextResponse } from "next/server";
-import { authOptions } from "@/lib/auth";
-import { verifyClientPortalToken } from "@/lib/client-portal-auth";
 import { generateChangeOrderBillingPdf } from "@/lib/pdf";
+import { getPortalClientId, isStaffRequest } from "@/lib/pdf-route-auth";
 import { prisma } from "@/lib/prisma";
-import { isStaffAccountEnabled } from "@/lib/staff-status";
 
 function notFound() {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -29,17 +26,15 @@ export async function GET(
     });
     if (!billing?.paymentSchedule) return notFound();
 
-    const session = await getServerSession(authOptions);
-    const staffEmail = session?.user?.email;
-    const staffAuthorized = Boolean(staffEmail && await isStaffAccountEnabled(staffEmail));
-
-    const token = req.nextUrl.searchParams.get("token") || req.cookies.get("client_portal_token")?.value;
-    const tokenPayload = token ? await verifyClientPortalToken(token) : null;
-    const invoiceClientId = billing.paymentSchedule.invoice.clientId
-        || billing.paymentSchedule.invoice.project?.clientId
-        || null;
-    const portalAuthorized = Boolean(tokenPayload && invoiceClientId && tokenPayload.clientId === invoiceClientId);
-    if (!staffAuthorized && !portalAuthorized) return notFound();
+    if (!await isStaffRequest()) {
+        // OR entitlement, mirroring getInvoiceForPortal: the invoice's own
+        // client or the project's client may fetch the billing backup.
+        const portalClientId = await getPortalClientId(req);
+        const invoice = billing.paymentSchedule.invoice;
+        const portalAuthorized = Boolean(portalClientId
+            && (portalClientId === invoice.clientId || portalClientId === invoice.project?.clientId));
+        if (!portalAuthorized) return notFound();
+    }
 
     try {
         const pdf = await generateChangeOrderBillingPdf(id, billingId);

--- a/src/app/api/pdf/change-orders/[id]/route.ts
+++ b/src/app/api/pdf/change-orders/[id]/route.ts
@@ -1,5 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { generateChangeOrderPdf } from "@/lib/pdf";
+import { getPortalClientId, isStaffRequest } from "@/lib/pdf-route-auth";
+import { prisma } from "@/lib/prisma";
+
+function notFound() {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+}
 
 export async function GET(
     req: NextRequest,
@@ -11,6 +17,23 @@ export async function GET(
         return NextResponse.json({ error: "Missing ID" }, { status: 400 });
     }
 
+    // Entitlement mirrors getChangeOrderForPortal (IDOR-4): staff may fetch any
+    // change order; a portal client only their own project's, and never a
+    // Draft — that includes invalidated-after-edit versions.
+    if (!await isStaffRequest()) {
+        const portalClientId = await getPortalClientId(req);
+        if (!portalClientId) return notFound();
+        const co = await prisma.changeOrder.findFirst({
+            where: {
+                id,
+                project: { clientId: portalClientId },
+                status: { in: ["Sent", "Approved", "Declined"] },
+            },
+            select: { id: true },
+        });
+        if (!co) return notFound();
+    }
+
     try {
         const pdfBuffer = await generateChangeOrderPdf(id);
         const inline = req.nextUrl.searchParams.get("inline") === "true";
@@ -19,6 +42,7 @@ export async function GET(
             status: 200,
             headers: {
                 "Content-Type": "application/pdf",
+                "Cache-Control": "private, no-store",
                 "Content-Disposition": inline
                     ? `inline; filename="ChangeOrder_${id}.pdf"`
                     : `attachment; filename="ChangeOrder_${id}.pdf"`,

--- a/src/app/api/pdf/invoices/[id]/route.ts
+++ b/src/app/api/pdf/invoices/[id]/route.ts
@@ -1,5 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { generateInvoicePdf } from "@/lib/pdf";
+import { getPortalClientId, isStaffRequest } from "@/lib/pdf-route-auth";
+import { prisma } from "@/lib/prisma";
+
+function notFound() {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+}
 
 export async function GET(
     req: NextRequest,
@@ -11,6 +17,22 @@ export async function GET(
         return NextResponse.json({ error: "Missing ID" }, { status: 400 });
     }
 
+    // This route is proxy-bypassed so portal clients can reach it without a
+    // staff session — it must authorize here. Entitlement mirrors
+    // getInvoiceForPortal: staff, or the client the invoice belongs to.
+    const invoice = await prisma.invoice.findUnique({
+        where: { id },
+        select: { clientId: true, project: { select: { clientId: true } } },
+    });
+    if (!invoice) return notFound();
+
+    if (!await isStaffRequest()) {
+        const portalClientId = await getPortalClientId(req);
+        const entitled = Boolean(portalClientId
+            && (portalClientId === invoice.clientId || portalClientId === invoice.project?.clientId));
+        if (!entitled) return notFound();
+    }
+
     try {
         const pdfBuffer = await generateInvoicePdf(id);
         const inline = req.nextUrl.searchParams.get("inline") === "true";
@@ -19,6 +41,7 @@ export async function GET(
             status: 200,
             headers: {
                 "Content-Type": "application/pdf",
+                "Cache-Control": "private, no-store",
                 "Content-Disposition": inline
                     ? `inline; filename="Invoice_${id}.pdf"`
                     : `attachment; filename="Invoice_${id}.pdf"`,

--- a/src/app/api/pdf/purchase-orders/[id]/route.ts
+++ b/src/app/api/pdf/purchase-orders/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { generatePurchaseOrderPdf } from "@/lib/pdf";
+import { isStaffRequest } from "@/lib/pdf-route-auth";
 
 export async function GET(
     req: NextRequest,
@@ -12,6 +13,11 @@ export async function GET(
         return NextResponse.json({ error: "Missing ID" }, { status: 400 });
     }
 
+    // Purchase orders are internal documents — staff only, no portal path.
+    if (!await isStaffRequest()) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
     try {
         const pdfBuffer = await generatePurchaseOrderPdf(id);
 
@@ -21,6 +27,7 @@ export async function GET(
             status: 200,
             headers: {
                 "Content-Type": "application/pdf",
+                "Cache-Control": "private, no-store",
                 "Content-Disposition": inline
                     ? `inline; filename="PurchaseOrder_${id}.pdf"`
                     : `attachment; filename="PurchaseOrder_${id}.pdf"`,

--- a/src/lib/pdf-route-auth.ts
+++ b/src/lib/pdf-route-auth.ts
@@ -1,0 +1,34 @@
+import { NextRequest } from "next/server";
+import { getSessionOrDev } from "@/lib/auth";
+import { verifyClientPortalToken } from "@/lib/client-portal-auth";
+import { resolveSessionClientId } from "@/lib/portal-auth";
+import { isStaffAccountEnabled } from "@/lib/staff-status";
+
+// Shared auth for the /api/pdf/* document routes. The proxy gates most of them,
+// but these handlers must not rely on that boundary alone: /api/pdf/invoices is
+// proxy-bypassed for portal clients, and NODE_ENV=development skips the proxy
+// entirely. Each route decides its own entitlement rule from these two facts.
+// getSessionOrDev keeps local `npm run dev` (which has no real session) working;
+// in production it is getServerSession.
+
+export async function isStaffRequest(): Promise<boolean> {
+    const session = await getSessionOrDev();
+    const email = session?.user?.email;
+    return Boolean(email && await isStaffAccountEnabled(email));
+}
+
+export async function getPortalClientId(req: NextRequest): Promise<string | null> {
+    const token = req.nextUrl.searchParams.get("token") || req.cookies.get("client_portal_token")?.value;
+    if (token) {
+        const payload = await verifyClientPortalToken(token);
+        if (payload?.clientId) return payload.clientId;
+    }
+    // Google-login clients carry a NextAuth session instead of a portal token;
+    // resolveSessionClientId identifies them the same way the portal pages do.
+    // Fail closed (404 upstream) rather than 500 if session resolution throws.
+    try {
+        return await resolveSessionClientId();
+    } catch {
+        return null;
+    }
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -34,11 +34,15 @@ const MOBILE_AUTHENTICATED_ROUTE_PATTERNS = [
 // api/selections/link-schedule is the same shape (staff-only, self-
 // authorizing, must return a clean 403) for the schedule-linking AI
 // suggestion route (docs/superpowers/plans/2026-07-31-selection-templates-due-dates.md).
+// api/pdf/estimates only redirects to the self-gating portal estimate page;
+// api/pdf/invoices and api/pdf/change-orders (incl. the billing sub-route)
+// self-authorize in the handler via src/lib/pdf-route-auth (staff session or
+// matching portal client), so portal clients can fetch their documents
+// without a staff session.
 // privacy / terms / account-deletion are static legal pages with no data access.
 // The app stores require them to be reachable by a logged-out reviewer, and Google
 // Play specifically requires a public account-deletion URL.
-const PUBLIC_PROXY_BYPASS_PATTERN = /^\/(?:api\/health$|api\/(?:auth|cron|twilio|webhook|payments|portal|integrations|mcp(?:\/|$)|version|pdf\/(?:estimates|invoices)|sub-portal|mobile|selections\/(?:item-comments|ai-sort|link-schedule))(?:\/|$)|login(?:\/|$)|portal(?:\/|$)|sub-portal(?:\/|$)|share(?:\/|$)|privacy(?:\/|$)|terms(?:\/|$)|account-deletion(?:\/|$)|support(?:\/|$)|_next\/(?:static|image)(?:\/|$)|favicon\.ico$|.*\.(?:png|jpg|svg|webmanifest)$)/;
-const CHANGE_ORDER_BILLING_PDF_PATTERN = /^\/api\/pdf\/change-orders\/[^/]+\/billing\/[^/]+\/?$/;
+const PUBLIC_PROXY_BYPASS_PATTERN = /^\/(?:api\/health$|api\/(?:auth|cron|twilio|webhook|payments|portal|integrations|mcp(?:\/|$)|version|pdf\/(?:estimates|invoices|change-orders)|sub-portal|mobile|selections\/(?:item-comments|ai-sort|link-schedule))(?:\/|$)|login(?:\/|$)|portal(?:\/|$)|sub-portal(?:\/|$)|share(?:\/|$)|privacy(?:\/|$)|terms(?:\/|$)|account-deletion(?:\/|$)|support(?:\/|$)|_next\/(?:static|image)(?:\/|$)|favicon\.ico$|.*\.(?:png|jpg|svg|webmanifest)$)/;
 
 // The legal pages are static server components that define no Server Actions.
 // Next's action IDs are global, so a bypassed path is a place an anonymous caller
@@ -47,7 +51,7 @@ const CHANGE_ORDER_BILLING_PDF_PATTERN = /^\/api\/pdf\/change-orders\/[^/]+\/bil
 const LEGAL_PAGE_PATTERN = /^\/(?:privacy|terms|account-deletion|support)(?:\/|$)/;
 
 export function isPublicProxyBypass(pathname: string) {
-    return PUBLIC_PROXY_BYPASS_PATTERN.test(pathname) || CHANGE_ORDER_BILLING_PDF_PATTERN.test(pathname);
+    return PUBLIC_PROXY_BYPASS_PATTERN.test(pathname);
 }
 
 function hasNextAuthSessionCookie(req: any) {
@@ -155,6 +159,6 @@ export const config = {
          * - favicon.ico, public folder images, etc
          * - manifest.webmanifest (PWA manifest — must be fetchable for install)
          */
-        "/((?!api/health$|api/auth|api/cron|api/twilio|api/webhook|api/payments|api/portal|api/integrations|api/mcp/|api/version|api/pdf/estimates|api/pdf/invoices|api/sub-portal|api/mobile|api/selections/item-comments|api/selections/ai-sort|api/selections/link-schedule|login|portal|sub-portal|share|privacy|terms|account-deletion|support|_next/static|_next/image|favicon.ico|.*\\.png|.*\\.jpg|.*\\.svg|.*\\.webmanifest).*)",
+        "/((?!api/health$|api/auth|api/cron|api/twilio|api/webhook|api/payments|api/portal|api/integrations|api/mcp/|api/version|api/pdf/estimates(?:/|$)|api/pdf/invoices(?:/|$)|api/pdf/change-orders(?:/|$)|api/sub-portal|api/mobile|api/selections/item-comments|api/selections/ai-sort|api/selections/link-schedule|login|portal|sub-portal|share|privacy|terms|account-deletion|support|_next/static|_next/image|favicon.ico|.*\\.png|.*\\.jpg|.*\\.svg|.*\\.webmanifest).*)",
     ],
 };


### PR DESCRIPTION
## Problem

During the 2026-08-05 change-order-description work, a draft change order's full PDF rendered in a browser session with no NextAuth session. Audit of `/api/pdf/*` found:

1. **`/api/pdf/invoices/[id]` was publicly downloadable on prod.** It is excluded from the proxy matcher (legacy exclusion for portal clients) and had zero in-handler auth — anyone with an invoice cuid got the full PDF. Confirmed with an unauthenticated probe: the request reached the handler (500 on a fake id) instead of redirecting to login.
2. The sibling routes (change orders, purchase orders, legacy `/api/pdf/[id]` estimate, daily logs) were protected **only** by the proxy — no in-handler auth, one matcher regression away from public, and fully open on any dev server since `NODE_ENV=development` skips the proxy entirely (which is what the original observation exercised).
3. `/api/pdf/estimates/[id]` is a bare redirect to the self-gating portal page — no exposure, unchanged.

## Fix

New `src/lib/pdf-route-auth.ts` (extracted from the already-gated billing PDF route):
- `isStaffRequest()` — session + enabled-staff DB check (`getSessionOrDev` keeps local dev working; dead code in production builds).
- `getPortalClientId()` — portal token from `?token=`/cookie, falling back to `resolveSessionClientId()` so Google-login clients aren't locked out.

Per-route entitlements:
- **Invoice PDF** — staff, or the invoice's own client / project client (mirrors `getInvoiceForPortal` OR-entitlement). 404 otherwise.
- **Change-order PDF** — staff, or the project's client for Sent/Approved/Declined only; Draft never serves to a client (mirrors `getChangeOrderForPortal`, the IDOR-4 rule). The proxy now bypasses `/api/pdf/change-orders` so the handler is the auth boundary — same model as its billing sub-route.
- **Purchase-order, legacy estimate, daily-log PDFs** — staff only.
- **Billing sub-route** — refactored onto the shared helper; entitlement aligned to the accessor's OR semantics; portal lookup short-circuited for staff.
- Proxy matcher pdf exclusions bounded with `(?:/|$)` so hypothetical sibling paths (`/api/pdf/invoices-foo`) stay behind the proxy.
- `Cache-Control: private, no-store` on all gated PDF responses.

## Verification

Anonymous probes against a local **production** build (`npm run start`):

| Route | Before | After |
|---|---|---|
| CO PDF (real draft id) | 307* / open in dev | **404** |
| CO billing PDF | 404 | 404 (unchanged) |
| Invoice PDF | **reached handler (PDF/500)** | **404** |
| PO / legacy / daily-log PDF | 307 | 307 (+in-handler gate) |
| `/api/pdf/change-ordersX/foo` sibling | router 404 (proxy skipped) | 307 to login |
| Estimate redirect | 302 | 302 (unchanged) |

`npm run build` (typecheck + next build) clean.

## Codex peer review

Two rounds. Fixed: OR-entitlement divergence, unreachable portal branch, Google-login client gap, matcher prefix boundary, missing Cache-Control, error-path 500, staff short-circuit. Defended: TOCTOU between the auth query and the generator's own re-fetch — identical pattern to the previously shipped billing route, microsecond window, worst case shows an entitled client their own CO mid-edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)