### PR TITLE
feat(mcp): chat can edit change orders (update_change_order + items in list_change_orders)

### DIFF
--- a/e2e/cost-plus-change-order.spec.ts
+++ b/e2e/cost-plus-change-order.spec.ts
@@ -826,12 +826,14 @@ test.describe.serial("PB-pipeline-004 cost-plus and split change orders", () => 
   // NOTE: this pins the MCP server version exactly, so it must be bumped in
   // lockstep with serverInfo in the route. 1.12.0 -> 1.13.0 when the PM tools
   // (files/folders, daily logs, punch, contacts) landed; 1.13.0 -> 1.14.0 when
-  // read_file/get_file_link and the connector audit trail landed; the voice-first
-  // cost-plus tools asserted below are unaffected and must keep working.
-  test("CPCO10: MCP is v1.14.0 and exposes the required voice-first tools and UI copy", () => {
+  // read_file/get_file_link and the connector audit trail landed; 1.14.0 ->
+  // 1.15.0 when update_change_order and items in list_change_orders landed;
+  // the voice-first cost-plus tools asserted below are unaffected and must
+  // keep working.
+  test("CPCO10: MCP is v1.15.0 and exposes the required voice-first tools and UI copy", () => {
     const mcp = readFileSync(join(process.cwd(), "src/app/api/mcp/[transport]/route.ts"), "utf8");
-    expect(mcp).toContain('version: "1.14.0"');
-    for (const tool of ["list_change_orders", "log_time", "log_expense", "bill_change_order"]) {
+    expect(mcp).toContain('version: "1.15.0"');
+    for (const tool of ["list_change_orders", "update_change_order", "log_time", "log_expense", "bill_change_order"]) {
       expect(mcp).toContain(`"${tool}"`);
     }
     expect(mcp).toContain("fingerprint");

--- a/scripts/verify-mcp-pm-tools.ts
+++ b/scripts/verify-mcp-pm-tools.ts
@@ -112,7 +112,7 @@ async function main() {
     // Static registry, security, migration, and no-Phase-2 contracts.
     assert.match(routeSource, /MCP_SECRET_RICHARD/);
     assert.match(routeSource, /timingSafeEqual/);
-    assert.match(routeSource, /serverInfo:\s*\{\s*name:\s*"probuild",\s*version:\s*"1\.14\.0"\s*\}/);
+    assert.match(routeSource, /serverInfo:\s*\{\s*name:\s*"probuild",\s*version:\s*"1\.15\.0"\s*\}/);
     for (const toolName of [
         "upload_file",
         "upload_files",

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -920,6 +920,12 @@ function createHandler(actor: RouteMcpActor) {
                     const costCodes = await prisma.costCode.findMany({ where: { isActive: true }, select: { id: true, code: true } });
                     const codeMap = new Map(costCodes.map(c => [c.code, c.id]));
                     const validTypes = ["Labor", "Material", "Allowance", "Subcontractor", "Equipment", "Other"];
+                    // An explicit costType must set BOTH the scalar `type` and the
+                    // costTypeId relation (scheduling prefers the relation) — a
+                    // keep-prior costTypeId under a changed `type` would leave the
+                    // item contradicting itself.
+                    const costTypes = await prisma.costType.findMany({ where: { isActive: true }, select: { id: true, name: true } });
+                    const typeMap = new Map(costTypes.map(t => [t.name, t.id]));
                     const priorItemIds = new Set(before.items.map(item => item.id));
                     data.items = args.items.map((item, idx) => {
                         const knownId = item.id !== undefined && priorItemIds.has(item.id);
@@ -946,7 +952,9 @@ function createHandler(actor: RouteMcpActor) {
                             id: knownId ? item.id : undefined,
                             name: item.name,
                             description: item.description,
-                            ...(item.costType && validTypes.includes(item.costType) ? { type: item.costType } : {}),
+                            ...(item.costType && validTypes.includes(item.costType)
+                                ? { type: item.costType, costTypeId: typeMap.get(item.costType) ?? null }
+                                : {}),
                             quantity: item.quantity,
                             unitCost: item.unitCost,
                             order: idx,

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -855,11 +855,15 @@ function createHandler(actor: RouteMcpActor) {
             "update_change_order",
             {
                 title: "Edit an unsigned change order",
-                annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+                // destructiveHint: replacement lists DELETE rows that are left out.
+                // Not idempotent: retrying a call whose new rows carry no id
+                // deletes and recreates those rows under fresh ids.
+                annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
                 description:
                     "Edits an unsigned Draft or Sent change order: title, description, pricing, line items, payment schedule. Omitted fields are unchanged. " +
                     "items and paymentSchedules are FULL REPLACEMENT lists — call list_change_orders first and resend every row you want to keep (with its id); rows left out are DELETED. " +
-                    "Item edits recompute the subtotal server-side. A scope edit to a Sent change order returns it to Draft (re-send with send_change_order before the customer can sign). " +
+                    "On a row with an existing id, omitted description/costCode/dueDate keep their stored values. Item edits recompute the subtotal server-side. " +
+                    "A scope edit to a Sent change order returns it to Draft (re-send with send_change_order before the customer can sign). " +
                     "Approved/signed change orders are locked; status cannot be changed here.",
                 inputSchema: {
                     changeOrderId: z.string().max(50).describe("Change order id from list_change_orders or list_project_billing"),
@@ -873,24 +877,30 @@ function createHandler(actor: RouteMcpActor) {
                         description: z.string().max(2000).optional().describe("Omitted on an existing row = keep its current description; empty string clears it"),
                         costCode: z.string().max(50).optional().describe("Omitted on an existing row = keep its current cost code; empty string clears it"),
                         costType: z.string().max(50).optional(),
-                        quantity: z.number().min(0).max(1_000_000),
-                        unitCost: z.number().min(0).max(10_000_000),
+                        quantity: z.number().min(0).max(10_000),
+                        unitCost: z.number().min(0).max(1_000_000),
                     })).min(1).max(100).optional().describe("Full replacement list of ALL line items (to clear every item, edit in ProBuild instead)"),
                     paymentSchedules: z.array(z.object({
                         id: z.string().max(50).optional().describe("Existing schedule id to update that row in place; omit for a new payment"),
                         name: z.string().min(1).max(300),
                         amount: z.number().positive().max(10_000_000),
-                        dueDate: z.string().optional(),
+                        dueDate: z.string().optional().describe("Omitted on an existing row = keep its current due date; empty string clears it"),
                         order: z.number().int().min(0).optional(),
                     })).max(20).optional().describe("Full replacement: two or more payments, or an empty array to remove the schedule. The final payment is adjusted so the schedule sums to the subtotal."),
                 },
             },
             async ({ changeOrderId, ...args }) => {
+                // Advisory prefetch: existence check, id-strip warnings, and the
+                // reverted-to-Draft note. All authoritative merge decisions
+                // (keep-prior fields, signed-scope lock, status) happen inside
+                // updateChangeOrderCore's FOR UPDATE transaction, so a concurrent
+                // edit between this read and the core can at worst mislabel a
+                // warning — never corrupt the row.
                 const before = await prisma.changeOrder.findUnique({
                     where: { id: changeOrderId },
                     select: {
                         code: true, status: true, projectId: true,
-                        items: { select: { id: true, costCodeId: true, description: true } },
+                        items: { select: { id: true } },
                     },
                 });
                 if (!before) return { ...textResult({ error: "Change order not found" }), isError: true };
@@ -904,35 +914,38 @@ function createHandler(actor: RouteMcpActor) {
 
                 if (args.items) {
                     // Same code-string → id mapping and type validation as create_change_order.
+                    // Keep-prior for omitted description/costCode/costType on existing rows is
+                    // resolved inside updateChangeOrderCore's locked transaction — this layer
+                    // only translates strings to ids (undefined passes through as "keep").
                     const costCodes = await prisma.costCode.findMany({ where: { isActive: true }, select: { id: true, code: true } });
                     const codeMap = new Map(costCodes.map(c => [c.code, c.id]));
                     const validTypes = ["Labor", "Material", "Allowance", "Subcontractor", "Equipment", "Other"];
-                    const priorById = new Map(before.items.map(item => [item.id, item]));
+                    const priorItemIds = new Set(before.items.map(item => item.id));
                     data.items = args.items.map((item, idx) => {
-                        const prior = item.id ? priorById.get(item.id) : undefined;
-                        if (item.id && !prior) {
+                        const knownId = item.id !== undefined && priorItemIds.has(item.id);
+                        if (item.id && !knownId) {
                             // Don't forward a foreign/stale id into the create path — it
                             // could collide with an item on another change order.
                             warnings.push(`Item id "${item.id}" is not on this change order — added as a new row instead.`);
                         }
-                        let costCodeId: string | null;
+                        let costCodeId: string | null | undefined;
                         if (item.costCode === undefined) {
-                            costCodeId = prior?.costCodeId ?? null;
+                            costCodeId = undefined; // keep-prior in the core
                         } else if (item.costCode === "") {
                             costCodeId = null;
                         } else if (codeMap.has(item.costCode)) {
                             costCodeId = codeMap.get(item.costCode)!;
                         } else {
-                            costCodeId = prior?.costCodeId ?? null;
-                            warnings.push(`Unknown cost code "${item.costCode}" on item "${item.name}" — ${costCodeId ? "kept its current code" : "left uncoded"}.`);
+                            costCodeId = undefined; // keep-prior; uncoded for a new row
+                            warnings.push(`Unknown cost code "${item.costCode}" on item "${item.name}" — ${knownId ? "kept its current code" : "left uncoded"}.`);
                         }
                         if (item.costType && !validTypes.includes(item.costType)) {
                             warnings.push(`Unknown cost type "${item.costType}" on item "${item.name}" — use one of: ${validTypes.join(", ")}.`);
                         }
                         return {
-                            id: prior ? item.id : undefined,
+                            id: knownId ? item.id : undefined,
                             name: item.name,
-                            description: item.description !== undefined ? item.description : (prior?.description ?? null),
+                            description: item.description,
                             ...(item.costType && validTypes.includes(item.costType) ? { type: item.costType } : {}),
                             quantity: item.quantity,
                             unitCost: item.unitCost,
@@ -946,7 +959,9 @@ function createHandler(actor: RouteMcpActor) {
                         id: row.id,
                         name: row.name,
                         amount: row.amount,
-                        dueDate: row.dueDate ?? null,
+                        // undefined passes through: the core keeps the stored due
+                        // date on a matching row; "" or null clears it.
+                        dueDate: row.dueDate,
                         order: row.order ?? idx,
                     }));
                 }

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -6,6 +6,7 @@ import { prisma } from "@/lib/prisma";
 import { createEstimateFromPhases, updateEstimateFromPhases, templateToPhases, estimateToPhases, CLOSED_PROJECT_STATUSES, CLOSED_LEAD_STAGES } from "@/lib/gpt-estimate";
 import { getProjectBilling, sendMilestoneInvoicesCore, resendInvoiceCore, createChangeOrderDraft, billChangeOrderCore, sendChangeOrderToClientCore, listReceivables, createInvoiceFromEstimateGuarded, previewCostPlusChangeOrderCore, billCostPlusChangeOrderCore } from "@/lib/billing-core";
 import { getCompanyPipeline, getStartCalendar, getUnappliedChangeOrders, getCrewConflicts } from "@/lib/schedule-core";
+import { updateChangeOrderCore, type ChangeOrderUpdateInput } from "@/lib/change-order-core";
 import { coTaxRate, coTaxLabel } from "@/lib/co-tax";
 import { ALLOWED_FILE_EXTENSIONS, fileExtension, mimeTypeForFileName, saveProjectFile } from "@/lib/project-files";
 import { calculateCrewTimeCosts, createExpenseCore, createTimeEntryCore, findCrewMatches } from "@/lib/time-expense-core";
@@ -166,7 +167,7 @@ function formatBytes(bytes: number): string {
 const WRITE_TOOLS = new Set([
     "create_estimate", "update_estimate", "send_estimate",
     "send_milestone_invoice", "resend_invoice", "create_invoice_from_estimate",
-    "create_change_order", "send_change_order", "bill_change_order",
+    "create_change_order", "update_change_order", "send_change_order", "bill_change_order",
     "create_lead", "log_time", "log_expense",
     "upload_file", "upload_files", "create_folder", "move_file",
     "create_daily_log", "add_punch_items",
@@ -186,7 +187,7 @@ const ENTITY_TYPE_BY_TOOL: Record<string, string> = {
     create_contract: "contract", update_contract: "contract", send_contract: "contract",
     create_estimate: "estimate", update_estimate: "estimate", send_estimate: "estimate",
     create_invoice_from_estimate: "invoice", send_milestone_invoice: "invoice", resend_invoice: "invoice",
-    create_change_order: "change_order", send_change_order: "change_order", bill_change_order: "change_order",
+    create_change_order: "change_order", update_change_order: "change_order", send_change_order: "change_order", bill_change_order: "change_order",
     apply_change_order_to_schedule: "change_order",
     create_lead: "lead",
     plan_schedule: "task", update_task_dates: "task", set_task_status: "task", assign_task_crew: "task",
@@ -851,6 +852,129 @@ function createHandler(actor: RouteMcpActor) {
         );
 
         server.registerTool(
+            "update_change_order",
+            {
+                title: "Edit an unsigned change order",
+                annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+                description:
+                    "Edits an unsigned Draft or Sent change order: title, description, pricing, line items, payment schedule. Omitted fields are unchanged. " +
+                    "items and paymentSchedules are FULL REPLACEMENT lists — call list_change_orders first and resend every row you want to keep (with its id); rows left out are DELETED. " +
+                    "Item edits recompute the subtotal server-side. A scope edit to a Sent change order returns it to Draft (re-send with send_change_order before the customer can sign). " +
+                    "Approved/signed change orders are locked; status cannot be changed here.",
+                inputSchema: {
+                    changeOrderId: z.string().max(50).describe("Change order id from list_change_orders or list_project_billing"),
+                    title: z.string().min(1).max(300).optional(),
+                    description: z.string().max(2000).optional().describe("Empty string clears the description"),
+                    pricingType: z.enum(["FIXED", "COST_PLUS"]).optional(),
+                    markupPercent: z.number().min(0).max(1000).nullable().optional(),
+                    items: z.array(z.object({
+                        id: z.string().max(50).optional().describe("Existing item id (from list_change_orders) to update that row in place; omit for a new item"),
+                        name: z.string().min(1).max(300),
+                        description: z.string().max(2000).optional().describe("Omitted on an existing row = keep its current description; empty string clears it"),
+                        costCode: z.string().max(50).optional().describe("Omitted on an existing row = keep its current cost code; empty string clears it"),
+                        costType: z.string().max(50).optional(),
+                        quantity: z.number().min(0).max(1_000_000),
+                        unitCost: z.number().min(0).max(10_000_000),
+                    })).min(1).max(100).optional().describe("Full replacement list of ALL line items (to clear every item, edit in ProBuild instead)"),
+                    paymentSchedules: z.array(z.object({
+                        id: z.string().max(50).optional().describe("Existing schedule id to update that row in place; omit for a new payment"),
+                        name: z.string().min(1).max(300),
+                        amount: z.number().positive().max(10_000_000),
+                        dueDate: z.string().optional(),
+                        order: z.number().int().min(0).optional(),
+                    })).max(20).optional().describe("Full replacement: two or more payments, or an empty array to remove the schedule. The final payment is adjusted so the schedule sums to the subtotal."),
+                },
+            },
+            async ({ changeOrderId, ...args }) => {
+                const before = await prisma.changeOrder.findUnique({
+                    where: { id: changeOrderId },
+                    select: {
+                        code: true, status: true, projectId: true,
+                        items: { select: { id: true, costCodeId: true, description: true } },
+                    },
+                });
+                if (!before) return { ...textResult({ error: "Change order not found" }), isError: true };
+
+                const warnings: string[] = [];
+                const data: ChangeOrderUpdateInput = {};
+                if (args.title !== undefined) data.title = args.title;
+                if (args.description !== undefined) data.description = args.description;
+                if (args.pricingType !== undefined) data.pricingType = args.pricingType;
+                if (args.markupPercent !== undefined) data.markupPercent = args.markupPercent;
+
+                if (args.items) {
+                    // Same code-string → id mapping and type validation as create_change_order.
+                    const costCodes = await prisma.costCode.findMany({ where: { isActive: true }, select: { id: true, code: true } });
+                    const codeMap = new Map(costCodes.map(c => [c.code, c.id]));
+                    const validTypes = ["Labor", "Material", "Allowance", "Subcontractor", "Equipment", "Other"];
+                    const priorById = new Map(before.items.map(item => [item.id, item]));
+                    data.items = args.items.map((item, idx) => {
+                        const prior = item.id ? priorById.get(item.id) : undefined;
+                        if (item.id && !prior) {
+                            // Don't forward a foreign/stale id into the create path — it
+                            // could collide with an item on another change order.
+                            warnings.push(`Item id "${item.id}" is not on this change order — added as a new row instead.`);
+                        }
+                        let costCodeId: string | null;
+                        if (item.costCode === undefined) {
+                            costCodeId = prior?.costCodeId ?? null;
+                        } else if (item.costCode === "") {
+                            costCodeId = null;
+                        } else if (codeMap.has(item.costCode)) {
+                            costCodeId = codeMap.get(item.costCode)!;
+                        } else {
+                            costCodeId = prior?.costCodeId ?? null;
+                            warnings.push(`Unknown cost code "${item.costCode}" on item "${item.name}" — ${costCodeId ? "kept its current code" : "left uncoded"}.`);
+                        }
+                        if (item.costType && !validTypes.includes(item.costType)) {
+                            warnings.push(`Unknown cost type "${item.costType}" on item "${item.name}" — use one of: ${validTypes.join(", ")}.`);
+                        }
+                        return {
+                            id: prior ? item.id : undefined,
+                            name: item.name,
+                            description: item.description !== undefined ? item.description : (prior?.description ?? null),
+                            ...(item.costType && validTypes.includes(item.costType) ? { type: item.costType } : {}),
+                            quantity: item.quantity,
+                            unitCost: item.unitCost,
+                            order: idx,
+                            costCodeId,
+                        };
+                    });
+                }
+                if (args.paymentSchedules) {
+                    data.paymentSchedules = args.paymentSchedules.map((row, idx) => ({
+                        id: row.id,
+                        name: row.name,
+                        amount: row.amount,
+                        dueDate: row.dueDate ?? null,
+                        order: row.order ?? idx,
+                    }));
+                }
+
+                let updated;
+                try {
+                    updated = await updateChangeOrderCore(changeOrderId, data);
+                } catch (error: any) {
+                    return { ...textResult({ error: error?.message || "Failed to update change order" }), isError: true };
+                }
+                revalidatePath(`/projects/${updated.projectId}/change-orders/${changeOrderId}`);
+                revalidatePath(`/projects/${updated.projectId}/change-orders`);
+                const revertedToDraft = before.status === "Sent" && updated.status === "Draft";
+                return textResult({
+                    changeOrderId,
+                    code: updated.code,
+                    status: updated.status,
+                    pricingType: updated.pricingType,
+                    markupPercent: updated.markupPercent,
+                    subtotal: Number(updated.totalAmount),
+                    warnings,
+                    ...(revertedToDraft ? { note: "Scope changed on a Sent change order — it is back in Draft and must be re-sent (send_change_order) before the customer can sign." } : {}),
+                    url: `https://probuild.goldentouchremodeling.com/projects/${updated.projectId}/change-orders/${changeOrderId}`,
+                });
+            },
+        );
+
+        server.registerTool(
             "send_change_order",
             {
                 title: "Send a change order to the customer for signature",
@@ -1107,7 +1231,7 @@ function createHandler(actor: RouteMcpActor) {
             {
                 title: "List project change orders and actuals",
                 annotations: { readOnlyHint: true },
-                description: "Lists change orders with pricing type, signature state, unbilled billable actuals, hours, and billed-to-date. Use this before logging or billing cost-plus work.",
+                description: "Lists change orders with line items, pricing type, signature state, unbilled billable actuals, hours, and billed-to-date. Use this before logging or billing cost-plus work, and to fetch current items (with ids) before update_change_order.",
                 inputSchema: { projectId: z.string().max(50) },
             },
             async ({ projectId }) => {
@@ -1115,6 +1239,7 @@ function createHandler(actor: RouteMcpActor) {
                     where: { projectId },
                     orderBy: { createdAt: "desc" },
                     include: {
+                        items: { orderBy: { order: "asc" }, select: { id: true, name: true, description: true, type: true, quantity: true, unitCost: true, total: true, costCode: { select: { code: true } } } },
                         timeEntries: { where: { isBillable: true, invoiceId: null, invoicedAt: null }, select: { durationHours: true, laborCost: true, burdenCost: true } },
                         expenses: { where: { isBillable: true, invoiceId: null, invoicedAt: null }, select: { amount: true } },
                         billings: { select: { totalCents: true, laborCents: true, expenseCents: true, markupCents: true, taxCents: true } },
@@ -1126,6 +1251,16 @@ function createHandler(actor: RouteMcpActor) {
                     code: co.code,
                     title: co.title,
                     status: co.status,
+                    items: co.items.map((item) => ({
+                        id: item.id,
+                        name: item.name,
+                        description: item.description,
+                        type: item.type,
+                        quantity: item.quantity,
+                        unitCost: Number(item.unitCost),
+                        total: Number(item.total),
+                        costCode: item.costCode?.code ?? null,
+                    })),
                     pricingType: co.pricingType,
                     markupPercent: co.markupPercent,
                     subtotal: Number(co.totalAmount),
@@ -2448,7 +2583,7 @@ function createHandler(actor: RouteMcpActor) {
         );
     },
     {
-        serverInfo: { name: "probuild", version: "1.14.0" },
+        serverInfo: { name: "probuild", version: "1.15.0" },
         capabilities: { tools: {} },
         instructions:
             "ProBuild is Golden Touch Remodeling's construction management system. " +

--- a/src/lib/change-order-core.ts
+++ b/src/lib/change-order-core.ts
@@ -174,27 +174,6 @@ export async function updateChangeOrderCore(id: string, data: ChangeOrderUpdateI
                 throw new Error(`Duplicate change-order item ID: ${duplicateItemId}`);
             }
 
-            let totalCents = 0;
-            const rows = items.map((item, idx) => {
-                const quantity = parseFloat(String(item.quantity ?? "")) || 0;
-                const unitCost = parseFloat(String(item.unitCost ?? "")) || 0;
-                const unitCents = Math.round(unitCost * 100);
-                const lineCents = coLineCents(quantity, unitCost);
-                totalCents += lineCents;
-                return {
-                    id: item.id || undefined,
-                    name: item.name || "",
-                    description: item.description || null,
-                    ...(item.type ? { type: item.type } : {}),
-                    quantity,
-                    unitCost: unitCents / 100,
-                    total: lineCents / 100,
-                    order: item.order ?? idx,
-                    costCodeId: item.costCodeId || null,
-                    costTypeId: item.costTypeId || null,
-                };
-            });
-
             const existing = await tx.changeOrderItem.findMany({
                 where: { changeOrderId: id },
                 select: {
@@ -212,6 +191,34 @@ export async function updateChangeOrderCore(id: string, data: ChangeOrderUpdateI
             });
             const existingIds = new Set(existing.map(i => i.id));
             const existingById = new Map(existing.map((item) => [item.id, item]));
+
+            let totalCents = 0;
+            const rows = items.map((item, idx) => {
+                const quantity = parseFloat(String(item.quantity ?? "")) || 0;
+                const unitCost = parseFloat(String(item.unitCost ?? "")) || 0;
+                const unitCents = Math.round(unitCost * 100);
+                const lineCents = coLineCents(quantity, unitCost);
+                totalCents += lineCents;
+                // On a row that matches an existing item, an omitted (undefined)
+                // description/costCodeId/costTypeId keeps the stored value —
+                // resolved here, under the same row lock as the write, so a
+                // partial payload can't erase relations it never mentioned. The
+                // editor always sends explicit values (x || null), so this only
+                // affects connector callers. Empty string / null still clears.
+                const prior = item.id ? existingById.get(item.id) : undefined;
+                return {
+                    id: item.id || undefined,
+                    name: item.name || "",
+                    description: item.description === undefined ? (prior?.description ?? null) : (item.description || null),
+                    ...(item.type ? { type: item.type } : {}),
+                    quantity,
+                    unitCost: unitCents / 100,
+                    total: lineCents / 100,
+                    order: item.order ?? idx,
+                    costCodeId: item.costCodeId === undefined ? (prior?.costCodeId ?? null) : (item.costCodeId || null),
+                    costTypeId: item.costTypeId === undefined ? (prior?.costTypeId ?? null) : (item.costTypeId || null),
+                };
+            });
             const incomingIds = new Set(rows.map(r => r.id).filter(Boolean));
             const toDelete = existing.filter(i => !incomingIds.has(i.id)).map(i => i.id);
             const itemRowsChanged = rows.length !== existing.length || rows.some((row) => {
@@ -256,13 +263,24 @@ export async function updateChangeOrderCore(id: string, data: ChangeOrderUpdateI
             orderBy: [{ order: "asc" }, { id: "asc" }],
             select: { id: true, name: true, amount: true, dueDate: true, order: true },
         });
-        const requestedSchedules = schedules ?? existingSchedules.map((row) => ({
-            id: row.id,
-            name: row.name,
-            amount: Number(row.amount),
-            dueDate: row.dueDate,
-            order: row.order,
-        }));
+        // Same keep-prior rule as item fields: an omitted (undefined) dueDate on
+        // a row that matches an existing schedule keeps the stored date; null or
+        // "" still clears it. Resolved under the row lock.
+        const priorScheduleById = new Map(existingSchedules.map((row) => [row.id, row]));
+        const requestedSchedules = schedules
+            ? schedules.map((row) => ({
+                ...row,
+                dueDate: row.dueDate === undefined && row.id && priorScheduleById.has(row.id)
+                    ? priorScheduleById.get(row.id)!.dueDate
+                    : row.dueDate,
+            }))
+            : existingSchedules.map((row) => ({
+                id: row.id,
+                name: row.name,
+                amount: Number(row.amount),
+                dueDate: row.dueDate,
+                order: row.order,
+            }));
 
         if (nextPricingType === "COST_PLUS" && requestedSchedules.length > 0) {
             throw new Error("Cost-plus change orders cannot have a fixed payment schedule.");


### PR DESCRIPTION
## What

Chat connectors (ChatGPT / Claude via the MCP endpoint) can now EDIT existing change orders. MCP server v1.15.0.

- New `update_change_order` write tool: title, description, pricingType, markupPercent, full-replacement line items and payment schedules. Thin wrapper over `updateChangeOrderCore`, which enforces everything under its FOR UPDATE lock: signed/Approved scope locked, status transitions forbidden, server-side integer-cents subtotal recompute, cost-plus schedule ban, Sent -> Draft auto-revert on scope change.
- `list_change_orders` now returns line items (with ids) so chat can read-modify-write.
- Core (`change-order-core.ts`): keep-prior semantics resolved under the row lock. On a row with a matching id, omitted (undefined) description / costCodeId / costTypeId / schedule dueDate keep their stored values; null / "" still clear. The web editor is unaffected (it always sends explicit `x || null` values).
- Audit wiring: added to WRITE_TOOLS + ENTITY_TYPE_BY_TOOL (`mcp_update_change_order` ActivityLog rows).

## Review

Codex peer review, 2 rounds.

Round 1 (5 real issues, all fixed): TOCTOU on wrapper prefetch merge (moved keep-prior into the locked core tx), costTypeId erased on partial payloads (keep-prior), omitted schedule dueDate cleared (keep-prior), over-wide money bounds vs coLineCents 12-sig-digit window (tightened to qty <= 10k, unitCost <= $1M), wrong MCP annotations (now destructiveHint: true, idempotentHint: false).

Round 2 (2 findings): explicit costType leaving a contradictory costTypeId relation — FIXED (explicit costType now resolves the CostType row id alongside the scalar). Second finding defended: the unknown-item-id strip uses the advisory prefetch; the only race outcome is a delete+recreate with a fresh id (content preserved) in a sub-second window — accepted, documented in code.

## Verification

- `npm run build` 0 errors.
- Live JSON-RPC smoke on the sanctioned Shop test project: create -> list (items with ids) -> update (rename/reprice/add; subtotal recomputed cent-exact) -> bogus item id demoted to new row with warning -> Approved CO refused with signed-scope error -> 1-row schedule refused -> schedule dueDates and item types survive omitting updates -> explicit costType flips type -> audit rows written (`mcp_update_change_order` + `_failed`).
- Scratch drafts CO-00062 / CO-00063 left as inert Drafts on Shop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
