### PR TITLE
fix(payments): back-dated receipt suppression + deposit auto-apply pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,19 @@ jobs:
       # their deterministic mocks. Without it the specs hit the real Anthropic
       # API on every PR and the forced-failure test marker is inert prose.
       SELECTION_AI_MOCK: "1"
+      # Routes getFreshQBTokens/buildQBPaymentRequest/sendQBPaymentCreateRequest
+      # (src/lib/quickbooks.ts, quickbooks-payments.ts) to the deterministic,
+      # no-network mock in src/lib/quickbooks-mock.ts. Real Intuit calls are
+      # forbidden in CI; without this e2e/deposit-ingest.spec.ts's QBO-linked
+      # cases would either hit the live API or fail with QBNotConnectedError
+      # (no Integration row exists in the throwaway DB).
+      E2E_QBO_MOCK: "1"
+      # Shared secret for POST /api/payments/deposit-ingest's Bearer auth
+      # (src/app/api/payments/deposit-ingest/route.ts). No external system
+      # depends on this value — it only gates e2e/deposit-ingest.spec.ts
+      # against the throwaway DB — so unlike the provider secrets above it's a
+      # literal here rather than a repo secret (there's nothing to rotate).
+      DEPOSIT_INGEST_SECRET: "e2e-ci-deposit-ingest-secret"
       GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
       GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
       STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
@@ -147,6 +160,16 @@ jobs:
 
       - name: Create schema in throwaway Postgres
         run: npx prisma db push --skip-generate
+
+      # DepositIngest's reservation index (stops two deposit files from
+      # claiming the same pending milestone — see the model's doc comment in
+      # prisma/schema.prisma) is a partial unique index, which Prisma cannot
+      # express and `db push` therefore never creates. e2e/deposit-ingest.spec.ts's
+      # reservation-blocking cases need it for real, so apply it here exactly
+      # like a prod deploy would (scripts/apply-deposit-ingest-schema.mjs is
+      # additive/idempotent — safe to run against the fresh throwaway DB).
+      - name: Apply DepositIngest reservation index
+        run: node scripts/apply-deposit-ingest-schema.mjs
 
       - name: Build application
         run: npm run build

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -35,6 +35,15 @@ Three safeguards now exist — keep all three intact:
    `isE2eStorageMockEnabled()` in `src/lib/supabase.ts`), since it fakes
    successful writes and must never engage outside a test environment.
 
+   **QuickBooks is hermetic too (August 2026).** `E2E_QBO_MOCK=1` (same
+   three-condition gate as the storage mock — see `isE2eQboMockEnabled()` in
+   `src/lib/quickbooks-mock.ts`) routes `getFreshQBTokens` /
+   `buildQBPaymentRequest` / `sendQBPaymentCreateRequest` to a deterministic,
+   no-network mock, so `e2e/deposit-ingest.spec.ts`'s QBO-linked cases never
+   call the real Intuit API. `POST /api/payments/deposit-ingest` also needs
+   `DEPOSIT_INGEST_SECRET` set to the value the spec sends as its Bearer
+   token (any value — nothing external depends on it).
+
 2. **`e2e/data.setup.ts` refuses to run against the live DB.**
    It aborts if `DATABASE_URL` (env or `.env`) looks like Supabase, unless
    `ALLOW_PROD_E2E=1` is explicitly set. Local `.env` points at prod, so a
@@ -74,7 +83,10 @@ $env:DIRECT_URL   = "postgresql://postgres:probuild@localhost:5433/postgres"
 $env:PLAYWRIGHT_TEST_SECRET = "any-local-secret"
 $env:E2E_STORAGE_MOCK = "1"     # in-memory storage stub — never the live bucket
 $env:SELECTION_AI_MOCK = "1"    # deterministic AI mocks — no real Anthropic calls
+$env:E2E_QBO_MOCK = "1"         # deterministic QuickBooks mock — no real Intuit calls
+$env:DEPOSIT_INGEST_SECRET = "any-local-secret"   # Bearer auth for /api/payments/deposit-ingest
 npx prisma db push --skip-generate
+node scripts/apply-deposit-ingest-schema.mjs   # DepositIngest's partial reservation index — not expressible in Prisma
 npx playwright test
 ```
 

--- a/e2e/deposit-ingest.spec.ts
+++ b/e2e/deposit-ingest.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, type APIRequestContext } from "@playwright/test";
 import { PrismaClient } from "@prisma/client";
 import { createHash } from "node:crypto";
+import { saveQBSettings } from "../src/lib/integration-store";
 
 /**
  * Deposit auto-apply pipeline (Phase B1) — hermetic e2e for
@@ -344,6 +345,11 @@ test.describe.serial("Deposit-ingest pipeline (Phase B1)", () => {
       invoiceId: F.nonQbo.invoice, invoiceCode: F.nonQbo.invoiceCode,
       schedules: [{ id: F.nonQbo.schedule, name: "NonQBO Deposit", amount: F.nonQbo.amount }],
     });
+    // The QBO mock replaces the network, NOT the connection state (see
+    // getFreshQBTokens) — QBO-linked cases need a connected settings row. Cleared in
+    // afterAll so later-ordered fail-closed specs (CI runs workers:1, serialized)
+    // keep their disconnected premise.
+    await saveQBSettings({ connected: true, accessToken: "e2e-mock", refreshToken: "e2e-mock", realmId: "e2e-mock-realm" });
     await seedFixture({
       projectId: F.weakMatch.project, projectName: F.weakMatch.projectName,
       invoiceId: F.weakMatch.invoice, invoiceCode: F.weakMatch.invoiceCode,
@@ -361,6 +367,7 @@ test.describe.serial("Deposit-ingest pipeline (Phase B1)", () => {
 
   test.afterAll(async () => {
     try {
+      await saveQBSettings({ connected: false, accessToken: undefined, refreshToken: undefined, realmId: undefined });
       await prisma.paymentNotification.deleteMany({
         where: { scheduleId: { in: [F.qbo.schedule, F.concurrent.schedule, F.reserve.schedule, F.resume.schedule, F.nonQbo.schedule, F.forceCorrect.schedule, F.settleCrash.scheduleSettled, F.settleCrash.scheduleUnsettled] } },
       });

--- a/e2e/deposit-ingest.spec.ts
+++ b/e2e/deposit-ingest.spec.ts
@@ -1,0 +1,751 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import { PrismaClient } from "@prisma/client";
+import { createHash } from "node:crypto";
+
+/**
+ * Deposit auto-apply pipeline (Phase B1) — hermetic e2e for
+ * POST /api/payments/deposit-ingest (src/app/api/payments/deposit-ingest/route.ts).
+ * Spec: C:\Users\jat00\.claude\plans\create-the-channel-for-elegant-hearth.md, section B1.
+ *
+ * Runs ONLY against the throwaway CI Postgres (data.setup.ts guards prod) —
+ * see docs/TESTING.md. Real QuickBooks calls are forbidden here: E2E_QBO_MOCK=1
+ * (same triple-gate as E2E_STORAGE_MOCK — see isE2eQboMockEnabled() in
+ * src/lib/quickbooks-mock.ts) routes getFreshQBTokens/buildQBPaymentRequest/
+ * sendQBPaymentCreateRequest to a deterministic, no-network mock. Because this
+ * spec drives the endpoint over real HTTP against the Playwright webServer (a
+ * SEPARATE Node process from this test file), the mock's captured calls are
+ * read back through the test-only seam at /api/payments/test-only/qbo-mock
+ * (also gated by isE2eQboMockEnabled(), so it 404s outside a Playwright run) —
+ * see that route's doc comment for why a plain module import can't work here.
+ *
+ * Auth: DEPOSIT_INGEST_SECRET must be set for the server under test (CI wires
+ * it as a literal in .github/workflows/ci.yml — nothing external depends on
+ * its value). Every test that needs a valid call reads it straight from
+ * process.env, same pattern as PLAYWRIGHT_TEST_SECRET elsewhere in e2e/.
+ */
+
+const prisma = new PrismaClient();
+const DEPOSIT_INGEST_PATH = "/api/payments/deposit-ingest";
+const QBO_MOCK_PATH = "/api/payments/test-only/qbo-mock";
+const SECRET = process.env.DEPOSIT_INGEST_SECRET || "";
+
+const CLIENT_ID = "di-e2e-client";
+const CLIENT_NAME = "Deposit Ingest E2E Client";
+
+// ── Small helpers ────────────────────────────────────────────────────────────
+
+async function postDeposit(
+  request: APIRequestContext,
+  body: unknown,
+  opts?: { force?: boolean; authHeader?: string | null; rawData?: string },
+) {
+  const qs = opts?.force ? "?force=1" : "";
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  const auth = opts?.authHeader === null ? undefined : opts?.authHeader ?? `Bearer ${SECRET}`;
+  if (auth !== undefined) headers.authorization = auth;
+  const data = opts?.rawData !== undefined ? opts.rawData : JSON.stringify(body);
+  const res = await request.post(`${DEPOSIT_INGEST_PATH}${qs}`, { headers, data });
+  return { res, body: await safeJson(res) };
+}
+
+async function safeJson(res: Awaited<ReturnType<APIRequestContext["post"]>>) {
+  try {
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+async function resetQboMock(request: APIRequestContext) {
+  const res = await request.post(QBO_MOCK_PATH, {
+    headers: { "content-type": "application/json" },
+    data: JSON.stringify({ action: "reset" }),
+  });
+  expect(res.ok(), "resetQboMock — is E2E_QBO_MOCK=1/PLAYWRIGHT_TEST_SECRET set on the server under test?").toBeTruthy();
+}
+
+async function seedQboInvoice(request: APIRequestContext, qbInvoiceId: string, balance: number, customerId: string) {
+  const res = await request.post(QBO_MOCK_PATH, {
+    headers: { "content-type": "application/json" },
+    data: JSON.stringify({ action: "seedInvoice", qbInvoiceId, balance, customerId }),
+  });
+  expect(res.ok()).toBeTruthy();
+}
+
+async function getQboMockState(request: APIRequestContext): Promise<{
+  calls: { readInvoice: number; paymentCreate: number };
+  paymentCreateCalls: Array<{ requestBody: string; requestId: string; at: number }>;
+}> {
+  const res = await request.get(QBO_MOCK_PATH);
+  expect(res.ok()).toBeTruthy();
+  return res.json();
+}
+
+/** Mirrors the private `depositRequestId` helper in route.ts — duplicated
+ *  here (not exported; route.ts is reviewed and left untouched) so the
+ *  byte-identical-replay test (case 5) can assert the mock received the
+ *  exact requestId the route computes from the fileId. */
+function computeDepositRequestId(fileId: string): string {
+  return createHash("sha256").update(`deposit-${fileId}`).digest("hex").slice(0, 50);
+}
+
+async function officeTasksMentioning(fileId: string) {
+  return prisma.officeTask.findMany({ where: { notes: { contains: fileId } } });
+}
+
+type ScheduleSpec = {
+  id: string;
+  name: string;
+  amount: number;
+  qbInvoiceId?: string | null;
+  qbPaymentId?: string | null;
+  status?: "Pending" | "Paid";
+};
+
+async function seedFixture(opts: {
+  projectId: string;
+  projectName: string;
+  invoiceId: string;
+  invoiceCode: string;
+  schedules: ScheduleSpec[];
+}) {
+  await prisma.client.upsert({
+    where: { id: CLIENT_ID },
+    update: {},
+    create: { id: CLIENT_ID, name: CLIENT_NAME, initials: "DI" },
+  });
+  await prisma.project.upsert({
+    where: { id: opts.projectId },
+    update: { name: opts.projectName, status: "In Progress" },
+    create: { id: opts.projectId, name: opts.projectName, clientId: CLIENT_ID, status: "In Progress" },
+  });
+  const total = opts.schedules.reduce((sum, s) => sum + s.amount, 0);
+  await prisma.invoice.upsert({
+    where: { id: opts.invoiceId },
+    update: { status: "Issued", totalAmount: total, balanceDue: total },
+    create: {
+      id: opts.invoiceId, code: opts.invoiceCode, projectId: opts.projectId, clientId: CLIENT_ID,
+      status: "Issued", totalAmount: total, balanceDue: total, issueDate: new Date(),
+    },
+  });
+  for (const s of opts.schedules) {
+    const status = s.status ?? "Pending";
+    const paidFields = status === "Paid"
+      ? { paidAt: new Date(), paymentDate: new Date(), paymentMethod: "quickbooks" }
+      : { paidAt: null, paymentDate: null, paymentMethod: null };
+    await prisma.paymentSchedule.upsert({
+      where: { id: s.id },
+      update: { status, amount: s.amount, qbInvoiceId: s.qbInvoiceId ?? null, qbPaymentId: s.qbPaymentId ?? null, referenceNumber: null, ...paidFields },
+      create: {
+        id: s.id, invoiceId: opts.invoiceId, name: s.name, amount: s.amount, status,
+        qbInvoiceId: s.qbInvoiceId ?? null, qbPaymentId: s.qbPaymentId ?? null, ...paidFields,
+      },
+    });
+  }
+}
+
+async function seedTiedProjects(idA: string, idB: string, name: string) {
+  await prisma.client.upsert({ where: { id: CLIENT_ID }, update: {}, create: { id: CLIENT_ID, name: CLIENT_NAME, initials: "DI" } });
+  for (const id of [idA, idB]) {
+    await prisma.project.upsert({
+      where: { id },
+      update: { name, status: "In Progress" },
+      create: { id, name, clientId: CLIENT_ID, status: "In Progress" },
+    });
+  }
+}
+
+// ── Fixture ids ───────────────────────────────────────────────────────────────
+
+const F = {
+  qbo: {
+    project: "di-e2e-qbo-project", projectName: "Nnexo QBO Happy Path Project",
+    invoice: "di-e2e-qbo-invoice", invoiceCode: "INV-DI-QBO",
+    schedule: "di-e2e-qbo-schedule", amount: 500,
+    qbInvoiceId: "di-mock-inv-qbo-1", fileId: "di-e2e-file-qbo-happy",
+  },
+  concurrent: {
+    project: "di-e2e-concurrent-project", projectName: "Nnexo Concurrent Project",
+    invoice: "di-e2e-concurrent-invoice", invoiceCode: "INV-DI-CONC",
+    schedule: "di-e2e-concurrent-schedule", amount: 300,
+    qbInvoiceId: "di-mock-inv-concurrent-1", fileId: "di-e2e-file-concurrent",
+  },
+  reserve: {
+    project: "di-e2e-reserve-project", projectName: "Nnexo Reserve Project",
+    invoice: "di-e2e-reserve-invoice", invoiceCode: "INV-DI-RES",
+    schedule: "di-e2e-reserve-schedule", amount: 250,
+    fileIdA: "di-e2e-file-reserve-a", fileIdB: "di-e2e-file-reserve-b",
+  },
+  resume: {
+    project: "di-e2e-resume-project", projectName: "Nnexo Resume Project",
+    invoice: "di-e2e-resume-invoice", invoiceCode: "INV-DI-RESUME",
+    schedule: "di-e2e-resume-schedule", amount: 400,
+    qbInvoiceId: "di-mock-inv-resume-1", fileId: "di-e2e-file-resume",
+  },
+  cronSame: {
+    project: "di-e2e-cronsame-project", projectName: "Nnexo CronSame Project",
+    invoice: "di-e2e-cronsame-invoice", invoiceCode: "INV-DI-CRONSAME",
+    schedule: "di-e2e-cronsame-schedule", amount: 275,
+    fileId: "di-e2e-file-cronsame", qbPaymentId: "di-cron-payment-same-1",
+  },
+  cronDiff: {
+    project: "di-e2e-crondiff-project", projectName: "Nnexo CronDiff Project",
+    invoice: "di-e2e-crondiff-invoice", invoiceCode: "INV-DI-CRONDIFF",
+    schedule: "di-e2e-crondiff-schedule", amount: 285,
+    fileId: "di-e2e-file-crondiff", rowQbPaymentId: "di-cron-payment-rowside-1", milestoneQbPaymentId: "di-cron-payment-milestoneside-DIFFERENT",
+  },
+  refuseUnresolvable: { fileId: "di-e2e-refuse-unresolvable-project" },
+  refuseTied: {
+    projectA: "di-e2e-tied-project-a", projectB: "di-e2e-tied-project-b",
+    name: "Zzqxw Bratwald Kettlecorn", fileId: "di-e2e-refuse-tied-project",
+  },
+  refuseZeroAmt: {
+    project: "di-e2e-zeroamt-project", projectName: "Nnexo Zeroamt Project",
+    invoice: "di-e2e-zeroamt-invoice", invoiceCode: "INV-DI-ZEROAMT",
+    schedule: "di-e2e-zeroamt-schedule", scheduleAmount: 999, postedAmount: 111,
+    fileId: "di-e2e-refuse-zero-amount",
+  },
+  refuseTwoAmt: {
+    project: "di-e2e-twoamt-project", projectName: "Nnexo Twoamt Project",
+    invoice: "di-e2e-twoamt-invoice", invoiceCode: "INV-DI-TWOAMT",
+    scheduleA: "di-e2e-twoamt-schedule-a", scheduleB: "di-e2e-twoamt-schedule-b", amount: 222,
+    fileId: "di-e2e-refuse-two-amount",
+  },
+  refuseNoCheckNumber: { fileId: "di-e2e-refuse-no-check-number" },
+  refuseNoCheckDate: { fileId: "di-e2e-refuse-no-check-date" },
+  refusePayer: {
+    project: "di-e2e-payer-project", projectName: "Nnexo Payer Project",
+    invoice: "di-e2e-payer-invoice", invoiceCode: "INV-DI-PAYER",
+    schedule: "di-e2e-payer-schedule", amount: 333,
+    fileId: "di-e2e-refuse-payer-conflict",
+  },
+  forceCorrect: {
+    project: "di-e2e-force-project", projectName: "Nnexo Force Project",
+    invoice: "di-e2e-force-invoice", invoiceCode: "INV-DI-FORCE",
+    schedule: "di-e2e-force-schedule", correctAmount: 350, wrongAmount: 999,
+    fileId: "di-e2e-file-force-correct",
+  },
+  forceCrossedQbo: { fileId: "di-e2e-file-force-crossed-qbo" },
+  nonQbo: {
+    project: "di-e2e-nonqbo-project", projectName: "Nnexo NonQBO Project",
+    invoice: "di-e2e-nonqbo-invoice", invoiceCode: "INV-DI-NONQBO",
+    schedule: "di-e2e-nonqbo-schedule", amount: 600,
+    fileId: "di-e2e-file-nonqbo",
+  },
+  validation: { fileId: "di-e2e-file-validation" },
+};
+
+const ALL_PROJECT_IDS = [
+  F.qbo.project, F.concurrent.project, F.reserve.project, F.resume.project,
+  F.cronSame.project, F.cronDiff.project, F.refuseTied.projectA, F.refuseTied.projectB,
+  F.refuseZeroAmt.project, F.refuseTwoAmt.project, F.refusePayer.project,
+  F.forceCorrect.project, F.nonQbo.project,
+];
+
+const ALL_FILE_IDS = [
+  F.qbo.fileId, F.concurrent.fileId, F.reserve.fileIdA, F.reserve.fileIdB, F.resume.fileId,
+  F.cronSame.fileId, F.cronDiff.fileId, F.refuseUnresolvable.fileId, F.refuseTied.fileId,
+  F.refuseZeroAmt.fileId, F.refuseTwoAmt.fileId, F.refuseNoCheckNumber.fileId, F.refuseNoCheckDate.fileId,
+  F.refusePayer.fileId, F.forceCorrect.fileId, F.forceCrossedQbo.fileId, F.nonQbo.fileId, F.validation.fileId,
+];
+
+test.describe.serial("Deposit-ingest pipeline (Phase B1)", () => {
+  test.beforeEach(() => {
+    test.skip(!SECRET, "requires DEPOSIT_INGEST_SECRET on the server under test — see .github/workflows/ci.yml / docs/TESTING.md");
+  });
+
+  test.beforeAll(async () => {
+    // createDepositReviewTask (route.ts) files every unmatched/reconcile task
+    // into `officeBoardColumn.findFirst({orderBy:[{position:"asc"},{createdAt:"asc"}]})`
+    // — a fresh throwaway DB has NO board columns (data.setup.ts doesn't seed
+    // one), so without this every officeTaskId assertion below would see null.
+    // Fixed id so re-running this beforeAll (retries) is idempotent; left in
+    // place (not deleted in afterAll) since other specs in the same run may
+    // also rely on at least one column existing.
+    await prisma.officeBoardColumn.upsert({
+      where: { id: "di-e2e-office-column" },
+      update: {},
+      create: { id: "di-e2e-office-column", name: "To Do", position: 0 },
+    });
+
+    await seedFixture({
+      projectId: F.qbo.project, projectName: F.qbo.projectName,
+      invoiceId: F.qbo.invoice, invoiceCode: F.qbo.invoiceCode,
+      schedules: [{ id: F.qbo.schedule, name: "QBO Deposit", amount: F.qbo.amount, qbInvoiceId: F.qbo.qbInvoiceId }],
+    });
+    await seedFixture({
+      projectId: F.concurrent.project, projectName: F.concurrent.projectName,
+      invoiceId: F.concurrent.invoice, invoiceCode: F.concurrent.invoiceCode,
+      schedules: [{ id: F.concurrent.schedule, name: "Concurrent Deposit", amount: F.concurrent.amount, qbInvoiceId: F.concurrent.qbInvoiceId }],
+    });
+    await seedFixture({
+      projectId: F.reserve.project, projectName: F.reserve.projectName,
+      invoiceId: F.reserve.invoice, invoiceCode: F.reserve.invoiceCode,
+      schedules: [{ id: F.reserve.schedule, name: "Reserve Deposit", amount: F.reserve.amount }],
+    });
+    await seedFixture({
+      projectId: F.resume.project, projectName: F.resume.projectName,
+      invoiceId: F.resume.invoice, invoiceCode: F.resume.invoiceCode,
+      schedules: [{ id: F.resume.schedule, name: "Resume Deposit", amount: F.resume.amount, qbInvoiceId: F.resume.qbInvoiceId }],
+    });
+    await seedFixture({
+      projectId: F.cronSame.project, projectName: F.cronSame.projectName,
+      invoiceId: F.cronSame.invoice, invoiceCode: F.cronSame.invoiceCode,
+      schedules: [{ id: F.cronSame.schedule, name: "CronSame Deposit", amount: F.cronSame.amount, status: "Paid", qbPaymentId: F.cronSame.qbPaymentId }],
+    });
+    await seedFixture({
+      projectId: F.cronDiff.project, projectName: F.cronDiff.projectName,
+      invoiceId: F.cronDiff.invoice, invoiceCode: F.cronDiff.invoiceCode,
+      schedules: [{ id: F.cronDiff.schedule, name: "CronDiff Deposit", amount: F.cronDiff.amount, status: "Paid", qbPaymentId: F.cronDiff.milestoneQbPaymentId }],
+    });
+    await seedTiedProjects(F.refuseTied.projectA, F.refuseTied.projectB, F.refuseTied.name);
+    await seedFixture({
+      projectId: F.refuseZeroAmt.project, projectName: F.refuseZeroAmt.projectName,
+      invoiceId: F.refuseZeroAmt.invoice, invoiceCode: F.refuseZeroAmt.invoiceCode,
+      schedules: [{ id: F.refuseZeroAmt.schedule, name: "ZeroAmt Deposit", amount: F.refuseZeroAmt.scheduleAmount }],
+    });
+    await seedFixture({
+      projectId: F.refuseTwoAmt.project, projectName: F.refuseTwoAmt.projectName,
+      invoiceId: F.refuseTwoAmt.invoice, invoiceCode: F.refuseTwoAmt.invoiceCode,
+      schedules: [
+        { id: F.refuseTwoAmt.scheduleA, name: "TwoAmt Deposit A", amount: F.refuseTwoAmt.amount },
+        { id: F.refuseTwoAmt.scheduleB, name: "TwoAmt Deposit B", amount: F.refuseTwoAmt.amount },
+      ],
+    });
+    await seedFixture({
+      projectId: F.refusePayer.project, projectName: F.refusePayer.projectName,
+      invoiceId: F.refusePayer.invoice, invoiceCode: F.refusePayer.invoiceCode,
+      schedules: [{ id: F.refusePayer.schedule, name: "Payer Deposit", amount: F.refusePayer.amount }],
+    });
+    await seedFixture({
+      projectId: F.forceCorrect.project, projectName: F.forceCorrect.projectName,
+      invoiceId: F.forceCorrect.invoice, invoiceCode: F.forceCorrect.invoiceCode,
+      schedules: [{ id: F.forceCorrect.schedule, name: "Force Deposit", amount: F.forceCorrect.correctAmount }],
+    });
+    await seedFixture({
+      projectId: F.nonQbo.project, projectName: F.nonQbo.projectName,
+      invoiceId: F.nonQbo.invoice, invoiceCode: F.nonQbo.invoiceCode,
+      schedules: [{ id: F.nonQbo.schedule, name: "NonQBO Deposit", amount: F.nonQbo.amount }],
+    });
+  });
+
+  test.afterAll(async () => {
+    try {
+      await prisma.paymentNotification.deleteMany({
+        where: { scheduleId: { in: [F.qbo.schedule, F.concurrent.schedule, F.reserve.schedule, F.resume.schedule, F.nonQbo.schedule, F.forceCorrect.schedule] } },
+      });
+      await prisma.activityLog.deleteMany({ where: { projectId: { in: ALL_PROJECT_IDS } } });
+      for (const fileId of ALL_FILE_IDS) {
+        await prisma.officeTask.deleteMany({ where: { notes: { contains: fileId } } });
+      }
+      await prisma.depositIngest.deleteMany({ where: { fileId: { in: ALL_FILE_IDS } } });
+      await prisma.invoice.deleteMany({ where: { projectId: { in: ALL_PROJECT_IDS } } }); // cascades PaymentSchedule
+      await prisma.project.deleteMany({ where: { id: { in: ALL_PROJECT_IDS } } });
+      await prisma.client.deleteMany({ where: { id: CLIENT_ID } });
+    } finally {
+      await prisma.$disconnect();
+    }
+  });
+
+  // ── 1 & 2: QBO-linked happy path, then idempotent re-POST ──────────────────
+  test("1-2: QBO-linked deposit applies (correct date/ref, PaymentNotification enqueued); re-POST is idempotent with no second QBO call", async ({ request }) => {
+    await resetQboMock(request);
+    await seedQboInvoice(request, F.qbo.qbInvoiceId, F.qbo.amount, "di-mock-cust-qbo-1");
+
+    const payload = {
+      fileId: F.qbo.fileId, projectName: F.qbo.projectName, amount: F.qbo.amount,
+      checkDate: "2026-07-20", checkNumber: "4501", fileUrl: "https://drive.example/qbo.jpg", fileName: "qbo.jpg",
+    };
+    const first = await postDeposit(request, payload);
+    expect(first.res.status()).toBe(200);
+    expect(first.body.ok).toBe(true);
+    expect(first.body.status).toBe("applied");
+    expect(first.body.scheduleId).toBe(F.qbo.schedule);
+    expect(first.body.qbPaymentId).toBeTruthy();
+    const qbPaymentId = first.body.qbPaymentId as string;
+
+    const schedule = await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: F.qbo.schedule } });
+    expect(schedule.status).toBe("Paid");
+    expect(schedule.paymentMethod).toBe("quickbooks");
+    expect(schedule.referenceNumber).toBe("4501");
+    expect(schedule.qbPaymentId).toBe(qbPaymentId);
+    expect(schedule.paymentDate?.toISOString().slice(0, 10)).toBe("2026-07-20");
+
+    const row = await prisma.depositIngest.findUniqueOrThrow({ where: { fileId: F.qbo.fileId } });
+    expect(row.status).toBe("applied");
+    expect(row.qbPaymentId).toBe(qbPaymentId);
+
+    const notes = await prisma.paymentNotification.findMany({ where: { scheduleId: F.qbo.schedule } });
+    expect(notes, "PaymentNotification outbox row exists for the settled milestone").toHaveLength(1);
+    expect(notes[0].scheduleType).toBe("invoice");
+
+    const afterFirst = await getQboMockState(request);
+    expect(afterFirst.calls.paymentCreate).toBe(1);
+
+    // ── Idempotent re-POST ──
+    const second = await postDeposit(request, payload);
+    expect(second.res.status()).toBe(200);
+    expect(second.body.ok).toBe(true);
+    expect(second.body.status).toBe("applied");
+    expect(second.body.alreadyApplied).toBe(true);
+    expect(second.body.qbPaymentId).toBe(qbPaymentId);
+
+    const afterSecond = await getQboMockState(request);
+    expect(afterSecond.calls.paymentCreate, "re-POST of an already-applied row makes no second QBO call").toBe(1);
+
+    const scheduleAfter = await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: F.qbo.schedule } });
+    expect(scheduleAfter.qbPaymentId, "no state change on re-POST").toBe(qbPaymentId);
+  });
+
+  // ── 3: Concurrent duplicates, same fileId ───────────────────────────────────
+  test("3: two concurrent POSTs of the SAME fileId apply exactly once, with exactly one QBO payment create", async ({ request }) => {
+    await resetQboMock(request);
+    await seedQboInvoice(request, F.concurrent.qbInvoiceId, F.concurrent.amount, "di-mock-cust-concurrent-1");
+
+    const payload = {
+      fileId: F.concurrent.fileId, projectName: F.concurrent.projectName, amount: F.concurrent.amount,
+      checkDate: "2026-07-21", checkNumber: "6001",
+    };
+    const [a, b] = await Promise.all([postDeposit(request, payload), postDeposit(request, payload)]);
+
+    for (const r of [a, b]) {
+      expect(r.res.status()).toBe(200);
+      expect(r.body.ok).toBe(true);
+      expect(["applied", "processing", "qbo_unknown", "qbo_created"]).toContain(r.body.status);
+    }
+
+    const mockState = await getQboMockState(request);
+    expect(mockState.calls.paymentCreate, "exactly one QBO payment create across both concurrent requests").toBe(1);
+
+    const schedule = await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: F.concurrent.schedule } });
+    expect(schedule.status).toBe("Paid");
+    expect(schedule.referenceNumber).toBe("6001");
+
+    const row = await prisma.depositIngest.findUniqueOrThrow({ where: { fileId: F.concurrent.fileId } });
+    expect(row.status).toBe("applied");
+    expect(row.qbPaymentId).toBe(schedule.qbPaymentId);
+  });
+
+  // ── 4: Reservation blocking, two different fileIds → one milestone ─────────
+  test("4: two different fileIds matching the same Pending milestone — one applies, the other is unmatched (already being applied)", async ({ request }) => {
+    const payloadA = { fileId: F.reserve.fileIdA, projectName: F.reserve.projectName, amount: F.reserve.amount, checkDate: "2026-07-22", checkNumber: "7001" };
+    const payloadB = { fileId: F.reserve.fileIdB, projectName: F.reserve.projectName, amount: F.reserve.amount, checkDate: "2026-07-22", checkNumber: "7002" };
+
+    const [a, b] = await Promise.all([postDeposit(request, payloadA), postDeposit(request, payloadB)]);
+    for (const r of [a, b]) {
+      expect(r.res.status()).toBe(200);
+      expect(r.body.ok).toBe(true);
+    }
+
+    const applied = [a, b].filter((r) => r.body.status === "applied");
+    const unmatched = [a, b].filter((r) => r.body.status === "unmatched");
+    expect(applied, "exactly one of the two deposits applies").toHaveLength(1);
+    expect(unmatched, "exactly one is refused by the reservation").toHaveLength(1);
+    expect(unmatched[0].body.reason).toContain("already being applied by another deposit");
+    expect(unmatched[0].body.officeTaskId).toBeTruthy();
+
+    const schedule = await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: F.reserve.schedule } });
+    expect(schedule.status).toBe("Paid");
+
+    const loserFileId = unmatched[0].body === a.body ? F.reserve.fileIdA : F.reserve.fileIdB;
+    const loserRow = await prisma.depositIngest.findUniqueOrThrow({ where: { fileId: loserFileId } });
+    expect(loserRow.status).toBe("unmatched");
+    expect(loserRow.paymentScheduleId, "the losing row never holds the reservation").toBeNull();
+  });
+
+  // ── 5: Crash-after-QBO-create resume — byte-identical replay ────────────────
+  test("5: qbo_unknown resume replays the byte-identical request body + requestid and resolves to applied", async ({ request }) => {
+    await resetQboMock(request);
+
+    const seededRequestBody = JSON.stringify({
+      TotalAmt: F.resume.amount,
+      TxnDate: "2026-07-15",
+      PaymentRefNum: "5551",
+      CustomerRef: { value: "di-mock-cust-resume-1" },
+      Line: [{ Amount: F.resume.amount, LinkedTxn: [{ TxnId: F.resume.qbInvoiceId, TxnType: "Invoice" }] }],
+    });
+    const extracted = {
+      fileId: F.resume.fileId, fileUrl: null, fileName: null, projectName: F.resume.projectName,
+      payerName: null, amount: F.resume.amount, checkDate: "2026-07-15", checkNumber: "5551", memo: null,
+    };
+    // processingStartedAt must be OLDER than the 5-minute stale-claim window
+    // (route.ts's STALE_PROCESSING_MS) — a fresh lease reads as "another
+    // request is actively working this file" and the route bails out with
+    // "in progress — retry shortly" WITHOUT ever calling resumeFromQboUnknown.
+    await prisma.depositIngest.create({
+      data: {
+        fileId: F.resume.fileId, status: "qbo_unknown", extracted: JSON.stringify(extracted),
+        paymentScheduleId: F.resume.schedule, qbRequestPayload: seededRequestBody, qbPaymentId: null,
+        attempts: 1, processingStartedAt: new Date(Date.now() - 6 * 60_000),
+      },
+    });
+
+    const res = await postDeposit(request, { fileId: F.resume.fileId, projectName: F.resume.projectName, amount: F.resume.amount, checkDate: "2026-07-15", checkNumber: "5551" });
+    expect(res.res.status()).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.status).toBe("applied");
+
+    const row = await prisma.depositIngest.findUniqueOrThrow({ where: { fileId: F.resume.fileId } });
+    expect(row.status).toBe("applied");
+    expect(row.qbRequestPayload, "the row's persisted request bytes are untouched by the replay").toBe(seededRequestBody);
+
+    const mockState = await getQboMockState(request);
+    const expectedRequestId = computeDepositRequestId(F.resume.fileId);
+    const replay = mockState.paymentCreateCalls.find((c) => c.requestId === expectedRequestId);
+    expect(replay, "the mock received a create call with the route's own requestid").toBeTruthy();
+    expect(replay?.requestBody, "replayed body is byte-identical to the seeded qbRequestPayload").toBe(seededRequestBody);
+
+    const schedule = await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: F.resume.schedule } });
+    expect(schedule.status).toBe("Paid");
+    expect(schedule.qbPaymentId).toBe(row.qbPaymentId);
+  });
+
+  // ── 6: Cron-race rule ────────────────────────────────────────────────────────
+  test("6a: qbo_created resume where the cron already settled with OUR qbPaymentId — success-if-same", async ({ request }) => {
+    await resetQboMock(request);
+    const extracted = {
+      fileId: F.cronSame.fileId, fileUrl: null, fileName: null, projectName: F.cronSame.projectName,
+      payerName: null, amount: F.cronSame.amount, checkDate: "2026-07-21", checkNumber: "9101", memo: null,
+    };
+    await prisma.depositIngest.create({
+      data: {
+        fileId: F.cronSame.fileId, status: "qbo_created", extracted: JSON.stringify(extracted),
+        paymentScheduleId: F.cronSame.schedule, qbPaymentId: F.cronSame.qbPaymentId,
+        attempts: 1, processingStartedAt: new Date(Date.now() - 6 * 60_000),
+      },
+    });
+
+    const res = await postDeposit(request, { fileId: F.cronSame.fileId, projectName: F.cronSame.projectName, amount: F.cronSame.amount, checkDate: "2026-07-21", checkNumber: "9101" });
+    expect(res.res.status()).toBe(200);
+    expect(res.body.status).toBe("applied");
+
+    const row = await prisma.depositIngest.findUniqueOrThrow({ where: { fileId: F.cronSame.fileId } });
+    expect(row.status).toBe("applied");
+
+    // resumeFromQboCreated never calls QBO at all (it only settles ProBuild).
+    const mockState = await getQboMockState(request);
+    expect(mockState.calls.readInvoice).toBe(0);
+    expect(mockState.calls.paymentCreate).toBe(0);
+  });
+
+  test("6b: qbo_created resume where the milestone settled with a DIFFERENT qbPaymentId — reconcile + one OfficeTask", async ({ request }) => {
+    const extracted = {
+      fileId: F.cronDiff.fileId, fileUrl: null, fileName: null, projectName: F.cronDiff.projectName,
+      payerName: null, amount: F.cronDiff.amount, checkDate: "2026-07-21", checkNumber: "9201", memo: null,
+    };
+    await prisma.depositIngest.create({
+      data: {
+        fileId: F.cronDiff.fileId, status: "qbo_created", extracted: JSON.stringify(extracted),
+        paymentScheduleId: F.cronDiff.schedule, qbPaymentId: F.cronDiff.rowQbPaymentId,
+        attempts: 1, processingStartedAt: new Date(Date.now() - 6 * 60_000),
+      },
+    });
+
+    const first = await postDeposit(request, { fileId: F.cronDiff.fileId, projectName: F.cronDiff.projectName, amount: F.cronDiff.amount, checkDate: "2026-07-21", checkNumber: "9201" });
+    expect(first.res.status()).toBe(200);
+    expect(first.body.status).toBe("reconcile");
+    expect(first.body.reason).toContain("different QuickBooks payment");
+    expect(first.body.officeTaskId).toBeTruthy();
+
+    const row = await prisma.depositIngest.findUniqueOrThrow({ where: { fileId: F.cronDiff.fileId } });
+    expect(row.status).toBe("reconcile");
+
+    // Milestone itself is untouched (still Paid with the cron's own qbPaymentId, not ours).
+    const schedule = await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: F.cronDiff.schedule } });
+    expect(schedule.qbPaymentId).toBe(F.cronDiff.milestoneQbPaymentId);
+
+    // Second POST (no force) — reconcile is terminal-to-the-bot; task self-heals but never duplicates.
+    const second = await postDeposit(request, { fileId: F.cronDiff.fileId, projectName: F.cronDiff.projectName, amount: F.cronDiff.amount, checkDate: "2026-07-21", checkNumber: "9201" });
+    expect(second.body.status).toBe("reconcile");
+    expect(second.body.officeTaskId).toBe(first.body.officeTaskId);
+
+    const tasks = await officeTasksMentioning(F.cronDiff.fileId);
+    expect(tasks, "exactly one OfficeTask even after a second POST").toHaveLength(1);
+  });
+
+  // ── 7: Match refusals — each unmatched + exactly ONE OfficeTask ────────────
+  test("7a: unresolvable project name", async ({ request }) => {
+    const payload = { fileId: F.refuseUnresolvable.fileId, projectName: "Zzqxw Nonexistent Ferngully 9999", amount: 123, checkDate: "2026-07-01", checkNumber: "1001" };
+    const first = await postDeposit(request, payload);
+    expect(first.body.status).toBe("unmatched");
+    expect(first.body.reason).toContain("no project matched");
+    expect(first.body.officeTaskId).toBeTruthy();
+
+    const second = await postDeposit(request, payload);
+    expect(second.body.officeTaskId).toBe(first.body.officeTaskId);
+    expect(await officeTasksMentioning(F.refuseUnresolvable.fileId)).toHaveLength(1);
+  });
+
+  test("7b: tied project names refuse (findBestProjectNameMatches ties)", async ({ request }) => {
+    const payload = { fileId: F.refuseTied.fileId, projectName: F.refuseTied.name, amount: 123, checkDate: "2026-07-01", checkNumber: "1002" };
+    const first = await postDeposit(request, payload);
+    expect(first.body.status).toBe("unmatched");
+    expect(first.body.reason).toContain("ambiguous");
+    expect(first.body.officeTaskId).toBeTruthy();
+
+    const second = await postDeposit(request, payload);
+    expect(second.body.officeTaskId).toBe(first.body.officeTaskId);
+    expect(await officeTasksMentioning(F.refuseTied.fileId)).toHaveLength(1);
+  });
+
+  test("7c: zero amount-matching Pending milestones", async ({ request }) => {
+    const payload = { fileId: F.refuseZeroAmt.fileId, projectName: F.refuseZeroAmt.projectName, amount: F.refuseZeroAmt.postedAmount, checkDate: "2026-07-01", checkNumber: "1003" };
+    const first = await postDeposit(request, payload);
+    expect(first.body.status).toBe("unmatched");
+    expect(first.body.reason).toContain("no pending milestone");
+    expect(first.body.officeTaskId).toBeTruthy();
+
+    const second = await postDeposit(request, payload);
+    expect(second.body.officeTaskId).toBe(first.body.officeTaskId);
+    expect(await officeTasksMentioning(F.refuseZeroAmt.fileId)).toHaveLength(1);
+  });
+
+  test("7d: two amount-matching Pending milestones (ambiguous)", async ({ request }) => {
+    const payload = { fileId: F.refuseTwoAmt.fileId, projectName: F.refuseTwoAmt.projectName, amount: F.refuseTwoAmt.amount, checkDate: "2026-07-01", checkNumber: "1004" };
+    const first = await postDeposit(request, payload);
+    expect(first.body.status).toBe("unmatched");
+    expect(first.body.reason).toContain("ambiguous");
+    expect(first.body.officeTaskId).toBeTruthy();
+
+    const second = await postDeposit(request, payload);
+    expect(second.body.officeTaskId).toBe(first.body.officeTaskId);
+    expect(await officeTasksMentioning(F.refuseTwoAmt.fileId)).toHaveLength(1);
+  });
+
+  test("7e: missing check number", async ({ request }) => {
+    const payload = { fileId: F.refuseNoCheckNumber.fileId, projectName: "Whatever Project Name", amount: 50, checkDate: "2026-07-01" };
+    const first = await postDeposit(request, payload);
+    expect(first.body.status).toBe("unmatched");
+    expect(first.body.reason).toBe("missing check number");
+    expect(first.body.officeTaskId).toBeTruthy();
+
+    const second = await postDeposit(request, payload);
+    expect(second.body.officeTaskId).toBe(first.body.officeTaskId);
+    expect(await officeTasksMentioning(F.refuseNoCheckNumber.fileId)).toHaveLength(1);
+  });
+
+  test("7f: missing check date", async ({ request }) => {
+    const payload = { fileId: F.refuseNoCheckDate.fileId, projectName: "Whatever Project Name", amount: 50, checkNumber: "2001" };
+    const first = await postDeposit(request, payload);
+    expect(first.body.status).toBe("unmatched");
+    expect(first.body.reason).toBe("missing or invalid check date");
+    expect(first.body.officeTaskId).toBeTruthy();
+
+    const second = await postDeposit(request, payload);
+    expect(second.body.officeTaskId).toBe(first.body.officeTaskId);
+    expect(await officeTasksMentioning(F.refuseNoCheckDate.fileId)).toHaveLength(1);
+  });
+
+  test("7g: payer gross-conflict with the client name", async ({ request }) => {
+    const payload = {
+      fileId: F.refusePayer.fileId, projectName: F.refusePayer.projectName, amount: F.refusePayer.amount,
+      checkDate: "2026-07-01", checkNumber: "3001", payerName: "Zqbrandt Talwick",
+    };
+    const first = await postDeposit(request, payload);
+    expect(first.body.status).toBe("unmatched");
+    expect(first.body.reason).toContain("shares no name with client");
+    expect(first.body.officeTaskId).toBeTruthy();
+
+    const second = await postDeposit(request, payload);
+    expect(second.body.officeTaskId).toBe(first.body.officeTaskId);
+    expect(await officeTasksMentioning(F.refusePayer.fileId)).toHaveLength(1);
+  });
+
+  // ── 8: force=1 ────────────────────────────────────────────────────────────
+  test("8a: force=1 re-runs an unmatched pre-QBO row with corrected data and applies", async ({ request }) => {
+    const wrong = { fileId: F.forceCorrect.fileId, projectName: F.forceCorrect.projectName, amount: F.forceCorrect.wrongAmount, checkDate: "2026-07-05", checkNumber: "4001" };
+    const first = await postDeposit(request, wrong);
+    expect(first.body.status).toBe("unmatched");
+    expect(first.body.reason).toContain("no pending milestone");
+
+    const corrected = { fileId: F.forceCorrect.fileId, projectName: F.forceCorrect.projectName, amount: F.forceCorrect.correctAmount, checkDate: "2026-07-05", checkNumber: "4001" };
+    const second = await postDeposit(request, corrected, { force: true });
+    expect(second.res.status()).toBe(200);
+    expect(second.body.status).toBe("applied");
+    expect(second.body.scheduleId).toBe(F.forceCorrect.schedule);
+
+    const schedule = await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: F.forceCorrect.schedule } });
+    expect(schedule.status).toBe("Paid");
+    expect(schedule.referenceNumber).toBe("4001");
+  });
+
+  test("8b: force=1 on a row that already crossed the QBO boundary is refused", async ({ request }) => {
+    await prisma.depositIngest.create({
+      data: {
+        fileId: F.forceCrossedQbo.fileId, status: "unmatched",
+        extracted: JSON.stringify({ fileId: F.forceCrossedQbo.fileId, projectName: "Whatever", amount: 1, checkDate: "2026-07-01", checkNumber: "1", payerName: null, fileUrl: null, fileName: null, memo: null }),
+        qbRequestPayload: JSON.stringify({ TotalAmt: 1 }), attempts: 1,
+      },
+    });
+
+    const res = await postDeposit(request, { fileId: F.forceCrossedQbo.fileId, projectName: "Whatever", amount: 1, checkDate: "2026-07-01", checkNumber: "1" }, { force: true });
+    expect(res.res.status()).toBe(200);
+    expect(res.body.status).toBe("unmatched");
+    expect(res.body.reason).toContain("reconcile it manually");
+
+    const row = await prisma.depositIngest.findUniqueOrThrow({ where: { fileId: F.forceCrossedQbo.fileId } });
+    expect(row.status, "no reprocessing happened").toBe("unmatched");
+  });
+
+  // ── 9: Non-QBO-linked milestone ─────────────────────────────────────────────
+  test("9: non-QBO-linked milestone applies via recordPaymentCore — no QBO calls, invoice balance recomputed", async ({ request }) => {
+    await resetQboMock(request);
+
+    const res = await postDeposit(request, { fileId: F.nonQbo.fileId, projectName: F.nonQbo.projectName, amount: F.nonQbo.amount, checkDate: "2026-07-10", checkNumber: "8001" });
+    expect(res.res.status()).toBe(200);
+    expect(res.body.status).toBe("applied");
+
+    const schedule = await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: F.nonQbo.schedule } });
+    expect(schedule.status).toBe("Paid");
+    expect(schedule.paymentMethod).toBe("check");
+    expect(schedule.referenceNumber).toBe("8001");
+    expect(schedule.paymentDate?.toISOString().slice(0, 10)).toBe("2026-07-10");
+
+    const invoice = await prisma.invoice.findUniqueOrThrow({ where: { id: F.nonQbo.invoice } });
+    expect(Number(invoice.balanceDue)).toBe(0);
+    expect(invoice.status).toBe("Paid");
+
+    const notes = await prisma.paymentNotification.findMany({ where: { scheduleId: F.nonQbo.schedule } });
+    expect(notes).toHaveLength(1);
+    expect(notes[0].status, "recordPaymentCore drains the outbox inline").toBe("PROCESSED");
+
+    const mockState = await getQboMockState(request);
+    expect(mockState.calls.readInvoice, "non-QBO path never touches the QuickBooks mock").toBe(0);
+    expect(mockState.calls.paymentCreate).toBe(0);
+  });
+
+  // ── 10: Auth ─────────────────────────────────────────────────────────────────
+  test("10a: missing Authorization header is refused with 401", async ({ request }) => {
+    const { res } = await postDeposit(request, { fileId: "di-e2e-auth-no-header", projectName: "X", amount: 1 }, { authHeader: null });
+    expect(res.status()).toBe(401);
+  });
+
+  test("10b: wrong secret is refused with 401", async ({ request }) => {
+    const { res } = await postDeposit(request, { fileId: "di-e2e-auth-wrong-secret", projectName: "X", amount: 1 }, { authHeader: "Bearer this-is-not-the-secret" });
+    expect(res.status()).toBe(401);
+  });
+
+  // NOTE: the "DEPOSIT_INGEST_SECRET unset" fail-closed branch
+  // (`if (!secret) return 401` at the top of the route) is NOT covered here —
+  // the secret is read from process.env at request time by the already-running
+  // server under test, and this spec has no way to unset it and restart that
+  // server mid-suite. Covered instead by code inspection (the same "fail
+  // closed when unset" pattern as /api/office-tasks/ingest) and the plan's
+  // manual verification step.
+
+  // ── 11: Validation ───────────────────────────────────────────────────────────
+  test("11a: a JSON `null` body is rejected with 400", async ({ request }) => {
+    const { res, body } = await postDeposit(request, null, { rawData: "null" });
+    expect(res.status()).toBe(400);
+    expect(body.ok).toBe(false);
+  });
+
+  test("11b: an amount with more than 2 decimal places is rejected with 400", async ({ request }) => {
+    const { res, body } = await postDeposit(request, {
+      fileId: F.validation.fileId, projectName: "Whatever Project", amount: 12.345, checkDate: "2026-07-01", checkNumber: "1",
+    });
+    expect(res.status()).toBe(400);
+    expect(body.ok).toBe(false);
+    expect(body.reason).toContain("2 decimal places");
+  });
+});

--- a/e2e/deposit-ingest.spec.ts
+++ b/e2e/deposit-ingest.spec.ts
@@ -233,13 +233,23 @@ const F = {
     fileId: "di-e2e-file-nonqbo",
   },
   validation: { fileId: "di-e2e-file-validation" },
+  // Case 12: crash recovery across the NON-QBO money boundary (settleStartedAt) —
+  // one invoice, two Pending milestones with distinct amounts so each sub-case
+  // resumes against its own reservation.
+  settleCrash: {
+    project: "di-e2e-scrash-project", projectName: "Nnexo SettleCrash Project",
+    invoice: "di-e2e-scrash-invoice", invoiceCode: "INV-DI-SCRASH",
+    scheduleSettled: "di-e2e-scrash-sched-a", amountSettled: 700,
+    scheduleUnsettled: "di-e2e-scrash-sched-b", amountUnsettled: 710,
+    fileIdSettled: "di-e2e-file-scrash-settled", fileIdUnsettled: "di-e2e-file-scrash-unsettled",
+  },
 };
 
 const ALL_PROJECT_IDS = [
   F.qbo.project, F.concurrent.project, F.reserve.project, F.resume.project,
   F.cronSame.project, F.cronDiff.project, F.refuseTied.projectA, F.refuseTied.projectB,
   F.refuseZeroAmt.project, F.refuseTwoAmt.project, F.refusePayer.project,
-  F.forceCorrect.project, F.nonQbo.project,
+  F.forceCorrect.project, F.nonQbo.project, F.settleCrash.project,
 ];
 
 const ALL_FILE_IDS = [
@@ -247,6 +257,7 @@ const ALL_FILE_IDS = [
   F.cronSame.fileId, F.cronDiff.fileId, F.refuseUnresolvable.fileId, F.refuseTied.fileId,
   F.refuseZeroAmt.fileId, F.refuseTwoAmt.fileId, F.refuseNoCheckNumber.fileId, F.refuseNoCheckDate.fileId,
   F.refusePayer.fileId, F.forceCorrect.fileId, F.forceCrossedQbo.fileId, F.nonQbo.fileId, F.validation.fileId,
+  F.settleCrash.fileIdSettled, F.settleCrash.fileIdUnsettled,
 ];
 
 test.describe.serial("Deposit-ingest pipeline (Phase B1)", () => {
@@ -327,12 +338,20 @@ test.describe.serial("Deposit-ingest pipeline (Phase B1)", () => {
       invoiceId: F.nonQbo.invoice, invoiceCode: F.nonQbo.invoiceCode,
       schedules: [{ id: F.nonQbo.schedule, name: "NonQBO Deposit", amount: F.nonQbo.amount }],
     });
+    await seedFixture({
+      projectId: F.settleCrash.project, projectName: F.settleCrash.projectName,
+      invoiceId: F.settleCrash.invoice, invoiceCode: F.settleCrash.invoiceCode,
+      schedules: [
+        { id: F.settleCrash.scheduleSettled, name: "SettleCrash Committed", amount: F.settleCrash.amountSettled },
+        { id: F.settleCrash.scheduleUnsettled, name: "SettleCrash Uncommitted", amount: F.settleCrash.amountUnsettled },
+      ],
+    });
   });
 
   test.afterAll(async () => {
     try {
       await prisma.paymentNotification.deleteMany({
-        where: { scheduleId: { in: [F.qbo.schedule, F.concurrent.schedule, F.reserve.schedule, F.resume.schedule, F.nonQbo.schedule, F.forceCorrect.schedule] } },
+        where: { scheduleId: { in: [F.qbo.schedule, F.concurrent.schedule, F.reserve.schedule, F.resume.schedule, F.nonQbo.schedule, F.forceCorrect.schedule, F.settleCrash.scheduleSettled, F.settleCrash.scheduleUnsettled] } },
       });
       await prisma.activityLog.deleteMany({ where: { projectId: { in: ALL_PROJECT_IDS } } });
       for (const fileId of ALL_FILE_IDS) {
@@ -712,6 +731,74 @@ test.describe.serial("Deposit-ingest pipeline (Phase B1)", () => {
     const mockState = await getQboMockState(request);
     expect(mockState.calls.readInvoice, "non-QBO path never touches the QuickBooks mock").toBe(0);
     expect(mockState.calls.paymentCreate).toBe(0);
+  });
+
+  // ── 12: Non-QBO money-boundary crash recovery (settleStartedAt) ──────────────
+  test("12a: settle committed, crash before applied-write — stale reclaim resumes the reserved row and finalizes applied without re-settling", async ({ request }) => {
+    await resetQboMock(request);
+    const extracted = {
+      fileId: F.settleCrash.fileIdSettled, fileUrl: null, fileName: null, projectName: F.settleCrash.projectName,
+      payerName: null, amount: F.settleCrash.amountSettled, checkDate: "2026-07-25", checkNumber: "7001", memo: null,
+    };
+    // Simulate: recordPaymentCore committed (milestone Paid with our method/ref/date),
+    // then the process died before the row's applied-write. Boundary marker set,
+    // reservation held, lease stale.
+    await prisma.paymentSchedule.update({
+      where: { id: F.settleCrash.scheduleSettled },
+      data: { status: "Paid", paymentMethod: "check", referenceNumber: "7001", paymentDate: new Date("2026-07-25T00:00:00Z"), paidAt: new Date() },
+    });
+    await prisma.depositIngest.create({
+      data: {
+        fileId: F.settleCrash.fileIdSettled, status: "processing", extracted: JSON.stringify(extracted),
+        paymentScheduleId: F.settleCrash.scheduleSettled, settleStartedAt: new Date(Date.now() - 6 * 60_000),
+        attempts: 1, processingStartedAt: new Date(Date.now() - 6 * 60_000),
+      },
+    });
+
+    const res = await postDeposit(request, {
+      fileId: F.settleCrash.fileIdSettled, projectName: F.settleCrash.projectName,
+      amount: F.settleCrash.amountSettled, checkDate: "2026-07-25", checkNumber: "7001",
+    });
+    expect(res.res.status()).toBe(200);
+    expect(res.body.status).toBe("applied");
+
+    const row = await prisma.depositIngest.findUniqueOrThrow({ where: { fileId: F.settleCrash.fileIdSettled } });
+    expect(row.status).toBe("applied");
+    expect(row.paymentScheduleId, "reservation survives the reclaim (boundary marker)").toBe(F.settleCrash.scheduleSettled);
+    const schedule = await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: F.settleCrash.scheduleSettled } });
+    expect(schedule.referenceNumber, "the committed settle is untouched").toBe("7001");
+    const tasks = await officeTasksMentioning(F.settleCrash.fileIdSettled);
+    expect(tasks, "recovered-as-ours is not a review case").toHaveLength(0);
+  });
+
+  test("12b: marker set but settle never committed — reclaim keeps the reservation and settles using the PRESERVED extracted payload, not the divergent re-POST", async ({ request }) => {
+    const extracted = {
+      fileId: F.settleCrash.fileIdUnsettled, fileUrl: null, fileName: null, projectName: F.settleCrash.projectName,
+      payerName: null, amount: F.settleCrash.amountUnsettled, checkDate: "2026-07-26", checkNumber: "7002", memo: null,
+    };
+    await prisma.depositIngest.create({
+      data: {
+        fileId: F.settleCrash.fileIdUnsettled, status: "processing", extracted: JSON.stringify(extracted),
+        paymentScheduleId: F.settleCrash.scheduleUnsettled, settleStartedAt: new Date(Date.now() - 6 * 60_000),
+        attempts: 1, processingStartedAt: new Date(Date.now() - 6 * 60_000),
+      },
+    });
+
+    // The bot re-sends with a DIVERGENT re-extraction (different check number/date):
+    // the reserved-row resume must settle with the ORIGINAL stored payload.
+    const res = await postDeposit(request, {
+      fileId: F.settleCrash.fileIdUnsettled, projectName: F.settleCrash.projectName,
+      amount: F.settleCrash.amountUnsettled, checkDate: "2026-07-27", checkNumber: "9999",
+    });
+    expect(res.res.status()).toBe(200);
+    expect(res.body.status).toBe("applied");
+
+    const schedule = await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: F.settleCrash.scheduleUnsettled } });
+    expect(schedule.status).toBe("Paid");
+    expect(schedule.referenceNumber, "settled with the preserved original check number").toBe("7002");
+    expect(schedule.paymentDate?.toISOString().slice(0, 10)).toBe("2026-07-26");
+    const row = await prisma.depositIngest.findUniqueOrThrow({ where: { fileId: F.settleCrash.fileIdUnsettled } });
+    expect(row.status).toBe("applied");
   });
 
   // ── 10: Auth ─────────────────────────────────────────────────────────────────

--- a/e2e/deposit-ingest.spec.ts
+++ b/e2e/deposit-ingest.spec.ts
@@ -233,6 +233,12 @@ const F = {
     fileId: "di-e2e-file-nonqbo",
   },
   validation: { fileId: "di-e2e-file-validation" },
+  weakMatch: {
+    project: "di-e2e-weak-project", projectName: "Weakguard Kitchen Remodel",
+    invoice: "di-e2e-weak-invoice", invoiceCode: "INV-DI-WEAK",
+    schedule: "di-e2e-weak-schedule", amount: 123,
+    fileId: "di-e2e-file-weakmatch",
+  },
   // Case 12: crash recovery across the NON-QBO money boundary (settleStartedAt) —
   // one invoice, two Pending milestones with distinct amounts so each sub-case
   // resumes against its own reservation.
@@ -249,7 +255,7 @@ const ALL_PROJECT_IDS = [
   F.qbo.project, F.concurrent.project, F.reserve.project, F.resume.project,
   F.cronSame.project, F.cronDiff.project, F.refuseTied.projectA, F.refuseTied.projectB,
   F.refuseZeroAmt.project, F.refuseTwoAmt.project, F.refusePayer.project,
-  F.forceCorrect.project, F.nonQbo.project, F.settleCrash.project,
+  F.forceCorrect.project, F.nonQbo.project, F.settleCrash.project, F.weakMatch.project,
 ];
 
 const ALL_FILE_IDS = [
@@ -257,7 +263,7 @@ const ALL_FILE_IDS = [
   F.cronSame.fileId, F.cronDiff.fileId, F.refuseUnresolvable.fileId, F.refuseTied.fileId,
   F.refuseZeroAmt.fileId, F.refuseTwoAmt.fileId, F.refuseNoCheckNumber.fileId, F.refuseNoCheckDate.fileId,
   F.refusePayer.fileId, F.forceCorrect.fileId, F.forceCrossedQbo.fileId, F.nonQbo.fileId, F.validation.fileId,
-  F.settleCrash.fileIdSettled, F.settleCrash.fileIdUnsettled,
+  F.settleCrash.fileIdSettled, F.settleCrash.fileIdUnsettled, F.weakMatch.fileId,
 ];
 
 test.describe.serial("Deposit-ingest pipeline (Phase B1)", () => {
@@ -337,6 +343,11 @@ test.describe.serial("Deposit-ingest pipeline (Phase B1)", () => {
       projectId: F.nonQbo.project, projectName: F.nonQbo.projectName,
       invoiceId: F.nonQbo.invoice, invoiceCode: F.nonQbo.invoiceCode,
       schedules: [{ id: F.nonQbo.schedule, name: "NonQBO Deposit", amount: F.nonQbo.amount }],
+    });
+    await seedFixture({
+      projectId: F.weakMatch.project, projectName: F.weakMatch.projectName,
+      invoiceId: F.weakMatch.invoice, invoiceCode: F.weakMatch.invoiceCode,
+      schedules: [{ id: F.weakMatch.schedule, name: "Weak Match Deposit", amount: F.weakMatch.amount }],
     });
     await seedFixture({
       projectId: F.settleCrash.project, projectName: F.settleCrash.projectName,
@@ -587,12 +598,29 @@ test.describe.serial("Deposit-ingest pipeline (Phase B1)", () => {
     const payload = { fileId: F.refuseUnresolvable.fileId, projectName: "Zzqxw Nonexistent Ferngully 9999", amount: 123, checkDate: "2026-07-01", checkNumber: "1001" };
     const first = await postDeposit(request, payload);
     expect(first.body.status).toBe("unmatched");
-    expect(first.body.reason).toContain("no project matched");
+    // The e2e DB is shared across specs in one CI run: sibling specs' projects can
+    // accidentally share two generic words with the gibberish label and turn "no
+    // project matched" into "ambiguous" or the first-word weak-match refusal. All
+    // three are correct refusals of an unresolvable name — the invariant under test
+    // is unmatched + exactly one task, not the specific reason string.
+    expect(first.body.reason).toMatch(/no project matched|ambiguous|first word differs/);
     expect(first.body.officeTaskId).toBeTruthy();
 
     const second = await postDeposit(request, payload);
     expect(second.body.officeTaskId).toBe(first.body.officeTaskId);
     expect(await officeTasksMentioning(F.refuseUnresolvable.fileId)).toHaveLength(1);
+  });
+
+  test("7a2: single weak fuzzy match (generic shared words, first word differs) refuses", async ({ request }) => {
+    // "Kitchen Remodel" alone scores 2 in the shared matcher — enough to route an
+    // expense receipt, not enough to move money. The winner (if unique) must also
+    // contain the label's first word (client surname convention).
+    const payload = { fileId: F.weakMatch.fileId, projectName: "Zzyxfirst Kitchen Remodel", amount: 123, checkDate: "2026-07-01", checkNumber: "1003" };
+    const first = await postDeposit(request, payload);
+    expect(first.body.status).toBe("unmatched");
+    expect(first.body.reason, "either the weak-match guard fires or sibling-spec data makes it ambiguous — both refuse").toMatch(/first word differs|ambiguous/);
+    const schedule = await prisma.paymentSchedule.findUniqueOrThrow({ where: { id: F.weakMatch.schedule } });
+    expect(schedule.status, "no money moved on a weak match").toBe("Pending");
   });
 
   test("7b: tied project names refuse (findBestProjectNameMatches ties)", async ({ request }) => {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -646,7 +646,12 @@ model DepositIngest {
   paymentScheduleId String?
   qbPaymentId       String? // set once the QuickBooks Payment is created
   qbRequestPayload  String? // exact JSON body sent to QBO POST /payment — replayed byte-identical on qbo_unknown recovery
-  officeTaskId      String? // set once, on the first unmatched/reconcile — re-POSTs never create a second task
+  // Money-boundary marker for the NON-QBO settle path (the analog of qbRequestPayload
+  // for the QBO path): stamped immediately before recordPaymentCore runs. While any
+  // boundary marker is set, retry reclaims preserve the reservation + extracted payload
+  // so recovery goes through the exact reserved-row path, never a re-match.
+  settleStartedAt DateTime?
+  officeTaskId    String? // set once, on the first unmatched/reconcile — re-POSTs never create a second task
 
   attempts            Int       @default(0)
   lastError           String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -621,6 +621,44 @@ model PaymentSchedule {
   @@index([scheduleTaskId])
 }
 
+// Deposit auto-apply pipeline (Phase B1): one row per Drive file the GTR
+// receipt bot classifies as a `customer_payment` (an incoming check/deposit
+// photo). Backs the crash-safe idempotency + state machine owned by
+// POST /api/payments/deposit-ingest — see that route for the full state
+// machine (processing/qbo_unknown/qbo_created/applied/unmatched/failed/reconcile).
+//
+// NOTE: a partial unique index reserves paymentScheduleId while a deposit is
+// in flight, so two different files can never both claim the same pending
+// milestone. Prisma cannot express a partial index — it is created ONLY by
+// scripts/apply-deposit-ingest-schema.mjs:
+//   CREATE UNIQUE INDEX ... ON "DepositIngest" ("paymentScheduleId")
+//     WHERE "status" IN ('processing','qbo_unknown','qbo_created','applied','reconcile')
+//     AND "paymentScheduleId" IS NOT NULL
+model DepositIngest {
+  id     String @id @default(cuid())
+  fileId String @unique // Drive file id — stable idempotency key across the bot's archive move
+
+  status    String // processing | qbo_unknown | qbo_created | applied | unmatched | failed | reconcile
+  extracted String // JSON snapshot of the inbound payload — carried into the OfficeTask + audit trail
+
+  // Reserved milestone (see the partial unique index note above). NULLed on
+  // pre-QBO-boundary retry exhaustion so the reservation frees the milestone.
+  paymentScheduleId String?
+  qbPaymentId       String? // set once the QuickBooks Payment is created
+  qbRequestPayload  String? // exact JSON body sent to QBO POST /payment — replayed byte-identical on qbo_unknown recovery
+  officeTaskId      String? // set once, on the first unmatched/reconcile — re-POSTs never create a second task
+
+  attempts            Int       @default(0)
+  lastError           String?
+  processingStartedAt DateTime? // claim lease — stale after 5 min, like the notification outbox
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([status])
+  @@index([paymentScheduleId])
+}
+
 // Progress billing: the billable artifact the user builds by picking
 // milestones and/or a custom amount, writing one client-facing description,
 // and staging exactly ONE QuickBooks invoice. An approved change order is

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -632,8 +632,11 @@ model PaymentSchedule {
 // milestone. Prisma cannot express a partial index — it is created ONLY by
 // scripts/apply-deposit-ingest-schema.mjs:
 //   CREATE UNIQUE INDEX ... ON "DepositIngest" ("paymentScheduleId")
-//     WHERE "status" IN ('processing','qbo_unknown','qbo_created','applied','reconcile')
+//     WHERE "status" IN ('processing','qbo_unknown','qbo_created','applied','reconcile','failed')
 //     AND "paymentScheduleId" IS NOT NULL
+// ('failed' is in the predicate for boundary-marked rows that keep their
+//  reservation; unmarked failed rows carry NULL and are excluded. 'unmatched'
+//  is deliberately NOT — that transition releases the milestone.)
 model DepositIngest {
   id     String @id @default(cuid())
   fileId String @unique // Drive file id — stable idempotency key across the bot's archive move

--- a/scripts/apply-deposit-ingest-schema.mjs
+++ b/scripts/apply-deposit-ingest-schema.mjs
@@ -45,14 +45,24 @@ const statements = [
      "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
      CONSTRAINT "DepositIngest_pkey" PRIMARY KEY ("id")
    )`,
+  // Additive upgrade path: the column also lives in CREATE TABLE above, which is a
+  // no-op when the table already exists — this ALTER is what actually adds it there.
+  `ALTER TABLE "DepositIngest" ADD COLUMN IF NOT EXISTS "settleStartedAt" TIMESTAMP(3)`,
   `CREATE UNIQUE INDEX IF NOT EXISTS "DepositIngest_fileId_key" ON "DepositIngest" ("fileId")`,
   `CREATE INDEX IF NOT EXISTS "DepositIngest_status_idx" ON "DepositIngest" ("status")`,
   `CREATE INDEX IF NOT EXISTS "DepositIngest_paymentScheduleId_idx" ON "DepositIngest" ("paymentScheduleId")`,
   // Partial reservation index — see the header comment + the matching note in
   // prisma/schema.prisma above the DepositIngest model. NOT expressible in Prisma.
+  // "failed" is IN the predicate: unmarked failed rows carry NULL paymentScheduleId
+  // (excluded by the IS NOT NULL clause), while a boundary-marked failed row keeps
+  // its index hold — without it, a marked failed row shadow-holds the milestone
+  // outside the index, a second file reserves it, and the first row's
+  // failed→processing CAS then throws unhandled P2002 forever (never reaching
+  // exhaustion). Rebuilt via DROP so re-runs converge on the correct predicate.
+  `DROP INDEX IF EXISTS "DepositIngest_paymentScheduleId_reservation_key"`,
   `CREATE UNIQUE INDEX IF NOT EXISTS "DepositIngest_paymentScheduleId_reservation_key"
      ON "DepositIngest" ("paymentScheduleId")
-     WHERE "status" IN ('processing', 'qbo_unknown', 'qbo_created', 'applied', 'reconcile')
+     WHERE "status" IN ('processing', 'qbo_unknown', 'qbo_created', 'applied', 'reconcile', 'failed')
        AND "paymentScheduleId" IS NOT NULL`,
   // Server-only table (payer names, amounts, QBO ids) in Supabase's exposed schema —
   // RLS on with no policies, so only the service role / direct Prisma access can read it

--- a/scripts/apply-deposit-ingest-schema.mjs
+++ b/scripts/apply-deposit-ingest-schema.mjs
@@ -36,6 +36,7 @@ const statements = [
      "paymentScheduleId" TEXT,
      "qbPaymentId" TEXT,
      "qbRequestPayload" TEXT,
+     "settleStartedAt" TIMESTAMP(3),
      "officeTaskId" TEXT,
      "attempts" INTEGER NOT NULL DEFAULT 0,
      "lastError" TEXT,

--- a/scripts/apply-deposit-ingest-schema.mjs
+++ b/scripts/apply-deposit-ingest-schema.mjs
@@ -53,6 +53,10 @@ const statements = [
      ON "DepositIngest" ("paymentScheduleId")
      WHERE "status" IN ('processing', 'qbo_unknown', 'qbo_created', 'applied', 'reconcile')
        AND "paymentScheduleId" IS NOT NULL`,
+  // Server-only table (payer names, amounts, QBO ids) in Supabase's exposed schema —
+  // RLS on with no policies, so only the service role / direct Prisma access can read it
+  // (matches the other apply-*.mjs scripts' convention for server-only tables).
+  `ALTER TABLE "DepositIngest" ENABLE ROW LEVEL SECURITY`,
 ];
 
 try {

--- a/scripts/apply-deposit-ingest-schema.mjs
+++ b/scripts/apply-deposit-ingest-schema.mjs
@@ -1,0 +1,69 @@
+// One-off additive migration for the deposit auto-apply pipeline (Phase B1)
+// (model DepositIngest in prisma/schema.prisma, driven by
+// src/app/api/payments/deposit-ingest/route.ts). Mirrors
+// scripts/apply-payment-notification-schema.mjs.
+//
+// Includes the partial reservation index Prisma cannot express: a unique
+// index on paymentScheduleId scoped to the "in flight or done" statuses, so
+// two different deposit files can never both claim the same pending
+// milestone (the loser's insert/update hits the unique violation and the
+// route maps that to an "unmatched" outcome).
+//
+// Run:  node scripts/apply-deposit-ingest-schema.mjs
+// (DDL via $executeRawUnsafe over the Supabase transaction pooler — the working
+//  path in this project; psql / prisma db push / migrate dev do not work here.)
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+function resolveDatabaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const f of [".env", ".env.local"]) {
+    if (!fs.existsSync(f)) continue;
+    const m = fs.readFileSync(f, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+    if (m) return m[1];
+  }
+  throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const prisma = new PrismaClient({ datasources: { db: { url: resolveDatabaseUrl() } } });
+
+const statements = [
+  `CREATE TABLE IF NOT EXISTS "DepositIngest" (
+     "id" TEXT NOT NULL,
+     "fileId" TEXT NOT NULL,
+     "status" TEXT NOT NULL,
+     "extracted" TEXT NOT NULL,
+     "paymentScheduleId" TEXT,
+     "qbPaymentId" TEXT,
+     "qbRequestPayload" TEXT,
+     "officeTaskId" TEXT,
+     "attempts" INTEGER NOT NULL DEFAULT 0,
+     "lastError" TEXT,
+     "processingStartedAt" TIMESTAMP(3),
+     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+     CONSTRAINT "DepositIngest_pkey" PRIMARY KEY ("id")
+   )`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "DepositIngest_fileId_key" ON "DepositIngest" ("fileId")`,
+  `CREATE INDEX IF NOT EXISTS "DepositIngest_status_idx" ON "DepositIngest" ("status")`,
+  `CREATE INDEX IF NOT EXISTS "DepositIngest_paymentScheduleId_idx" ON "DepositIngest" ("paymentScheduleId")`,
+  // Partial reservation index — see the header comment + the matching note in
+  // prisma/schema.prisma above the DepositIngest model. NOT expressible in Prisma.
+  `CREATE UNIQUE INDEX IF NOT EXISTS "DepositIngest_paymentScheduleId_reservation_key"
+     ON "DepositIngest" ("paymentScheduleId")
+     WHERE "status" IN ('processing', 'qbo_unknown', 'qbo_created', 'applied', 'reconcile')
+       AND "paymentScheduleId" IS NOT NULL`,
+];
+
+try {
+  for (const sql of statements) {
+    await prisma.$executeRawUnsafe(sql);
+    console.log("✔ applied:", sql.split("\n")[0]);
+  }
+  console.log("Done.");
+} catch (e) {
+  console.error("Migration failed:", e);
+  process.exitCode = 1;
+} finally {
+  await prisma.$disconnect();
+}

--- a/scripts/apply-deposit-ingest-schema.mjs
+++ b/scripts/apply-deposit-ingest-schema.mjs
@@ -59,6 +59,13 @@ const statements = [
   // outside the index, a second file reserves it, and the first row's
   // failed→processing CAS then throws unhandled P2002 forever (never reaching
   // exhaustion). Rebuilt via DROP so re-runs converge on the correct predicate.
+  // Legacy-data preflight: pre-predicate-change code could leave an UNMARKED failed
+  // row holding a reservation; such rows are exactly the ones current code releases,
+  // and clearing them first guarantees the CREATE below can never fail mid-rebuild
+  // (the statements are separate pooler calls — a failed CREATE after a committed
+  // DROP would leave the table with NO reservation index).
+  `UPDATE "DepositIngest" SET "paymentScheduleId" = NULL
+     WHERE "status" = 'failed' AND "settleStartedAt" IS NULL AND "paymentScheduleId" IS NOT NULL`,
   `DROP INDEX IF EXISTS "DepositIngest_paymentScheduleId_reservation_key"`,
   `CREATE UNIQUE INDEX IF NOT EXISTS "DepositIngest_paymentScheduleId_reservation_key"
      ON "DepositIngest" ("paymentScheduleId")

--- a/src/app/api/payments/deposit-ingest/route.ts
+++ b/src/app/api/payments/deposit-ingest/route.ts
@@ -1,0 +1,572 @@
+import { NextResponse } from "next/server";
+import { createHash } from "node:crypto";
+import type { DepositIngest } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { revalidatePath } from "next/cache";
+import { findBestProjectNameMatches, normalizeWords } from "@/lib/project-match";
+import { toNum } from "@/lib/prisma-helpers";
+import { recordPaymentCore } from "@/lib/payment-record-core";
+import { getFreshQBTokens, settleMilestoneFromQBPayment } from "@/lib/quickbooks-payments";
+import { buildQBPaymentRequest, sendQBPaymentCreateRequest, type QBTokens } from "@/lib/quickbooks";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+/**
+ * Deposit auto-apply pipeline (Phase B1). The GTR receipt bot classifies an
+ * incoming check/deposit photo as `customer_payment`, does its own Gemini
+ * extraction, and POSTs the metadata here — no photo bytes, one request per
+ * Drive file. This endpoint owns ALL matching and money writes: it applies
+ * the deposit against the one Pending milestone it uniquely matches, in
+ * QuickBooks (if the milestone is QBO-linked) AND ProBuild, or files an
+ * OfficeTask for a human when the match isn't clean.
+ *
+ * Auth: Authorization: Bearer ${DEPOSIT_INGEST_SECRET}. `/api/payments/*` is
+ * already in the generic proxy bypass (src/proxy.ts), so this in-handler
+ * Bearer check is the sole gate — fail closed (401) when the env var is
+ * unset, exactly like /api/office-tasks/ingest.
+ *
+ * State machine (DepositIngest row, keyed by the Drive fileId):
+ *   processing   — claimed, working the match (or a non-QBO apply, which has
+ *                  no further boundary). Stale-claim re-claimable (5 min).
+ *   qbo_unknown  — the QBO Payment create request was SENT (or is about to
+ *                  be — the row's qbRequestPayload is persisted BEFORE the
+ *                  network call fires) but the response was lost/timed out.
+ *                  Recovery replays the byte-identical request with the same
+ *                  requestid; Intuit returns the ORIGINAL response instead of
+ *                  creating a duplicate Payment.
+ *   qbo_created  — the QBO Payment exists (qbPaymentId set); ProBuild settle
+ *                  is pending. Resume from settle.
+ *   applied      — terminal success.
+ *   unmatched    — terminal to the bot (an OfficeTask was filed). A human can
+ *                  force a retry with ?force=1 after fixing the cause, UNLESS
+ *                  the row already crossed the QBO boundary (never force-reset
+ *                  those — reconcile manually instead).
+ *   failed       — retryable, PRE-QBO-boundary failures only (a guard
+ *                  rejection, QB not connected, ...). Any failure once the
+ *                  QBO request begins goes to qbo_unknown, never failed.
+ *   reconcile    — manual. Bounded retries (MAX_ATTEMPTS); on exhaustion or a
+ *                  genuine post-settle conflict, files ONE OfficeTask.
+ *
+ * Reservation: a partial unique index on paymentScheduleId (see
+ * scripts/apply-deposit-ingest-schema.mjs — not expressible in Prisma) stops
+ * two different deposit files from claiming the same pending milestone. The
+ * loser's reservation attempt hits the unique violation and goes unmatched.
+ */
+
+const MAX_ATTEMPTS = 8; // like the notification outbox (src/lib/payment-outbox.ts)
+const STALE_PROCESSING_MS = 5 * 60_000;
+const OPEN_INVOICE_STATUSES = ["Issued", "Overdue", "Partially Paid"]; // matches src/lib/open-invoices-report.ts's canon
+
+interface NormalizedPayload {
+    fileId: string;
+    fileUrl: string | null;
+    fileName: string | null;
+    projectName: string;
+    payerName: string | null;
+    amount: number;
+    checkDate: string | null; // YYYY-MM-DD, validated separately (required, but not a 400 — see below)
+    checkNumber: string | null; // required, but not a 400 — see below
+    memo: string | null;
+}
+
+interface MatchedSchedule {
+    id: string;
+    invoiceId: string;
+    qbInvoiceId: string | null;
+    invoiceCode: string;
+}
+
+export async function POST(req: Request) {
+    const secret = process.env.DEPOSIT_INGEST_SECRET;
+    if (!secret) {
+        console.error("DEPOSIT_INGEST_SECRET is not configured");
+        return NextResponse.json({ ok: false, reason: "unauthorized" }, { status: 401 });
+    }
+    const authHeader = req.headers.get("authorization");
+    if (authHeader !== `Bearer ${secret}`) {
+        return NextResponse.json({ ok: false, reason: "unauthorized" }, { status: 401 });
+    }
+
+    let raw: Record<string, unknown>;
+    try {
+        raw = await req.json();
+    } catch {
+        return NextResponse.json({ ok: false, reason: "invalid-json" }, { status: 400 });
+    }
+
+    const fileId = String(raw.fileId ?? "").trim();
+    const projectName = String(raw.projectName ?? "").trim();
+    const amount = Number(raw.amount);
+    // Hard 400s: without these, there's no row to claim and nothing to match against.
+    // checkDate/checkNumber are ALSO required but are deliberately NOT 400s — the bot's
+    // Gemini extraction can legitimately come back incomplete, and that's an `unmatched`
+    // outcome (with an OfficeTask), not a request the bot needs to special-case.
+    if (!fileId) return NextResponse.json({ ok: false, reason: "fileId is required" }, { status: 400 });
+    if (!projectName) return NextResponse.json({ ok: false, reason: "projectName is required" }, { status: 400 });
+    if (!Number.isFinite(amount) || amount <= 0) {
+        return NextResponse.json({ ok: false, reason: "amount must be a positive number" }, { status: 400 });
+    }
+
+    const payload: NormalizedPayload = {
+        fileId,
+        projectName,
+        amount,
+        fileUrl: typeof raw.fileUrl === "string" && raw.fileUrl.trim() ? raw.fileUrl.trim() : null,
+        fileName: typeof raw.fileName === "string" && raw.fileName.trim() ? raw.fileName.trim() : null,
+        payerName: typeof raw.payerName === "string" && raw.payerName.trim() ? raw.payerName.trim() : null,
+        checkDate: typeof raw.checkDate === "string" ? raw.checkDate.trim() : null,
+        checkNumber: typeof raw.checkNumber === "string" && raw.checkNumber.trim() ? raw.checkNumber.trim() : null,
+        memo: typeof raw.memo === "string" && raw.memo.trim() ? raw.memo.trim() : null,
+    };
+
+    const force = new URL(req.url).searchParams.get("force") === "1";
+
+    // ── Idempotency / claim ─────────────────────────────────────────────────
+    let row = await prisma.depositIngest.findUnique({ where: { fileId } });
+    let freshlyClaimed = false;
+
+    if (!row) {
+        try {
+            row = await prisma.depositIngest.create({
+                data: {
+                    fileId,
+                    status: "processing",
+                    extracted: JSON.stringify(payload),
+                    attempts: 1,
+                    processingStartedAt: new Date(),
+                },
+            });
+            freshlyClaimed = true;
+        } catch (e: any) {
+            if (e?.code !== "P2002") throw e;
+            // Lost the create race to a concurrent duplicate request — fall through
+            // to the existing-row handling below.
+            row = await prisma.depositIngest.findUnique({ where: { fileId } });
+        }
+    }
+    if (!row) {
+        return NextResponse.json({ ok: false, reason: "claim-race" }, { status: 500 });
+    }
+
+    // ── Terminal states ──────────────────────────────────────────────────────
+    if (row.status === "applied") {
+        let invoiceCode: string | undefined;
+        if (row.paymentScheduleId) {
+            const s = await prisma.paymentSchedule.findUnique({
+                where: { id: row.paymentScheduleId },
+                select: { invoice: { select: { code: true } } },
+            });
+            invoiceCode = s?.invoice.code;
+        }
+        return NextResponse.json({
+            ok: true, status: "applied", alreadyApplied: true,
+            scheduleId: row.paymentScheduleId, qbPaymentId: row.qbPaymentId, invoiceCode,
+        });
+    }
+    if (row.status === "reconcile") {
+        return NextResponse.json({ ok: true, status: "reconcile", reason: row.lastError, officeTaskId: row.officeTaskId });
+    }
+    if (row.status === "unmatched" && !force) {
+        return NextResponse.json({ ok: true, status: "unmatched", reason: row.lastError, officeTaskId: row.officeTaskId });
+    }
+
+    // ── Force-reset an unmatched row (human retry after fixing the cause) ──
+    // Never force-reset a row that already crossed the QBO boundary — that money
+    // decision needs a human looking at QuickBooks, not a silent re-run.
+    if (row.status === "unmatched" && force) {
+        if (row.qbPaymentId || row.qbRequestPayload) {
+            return NextResponse.json({
+                ok: true, status: "unmatched",
+                reason: "cannot force-retry — this deposit already reached QuickBooks; reconcile it manually",
+                officeTaskId: row.officeTaskId,
+            });
+        }
+        const reclaimed = await prisma.depositIngest.updateMany({
+            where: { id: row.id, status: "unmatched" },
+            data: {
+                status: "processing", extracted: JSON.stringify(payload),
+                attempts: { increment: 1 }, processingStartedAt: new Date(),
+                lastError: null, paymentScheduleId: null,
+            },
+        });
+        if (reclaimed.count === 0) {
+            const fresh = await prisma.depositIngest.findUnique({ where: { id: row.id } });
+            return NextResponse.json({ ok: true, status: fresh?.status ?? "unmatched", reason: fresh?.lastError ?? null });
+        }
+        freshlyClaimed = true;
+        row = (await prisma.depositIngest.findUnique({ where: { id: row.id } }))!;
+    }
+
+    // ── Stale-claim reclaim (worker died mid-flight) ────────────────────────
+    // "failed" has no lease (nothing is actively in-flight for it) — always retryable.
+    // processing/qbo_unknown/qbo_created only reclaim once the 5-minute lease is stale;
+    // a fresh lease means another request is actively working this file right now.
+    const inFlightStatuses = ["processing", "qbo_unknown", "qbo_created", "failed"];
+    if (!freshlyClaimed && inFlightStatuses.includes(row.status)) {
+        const needsLease = row.status !== "failed";
+        const staleBefore = new Date(Date.now() - STALE_PROCESSING_MS);
+        const claim = await prisma.depositIngest.updateMany({
+            where: {
+                id: row.id, status: row.status,
+                ...(needsLease ? { processingStartedAt: { lt: staleBefore } } : {}),
+            },
+            data: {
+                attempts: { increment: 1 }, processingStartedAt: new Date(),
+                // Only overwrite the audit-trail payload for pre-QBO-boundary retries — a
+                // qbo_unknown/qbo_created resume deliberately replays against the ORIGINAL
+                // extracted values (see resumeFromQboUnknown/resumeFromQboCreated below).
+                ...(row.status === "processing" || row.status === "failed" ? { extracted: JSON.stringify(payload) } : {}),
+            },
+        });
+        if (claim.count > 0) {
+            freshlyClaimed = true;
+            row = (await prisma.depositIngest.findUnique({ where: { id: row.id } }))!;
+        }
+    }
+
+    if (!freshlyClaimed) {
+        // Someone else is actively working this file (fresh lease) — the bot's next
+        // 10-minute run retries safely (idempotent by fileId).
+        return NextResponse.json({ ok: true, status: row.status, reason: "in progress — retry shortly" });
+    }
+
+    if (row.attempts > MAX_ATTEMPTS) {
+        const crossedQboBoundary = !!row.qbPaymentId || !!row.qbRequestPayload;
+        return await finalizeReconcile(
+            row,
+            `exceeded ${MAX_ATTEMPTS} retry attempts (last error: ${row.lastError ?? "none"})`,
+            { nullReservation: !crossedQboBoundary },
+        );
+    }
+
+    try {
+        if (row.status === "qbo_created") return await resumeFromQboCreated(row);
+        if (row.status === "qbo_unknown") return await resumeFromQboUnknown(row);
+        return await matchAndApply(row, payload);
+    } catch (e: any) {
+        // Any exception that escapes this far is, by construction, one the QBO-crossing
+        // steps (send, settle) didn't already handle internally — but re-read the row's
+        // PERSISTED state rather than assume, since e.g. settleMilestoneFromQBPayment can
+        // throw AFTER qbPaymentId was already committed (a real QuickBooks Payment exists).
+        const message = e instanceof Error ? e.message : String(e);
+        const fresh = (await prisma.depositIngest.findUnique({ where: { id: row.id } })) ?? row;
+        const crossedQboBoundary = !!fresh.qbPaymentId || !!fresh.qbRequestPayload;
+        if (fresh.attempts >= MAX_ATTEMPTS) {
+            return await finalizeReconcile(fresh, message, { nullReservation: !crossedQboBoundary });
+        }
+        const retryStatus = !crossedQboBoundary ? "failed" : fresh.qbPaymentId ? "qbo_created" : "qbo_unknown";
+        await prisma.depositIngest.updateMany({
+            where: { id: fresh.id },
+            data: { status: retryStatus, lastError: message.slice(0, 1000) },
+        });
+        return NextResponse.json({ ok: false, status: retryStatus, reason: message });
+    }
+}
+
+// ── Matching + apply ─────────────────────────────────────────────────────────
+
+async function matchAndApply(row: DepositIngest, payload: NormalizedPayload): Promise<NextResponse> {
+    let schedule: MatchedSchedule | null = null;
+
+    if (row.paymentScheduleId) {
+        // A prior crashed attempt already reserved a schedule — resume with THAT
+        // reservation rather than re-matching (state may have moved since).
+        schedule = await loadMatchedSchedule(row.paymentScheduleId);
+        if (!schedule) {
+            return await finalizeReconcile(row, "reserved milestone no longer exists", {});
+        }
+    } else {
+        if (!payload.checkNumber) {
+            return await finalizeUnmatched(row, "missing check number");
+        }
+        if (!isValidCheckDate(payload.checkDate)) {
+            return await finalizeUnmatched(row, "missing or invalid check date");
+        }
+
+        const projects = await prisma.project.findMany({
+            select: { id: true, name: true, client: { select: { name: true } } },
+        });
+        const projectMatches = findBestProjectNameMatches(payload.projectName, projects);
+        if (projectMatches.length !== 1) {
+            return await finalizeUnmatched(row, projectMatches.length === 0
+                ? `no project matched "${payload.projectName}"`
+                : `"${payload.projectName}" matched ${projectMatches.length} projects — ambiguous`);
+        }
+        const project = projectMatches[0];
+
+        // Conservative gross-conflict check only: the Drive-folder project match is
+        // authoritative, the payer line is corroboration. Skip when there's nothing
+        // meaningful to compare (short/empty names on either side).
+        if (payload.payerName) {
+            const payerWords = normalizeWords(payload.payerName).filter(w => w.length > 2);
+            const clientWords = normalizeWords(project.client.name).filter(w => w.length > 2);
+            if (payerWords.length > 0 && clientWords.length > 0 && !payerWords.some(w => clientWords.includes(w))) {
+                return await finalizeUnmatched(row, `payer "${payload.payerName}" shares no name with client "${project.client.name}"`);
+            }
+        }
+
+        const candidates = await prisma.paymentSchedule.findMany({
+            where: { status: "Pending", invoice: { projectId: project.id, status: { in: OPEN_INVOICE_STATUSES } } },
+            select: { id: true, amount: true, invoiceId: true, qbInvoiceId: true, invoice: { select: { code: true } } },
+        });
+        const amountMatches = candidates.filter(c => Math.abs(toNum(c.amount) - payload.amount) <= 0.005);
+        if (amountMatches.length !== 1) {
+            return await finalizeUnmatched(row, amountMatches.length === 0
+                ? `no pending milestone on "${project.name}" matches $${payload.amount}`
+                : `${amountMatches.length} pending milestones on "${project.name}" match $${payload.amount} — ambiguous`);
+        }
+        const picked = amountMatches[0];
+
+        // Reserve — the partial unique index (scripts/apply-deposit-ingest-schema.mjs)
+        // stops a second deposit file from claiming the same milestone concurrently.
+        try {
+            await prisma.depositIngest.update({ where: { id: row.id }, data: { paymentScheduleId: picked.id } });
+        } catch (e: any) {
+            if (e?.code === "P2002") {
+                return await finalizeUnmatched(row, "milestone already being applied by another deposit");
+            }
+            throw e;
+        }
+        schedule = { id: picked.id, invoiceId: picked.invoiceId, qbInvoiceId: picked.qbInvoiceId, invoiceCode: picked.invoice.code };
+    }
+
+    return schedule.qbInvoiceId
+        ? await applyQboLinked(row, schedule, payload)
+        : await applyNonQbo(row, schedule, payload);
+}
+
+async function applyNonQbo(row: DepositIngest, schedule: MatchedSchedule, payload: NormalizedPayload): Promise<NextResponse> {
+    const paymentDate = parseCheckDateLocalMidnight(payload.checkDate!);
+    const result = await recordPaymentCore(schedule.id, schedule.invoiceId, {
+        paymentDate, method: "check", referenceNumber: payload.checkNumber, notes: payload.memo,
+    });
+    if (!result.success) {
+        // Idempotent-retry check: if the milestone is ALREADY paid with OUR OWN check
+        // number/method, an earlier attempt of THIS deposit won the claim and we just
+        // crashed before recording "applied" — that's success, not a conflict.
+        const fresh = await prisma.paymentSchedule.findUnique({
+            where: { id: schedule.id },
+            select: { status: true, paymentMethod: true, referenceNumber: true },
+        });
+        const isOurs = fresh?.status === "Paid" && fresh.paymentMethod === "check" && fresh.referenceNumber === payload.checkNumber;
+        if (!isOurs) {
+            return await finalizeReconcile(row, `ProBuild settle failed: ${result.error}`, { nullReservation: true });
+        }
+    }
+    await prisma.depositIngest.update({ where: { id: row.id }, data: { status: "applied", lastError: null } });
+    return NextResponse.json({ ok: true, status: "applied", scheduleId: schedule.id, invoiceCode: schedule.invoiceCode });
+}
+
+async function applyQboLinked(row: DepositIngest, schedule: MatchedSchedule, payload: NormalizedPayload): Promise<NextResponse> {
+    const tokens = await getFreshQBTokens(); // throws QBNotConnectedError → top-level catch → "failed" (pre-QBO, no boundary crossed)
+
+    const built = await buildQBPaymentRequest(tokens, schedule.qbInvoiceId!, {
+        amount: payload.amount,
+        txnDate: payload.checkDate!,
+        paymentRefNum: payload.checkNumber!,
+    });
+    if (!built.ok) {
+        throw new Error(`QuickBooks guard failed (${built.reason}) for invoice ${schedule.invoiceCode}`);
+    }
+
+    // Persist the EXACT bytes BEFORE the network call fires — a crash/timeout on the
+    // send still leaves the row able to replay byte-identically with the same requestid.
+    await prisma.depositIngest.update({
+        where: { id: row.id },
+        data: { status: "qbo_unknown", qbRequestPayload: built.requestBody },
+    });
+
+    const requestId = depositRequestId(payload.fileId);
+    return await sendAndSettle(row.id, schedule, {
+        checkDate: payload.checkDate!, checkNumber: payload.checkNumber!, requestId, requestBody: built.requestBody,
+    }, tokens);
+}
+
+async function resumeFromQboUnknown(row: DepositIngest): Promise<NextResponse> {
+    const schedule = await loadMatchedSchedule(row.paymentScheduleId!);
+    if (!schedule) return await finalizeReconcile(row, "reserved milestone no longer exists", {});
+    const extracted = JSON.parse(row.extracted) as NormalizedPayload;
+
+    let tokens: QBTokens;
+    try {
+        tokens = await getFreshQBTokens();
+    } catch (e: any) {
+        // Stay qbo_unknown — a brief QB outage doesn't downgrade the state (the
+        // original send may or may not have gone through).
+        await prisma.depositIngest.updateMany({
+            where: { id: row.id, status: "qbo_unknown" },
+            data: { lastError: String(e?.message ?? e).slice(0, 1000) },
+        });
+        return NextResponse.json({ ok: false, status: "qbo_unknown", reason: "QuickBooks unavailable" });
+    }
+
+    const requestId = depositRequestId(extracted.fileId);
+    return await sendAndSettle(row.id, schedule, {
+        checkDate: extracted.checkDate!, checkNumber: extracted.checkNumber!, requestId, requestBody: row.qbRequestPayload!,
+    }, tokens);
+}
+
+async function resumeFromQboCreated(row: DepositIngest): Promise<NextResponse> {
+    const schedule = await loadMatchedSchedule(row.paymentScheduleId!);
+    if (!schedule) return await finalizeReconcile(row, "reserved milestone no longer exists", {});
+    const extracted = JSON.parse(row.extracted) as NormalizedPayload;
+    return await settleAndFinalize(row.id, schedule, {
+        checkDate: extracted.checkDate!, checkNumber: extracted.checkNumber!, qbPaymentId: row.qbPaymentId!,
+    });
+}
+
+async function sendAndSettle(
+    rowId: string,
+    schedule: MatchedSchedule,
+    ctx: { checkDate: string; checkNumber: string; requestId: string; requestBody: string },
+    tokens: QBTokens,
+): Promise<NextResponse> {
+    let paymentId: string;
+    try {
+        const sent = await sendQBPaymentCreateRequest(tokens, ctx.requestBody, ctx.requestId);
+        paymentId = sent.paymentId;
+    } catch (e: any) {
+        // Response lost/timed out — stay qbo_unknown. The row already holds the exact
+        // bytes sent, so the next request with this fileId replays byte-identically via
+        // the same requestid; Intuit returns the ORIGINAL Payment instead of a duplicate.
+        const message = e instanceof Error ? e.message : String(e);
+        await prisma.depositIngest.updateMany({
+            where: { id: rowId, status: "qbo_unknown" },
+            data: { lastError: message.slice(0, 1000) },
+        });
+        return NextResponse.json({ ok: false, status: "qbo_unknown", reason: message });
+    }
+
+    await prisma.depositIngest.update({
+        where: { id: rowId },
+        data: { status: "qbo_created", qbPaymentId: paymentId, lastError: null },
+    });
+
+    return await settleAndFinalize(rowId, schedule, { checkDate: ctx.checkDate, checkNumber: ctx.checkNumber, qbPaymentId: paymentId });
+}
+
+async function settleAndFinalize(
+    rowId: string,
+    schedule: MatchedSchedule,
+    ctx: { checkDate: string; checkNumber: string; qbPaymentId: string },
+): Promise<NextResponse> {
+    const paidAt = new Date(`${ctx.checkDate}T12:00:00`);
+    const settled = await settleMilestoneFromQBPayment({
+        paymentScheduleId: schedule.id,
+        invoiceId: schedule.invoiceId,
+        qbPaymentId: ctx.qbPaymentId,
+        paidAt,
+        referenceNumber: ctx.checkNumber,
+    });
+
+    if (!settled) {
+        // Lost the claim — success ONLY if a concurrent settle (the hourly cron polling
+        // the payment we just created) landed with OUR SAME qbPaymentId; a different or
+        // absent qbPaymentId is a genuine conflict that needs a human.
+        const fresh = await prisma.paymentSchedule.findUnique({ where: { id: schedule.id }, select: { qbPaymentId: true } });
+        if (fresh?.qbPaymentId !== ctx.qbPaymentId) {
+            const row = await prisma.depositIngest.findUnique({ where: { id: rowId } });
+            if (!row) throw new Error("DepositIngest row vanished mid-settle");
+            return await finalizeReconcile(row, "milestone settled with a different QuickBooks payment than this deposit created — reconcile manually", {});
+        }
+    }
+
+    await prisma.depositIngest.update({ where: { id: rowId }, data: { status: "applied", lastError: null } });
+    return NextResponse.json({ ok: true, status: "applied", scheduleId: schedule.id, invoiceCode: schedule.invoiceCode, qbPaymentId: ctx.qbPaymentId });
+}
+
+// ── Terminal-state helpers ───────────────────────────────────────────────────
+
+async function finalizeUnmatched(row: DepositIngest, reason: string): Promise<NextResponse> {
+    if (row.officeTaskId) {
+        await prisma.depositIngest.update({ where: { id: row.id }, data: { status: "unmatched", lastError: reason } });
+        return NextResponse.json({ ok: true, status: "unmatched", reason, officeTaskId: row.officeTaskId });
+    }
+    const extracted = JSON.parse(row.extracted) as NormalizedPayload;
+    const officeTaskId = await createDepositReviewTask(extracted, reason, "unmatched");
+    await prisma.depositIngest.update({ where: { id: row.id }, data: { status: "unmatched", lastError: reason, officeTaskId } });
+    return NextResponse.json({ ok: true, status: "unmatched", reason, officeTaskId });
+}
+
+async function finalizeReconcile(row: DepositIngest, reason: string, opts: { nullReservation?: boolean }): Promise<NextResponse> {
+    await prisma.depositIngest.update({
+        where: { id: row.id },
+        data: { status: "reconcile", lastError: reason.slice(0, 1000), ...(opts.nullReservation ? { paymentScheduleId: null } : {}) },
+    });
+    if (row.officeTaskId) {
+        return NextResponse.json({ ok: true, status: "reconcile", reason, officeTaskId: row.officeTaskId });
+    }
+    const extracted = JSON.parse(row.extracted) as NormalizedPayload;
+    const officeTaskId = await createDepositReviewTask(extracted, reason, "reconcile");
+    await prisma.depositIngest.update({ where: { id: row.id }, data: { officeTaskId } });
+    return NextResponse.json({ ok: true, status: "reconcile", reason, officeTaskId });
+}
+
+/** Column-resolution + position logic inlined from src/app/api/office-tasks/ingest/route.ts. */
+async function createDepositReviewTask(payload: NormalizedPayload, reason: string, kind: "unmatched" | "reconcile"): Promise<string | null> {
+    const column = await prisma.officeBoardColumn.findFirst({ orderBy: [{ position: "asc" }, { createdAt: "asc" }] });
+    if (!column) {
+        console.error("No OfficeBoardColumn configured — cannot file deposit review task");
+        return null;
+    }
+    const who = payload.payerName || payload.fileName || "deposit";
+    const title = `Deposit needs review (${kind}): ${who} $${payload.amount}`.slice(0, 300);
+    const notes = [
+        `Reason: ${reason}`,
+        payload.fileUrl ? `File: ${payload.fileUrl}` : null,
+        `Extraction: ${JSON.stringify(payload)}`,
+        `Source: deposit-ingest`,
+    ].filter(Boolean).join("\n");
+
+    const task = await prisma.$transaction(async (tx) => {
+        const last = await tx.officeTask.findFirst({
+            where: { columnId: column.id, archivedAt: null },
+            orderBy: [{ position: "desc" }, { createdAt: "desc" }, { id: "desc" }],
+            select: { position: true },
+        });
+        return tx.officeTask.create({
+            data: {
+                title, columnId: column.id, status: column.name,
+                position: (last?.position ?? -1) + 1,
+                notes, createdById: null,
+            },
+            select: { id: true },
+        });
+    });
+    revalidatePath("/tasks");
+    return task.id;
+}
+
+// ── Small helpers ────────────────────────────────────────────────────────────
+
+async function loadMatchedSchedule(scheduleId: string): Promise<MatchedSchedule | null> {
+    const s = await prisma.paymentSchedule.findUnique({
+        where: { id: scheduleId },
+        select: { id: true, invoiceId: true, qbInvoiceId: true, invoice: { select: { code: true } } },
+    });
+    if (!s) return null;
+    return { id: s.id, invoiceId: s.invoiceId, qbInvoiceId: s.qbInvoiceId, invoiceCode: s.invoice.code };
+}
+
+/** Mirrors qbo-receipt-push.ts's receiptRequestId pattern: a stable hash of the
+ *  full fileId, capped at QBO's 50-char requestid limit, namespaced so a
+ *  deposit sharing a Drive fileId with anything else can never collide on
+ *  QBO's server-side create idempotency key. */
+function depositRequestId(fileId: string): string {
+    return createHash("sha256").update(`deposit-${fileId}`).digest("hex").slice(0, 50);
+}
+
+/** Same round-trip validation qbo-receipt-push.ts's isValidCalendarDate uses. */
+function isValidCheckDate(value: string | null): value is string {
+    if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+    const parsed = new Date(`${value}T00:00:00.000Z`);
+    return Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+/** Strict YYYY-MM-DD → LOCAL midnight, matching actions.ts's parsePaymentDateInput
+ *  (the value is already validated by isValidCheckDate before this is called). */
+function parseCheckDateLocalMidnight(value: string): Date {
+    const [y, mo, d] = value.split("-").map(Number);
+    return new Date(y, mo - 1, d);
+}

--- a/src/app/api/payments/deposit-ingest/route.ts
+++ b/src/app/api/payments/deposit-ingest/route.ts
@@ -302,11 +302,11 @@ export async function POST(req: Request) {
             where: { id: fresh.id, status: { in: ["processing", "qbo_unknown", "qbo_created", "failed"] } },
             data: {
                 status: retryStatus, lastError: message.slice(0, 1000),
-                // Entering "failed" pre-boundary leaves the reservation index — release
-                // the milestone so the row can't shadow-hold it un-indexed (that retry
-                // re-matches and re-reserves from scratch). Past the NON-QBO boundary
-                // (settleStartedAt) the reservation is preserved: the retry must resume
-                // the reserved-row path, because the settle may already have committed.
+                // Pre-boundary "failed" releases the milestone (NULL leaves the partial
+                // index; that retry re-matches and re-reserves from scratch). Past the
+                // NON-QBO boundary (settleStartedAt) the reservation is preserved — and
+                // "failed" is in the index predicate, so the hold stays continuously
+                // indexed and no second file can slip in before the retry resumes.
                 ...(retryStatus === "failed" && !fresh.settleStartedAt ? { paymentScheduleId: null } : {}),
             },
         });
@@ -416,7 +416,10 @@ async function applyNonQbo(row: DepositIngest, schedule: MatchedSchedule, payloa
         });
         const isOurs = fresh?.status === "Paid" && fresh.paymentMethod === "check" && fresh.referenceNumber === payload.checkNumber;
         if (!isOurs) {
-            return await finalizeReconcile(row, `ProBuild settle failed: ${result.error}`, { nullReservation: true });
+            // Reservation kept: settleStartedAt is stamped, so the reconcile human
+            // must see exactly which milestone this deposit was applying to (and the
+            // index hold stops another file from claiming it mid-review).
+            return await finalizeReconcile(row, `ProBuild settle failed: ${result.error}`, {});
         }
     }
     await prisma.depositIngest.update({ where: { id: row.id }, data: { status: "applied", lastError: null } });

--- a/src/app/api/payments/deposit-ingest/route.ts
+++ b/src/app/api/payments/deposit-ingest/route.ts
@@ -193,10 +193,10 @@ export async function POST(req: Request) {
     // Never force-reset a row that already crossed the QBO boundary — that money
     // decision needs a human looking at QuickBooks, not a silent re-run.
     if (row.status === "unmatched" && force) {
-        if (row.qbPaymentId || row.qbRequestPayload) {
+        if (row.qbPaymentId || row.qbRequestPayload || row.settleStartedAt) {
             return NextResponse.json({
                 ok: true, status: "unmatched",
-                reason: "cannot force-retry — this deposit already reached QuickBooks; reconcile it manually",
+                reason: "cannot force-retry — this deposit already crossed a money boundary (QuickBooks or a ProBuild settle); reconcile it manually",
                 officeTaskId: row.officeTaskId,
             });
         }
@@ -224,7 +224,14 @@ export async function POST(req: Request) {
     if (!freshlyClaimed && inFlightStatuses.includes(row.status)) {
         const needsLease = row.status !== "failed";
         const staleBefore = new Date(Date.now() - STALE_PROCESSING_MS);
-        const preQbo = row.status === "processing" || row.status === "failed";
+        const retriable = row.status === "processing" || row.status === "failed";
+        // Clean-slate ONLY before any money boundary: qbRequestPayload marks the QBO
+        // boundary, settleStartedAt marks the non-QBO one. Once either is set, the
+        // reservation and ORIGINAL extracted payload are preserved so recovery goes
+        // through the exact reserved-row path (matchAndApply's reserved branch /
+        // resumeFromQboUnknown) — never a heuristic re-match against a settle that
+        // may already have committed.
+        const boundaryMarked = !!(row.qbPaymentId || row.qbRequestPayload || row.settleStartedAt);
         const claim = await prisma.depositIngest.updateMany({
             where: {
                 id: row.id, status: row.status,
@@ -235,16 +242,11 @@ export async function POST(req: Request) {
                 // concurrent retry match the same claim (failed has no lease) and both
                 // would send QBO bodies under the same requestid. The winner takes a
                 // fresh processing lease; the loser's status CAS fails.
-                status: preQbo ? "processing" : row.status,
+                status: retriable ? "processing" : row.status,
                 attempts: { increment: 1 }, processingStartedAt: new Date(),
-                // Pre-QBO retries restart from a clean slate: fresh payload AND a
-                // released reservation, so matching re-runs end-to-end against current
-                // inputs — a stale reservation must never survive a payload overwrite.
-                // (A "processing"/"failed" row is pre-QBO-boundary by construction: the
-                // status flips to qbo_unknown before qbRequestPayload is ever sent.)
                 // qbo_unknown/qbo_created resumes deliberately replay the ORIGINAL
                 // extracted values (see resumeFromQboUnknown/resumeFromQboCreated).
-                ...(preQbo ? { extracted: JSON.stringify(payload), paymentScheduleId: null } : {}),
+                ...(retriable && !boundaryMarked ? { extracted: JSON.stringify(payload), paymentScheduleId: null } : {}),
             },
         });
         if (claim.count > 0) {
@@ -266,11 +268,11 @@ export async function POST(req: Request) {
     // crash mid-attempt-MAX) reconciles. The post-failure check in the catch below uses
     // `>=` because it runs AFTER the attempt completed. Together: at most MAX real runs.
     if (row.attempts > MAX_ATTEMPTS) {
-        const crossedQboBoundary = !!row.qbPaymentId || !!row.qbRequestPayload;
+        const crossedAnyBoundary = !!row.qbPaymentId || !!row.qbRequestPayload || !!row.settleStartedAt;
         return await finalizeReconcile(
             row,
             `exceeded ${MAX_ATTEMPTS} retry attempts (last error: ${row.lastError ?? "none"})`,
-            { nullReservation: !crossedQboBoundary },
+            { nullReservation: !crossedAnyBoundary },
         );
     }
 
@@ -286,8 +288,11 @@ export async function POST(req: Request) {
         const message = e instanceof Error ? e.message : String(e);
         const fresh = (await prisma.depositIngest.findUnique({ where: { id: row.id } })) ?? row;
         const crossedQboBoundary = !!fresh.qbPaymentId || !!fresh.qbRequestPayload;
+        const crossedAnyBoundary = crossedQboBoundary || !!fresh.settleStartedAt;
         if (fresh.attempts >= MAX_ATTEMPTS) {
-            return await finalizeReconcile(fresh, message, { nullReservation: !crossedQboBoundary });
+            // Reservation survives exhaustion whenever ANY money boundary was crossed —
+            // the reconcile human must see which milestone this deposit may have paid.
+            return await finalizeReconcile(fresh, message, { nullReservation: !crossedAnyBoundary });
         }
         const retryStatus = !crossedQboBoundary ? "failed" : fresh.qbPaymentId ? "qbo_created" : "qbo_unknown";
         await prisma.depositIngest.updateMany({
@@ -297,10 +302,12 @@ export async function POST(req: Request) {
             where: { id: fresh.id, status: { in: ["processing", "qbo_unknown", "qbo_created", "failed"] } },
             data: {
                 status: retryStatus, lastError: message.slice(0, 1000),
-                // Entering "failed" leaves the reservation index — release the milestone
-                // explicitly so the row can't shadow-hold it un-indexed (the retry
-                // re-matches and re-reserves from scratch).
-                ...(retryStatus === "failed" ? { paymentScheduleId: null } : {}),
+                // Entering "failed" pre-boundary leaves the reservation index — release
+                // the milestone so the row can't shadow-hold it un-indexed (that retry
+                // re-matches and re-reserves from scratch). Past the NON-QBO boundary
+                // (settleStartedAt) the reservation is preserved: the retry must resume
+                // the reserved-row path, because the settle may already have committed.
+                ...(retryStatus === "failed" && !fresh.settleStartedAt ? { paymentScheduleId: null } : {}),
             },
         });
         return NextResponse.json({ ok: false, status: retryStatus, reason: message });
@@ -314,7 +321,16 @@ async function matchAndApply(row: DepositIngest, payload: NormalizedPayload): Pr
 
     if (row.paymentScheduleId) {
         // A prior crashed attempt already reserved a schedule — resume with THAT
-        // reservation rather than re-matching (state may have moved since).
+        // reservation rather than re-matching (state may have moved since), and with
+        // the PRESERVED original payload: the boundary-marked reclaim deliberately
+        // kept row.extracted, and the settle (possibly already committed) used those
+        // values — a re-extracted inbound payload must not shift the check number or
+        // date mid-recovery.
+        try {
+            payload = JSON.parse(row.extracted) as NormalizedPayload;
+        } catch {
+            return await finalizeReconcile(row, "reserved row has unreadable extracted payload", {});
+        }
         schedule = await loadMatchedSchedule(row.paymentScheduleId);
         if (!schedule) {
             return await finalizeReconcile(row, "reserved milestone no longer exists", {});
@@ -349,38 +365,6 @@ async function matchAndApply(row: DepositIngest, payload: NormalizedPayload): Pr
             }
         }
 
-        // Crash recovery for the non-QBO path: a prior attempt may have SETTLED the
-        // milestone (recordPaymentCore committed) and died before the "applied" write —
-        // and the pre-QBO reclaim then released the reservation, so this retry arrives
-        // with no pointer to it. The physical check is identified by project + check
-        // number + amount: a Paid milestone bearing exactly those IS our earlier
-        // attempt. This runs BEFORE Pending matching so the deposit can never re-apply
-        // to a different (later-added) same-amount milestone.
-        const priorSettle = await prisma.paymentSchedule.findFirst({
-            where: {
-                status: "Paid", paymentMethod: "check", referenceNumber: payload.checkNumber,
-                invoice: { projectId: project.id },
-            },
-            select: { id: true, amount: true, invoice: { select: { code: true } } },
-        });
-        if (priorSettle && Math.abs(toNum(priorSettle.amount) - payload.amount) <= 0.005) {
-            try {
-                await prisma.depositIngest.update({
-                    where: { id: row.id },
-                    data: { status: "applied", paymentScheduleId: priorSettle.id, lastError: null },
-                });
-            } catch (e: any) {
-                if (e?.code !== "P2002") throw e;
-                // Another deposit row terminally holds this schedule — this file is a
-                // second photo of an already-applied check, not a recovery of our own.
-                return await finalizeUnmatched(row, `check #${payload.checkNumber} was already applied via another deposit file`);
-            }
-            return NextResponse.json({
-                ok: true, status: "applied", recovered: true,
-                scheduleId: priorSettle.id, invoiceCode: priorSettle.invoice.code,
-            });
-        }
-
         const candidates = await prisma.paymentSchedule.findMany({
             where: { status: "Pending", invoice: { projectId: project.id, status: { in: OPEN_INVOICE_STATUSES } } },
             select: { id: true, amount: true, invoiceId: true, qbInvoiceId: true, invoice: { select: { code: true } } },
@@ -412,6 +396,12 @@ async function matchAndApply(row: DepositIngest, payload: NormalizedPayload): Pr
 }
 
 async function applyNonQbo(row: DepositIngest, schedule: MatchedSchedule, payload: NormalizedPayload): Promise<NextResponse> {
+    // Money-boundary marker (the non-QBO analog of persisting qbRequestPayload):
+    // stamped BEFORE the settle so any crash from here on preserves the reservation
+    // and the original payload, and recovery resumes THIS reserved row exactly.
+    if (!row.settleStartedAt) {
+        await prisma.depositIngest.update({ where: { id: row.id }, data: { settleStartedAt: new Date() } });
+    }
     const paymentDate = parseCheckDateLocalMidnight(payload.checkDate!);
     const result = await recordPaymentCore(schedule.id, schedule.invoiceId, {
         paymentDate, method: "check", referenceNumber: payload.checkNumber, notes: payload.memo,

--- a/src/app/api/payments/deposit-ingest/route.ts
+++ b/src/app/api/payments/deposit-ingest/route.ts
@@ -255,8 +255,10 @@ export async function POST(req: Request) {
 
     if (!freshlyClaimed) {
         // Someone else is actively working this file (fresh lease) — the bot's next
-        // 10-minute run retries safely (idempotent by fileId).
-        return NextResponse.json({ ok: true, status: row.status, reason: "in progress — retry shortly" });
+        // 10-minute run retries safely (idempotent by fileId). Re-read for the current
+        // status: our snapshot can be stale (e.g. a failed→processing CAS we just lost).
+        const current = await prisma.depositIngest.findUnique({ where: { id: row.id }, select: { status: true } });
+        return NextResponse.json({ ok: true, status: current?.status ?? row.status, reason: "in progress — retry shortly" });
     }
 
     // `>` (not `>=`): the claim above just incremented attempts, so this value IS the
@@ -345,6 +347,38 @@ async function matchAndApply(row: DepositIngest, payload: NormalizedPayload): Pr
             if (payerWords.length > 0 && clientWords.length > 0 && !payerWords.some(w => clientWords.includes(w))) {
                 return await finalizeUnmatched(row, `payer "${payload.payerName}" shares no name with client "${project.client.name}"`);
             }
+        }
+
+        // Crash recovery for the non-QBO path: a prior attempt may have SETTLED the
+        // milestone (recordPaymentCore committed) and died before the "applied" write —
+        // and the pre-QBO reclaim then released the reservation, so this retry arrives
+        // with no pointer to it. The physical check is identified by project + check
+        // number + amount: a Paid milestone bearing exactly those IS our earlier
+        // attempt. This runs BEFORE Pending matching so the deposit can never re-apply
+        // to a different (later-added) same-amount milestone.
+        const priorSettle = await prisma.paymentSchedule.findFirst({
+            where: {
+                status: "Paid", paymentMethod: "check", referenceNumber: payload.checkNumber,
+                invoice: { projectId: project.id },
+            },
+            select: { id: true, amount: true, invoice: { select: { code: true } } },
+        });
+        if (priorSettle && Math.abs(toNum(priorSettle.amount) - payload.amount) <= 0.005) {
+            try {
+                await prisma.depositIngest.update({
+                    where: { id: row.id },
+                    data: { status: "applied", paymentScheduleId: priorSettle.id, lastError: null },
+                });
+            } catch (e: any) {
+                if (e?.code !== "P2002") throw e;
+                // Another deposit row terminally holds this schedule — this file is a
+                // second photo of an already-applied check, not a recovery of our own.
+                return await finalizeUnmatched(row, `check #${payload.checkNumber} was already applied via another deposit file`);
+            }
+            return NextResponse.json({
+                ok: true, status: "applied", recovered: true,
+                scheduleId: priorSettle.id, invoiceCode: priorSettle.invoice.code,
+            });
         }
 
         const candidates = await prisma.paymentSchedule.findMany({

--- a/src/app/api/payments/deposit-ingest/route.ts
+++ b/src/app/api/payments/deposit-ingest/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { createHash } from "node:crypto";
+import { createHash, timingSafeEqual } from "node:crypto";
 import type { DepositIngest } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
@@ -83,8 +83,12 @@ export async function POST(req: Request) {
         console.error("DEPOSIT_INGEST_SECRET is not configured");
         return NextResponse.json({ ok: false, reason: "unauthorized" }, { status: 401 });
     }
-    const authHeader = req.headers.get("authorization");
-    if (authHeader !== `Bearer ${secret}`) {
+    // Hash both sides to fixed length so timingSafeEqual is usable regardless of
+    // header length — removes the string-compare timing side channel.
+    const authHeader = req.headers.get("authorization") ?? "";
+    const expectedDigest = createHash("sha256").update(`Bearer ${secret}`).digest();
+    const gotDigest = createHash("sha256").update(authHeader).digest();
+    if (!timingSafeEqual(expectedDigest, gotDigest)) {
         return NextResponse.json({ ok: false, reason: "unauthorized" }, { status: 401 });
     }
 
@@ -94,19 +98,30 @@ export async function POST(req: Request) {
     } catch {
         return NextResponse.json({ ok: false, reason: "invalid-json" }, { status: 400 });
     }
+    // JSON `null`/arrays parse fine but aren't a payload — 400, not a 500 from field access.
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+        return NextResponse.json({ ok: false, reason: "invalid-json" }, { status: 400 });
+    }
 
     const fileId = String(raw.fileId ?? "").trim();
     const projectName = String(raw.projectName ?? "").trim();
-    const amount = Number(raw.amount);
+    const rawAmount = Number(raw.amount);
     // Hard 400s: without these, there's no row to claim and nothing to match against.
     // checkDate/checkNumber are ALSO required but are deliberately NOT 400s — the bot's
     // Gemini extraction can legitimately come back incomplete, and that's an `unmatched`
     // outcome (with an OfficeTask), not a request the bot needs to special-case.
-    if (!fileId) return NextResponse.json({ ok: false, reason: "fileId is required" }, { status: 400 });
-    if (!projectName) return NextResponse.json({ ok: false, reason: "projectName is required" }, { status: 400 });
-    if (!Number.isFinite(amount) || amount <= 0) {
+    if (!fileId || fileId.length > 200) return NextResponse.json({ ok: false, reason: "fileId is required (max 200 chars)" }, { status: 400 });
+    if (!projectName || projectName.length > 300) return NextResponse.json({ ok: false, reason: "projectName is required (max 300 chars)" }, { status: 400 });
+    if (!Number.isFinite(rawAmount) || rawAmount <= 0) {
         return NextResponse.json({ ok: false, reason: "amount must be a positive number" }, { status: 400 });
     }
+    // Money is cents-exact: a 3-decimal extraction (100.005) would pass the epsilon
+    // match yet reach QBO unrounded. Normalize once, reject anything not representable.
+    const amountCents = Math.round(rawAmount * 100);
+    if (Math.abs(rawAmount * 100 - amountCents) > 1e-6 || amountCents <= 0) {
+        return NextResponse.json({ ok: false, reason: "amount must have at most 2 decimal places" }, { status: 400 });
+    }
+    const amount = amountCents / 100;
 
     const payload: NormalizedPayload = {
         fileId,
@@ -209,17 +224,27 @@ export async function POST(req: Request) {
     if (!freshlyClaimed && inFlightStatuses.includes(row.status)) {
         const needsLease = row.status !== "failed";
         const staleBefore = new Date(Date.now() - STALE_PROCESSING_MS);
+        const preQbo = row.status === "processing" || row.status === "failed";
         const claim = await prisma.depositIngest.updateMany({
             where: {
                 id: row.id, status: row.status,
                 ...(needsLease ? { processingStartedAt: { lt: staleBefore } } : {}),
             },
             data: {
+                // CAS failed→processing: leaving status as "failed" would let a second
+                // concurrent retry match the same claim (failed has no lease) and both
+                // would send QBO bodies under the same requestid. The winner takes a
+                // fresh processing lease; the loser's status CAS fails.
+                status: preQbo ? "processing" : row.status,
                 attempts: { increment: 1 }, processingStartedAt: new Date(),
-                // Only overwrite the audit-trail payload for pre-QBO-boundary retries — a
-                // qbo_unknown/qbo_created resume deliberately replays against the ORIGINAL
-                // extracted values (see resumeFromQboUnknown/resumeFromQboCreated below).
-                ...(row.status === "processing" || row.status === "failed" ? { extracted: JSON.stringify(payload) } : {}),
+                // Pre-QBO retries restart from a clean slate: fresh payload AND a
+                // released reservation, so matching re-runs end-to-end against current
+                // inputs — a stale reservation must never survive a payload overwrite.
+                // (A "processing"/"failed" row is pre-QBO-boundary by construction: the
+                // status flips to qbo_unknown before qbRequestPayload is ever sent.)
+                // qbo_unknown/qbo_created resumes deliberately replay the ORIGINAL
+                // extracted values (see resumeFromQboUnknown/resumeFromQboCreated).
+                ...(preQbo ? { extracted: JSON.stringify(payload), paymentScheduleId: null } : {}),
             },
         });
         if (claim.count > 0) {
@@ -264,8 +289,17 @@ export async function POST(req: Request) {
         }
         const retryStatus = !crossedQboBoundary ? "failed" : fresh.qbPaymentId ? "qbo_created" : "qbo_unknown";
         await prisma.depositIngest.updateMany({
-            where: { id: fresh.id },
-            data: { status: retryStatus, lastError: message.slice(0, 1000) },
+            // Conditioned on an active status: a throw AFTER a terminal write (e.g. the
+            // review-task transaction hiccuping post-finalize) must never regress
+            // applied/unmatched/reconcile back into the retry loop.
+            where: { id: fresh.id, status: { in: ["processing", "qbo_unknown", "qbo_created", "failed"] } },
+            data: {
+                status: retryStatus, lastError: message.slice(0, 1000),
+                // Entering "failed" leaves the reservation index — release the milestone
+                // explicitly so the row can't shadow-hold it un-indexed (the retry
+                // re-matches and re-reserves from scratch).
+                ...(retryStatus === "failed" ? { paymentScheduleId: null } : {}),
+            },
         });
         return NextResponse.json({ ok: false, status: retryStatus, reason: message });
     }
@@ -513,24 +547,27 @@ async function finalizeReconcile(row: DepositIngest, reason: string, opts: { nul
  *  officeTaskId-is-null update — a claim loser deletes its own just-created copy, so
  *  exactly one task survives no matter how many callers race. */
 async function ensureReviewTask(row: DepositIngest, reason: string, kind: "unmatched" | "reconcile"): Promise<string | null> {
-    let extracted: NormalizedPayload;
+    // Never throws: callers run AFTER the terminal-state write, and an exception here
+    // would fall into the outer catch — which must not touch terminal rows (and a
+    // missing task self-heals on the next read anyway).
     try {
-        extracted = JSON.parse(row.extracted) as NormalizedPayload;
-    } catch {
+        const extracted = JSON.parse(row.extracted) as NormalizedPayload;
+        const officeTaskId = await createDepositReviewTask(extracted, reason, kind);
+        if (!officeTaskId) return null;
+        const claim = await prisma.depositIngest.updateMany({
+            where: { id: row.id, officeTaskId: null },
+            data: { officeTaskId },
+        });
+        if (claim.count === 0) {
+            await prisma.officeTask.delete({ where: { id: officeTaskId } }).catch(() => {});
+            const fresh = await prisma.depositIngest.findUnique({ where: { id: row.id }, select: { officeTaskId: true } });
+            return fresh?.officeTaskId ?? null;
+        }
+        return officeTaskId;
+    } catch (e) {
+        console.error("[deposit-ingest] review-task create failed (will heal on next read):", e);
         return null;
     }
-    const officeTaskId = await createDepositReviewTask(extracted, reason, kind);
-    if (!officeTaskId) return null;
-    const claim = await prisma.depositIngest.updateMany({
-        where: { id: row.id, officeTaskId: null },
-        data: { officeTaskId },
-    });
-    if (claim.count === 0) {
-        await prisma.officeTask.delete({ where: { id: officeTaskId } }).catch(() => {});
-        const fresh = await prisma.depositIngest.findUnique({ where: { id: row.id }, select: { officeTaskId: true } });
-        return fresh?.officeTaskId ?? null;
-    }
-    return officeTaskId;
 }
 
 /** Column-resolution + position logic inlined from src/app/api/office-tasks/ingest/route.ts. */

--- a/src/app/api/payments/deposit-ingest/route.ts
+++ b/src/app/api/payments/deposit-ingest/route.ts
@@ -165,10 +165,13 @@ export async function POST(req: Request) {
         });
     }
     if (row.status === "reconcile") {
-        return NextResponse.json({ ok: true, status: "reconcile", reason: row.lastError, officeTaskId: row.officeTaskId });
+        // Heal a crash between the terminal write and the task create (see ensureReviewTask).
+        const officeTaskId = row.officeTaskId ?? await ensureReviewTask(row, row.lastError ?? "reconcile", "reconcile");
+        return NextResponse.json({ ok: true, status: "reconcile", reason: row.lastError, officeTaskId });
     }
     if (row.status === "unmatched" && !force) {
-        return NextResponse.json({ ok: true, status: "unmatched", reason: row.lastError, officeTaskId: row.officeTaskId });
+        const officeTaskId = row.officeTaskId ?? await ensureReviewTask(row, row.lastError ?? "unmatched", "unmatched");
+        return NextResponse.json({ ok: true, status: "unmatched", reason: row.lastError, officeTaskId });
     }
 
     // ── Force-reset an unmatched row (human retry after fixing the cause) ──
@@ -231,6 +234,10 @@ export async function POST(req: Request) {
         return NextResponse.json({ ok: true, status: row.status, reason: "in progress — retry shortly" });
     }
 
+    // `>` (not `>=`): the claim above just incremented attempts, so this value IS the
+    // attempt number about to run — 1..MAX_ATTEMPTS execute, MAX+1 (a reclaim after a
+    // crash mid-attempt-MAX) reconciles. The post-failure check in the catch below uses
+    // `>=` because it runs AFTER the attempt completed. Together: at most MAX real runs.
     if (row.attempts > MAX_ATTEMPTS) {
         const crossedQboBoundary = !!row.qbPaymentId || !!row.qbRequestPayload;
         return await finalizeReconcile(
@@ -478,14 +485,17 @@ async function settleAndFinalize(
 
 // ── Terminal-state helpers ───────────────────────────────────────────────────
 
+// Terminal state is ALWAYS persisted before the review task is created: a crash
+// between the two leaves a terminal row whose missing task is healed on the next
+// re-POST (the terminal-state reads above call ensureReviewTask), whereas the
+// reverse order would leave a NON-terminal row that re-runs the match on the next
+// retry and files a duplicate task. A briefly-missing task is also visible
+// elsewhere (the bot parks the file in _Needs Review); a duplicate would not be.
 async function finalizeUnmatched(row: DepositIngest, reason: string): Promise<NextResponse> {
-    if (row.officeTaskId) {
-        await prisma.depositIngest.update({ where: { id: row.id }, data: { status: "unmatched", lastError: reason } });
-        return NextResponse.json({ ok: true, status: "unmatched", reason, officeTaskId: row.officeTaskId });
-    }
-    const extracted = JSON.parse(row.extracted) as NormalizedPayload;
-    const officeTaskId = await createDepositReviewTask(extracted, reason, "unmatched");
-    await prisma.depositIngest.update({ where: { id: row.id }, data: { status: "unmatched", lastError: reason, officeTaskId } });
+    // "unmatched" is not in the partial reservation index's status list, so this
+    // transition releases any held milestone reservation by itself.
+    await prisma.depositIngest.update({ where: { id: row.id }, data: { status: "unmatched", lastError: reason.slice(0, 1000) } });
+    const officeTaskId = row.officeTaskId ?? await ensureReviewTask(row, reason, "unmatched");
     return NextResponse.json({ ok: true, status: "unmatched", reason, officeTaskId });
 }
 
@@ -494,13 +504,33 @@ async function finalizeReconcile(row: DepositIngest, reason: string, opts: { nul
         where: { id: row.id },
         data: { status: "reconcile", lastError: reason.slice(0, 1000), ...(opts.nullReservation ? { paymentScheduleId: null } : {}) },
     });
-    if (row.officeTaskId) {
-        return NextResponse.json({ ok: true, status: "reconcile", reason, officeTaskId: row.officeTaskId });
-    }
-    const extracted = JSON.parse(row.extracted) as NormalizedPayload;
-    const officeTaskId = await createDepositReviewTask(extracted, reason, "reconcile");
-    await prisma.depositIngest.update({ where: { id: row.id }, data: { officeTaskId } });
+    const officeTaskId = row.officeTaskId ?? await ensureReviewTask(row, reason, "reconcile");
     return NextResponse.json({ ok: true, status: "reconcile", reason, officeTaskId });
+}
+
+/** Create the ONE review task for a terminal row, tolerating crashes and concurrent
+ *  healers: the task is created first, then claimed onto the row with an atomic
+ *  officeTaskId-is-null update — a claim loser deletes its own just-created copy, so
+ *  exactly one task survives no matter how many callers race. */
+async function ensureReviewTask(row: DepositIngest, reason: string, kind: "unmatched" | "reconcile"): Promise<string | null> {
+    let extracted: NormalizedPayload;
+    try {
+        extracted = JSON.parse(row.extracted) as NormalizedPayload;
+    } catch {
+        return null;
+    }
+    const officeTaskId = await createDepositReviewTask(extracted, reason, kind);
+    if (!officeTaskId) return null;
+    const claim = await prisma.depositIngest.updateMany({
+        where: { id: row.id, officeTaskId: null },
+        data: { officeTaskId },
+    });
+    if (claim.count === 0) {
+        await prisma.officeTask.delete({ where: { id: officeTaskId } }).catch(() => {});
+        const fresh = await prisma.depositIngest.findUnique({ where: { id: row.id }, select: { officeTaskId: true } });
+        return fresh?.officeTaskId ?? null;
+    }
+    return officeTaskId;
 }
 
 /** Column-resolution + position logic inlined from src/app/api/office-tasks/ingest/route.ts. */

--- a/src/app/api/payments/deposit-ingest/route.ts
+++ b/src/app/api/payments/deposit-ingest/route.ts
@@ -354,6 +354,16 @@ async function matchAndApply(row: DepositIngest, payload: NormalizedPayload): Pr
         }
         const project = projectMatches[0];
 
+        // Money-grade bar on top of the shared fuzzy matcher: the label's first word
+        // (the client surname by folder convention) must appear in the winning project's
+        // name. The matcher alone scores two shared GENERIC words ("Kitchen Remodel")
+        // as a match, which is fine for routing expense receipts but could point a
+        // deposit at the wrong client's project when the payer line failed to extract.
+        const labelWords = normalizeWords(payload.projectName);
+        if (labelWords.length === 0 || !normalizeWords(project.name).includes(labelWords[0])) {
+            return await finalizeUnmatched(row, `"${payload.projectName}" only weakly matched "${project.name}" (first word differs) — not safe for money`);
+        }
+
         // Conservative gross-conflict check only: the Drive-folder project match is
         // authoritative, the payer line is corroboration. Skip when there's nothing
         // meaningful to compare (short/empty names on either side).

--- a/src/app/api/payments/test-only/qbo-mock/route.ts
+++ b/src/app/api/payments/test-only/qbo-mock/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import {
+    isE2eQboMockEnabled,
+    resetMockQbo,
+    setMockQboInvoice,
+    getMockQboCallCounts,
+    getMockQboPaymentCreateCalls,
+} from "@/lib/quickbooks-mock";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Test-only seam for e2e/deposit-ingest.spec.ts's QuickBooks mock
+ * (E2E_QBO_MOCK — see src/lib/quickbooks-mock.ts). The spec drives
+ * /api/payments/deposit-ingest over real HTTP against the Playwright
+ * webServer, a SEPARATE Node process from the test runner, so it can't
+ * import quickbooks-mock.ts and read its module-level state directly (that
+ * would be a different module instance). This route reads/seeds/resets that
+ * state FROM INSIDE the server process instead.
+ *
+ * Gated by the exact same isE2eQboMockEnabled() triple-gate as the mock
+ * itself (E2E_QBO_MOCK=1, off Vercel, PLAYWRIGHT_TEST_SECRET set) — that
+ * combination can never hold on a real deploy (Vercel always sets VERCEL=1),
+ * so this 404s everywhere except a Playwright e2e run. Reachable without a
+ * staff session because it lives under /api/payments/, already in the proxy's
+ * generic bypass (src/proxy.ts) — safe because the in-handler gate above is
+ * the real lock, exactly like /api/payments/deposit-ingest's own Bearer check.
+ */
+function guard(): NextResponse | null {
+    if (!isE2eQboMockEnabled()) {
+        return NextResponse.json({ error: "not found" }, { status: 404 });
+    }
+    return null;
+}
+
+export async function GET() {
+    const blocked = guard();
+    if (blocked) return blocked;
+    return NextResponse.json({
+        ok: true,
+        calls: getMockQboCallCounts(),
+        paymentCreateCalls: getMockQboPaymentCreateCalls(),
+    });
+}
+
+export async function POST(req: Request) {
+    const blocked = guard();
+    if (blocked) return blocked;
+
+    let body: Record<string, unknown>;
+    try {
+        body = await req.json();
+    } catch {
+        return NextResponse.json({ ok: false, error: "invalid-json" }, { status: 400 });
+    }
+
+    if (body?.action === "reset") {
+        resetMockQbo();
+        return NextResponse.json({ ok: true });
+    }
+
+    if (body?.action === "seedInvoice") {
+        const { qbInvoiceId, balance, customerId } = body as { qbInvoiceId?: unknown; balance?: unknown; customerId?: unknown };
+        if (typeof qbInvoiceId !== "string" || typeof balance !== "number" || typeof customerId !== "string") {
+            return NextResponse.json({ ok: false, error: "qbInvoiceId (string), balance (number), customerId (string) required" }, { status: 400 });
+        }
+        setMockQboInvoice(qbInvoiceId, { balance, customerId });
+        return NextResponse.json({ ok: true });
+    }
+
+    return NextResponse.json({ ok: false, error: "unknown action" }, { status: 400 });
+}

--- a/src/components/RecordPaymentModal.tsx
+++ b/src/components/RecordPaymentModal.tsx
@@ -119,7 +119,7 @@ export default function RecordPaymentModal({
                         />
                         {isBackdatedPayment(paymentDate) && (
                             <p className="mt-1.5 text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-2.5 py-1.5">
-                                Back-dated payment — the client won&apos;t be emailed a receipt automatically. Use Send Receipt on the invoice if you want one.
+                                Back-dated payment — the client won&apos;t be emailed a receipt automatically. Use the Send Receipt button if you want one.
                             </p>
                         )}
                     </div>

--- a/src/components/RecordPaymentModal.tsx
+++ b/src/components/RecordPaymentModal.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { formatCurrency } from "@/lib/utils";
 import { formatLocalDateString } from "@/lib/sales-tax-report";
+import { isBackdatedPayment } from "@/lib/payment-date";
 
 const PAYMENT_METHODS = [
     { key: "check", label: "Check", icon: "M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" },
@@ -116,6 +117,11 @@ export default function RecordPaymentModal({
                             onChange={(e) => setPaymentDate(e.target.value)}
                             required
                         />
+                        {isBackdatedPayment(paymentDate) && (
+                            <p className="mt-1.5 text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-2.5 py-1.5">
+                                Back-dated payment — the client won&apos;t be emailed a receipt automatically. Use Send Receipt on the invoice if you want one.
+                            </p>
+                        )}
                     </div>
 
                     {/* Payment Method Grid */}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -21,6 +21,7 @@ import { logActivity } from "./activity-log";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { appendPunchItemsInTransaction } from "./punch-items";
 import { enqueueMilestonePaid, drainPaymentNotifications } from "./payment-outbox";
+import { recordPaymentCore } from "./payment-record-core";
 import { deleteChangeOrderCore, updateChangeOrderCore } from "./change-order-core";
 import { approveChangeOrderWithSignature } from "./change-order-approval";
 import { applyChangeOrderToSchedule, autoGenerateScheduleForApprovedEstimate, canonicalContractEstimateQuery, deriveEstimateItemHours, setProjectStartDate, shiftNotStartedTasks, parseStartDateInput, generateScheduleFromEstimate, setProjectCrew, setTaskCrew, lockTaskAssignmentParent, touchTaskAssignmentRevision } from "./schedule-core";
@@ -3586,110 +3587,13 @@ export async function recordPayment(
         return { success: false, error: "Invalid payment date" as const };
     }
 
-    const tx = await withTxRetry(() => prisma.$transaction(async (t) => {
-        // Canonical lock order: Estimate → Invoice → schedules. Two concurrent payments on
-        // DIFFERENT milestones of the SAME invoice each claim their own schedule row (no mutual
-        // block), so without a parent lock they both read a stale sibling set and overwrite each
-        // other's Invoice.balanceDue — one payment's balance effect is silently lost, and no
-        // deadlock fires to trigger a retry. Locking the parent(s) first serializes the recompute:
-        // the second call blocks until the first commits, then recomputes against fresh state.
-        // Read the estimate link (non-locking) so we can lock Estimate BEFORE Invoice, matching
-        // recordEstimatePayment's mirror order so the two flows never invert and deadlock.
-        const invLink = await t.invoice.findUnique({ where: { id: invoiceId }, select: { estimateId: true } });
-        await lockMoneyParents(t, { estimateId: invLink?.estimateId, invoiceId });
-
-        const payment = await t.paymentSchedule.findUnique({ where: { id: paymentId } });
-        if (!payment) return { success: false as const, error: "Milestone not found" as const };
-        if (payment.status === "Paid") return { success: false as const, error: "Milestone already paid" as const };
-        if (payment.invoiceId !== invoiceId) return { success: false as const, error: "Milestone/invoice mismatch" as const };
-
-        const claim = await t.paymentSchedule.updateMany({
-            where: { id: paymentId, status: { not: "Paid" } },
-            data: {
-                status: "Paid",
-                paymentDate,
-                paidAt: new Date(),
-                paymentMethod: method,
-                referenceNumber,
-                notes,
-            },
-        });
-        if (claim.count === 0) return { success: false as const, error: "Milestone already paid" as const };
-
-        // Recalculate from scratch (matches Stripe webhook) to avoid drift.
-        const invoice = await t.invoice.findUnique({ where: { id: invoiceId } });
-        if (!invoice) return { success: false as const, error: "Invoice not found" as const };
-
-        const allSchedules = await t.paymentSchedule.findMany({ where: { invoiceId } });
-        const totalPaid = allSchedules
-            .filter((s) => s.status === "Paid")
-            .reduce((sum, s) => sum + toNum(s.amount), 0);
-        const newBalance = Math.max(0, toNum(invoice.totalAmount) - totalPaid);
-        const newStatus =
-            newBalance <= 0 ? "Paid"
-            : totalPaid > 0 ? "Partially Paid"
-            : invoice.status;
-
-        await t.invoice.update({
-            where: { id: invoiceId },
-            data: { balanceDue: newBalance, status: newStatus },
-        });
-
-        // Mirror to the estimate-side milestone copy so the estimate editor and
-        // its balance don't drift from the invoice that actually got paid.
-        // Link-first (this milestone's sourceScheduleId points at its estimate
-        // original); name+amount fallback only when exactly one row matches.
-        if (invoice.estimateId) {
-            let estCopy: { id: string } | null = null;
-            if (payment.sourceScheduleId) {
-                estCopy = await t.estimatePaymentSchedule.findFirst({
-                    where: { id: payment.sourceScheduleId, estimateId: invoice.estimateId, status: { not: "Paid" } },
-                });
-            } else {
-                const candidates = await t.estimatePaymentSchedule.findMany({
-                    where: { estimateId: invoice.estimateId, status: { not: "Paid" }, name: payment.name },
-                    take: 2,
-                });
-                const matching = candidates.filter(c => toNum(c.amount) === toNum(payment.amount));
-                estCopy = matching.length === 1 ? matching[0] : null;
-            }
-            if (estCopy) {
-                const mirrorClaim = await t.estimatePaymentSchedule.updateMany({
-                    where: { id: estCopy.id, status: { not: "Paid" } },
-                    data: { status: "Paid", paymentDate, paidAt: new Date(), paymentMethod: method, referenceNumber },
-                });
-                if (mirrorClaim.count > 0) {
-                    const estimate = await t.estimate.findUnique({ where: { id: invoice.estimateId } });
-                    if (estimate) {
-                        const estSiblings = await t.estimatePaymentSchedule.findMany({ where: { estimateId: invoice.estimateId } });
-                        const estPaid = estSiblings.filter(s => s.status === "Paid").reduce((sum, s) => sum + toNum(s.amount), 0);
-                        const estBalance = Math.max(0, toNum(estimate.totalAmount) - estPaid);
-                        const estFirstPayment = !["Paid", "Partially Paid"].includes(estimate.status);
-                        await t.estimate.update({
-                            where: { id: invoice.estimateId },
-                            data: {
-                                balanceDue: estBalance,
-                                status: estBalance <= 0 ? "Paid" : estPaid > 0 ? "Partially Paid" : estimate.status,
-                                // Captured so unrecording can restore the pre-payment status
-                                ...(estFirstPayment && { statusBeforePayment: estimate.status }),
-                            },
-                        });
-                    }
-                }
-            }
-        }
-
-        // Durable notification: enqueue INSIDE the tx so it commits atomically with the
-        // settle — a crash before delivery can't drop the team alert / receipt / activity log.
-        await enqueueMilestonePaid(t, { scheduleId: paymentId, scheduleType: "invoice" });
-        return { success: true as const, projectId: invoice.projectId };
-    }));
-
-    if (!tx.success) return tx;
-
-    // Inline fast-path delivery of the just-enqueued notification (single canonical writer,
-    // via the outbox). Best-effort — the cron backstop redelivers anything left pending.
-    await drainPaymentNotifications({ scheduleId: paymentId }).catch(() => {});
+    // Core transaction (claim → recalc → estimate mirror → enqueue notification)
+    // lives in payment-record-core.ts, shared with the deposit-ingest endpoint
+    // (src/app/api/payments/deposit-ingest/route.ts, Phase B1) so both settle a
+    // milestone through the exact same claim-then-recalculate-then-mirror path.
+    const result = await recordPaymentCore(paymentId, invoiceId, { paymentDate, method, referenceNumber, notes });
+    if (!result.success) return result;
+    const tx = result;
 
     revalidatePath(`/projects/${tx.projectId}/invoices`);
     revalidatePath(`/projects/${tx.projectId}/invoices/${invoiceId}`);

--- a/src/lib/payment-date.ts
+++ b/src/lib/payment-date.ts
@@ -1,0 +1,59 @@
+/**
+ * Back-dated payment classification, shared by the server-side notifier
+ * (payment-notifications.ts) and the client-side RecordPaymentModal. Must stay
+ * free of Prisma/server-only imports — it is bundled into client components.
+ */
+
+/** Receipts stop auto-sending when the payment date is older than this many calendar days. */
+export const BACKDATED_RECEIPT_CUTOFF_DAYS = 3;
+
+const BUSINESS_TZ = "America/Los_Angeles";
+
+// Days-since-epoch for a calendar date (UTC-anchored so the subtraction is exact).
+function dayNumber(y: number, m: number, d: number): number {
+    return Date.UTC(y, m - 1, d) / 86_400_000;
+}
+
+// "Today" as the business's calendar day (America/Los_Angeles), regardless of
+// where the server or browser runs. en-CA formats as YYYY-MM-DD.
+function todayDayNumber(now: Date): number {
+    const ymd = new Intl.DateTimeFormat("en-CA", {
+        timeZone: BUSINESS_TZ, year: "numeric", month: "2-digit", day: "2-digit",
+    }).format(now);
+    const [y, m, d] = ymd.split("-").map(Number);
+    return dayNumber(y, m, d);
+}
+
+/**
+ * True when the payment's calendar date is more than BACKDATED_RECEIPT_CUTOFF_DAYS
+ * before today (America/Los_Angeles). Calendar-day math, not elapsed-hours, so the
+ * answer doesn't flip with the time of day.
+ *
+ * Accepts a Date (a stored PaymentSchedule.paymentDate — parsePaymentDateInput
+ * stores the picked day as midnight in the WRITER's timezone: UTC on Vercel, US-local
+ * in dev. Both land inside the same UTC calendar day for US-or-west-of-UTC writers,
+ * so the intended day is recovered through the UTC date fields regardless of where
+ * this code runs) or a "YYYY-MM-DD" string (the date-picker value in
+ * RecordPaymentModal). Null/undefined/invalid input → false (treated as "today",
+ * never suppresses).
+ */
+export function isBackdatedPayment(
+    paymentDate: Date | string | null | undefined,
+    now: Date = new Date(),
+): boolean {
+    if (!paymentDate) return false;
+    let paymentDay: number;
+    if (typeof paymentDate === "string") {
+        const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(paymentDate.trim());
+        if (!m) return false;
+        paymentDay = dayNumber(Number(m[1]), Number(m[2]), Number(m[3]));
+    } else {
+        if (isNaN(paymentDate.getTime())) return false;
+        paymentDay = dayNumber(
+            paymentDate.getUTCFullYear(),
+            paymentDate.getUTCMonth() + 1,
+            paymentDate.getUTCDate(),
+        );
+    }
+    return todayDayNumber(now) - paymentDay > BACKDATED_RECEIPT_CUTOFF_DAYS;
+}

--- a/src/lib/payment-date.ts
+++ b/src/lib/payment-date.ts
@@ -15,13 +15,14 @@ function dayNumber(y: number, m: number, d: number): number {
 }
 
 // "Today" as the business's calendar day (America/Los_Angeles), regardless of
-// where the server or browser runs. en-CA formats as YYYY-MM-DD.
+// where the server or browser runs. formatToParts avoids any locale-dependent
+// assembled-string format assumptions.
 function todayDayNumber(now: Date): number {
-    const ymd = new Intl.DateTimeFormat("en-CA", {
+    const parts = new Intl.DateTimeFormat("en-CA", {
         timeZone: BUSINESS_TZ, year: "numeric", month: "2-digit", day: "2-digit",
-    }).format(now);
-    const [y, m, d] = ymd.split("-").map(Number);
-    return dayNumber(y, m, d);
+    }).formatToParts(now);
+    const get = (type: string) => Number(parts.find((p) => p.type === type)?.value);
+    return dayNumber(get("year"), get("month"), get("day"));
 }
 
 /**

--- a/src/lib/payment-notifications.ts
+++ b/src/lib/payment-notifications.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { sendNotification } from "@/lib/email";
 import { formatCurrency } from "@/lib/utils";
+import { isBackdatedPayment } from "@/lib/payment-date";
 
 function isToggleOn(settings: { notificationToggles?: string | null } | null, key: string): boolean {
     if (!settings?.notificationToggles) return true;
@@ -191,7 +192,11 @@ export async function notifyMilestonePaid(paymentScheduleId: string, opts?: { de
         // 3. Client receipt (once per milestone — receiptSentAt is the guard).
         //    Stamp receiptSentAt ONLY when the send actually succeeded, so a failed
         //    send stays retryable by the outbox drainer instead of being marked sent.
-        if (s.invoice.client?.email && !s.receiptSentAt) {
+        //    Back-dated payments (recorded days after the money actually arrived) skip
+        //    the auto-receipt — a stale "Payment Confirmed" email blindsides the client.
+        //    receiptSentAt stays null so staff can still send one via the Send Receipt
+        //    button when they want to.
+        if (s.invoice.client?.email && !s.receiptSentAt && !isBackdatedPayment(s.paymentDate)) {
             const portalUrl = `${process.env.NEXT_PUBLIC_APP_URL || "https://probuild.goldentouchremodeling.com"}/portal/invoices/${s.invoice.id}`;
             const receiptSend = await sendNotification(
                 s.invoice.client.email,
@@ -239,7 +244,7 @@ export async function notifyEstimateMilestonePaid(scheduleId: string, opts?: { d
         const s = await prisma.estimatePaymentSchedule.findUnique({
             where: { id: scheduleId },
             select: {
-                id: true, name: true, amount: true, status: true, paymentMethod: true, referenceNumber: true, receiptSentAt: true,
+                id: true, name: true, amount: true, status: true, paymentMethod: true, referenceNumber: true, receiptSentAt: true, paymentDate: true,
                 estimate: {
                     select: {
                         id: true, code: true, title: true, projectId: true, leadId: true, balanceDue: true,
@@ -305,10 +310,12 @@ export async function notifyEstimateMilestonePaid(scheduleId: string, opts?: { d
             if (adminSend && !adminSend.success) ok = false;
         }
 
-        // 3. Client receipt (once per milestone — receiptSentAt guard, stamped only on success)
+        // 3. Client receipt (once per milestone — receiptSentAt guard, stamped only on success).
+        //    Back-dated payments skip the auto-receipt (see notifyMilestonePaid); receiptSentAt
+        //    stays null so a manual Send Receipt is still possible.
         const clientEmail = est.project?.client?.email || est.lead?.client?.email || null;
         const clientName = est.project?.client?.name || est.lead?.client?.name || est.lead?.name || "";
-        if (clientEmail && !s.receiptSentAt) {
+        if (clientEmail && !s.receiptSentAt && !isBackdatedPayment(s.paymentDate)) {
             const portalUrl = `${process.env.NEXT_PUBLIC_APP_URL || "https://probuild.goldentouchremodeling.com"}/portal/estimates/${est.id}`;
             const receiptSend = await sendNotification(
                 clientEmail,

--- a/src/lib/payment-record-core.ts
+++ b/src/lib/payment-record-core.ts
@@ -1,0 +1,140 @@
+import { prisma } from "./prisma";
+import { withTxRetry, lockMoneyParents } from "./tx-retry";
+import { enqueueMilestonePaid, drainPaymentNotifications } from "./payment-outbox";
+import { toNum } from "./prisma-helpers";
+
+/**
+ * Manual (non-QuickBooks) milestone settlement core — the transaction body of
+ * the `recordPayment` server action (src/lib/actions.ts), extracted so both
+ * that action AND the deposit-ingest endpoint
+ * (src/app/api/payments/deposit-ingest/route.ts, Phase B1) settle a milestone
+ * through the exact same claim-then-recalculate-then-mirror transaction.
+ *
+ * No session assertion here — this is system context. Callers own their own
+ * authorization (`assertInvoicePermission` for the action; the Bearer secret
+ * + strict matching for the endpoint) and must validate `input` themselves
+ * (method allowlist, check-number-required-for-check, a real Date) before
+ * calling in: this function trusts its input.
+ */
+export async function recordPaymentCore(
+    paymentId: string,
+    invoiceId: string,
+    input: {
+        paymentDate: Date;
+        method: string;
+        referenceNumber: string | null;
+        notes: string | null;
+    },
+): Promise<
+    | { success: true; projectId: string }
+    | { success: false; error: string }
+> {
+    const { paymentDate, method, referenceNumber, notes } = input;
+
+    const tx = await withTxRetry(() => prisma.$transaction(async (t) => {
+        // Canonical lock order: Estimate → Invoice → schedules. Two concurrent payments on
+        // DIFFERENT milestones of the SAME invoice each claim their own schedule row (no mutual
+        // block), so without a parent lock they both read a stale sibling set and overwrite each
+        // other's Invoice.balanceDue — one payment's balance effect is silently lost, and no
+        // deadlock fires to trigger a retry. Locking the parent(s) first serializes the recompute:
+        // the second call blocks until the first commits, then recomputes against fresh state.
+        // Read the estimate link (non-locking) so we can lock Estimate BEFORE Invoice, matching
+        // recordEstimatePayment's mirror order so the two flows never invert and deadlock.
+        const invLink = await t.invoice.findUnique({ where: { id: invoiceId }, select: { estimateId: true } });
+        await lockMoneyParents(t, { estimateId: invLink?.estimateId, invoiceId });
+
+        const payment = await t.paymentSchedule.findUnique({ where: { id: paymentId } });
+        if (!payment) return { success: false as const, error: "Milestone not found" };
+        if (payment.status === "Paid") return { success: false as const, error: "Milestone already paid" };
+        if (payment.invoiceId !== invoiceId) return { success: false as const, error: "Milestone/invoice mismatch" };
+
+        const claim = await t.paymentSchedule.updateMany({
+            where: { id: paymentId, status: { not: "Paid" } },
+            data: {
+                status: "Paid",
+                paymentDate,
+                paidAt: new Date(),
+                paymentMethod: method,
+                referenceNumber,
+                notes,
+            },
+        });
+        if (claim.count === 0) return { success: false as const, error: "Milestone already paid" };
+
+        // Recalculate from scratch (matches Stripe webhook) to avoid drift.
+        const invoice = await t.invoice.findUnique({ where: { id: invoiceId } });
+        if (!invoice) return { success: false as const, error: "Invoice not found" };
+
+        const allSchedules = await t.paymentSchedule.findMany({ where: { invoiceId } });
+        const totalPaid = allSchedules
+            .filter((s) => s.status === "Paid")
+            .reduce((sum, s) => sum + toNum(s.amount), 0);
+        const newBalance = Math.max(0, toNum(invoice.totalAmount) - totalPaid);
+        const newStatus =
+            newBalance <= 0 ? "Paid"
+            : totalPaid > 0 ? "Partially Paid"
+            : invoice.status;
+
+        await t.invoice.update({
+            where: { id: invoiceId },
+            data: { balanceDue: newBalance, status: newStatus },
+        });
+
+        // Mirror to the estimate-side milestone copy so the estimate editor and
+        // its balance don't drift from the invoice that actually got paid.
+        // Link-first (this milestone's sourceScheduleId points at its estimate
+        // original); name+amount fallback only when exactly one row matches.
+        if (invoice.estimateId) {
+            let estCopy: { id: string } | null = null;
+            if (payment.sourceScheduleId) {
+                estCopy = await t.estimatePaymentSchedule.findFirst({
+                    where: { id: payment.sourceScheduleId, estimateId: invoice.estimateId, status: { not: "Paid" } },
+                });
+            } else {
+                const candidates = await t.estimatePaymentSchedule.findMany({
+                    where: { estimateId: invoice.estimateId, status: { not: "Paid" }, name: payment.name },
+                    take: 2,
+                });
+                const matching = candidates.filter(c => toNum(c.amount) === toNum(payment.amount));
+                estCopy = matching.length === 1 ? matching[0] : null;
+            }
+            if (estCopy) {
+                const mirrorClaim = await t.estimatePaymentSchedule.updateMany({
+                    where: { id: estCopy.id, status: { not: "Paid" } },
+                    data: { status: "Paid", paymentDate, paidAt: new Date(), paymentMethod: method, referenceNumber },
+                });
+                if (mirrorClaim.count > 0) {
+                    const estimate = await t.estimate.findUnique({ where: { id: invoice.estimateId } });
+                    if (estimate) {
+                        const estSiblings = await t.estimatePaymentSchedule.findMany({ where: { estimateId: invoice.estimateId } });
+                        const estPaid = estSiblings.filter(s => s.status === "Paid").reduce((sum, s) => sum + toNum(s.amount), 0);
+                        const estBalance = Math.max(0, toNum(estimate.totalAmount) - estPaid);
+                        const estFirstPayment = !["Paid", "Partially Paid"].includes(estimate.status);
+                        await t.estimate.update({
+                            where: { id: invoice.estimateId },
+                            data: {
+                                balanceDue: estBalance,
+                                status: estBalance <= 0 ? "Paid" : estPaid > 0 ? "Partially Paid" : estimate.status,
+                                // Captured so unrecording can restore the pre-payment status
+                                ...(estFirstPayment && { statusBeforePayment: estimate.status }),
+                            },
+                        });
+                    }
+                }
+            }
+        }
+
+        // Durable notification: enqueue INSIDE the tx so it commits atomically with the
+        // settle — a crash before delivery can't drop the team alert / receipt / activity log.
+        await enqueueMilestonePaid(t, { scheduleId: paymentId, scheduleType: "invoice" });
+        return { success: true as const, projectId: invoice.projectId };
+    }));
+
+    if (!tx.success) return tx;
+
+    // Inline fast-path delivery of the just-enqueued notification (single canonical writer,
+    // via the outbox). Best-effort — the cron backstop redelivers anything left pending.
+    await drainPaymentNotifications({ scheduleId: paymentId }).catch(() => {});
+
+    return { success: true, projectId: tx.projectId };
+}

--- a/src/lib/quickbooks-mock.ts
+++ b/src/lib/quickbooks-mock.ts
@@ -1,0 +1,124 @@
+// Test-only QuickBooks mock — engages ONLY when E2E_QBO_MOCK=1, mirroring the
+// existing triple-gate convention (see isE2eStorageMockEnabled() in
+// supabase.ts): an explicit opt-in flag, off Vercel (a real deploy always
+// sets VERCEL=1, so this combination can never hold there), AND the
+// Playwright test-auth secret present. This is a money-path mock (fake
+// QuickBooks Payment creates), so it uses the STRICTEST existing gate — the
+// storage mock's three-condition bar — not the single-flag SELECTION_AI_MOCK
+// gate.
+//
+// Call sites (each checks isE2eQboMockEnabled() first and, when true, returns
+// a canned result with NO network I/O):
+//   - quickbooks-payments.ts: getFreshQBTokens()
+//   - quickbooks.ts: buildQBPaymentRequest() (skips the readQBInvoice() call
+//     it would otherwise make), sendQBPaymentCreateRequest()
+//
+// Cross-process visibility: e2e/deposit-ingest.spec.ts drives the deposit-
+// ingest endpoint over real HTTP against the Playwright webServer — a
+// SEPARATE Node process from the test runner — so the spec can't just import
+// this module and read its state directly (that would be a different module
+// instance in a different process). src/app/api/payments/test-only/qbo-mock/
+// route.ts, gated by the same isE2eQboMockEnabled() check, is the seam: it
+// reads/seeds/resets this state FROM INSIDE the server process, and the spec
+// drives it over HTTP like any other endpoint.
+import type { QBTokens } from "./quickbooks";
+
+export function isE2eQboMockEnabled(): boolean {
+    return (
+        process.env.E2E_QBO_MOCK === "1" &&
+        !process.env.VERCEL &&
+        !!process.env.PLAYWRIGHT_TEST_SECRET
+    );
+}
+
+export const MOCK_QB_TOKENS: QBTokens = {
+    accessToken: "e2e-mock-qb-access-token",
+    refreshToken: "e2e-mock-qb-refresh-token",
+    realmId: "e2e-mock-realm",
+};
+
+export interface MockQboInvoiceState {
+    balance: number;
+    customerId: string;
+}
+
+export interface CapturedReadInvoiceCall {
+    qbInvoiceId: string;
+    at: number;
+}
+
+export interface CapturedPaymentCreateCall {
+    requestBody: string;
+    requestId: string;
+    at: number;
+}
+
+// globalThis-cached, same pattern as supabase-storage-mock.ts's object Map —
+// Next.js can reload route modules between requests in dev; the underlying
+// Node process (and this state) does not change.
+const globalCache = globalThis as unknown as {
+    __e2eQboMock?: {
+        invoices: Map<string, MockQboInvoiceState>;
+        readInvoiceCalls: CapturedReadInvoiceCall[];
+        paymentCreateCalls: CapturedPaymentCreateCall[];
+        paymentByRequestId: Map<string, { paymentId: string; amount: number }>;
+        paymentIdSeq: number;
+    };
+};
+
+function state() {
+    globalCache.__e2eQboMock ??= {
+        invoices: new Map(),
+        readInvoiceCalls: [],
+        paymentCreateCalls: [],
+        paymentByRequestId: new Map(),
+        paymentIdSeq: 0,
+    };
+    return globalCache.__e2eQboMock;
+}
+
+export function resetMockQbo(): void {
+    const s = state();
+    s.invoices.clear();
+    s.readInvoiceCalls.length = 0;
+    s.paymentCreateCalls.length = 0;
+    s.paymentByRequestId.clear();
+    s.paymentIdSeq = 0;
+}
+
+export function setMockQboInvoice(qbInvoiceId: string, invoiceState: MockQboInvoiceState): void {
+    state().invoices.set(qbInvoiceId, invoiceState);
+}
+
+export function getMockQboInvoice(qbInvoiceId: string): MockQboInvoiceState | undefined {
+    return state().invoices.get(qbInvoiceId);
+}
+
+export function recordMockReadInvoiceCall(qbInvoiceId: string): void {
+    state().readInvoiceCalls.push({ qbInvoiceId, at: Date.now() });
+}
+
+/** Mirrors QBO's real `requestid` create-idempotency: the SAME requestId
+ *  always returns the SAME payment instead of creating a duplicate — exactly
+ *  the behavior the deposit-ingest endpoint's qbo_unknown replay path
+ *  depends on (see sendQBPaymentCreateRequest's doc comment). */
+export function mockSendQBPaymentCreate(requestBody: string, requestId: string): { paymentId: string; amount: number } {
+    const s = state();
+    s.paymentCreateCalls.push({ requestBody, requestId, at: Date.now() });
+    const existing = s.paymentByRequestId.get(requestId);
+    if (existing) return existing;
+    s.paymentIdSeq += 1;
+    const parsed = JSON.parse(requestBody) as { TotalAmt?: number };
+    const result = { paymentId: `e2e-mock-qb-payment-${s.paymentIdSeq}`, amount: Number(parsed.TotalAmt ?? 0) };
+    s.paymentByRequestId.set(requestId, result);
+    return result;
+}
+
+export function getMockQboCallCounts(): { readInvoice: number; paymentCreate: number } {
+    const s = state();
+    return { readInvoice: s.readInvoiceCalls.length, paymentCreate: s.paymentCreateCalls.length };
+}
+
+export function getMockQboPaymentCreateCalls(): CapturedPaymentCreateCall[] {
+    return [...state().paymentCreateCalls];
+}

--- a/src/lib/quickbooks-payments.ts
+++ b/src/lib/quickbooks-payments.ts
@@ -40,8 +40,16 @@ export class QBNotConnectedError extends Error {
 
 /** Fresh tokens, persisting the rotated refresh token. Throws QBNotConnectedError. */
 export async function getFreshQBTokens(): Promise<QBTokens> {
-    // E2E_QBO_MOCK (deposit-ingest hermeticity) — see quickbooks-mock.ts.
-    if (isE2eQboMockEnabled()) return MOCK_QB_TOKENS;
+    // E2E_QBO_MOCK (deposit-ingest hermeticity) — see quickbooks-mock.ts. The mock
+    // replaces the NETWORK, not the CONNECTION STATE: with no connected settings row
+    // it still throws QBNotConnectedError, so fail-closed specs (e.g.
+    // milestone-payment-request) keep their "rail is down" premise; specs that need
+    // QuickBooks seed a connected row (see e2e/deposit-ingest.spec.ts beforeAll).
+    if (isE2eQboMockEnabled()) {
+        const qb = await getQBSettings();
+        if (!qb.connected) throw new QBNotConnectedError();
+        return MOCK_QB_TOKENS;
+    }
     const qb = await getQBSettings();
     if (!qb.connected || !qb.accessToken || !qb.refreshToken || !qb.realmId) {
         throw new QBNotConnectedError();

--- a/src/lib/quickbooks-payments.ts
+++ b/src/lib/quickbooks-payments.ts
@@ -28,6 +28,7 @@ import {
     getQBPayment,
     deleteQBInvoice,
 } from "./quickbooks";
+import { isE2eQboMockEnabled, MOCK_QB_TOKENS } from "./quickbooks-mock";
 import type { QBSyncIssue } from "./payment-notifications";
 
 export class QBNotConnectedError extends Error {
@@ -39,6 +40,8 @@ export class QBNotConnectedError extends Error {
 
 /** Fresh tokens, persisting the rotated refresh token. Throws QBNotConnectedError. */
 export async function getFreshQBTokens(): Promise<QBTokens> {
+    // E2E_QBO_MOCK (deposit-ingest hermeticity) — see quickbooks-mock.ts.
+    if (isE2eQboMockEnabled()) return MOCK_QB_TOKENS;
     const qb = await getQBSettings();
     if (!qb.connected || !qb.accessToken || !qb.refreshToken || !qb.realmId) {
         throw new QBNotConnectedError();

--- a/src/lib/quickbooks-payments.ts
+++ b/src/lib/quickbooks-payments.ts
@@ -430,14 +430,32 @@ export async function settleProgressBillingPaidCore(
 }
 
 /**
- * Mark a milestone Paid from a QuickBooks settlement. Mirrors the Stripe
- * webhook's claim-then-recalculate transaction so balances never drift.
+ * Settle ONE milestone from a QuickBooks payment: claim it Paid, recompute
+ * the parent invoice, mirror the estimate copy, and enqueue the paid
+ * notification. Mirrors the Stripe webhook's claim-then-recalculate
+ * transaction so balances never drift.
+ *
+ * Exported (not just the hourly sync's private helper) so the deposit-ingest
+ * endpoint (src/app/api/payments/deposit-ingest/route.ts, Phase B1) can
+ * settle a milestone from a deposit-triggered QuickBooks Payment the exact
+ * same way the cron settles one it discovers on its own poll. Claim-once via
+ * `settleMilestonePaidInTx`'s `status: { not: "Paid" }` guard: a caller that
+ * loses the claim (the cron beat it to this schedule, or vice versa) gets
+ * `false` back and must NOT treat that as a generic failure — re-read the
+ * schedule and compare `qbPaymentId`. The same `qbPaymentId` means the OTHER
+ * caller settled it with OUR OWN QuickBooks payment (deposit-ingest raced the
+ * cron's poll of the payment it just created) and this is a success, not a
+ * conflict; a different or absent `qbPaymentId` is a genuine conflict the
+ * caller must route to manual reconciliation.
  */
-async function markMilestonePaidFromQB(
-    paymentScheduleId: string,
-    invoiceId: string,
-    payment: { paidAt: Date; referenceNumber: string | null; qbPaymentId: string | null }
-): Promise<boolean> {
+export async function settleMilestoneFromQBPayment(input: {
+    paymentScheduleId: string;
+    invoiceId: string;
+    qbPaymentId: string | null;
+    paidAt: Date;
+    referenceNumber: string | null;
+}): Promise<boolean> {
+    const { paymentScheduleId, invoiceId, ...payment } = input;
     return withTxRetry(() => prisma.$transaction(async (t) => {
         // Canonical lock order: Estimate → Invoice → schedules. This settle mirrors onto the
         // estimate copy, so read the estimate link (non-locking) and lock Estimate before Invoice,
@@ -464,7 +482,7 @@ async function markMilestonePaidFromQB(
  * drifts from the ProBuild milestone; this brings ProBuild back in line so the
  * books stay truthful before the invoice is (re)sent.
  *
- * Recalc/mirror logic is modeled on `markMilestonePaidFromQB` above — link-first
+ * Recalc/mirror logic is modeled on `settleMilestoneFromQBPayment` above — link-first
  * via `sourceScheduleId`, single-candidate name+amount fallback for pre-link
  * rows, claimed updates that never touch a settled row. Amounts are tax-inclusive
  * so we recompute the invoice/estimate totals from the milestone amounts and
@@ -515,7 +533,7 @@ export async function reconcileMilestoneToQbo(
             return { ok: true, oldAmount, newAmount, invoiceId: schedule.invoiceId, estimateTouched: false };
         }
 
-        // 1) Claimed update of the invoice-side amount — mirrors markMilestonePaidFromQB's
+        // 1) Claimed update of the invoice-side amount — mirrors settleMilestoneFromQBPayment's
         //    pattern so a concurrent settle (QB sync / Stripe) that marks the row Paid
         //    between the read above and this write can't have its amount overwritten.
         const claim = await t.paymentSchedule.updateMany({
@@ -526,7 +544,7 @@ export async function reconcileMilestoneToQbo(
             return { ok: false, error: "Milestone changed status (paid or canceled) — reload and try again." };
         }
 
-        // 2) Recompute the parent invoice (mirror markMilestonePaidFromQB's recalc,
+        // 2) Recompute the parent invoice (mirror settleMilestoneFromQBPayment's recalc,
         //    extended to also move totalAmount since an amount change moves the grand total).
         const invoice = await t.invoice.findUnique({ where: { id: schedule.invoiceId } });
         if (!invoice) return { ok: false, error: "Invoice not found" };
@@ -554,7 +572,7 @@ export async function reconcileMilestoneToQbo(
 
         // 3) Mirror onto the estimate-side copy (link-first via sourceScheduleId,
         //    name + OLD-amount fallback for pre-link rows; only touch an unpaid copy)
-        //    and recompute the estimate, matching markMilestonePaidFromQB's mirror block.
+        //    and recompute the estimate, matching settleMilestoneFromQBPayment's mirror block.
         let estimateTouched = false;
         if (invoice.estimateId) {
             let estCopy: { id: string } | null = null;
@@ -721,7 +739,9 @@ export async function syncQuickBooksPayments(scope?: { invoiceId?: string; proje
                     if (p?.txnDate) paidAt = new Date(`${p.txnDate}T12:00:00`);
                     referenceNumber = p?.referenceNumber || null;
                 }
-                const recorded = await markMilestonePaidFromQB(schedule.id, schedule.invoiceId, {
+                const recorded = await settleMilestoneFromQBPayment({
+                    paymentScheduleId: schedule.id,
+                    invoiceId: schedule.invoiceId,
                     paidAt,
                     referenceNumber,
                     qbPaymentId: paymentId,

--- a/src/lib/quickbooks.ts
+++ b/src/lib/quickbooks.ts
@@ -3,6 +3,12 @@
  * Uses OAuth2 tokens stored in integration-store.
  * Docs: https://developer.intuit.com/app/developer/qbo/docs/api/accounting
  */
+import {
+    isE2eQboMockEnabled,
+    recordMockReadInvoiceCall,
+    getMockQboInvoice,
+    mockSendQBPaymentCreate,
+} from "./quickbooks-mock";
 
 export const QB_API_BASE = process.env.QB_SANDBOX === "true"
     ? "https://sandbox-quickbooks.api.intuit.com/v3/company"
@@ -450,6 +456,26 @@ export async function buildQBPaymentRequest(
     qbInvoiceId: string,
     opts: { amount: number; txnDate: string; paymentRefNum: string },
 ): Promise<{ ok: true; requestBody: string } | QBPaymentBuildFailure> {
+    // E2E_QBO_MOCK (deposit-ingest hermeticity, gated in quickbooks-mock.ts):
+    // skip the real readQBInvoice() network call entirely — the caller seeds
+    // this mock's invoice state via /api/payments/test-only/qbo-mock.
+    if (isE2eQboMockEnabled()) {
+        recordMockReadInvoiceCall(qbInvoiceId);
+        const inv = getMockQboInvoice(qbInvoiceId);
+        if (!inv) return { ok: false, reason: "invoice-not-found" };
+        if (!inv.customerId) return { ok: false, reason: "missing-customer" };
+        if (Math.round(inv.balance * 100) !== Math.round(opts.amount * 100)) {
+            return { ok: false, reason: "balance-mismatch", qbBalance: inv.balance, expected: opts.amount };
+        }
+        const mockPayload = {
+            TotalAmt: opts.amount,
+            TxnDate: opts.txnDate,
+            PaymentRefNum: opts.paymentRefNum,
+            CustomerRef: { value: inv.customerId },
+            Line: [{ Amount: opts.amount, LinkedTxn: [{ TxnId: qbInvoiceId, TxnType: "Invoice" }] }],
+        };
+        return { ok: true, requestBody: JSON.stringify(mockPayload) };
+    }
     const inv = await readQBInvoice(tokens, qbInvoiceId);
     if (!inv) return { ok: false, reason: "invoice-not-found" };
     if (!inv.customerId) return { ok: false, reason: "missing-customer" };
@@ -480,6 +506,13 @@ export async function sendQBPaymentCreateRequest(
     requestBody: string,
     requestId: string,
 ): Promise<{ paymentId: string; amount: number }> {
+    // E2E_QBO_MOCK: no network I/O — see quickbooks-mock.ts's doc comment.
+    // mockSendQBPaymentCreate replicates QBO's requestid dedupe (the SAME
+    // requestId always returns the SAME payment), which the qbo_unknown
+    // replay path below depends on.
+    if (isE2eQboMockEnabled()) {
+        return mockSendQBPaymentCreate(requestBody, requestId);
+    }
     const res = await qbFetch(`/payment?requestid=${encodeURIComponent(requestId)}`, tokens, {
         method: "POST",
         body: requestBody,

--- a/src/lib/quickbooks.ts
+++ b/src/lib/quickbooks.ts
@@ -430,6 +430,85 @@ export async function createQBPaymentForInvoice(tokens: QBTokens, qbInvoiceId: s
     return { paymentId: String(p.Id), amount: Number(p.TotalAmt ?? inv.balance) };
 }
 
+export type QBPaymentBuildFailure =
+    | { ok: false; reason: "invoice-not-found" }
+    | { ok: false; reason: "missing-customer" }
+    | { ok: false; reason: "balance-mismatch"; qbBalance: number; expected: number };
+
+/**
+ * Build (but do not send) the exact JSON body for a Payment create against a
+ * specific amount/date/check-ref — split out from the deposit-ingest send
+ * step so a caller can PERSIST the body before the network call fires (the
+ * deposit-ingest endpoint's `qbo_unknown` recovery depends on the row already
+ * holding the exact bytes it's about to send, in case the process dies
+ * mid-request or the response is lost). Guards the QBO invoice's open balance
+ * against `opts.amount` to the cent — a deposit must exactly retire the
+ * milestone it matched, never partially settle it.
+ */
+export async function buildQBPaymentRequest(
+    tokens: QBTokens,
+    qbInvoiceId: string,
+    opts: { amount: number; txnDate: string; paymentRefNum: string },
+): Promise<{ ok: true; requestBody: string } | QBPaymentBuildFailure> {
+    const inv = await readQBInvoice(tokens, qbInvoiceId);
+    if (!inv) return { ok: false, reason: "invoice-not-found" };
+    if (!inv.customerId) return { ok: false, reason: "missing-customer" };
+    if (Math.round(inv.balance * 100) !== Math.round(opts.amount * 100)) {
+        return { ok: false, reason: "balance-mismatch", qbBalance: inv.balance, expected: opts.amount };
+    }
+    const payload = {
+        TotalAmt: opts.amount,
+        TxnDate: opts.txnDate,
+        PaymentRefNum: opts.paymentRefNum,
+        CustomerRef: { value: inv.customerId },
+        Line: [{ Amount: opts.amount, LinkedTxn: [{ TxnId: qbInvoiceId, TxnType: "Invoice" }] }],
+    };
+    return { ok: true, requestBody: JSON.stringify(payload) };
+}
+
+/**
+ * Send a Payment create request whose body was already built (by
+ * `buildQBPaymentRequest`) and possibly already persisted. The SAME function
+ * is the replay path: calling it again with the identical `requestBody` +
+ * `requestId` after a lost response returns Intuit's ORIGINAL response
+ * instead of creating a duplicate Payment (`requestid` is QBO's server-side
+ * idempotency key on the create) — see qbo-receipt-push.ts's requestid
+ * pattern, `?requestid=...` as a query param.
+ */
+export async function sendQBPaymentCreateRequest(
+    tokens: QBTokens,
+    requestBody: string,
+    requestId: string,
+): Promise<{ paymentId: string; amount: number }> {
+    const res = await qbFetch(`/payment?requestid=${encodeURIComponent(requestId)}`, tokens, {
+        method: "POST",
+        body: requestBody,
+    });
+    if (!res.ok) throw new Error(`QB payment create failed: ${await res.text()}`);
+    const data = await res.json().catch(() => null);
+    const p = data?.Payment;
+    if (!p?.Id) throw new Error("QB payment create returned no Payment body");
+    return { paymentId: String(p.Id), amount: Number(p.TotalAmt ?? 0) };
+}
+
+/**
+ * Convenience wrapper for callers that don't need the persist-before-send
+ * seam: build + guard + send in one call. The deposit-ingest endpoint does
+ * NOT use this directly — it calls `buildQBPaymentRequest` and
+ * `sendQBPaymentCreateRequest` separately so it can commit the request body
+ * to the DepositIngest row between the two steps.
+ */
+export async function createQBPaymentForInvoiceWithDetails(
+    tokens: QBTokens,
+    qbInvoiceId: string,
+    opts: { amount: number; txnDate: string; paymentRefNum: string; requestId: string },
+): Promise<{ ok: true; paymentId: string; amount: number; requestBody: string } | QBPaymentBuildFailure> {
+    const built = await buildQBPaymentRequest(tokens, qbInvoiceId, opts);
+    if (!built.ok) return built;
+    const sent = await sendQBPaymentCreateRequest(tokens, built.requestBody, opts.requestId);
+    return { ok: true, paymentId: sent.paymentId, amount: sent.amount, requestBody: built.requestBody };
+}
+
 /** Hard-delete a payment (test cleanup). */
 export async function deleteQBPayment(tokens: QBTokens, paymentId: string): Promise<boolean> {
     const get = await qbFetch(`/payment/${paymentId}`, tokens, { method: "GET" });


### PR DESCRIPTION
## What

**Phase A — back-dated receipt suppression (DEPLOYED).** Payments recorded with a payment date more than 3 calendar days in the past (America/Los_Angeles) no longer auto-email the client a "Payment Confirmed" receipt — on every settle path (manual record, QBO sync, estimate mirror). `receiptSentAt` stays null so Send Receipt still offers a deliberate manual send; team alert + activity log unchanged. RecordPaymentModal warns when the chosen date will suppress.

Why: the Berg payment (received 7/21, recorded 8/6) fired a fresh receipt at the client 16 days late.

**Phase B1 — deposit auto-apply endpoint (DEPLOYED, inert until bot v3.4).** `POST /api/payments/deposit-ingest`: secret-authed (timing-safe, fail-closed), metadata-only payloads from the receipts Apps Script keyed by Drive fileId. Strict matching (single project via first-word-guarded name match, single Pending milestone at exact cents, payer corroboration), crash-safe state machine (`processing/qbo_unknown/qbo_created/applied/unmatched/failed/reconcile`) with a partial-unique milestone reservation index, QBO Payment creation with TxnDate/PaymentRefNum and byte-identical requestid replay, settle via the exported claim-once core. Ambiguity files an OfficeTask instead of guessing. First production ProBuild→QBO payment write.

Refactors (behavior-preserving): `recordPaymentCore` extracted from the recordPayment action; `settleMilestoneFromQBPayment` exported from the private markMilestonePaidFromQB; QBO payment build/send split in quickbooks.ts.

**Tests:** 25-case hermetic e2e suite (`e2e/deposit-ingest.spec.ts`) — races, crash-resume for both money boundaries, reservation blocking, match refusals — under a new triple-gated `E2E_QBO_MOCK` that replaces the QBO network but preserves connection state (existing fail-closed specs unaffected). CI fully green.

**Deployed 2026-08-06:** schema applied (RLS on), `DEPOSIT_INGEST_SECRET` set, prod probes pass (401 wrong secret / clean validation 400).

## Review trail
Plan: Codex gpt-5.6-sol, 7 rounds, APPROVED. Implementation: acceptance checker + 4 Codex review rounds + diff-only sanity passes; all blockers fixed (task-create ordering, failed-claim CAS, boundary markers, reservation predicate, legacy-safe migration, weak-match money guard).

## Remaining (follow-up work, not this PR)
Receipt bot v3.4 `customer_payment` branch (export LIVE Apps Script source first — workspace copy is stale), Vanessa bank-feed-match heads-up before enabling, Shop-project end-to-end test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)