### PR TITLE
Daily-log-driven time entry accuracy + mobile launch test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,10 @@ jobs:
       # their deterministic mocks. Without it the specs hit the real Anthropic
       # API on every PR and the forced-failure test marker is inert prose.
       SELECTION_AI_MOCK: "1"
+      # Forces the Stage A daily-log task matcher (daily-log-task-match.ts) onto
+      # its deterministic keyword fallback instead of calling Gemini, so
+      # time-suggestion.spec.ts's Stage A end-to-end test is reproducible in CI.
+      DAILY_LOG_MATCH_AI_MOCK: "1"
       GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
       GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
       STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}

--- a/docs/MOBILE-TESTING.md
+++ b/docs/MOBILE-TESTING.md
@@ -1,0 +1,41 @@
+# Mobile App Testing
+
+How the ProBuild mobile app (repo `gtr-probuild-mobile`, Expo 54) is tested. Four layers, from cheapest to heaviest. See `docs/TESTING.md` for the web suite and the hermetic-DB rules that apply to everything here.
+
+## Layer 1 — API contract tests (this repo, runs in CI)
+
+`e2e/mobile-api.spec.ts` hits the mobile-facing endpoints directly (PIN login, `/api/mobile/me`, time-entries auth matrix + cost math, schedule/today, time-suggestion). Runs in the normal `npx playwright test` pipeline on every PR against the throwaway Postgres container. Fixtures come from `e2e/data.setup.ts` (`field-crew@test.local` PIN 246810, `manager@test.local` PIN 135790, the `e2e-mob-*` estimate/task/daily-log rows).
+
+## Layer 2 — Expo-web E2E (local launch gate, NOT in CI)
+
+The mobile app's web build runs the same React code as iOS/Android, so a browser suite drives the real field screens. Specs live in `e2e/mobile-app/` and run with their own config:
+
+```bash
+set MOBILE_APP_DIR=C:\Users\jat00\workspaces\golden-touch\active\gtr-probuild-mobile
+npm run test:mobile-e2e
+```
+
+What that does (`e2e/mobile-app/run-mobile-e2e.mjs`):
+1. `npx expo export --platform web` in the mobile checkout (skip with `SKIP_MOBILE_BUILD=1`).
+2. Runs `playwright.config.mobile.ts`: Next dev server on :3000 + `serve-mobile-web.mjs` on :19006 (static export, `/api/*` proxied to :3000 — the same same-origin shape prod uses via Vercel rewrites; no CORS, no app changes).
+3. Specs log in via PIN through the real UI (Google OAuth is not headless-testable — that's on the device checklist). `workers: 1` on purpose: the specs share one crew user and mutate punches; do not parallelize.
+
+DB rules: point `DATABASE_URL` at a local throwaway Postgres (docs/TESTING.md local recipe) with `PLAYWRIGHT_TEST_SECRET`, `E2E_STORAGE_MOCK=1`, `SELECTION_AI_MOCK=1`, `DAILY_LOG_MATCH_AI_MOCK=1`. The `data.setup.ts` prod-DB guard aborts if it smells Supabase.
+
+Not in CI because the two repos are separate on GitHub; wiring a cross-repo checkout (PAT + actions/checkout) is a known follow-up. Until then this suite is the documented pre-release gate: run it before every store/TestFlight/OTA release.
+
+## Layer 3 — Unit tests (mobile repo)
+
+`apps/mobile`: `npm test` (jest-expo). Covers the API client's failure modes (401 → logout, timeouts, suggestion fetch never throwing), the auth store bootstrap, and pure time math. Cheap — run on any mobile change.
+
+## Layer 4 — Manual device checklist (native-only)
+
+`MANUAL-DEVICE-CHECKLIST.md` in the mobile repo root: Google OAuth, secure-store persistence, background geofence, push notifications, camera, LiDAR/AR, OTA application, meal-break modal, and the clock-in suggestion dialog on a real project. One iOS + one Android pass before each release. ~30 minutes.
+
+## Release gate summary
+
+Before `eas update` / `eas submit`:
+1. CI green on the web repo (includes Layer 1).
+2. `npm run test:mobile-e2e` green locally (Layer 2).
+3. `npm test` green in `apps/mobile` (Layer 3).
+4. Device checklist pass on both platforms (Layer 4).

--- a/e2e/cost-plus-change-order.spec.ts
+++ b/e2e/cost-plus-change-order.spec.ts
@@ -828,11 +828,11 @@ test.describe.serial("PB-pipeline-004 cost-plus and split change orders", () => 
   // (files/folders, daily logs, punch, contacts) landed; 1.13.0 -> 1.14.0 when
   // read_file/get_file_link and the connector audit trail landed; 1.14.0 ->
   // 1.15.0 when update_change_order and items in list_change_orders landed;
-  // the voice-first cost-plus tools asserted below are unaffected and must
-  // keep working.
-  test("CPCO10: MCP is v1.15.0 and exposes the required voice-first tools and UI copy", () => {
+  // 1.15.0 -> 1.16.0 when create_daily_log gained nextSteps; the voice-first
+  // cost-plus tools asserted below are unaffected and must keep working.
+  test("CPCO10: MCP is v1.16.0 and exposes the required voice-first tools and UI copy", () => {
     const mcp = readFileSync(join(process.cwd(), "src/app/api/mcp/[transport]/route.ts"), "utf8");
-    expect(mcp).toContain('version: "1.15.0"');
+    expect(mcp).toContain('version: "1.16.0"');
     for (const tool of ["list_change_orders", "update_change_order", "log_time", "log_expense", "bill_change_order"]) {
       expect(mcp).toContain(`"${tool}"`);
     }

--- a/e2e/data.setup.ts
+++ b/e2e/data.setup.ts
@@ -287,7 +287,19 @@ setup("guard prod DB + seed test data + probe anthropic", async () => {
         });
         console.log("[data.setup] schedule task + assignment upserted:", { id: MOBILE_TASK_DRYW_ID, assignee: fieldCrew.id });
 
-        const dailyLogDate = daysAgo(1);
+        // DailyLog.date convention: every real writer stores UTC MIDNIGHT of the
+        // intended company-local (America/Los_Angeles) calendar day, never a raw
+        // timestamp — the suggestion engine reads the ISO date part as the day.
+        // A raw timestamp here sorts above date-only rows from the same day and
+        // flips "latest log" ordering depending on the wall clock (bit CI once).
+        const companyDayUtcMidnight = (offsetDays: number) => {
+            const parts = new Intl.DateTimeFormat("en-CA", {
+                timeZone: "America/Los_Angeles", year: "numeric", month: "2-digit", day: "2-digit",
+            }).formatToParts(new Date(Date.now() + offsetDays * 24 * 60 * 60 * 1000));
+            const get = (type: string) => parts.find(p => p.type === type)?.value ?? "";
+            return new Date(`${get("year")}-${get("month")}-${get("day")}T00:00:00.000Z`);
+        };
+        const dailyLogDate = companyDayUtcMidnight(-1);
         await prisma.dailyLog.upsert({
             where: { id: MOBILE_DAILYLOG_ID },
             update: { date: dailyLogDate },

--- a/e2e/data.setup.ts
+++ b/e2e/data.setup.ts
@@ -1,5 +1,6 @@
 import { test as setup } from "@playwright/test";
 import { PrismaClient } from "@prisma/client";
+import bcrypt from "bcryptjs";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
@@ -9,6 +10,22 @@ const TEST_CLIENT_ID = "test-client-do-not-delete";
 const ADMIN_EMAIL = "jadkins@goldentouchremodeling.com";
 const DEV_ADMIN_EMAIL = "gtrsupport@goldentouchremodeling.com";
 const SENTINEL_PATH = resolve(__dirname, ".anthropic-status");
+
+// Mobile-app + suggestion spec fixtures — stable hardcoded IDs (prefix e2e-mob-)
+// attached to the PROJECT_ID test project above.
+const FIELD_CREW_EMAIL = "field-crew@test.local";
+const FIELD_CREW_PIN = "246810";
+const MANAGER_EMAIL = "manager@test.local";
+const MANAGER_PIN = "135790";
+const COST_CODE_DEMO_ID = "e2e-mob-cc-demo";
+const COST_CODE_DRYW_ID = "e2e-mob-cc-dryw";
+const MOBILE_ESTIMATE_ID = "e2e-mob-estimate";
+const MOBILE_ITEM_DEMO_ID = "e2e-mob-item-demo";
+const MOBILE_ITEM_DRYW_ID = "e2e-mob-item-dryw";
+const MOBILE_TASK_DRYW_ID = "e2e-mob-task-dryw";
+const MOBILE_DAILYLOG_ID = "e2e-mob-dailylog";
+const MOBILE_DAILYLOG_PHOTO_ID = "e2e-mob-dailylog-photo";
+const MOBILE_TIME_ENTRY_HIST_ID = "e2e-mob-entry-hist";
 
 // Substrings that identify the LIVE database. The e2e suite creates leads,
 // estimates, and invoices — it must never do that against production data.
@@ -119,6 +136,199 @@ setup("guard prod DB + seed test data + probe anthropic", async () => {
             },
         });
         console.log("[data.setup] estimate upserted:", { id: estimate.id, title: estimate.title });
+
+        // --- Mobile-app + suggestion spec fixtures ---
+        // Field-crew + manager users, a PIN-loginable pair whose hash matches
+        // /api/mobile/login's bcrypt.compare(pinCode, user.pinCode) check.
+        const daysAgo = (n: number) => new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+        const daysFromNow = (n: number) => new Date(Date.now() + n * 24 * 60 * 60 * 1000);
+        const atHour = (date: Date, hour: number) => {
+            const d = new Date(date);
+            d.setHours(hour, 0, 0, 0);
+            return d;
+        };
+
+        const fieldCrewPinHash = await bcrypt.hash(FIELD_CREW_PIN, 10);
+        const fieldCrew = await prisma.user.upsert({
+            where: { email: FIELD_CREW_EMAIL },
+            update: {
+                role: "FIELD_CREW",
+                status: "ACTIVATED",
+                pinCode: fieldCrewPinHash,
+                hourlyRate: 50,
+                burdenRate: 10,
+            },
+            create: {
+                email: FIELD_CREW_EMAIL,
+                name: "E2E Field Crew",
+                role: "FIELD_CREW",
+                status: "ACTIVATED",
+                pinCode: fieldCrewPinHash,
+                hourlyRate: 50,
+                burdenRate: 10,
+            },
+        });
+        console.log("[data.setup] field-crew user upserted:", { id: fieldCrew.id, email: fieldCrew.email });
+
+        const managerPinHash = await bcrypt.hash(MANAGER_PIN, 10);
+        const manager = await prisma.user.upsert({
+            where: { email: MANAGER_EMAIL },
+            update: {
+                role: "MANAGER",
+                status: "ACTIVATED",
+                pinCode: managerPinHash,
+                hourlyRate: 60,
+            },
+            create: {
+                email: MANAGER_EMAIL,
+                name: "E2E Manager",
+                role: "MANAGER",
+                status: "ACTIVATED",
+                pinCode: managerPinHash,
+                hourlyRate: 60,
+            },
+        });
+        console.log("[data.setup] manager user upserted:", { id: manager.id, email: manager.email });
+
+        // Grant project access both ways userCanAccessProject checks (ProjectAccess row
+        // OR the crew relation) — seeding both keeps the fixture valid regardless of
+        // which path a given spec exercises.
+        await prisma.projectAccess.upsert({
+            where: { userId_projectId: { userId: fieldCrew.id, projectId: PROJECT_ID } },
+            update: {},
+            create: { userId: fieldCrew.id, projectId: PROJECT_ID },
+        });
+        await prisma.project.update({
+            where: { id: PROJECT_ID },
+            data: { crew: { connect: { id: fieldCrew.id } } },
+        });
+
+        const costCodeDemo = await prisma.costCode.upsert({
+            where: { id: COST_CODE_DEMO_ID },
+            update: {},
+            create: { id: COST_CODE_DEMO_ID, code: "01-DEMO", name: "Demolition" },
+        });
+        const costCodeDryw = await prisma.costCode.upsert({
+            where: { id: COST_CODE_DRYW_ID },
+            update: {},
+            create: { id: COST_CODE_DRYW_ID, code: "05-DRYW", name: "Drywall" },
+        });
+        console.log("[data.setup] cost codes upserted:", { demo: costCodeDemo.id, dryw: costCodeDryw.id });
+
+        const mobileEstimate = await prisma.estimate.upsert({
+            where: { id: MOBILE_ESTIMATE_ID },
+            update: { status: "Approved", archivedAt: null },
+            create: {
+                id: MOBILE_ESTIMATE_ID,
+                title: "E2E Mobile Estimate — DO NOT DELETE",
+                code: "EST-E2E-MOB",
+                status: "Approved",
+                projectId: PROJECT_ID,
+                totalAmount: 2000,
+                balanceDue: 2000,
+                archivedAt: null,
+            },
+        });
+        console.log("[data.setup] mobile estimate upserted:", { id: mobileEstimate.id, status: mobileEstimate.status });
+
+        await prisma.estimateItem.upsert({
+            where: { id: MOBILE_ITEM_DEMO_ID },
+            update: {},
+            create: {
+                id: MOBILE_ITEM_DEMO_ID,
+                estimateId: MOBILE_ESTIMATE_ID,
+                name: "Demolition phase",
+                parentId: null,
+                costCodeId: COST_CODE_DEMO_ID,
+                quantity: 1,
+                unitCost: 1000,
+                total: 1000,
+            },
+        });
+        await prisma.estimateItem.upsert({
+            where: { id: MOBILE_ITEM_DRYW_ID },
+            update: {},
+            create: {
+                id: MOBILE_ITEM_DRYW_ID,
+                estimateId: MOBILE_ESTIMATE_ID,
+                name: "Drywall phase",
+                parentId: null,
+                costCodeId: COST_CODE_DRYW_ID,
+                quantity: 1,
+                unitCost: 1000,
+                total: 1000,
+            },
+        });
+        console.log("[data.setup] mobile estimate items upserted:", { demo: MOBILE_ITEM_DEMO_ID, dryw: MOBILE_ITEM_DRYW_ID });
+
+        // Active "today" whenever the suite runs — recomputed on every run (including
+        // update) so a stale first-run window doesn't age out of the active range.
+        const scheduleStart = daysAgo(3);
+        const scheduleEnd = daysFromNow(4);
+        await prisma.scheduleTask.upsert({
+            where: { id: MOBILE_TASK_DRYW_ID },
+            update: { startDate: scheduleStart, endDate: scheduleEnd, status: "In Progress" },
+            create: {
+                id: MOBILE_TASK_DRYW_ID,
+                projectId: PROJECT_ID,
+                name: "Hang drywall in hall bath",
+                type: "task",
+                status: "In Progress",
+                startDate: scheduleStart,
+                endDate: scheduleEnd,
+                // @unique — must stay 1:1 with MOBILE_ITEM_DRYW_ID across re-runs.
+                estimateItemId: MOBILE_ITEM_DRYW_ID,
+            },
+        });
+        await prisma.taskAssignment.upsert({
+            where: { taskId_userId: { taskId: MOBILE_TASK_DRYW_ID, userId: fieldCrew.id } },
+            update: {},
+            create: { taskId: MOBILE_TASK_DRYW_ID, userId: fieldCrew.id },
+        });
+        console.log("[data.setup] schedule task + assignment upserted:", { id: MOBILE_TASK_DRYW_ID, assignee: fieldCrew.id });
+
+        const dailyLogDate = daysAgo(1);
+        await prisma.dailyLog.upsert({
+            where: { id: MOBILE_DAILYLOG_ID },
+            update: { date: dailyLogDate },
+            create: {
+                id: MOBILE_DAILYLOG_ID,
+                projectId: PROJECT_ID,
+                createdById: fieldCrew.id,
+                date: dailyLogDate,
+                workPerformed: "Demo complete in hall bath, hauled debris",
+                nextSteps: "Start hanging drywall in the hall bath",
+            },
+        });
+        await prisma.dailyLogPhoto.upsert({
+            where: { id: MOBILE_DAILYLOG_PHOTO_ID },
+            update: {},
+            create: {
+                id: MOBILE_DAILYLOG_PHOTO_ID,
+                dailyLogId: MOBILE_DAILYLOG_ID,
+                url: "https://example.test/e2e/drywall.jpg",
+                caption: "drywall stacked in hallway",
+            },
+        });
+        console.log("[data.setup] daily log + photo upserted:", { id: MOBILE_DAILYLOG_ID, photo: MOBILE_DAILYLOG_PHOTO_ID });
+
+        const histStart = atHour(daysAgo(1), 8);
+        const histEnd = atHour(daysAgo(1), 12);
+        await prisma.timeEntry.upsert({
+            where: { id: MOBILE_TIME_ENTRY_HIST_ID },
+            update: { startTime: histStart, endTime: histEnd },
+            create: {
+                id: MOBILE_TIME_ENTRY_HIST_ID,
+                userId: fieldCrew.id,
+                projectId: PROJECT_ID,
+                costCodeId: COST_CODE_DEMO_ID,
+                estimateItemId: MOBILE_ITEM_DEMO_ID,
+                startTime: histStart,
+                endTime: histEnd,
+                durationHours: 4,
+            },
+        });
+        console.log("[data.setup] historical time entry upserted:", { id: MOBILE_TIME_ENTRY_HIST_ID });
 
         const verify = await prisma.project.findUnique({ where: { id: PROJECT_ID }, select: { id: true, name: true } });
         console.log("[data.setup] verify project exists:", verify);

--- a/e2e/mobile-api.spec.ts
+++ b/e2e/mobile-api.spec.ts
@@ -1,0 +1,188 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import { PrismaClient } from "@prisma/client";
+
+// Contract tests for the mobile-app API surface — request-context only, no
+// browser. Covers login, /me, time-entries CRUD (auth + math), schedule/today,
+// and the time-suggestion endpoint's own validation (the ranking logic itself
+// is covered by time-suggestion.spec.ts).
+
+const BASE_URL = "http://localhost:3000";
+
+const PROJECT_ID = "cmml6vt3y000lpwrh0p9p3k12";
+const COST_CODE_DEMO_ID = "e2e-mob-cc-demo";
+const MOBILE_ITEM_DEMO_ID = "e2e-mob-item-demo";
+const MOBILE_TASK_DRYW_ID = "e2e-mob-task-dryw";
+const FIELD_CREW_EMAIL = "field-crew@test.local";
+const FIELD_CREW_PIN = "246810";
+const MANAGER_EMAIL = "manager@test.local";
+const MANAGER_PIN = "135790";
+
+const RUN = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+const MGR_ENTRY_ID = `e2e-tsug-mgrentry-${RUN}`;
+const MGR_OWNED_ENTRY_ID = `e2e-tsug-mgrowned-${RUN}`;
+
+const prisma = new PrismaClient();
+
+async function mobileLogin(request: APIRequestContext, email: string, pinCode: string): Promise<string> {
+    const res = await request.post("/api/mobile/login", { data: { email, pinCode } });
+    expect(res.ok(), `login failed: ${await res.text()}`).toBeTruthy();
+    return ((await res.json()) as { token: string }).token;
+}
+
+test.describe.serial("Mobile API contract", () => {
+    let api: APIRequestContext;
+    let fieldCrewToken: string;
+    let managerToken: string;
+    let fieldCrewId: string;
+    let managerId: string;
+    const createdEntryIds = new Set<string>();
+
+    test.beforeAll(async ({ playwright }) => {
+        api = await playwright.request.newContext({ baseURL: BASE_URL, storageState: { cookies: [], origins: [] } });
+        fieldCrewToken = await mobileLogin(api, FIELD_CREW_EMAIL, FIELD_CREW_PIN);
+        managerToken = await mobileLogin(api, MANAGER_EMAIL, MANAGER_PIN);
+        const [fieldCrew, manager] = await Promise.all([
+            prisma.user.findUniqueOrThrow({ where: { email: FIELD_CREW_EMAIL }, select: { id: true } }),
+            prisma.user.findUniqueOrThrow({ where: { email: MANAGER_EMAIL }, select: { id: true } }),
+        ]);
+        fieldCrewId = fieldCrew.id;
+        managerId = manager.id;
+    });
+
+    test.afterAll(async () => {
+        for (const id of createdEntryIds) {
+            await prisma.timeEntry.deleteMany({ where: { id } });
+        }
+        await prisma.timeEntry.deleteMany({ where: { id: MGR_ENTRY_ID } });
+        await prisma.timeEntry.deleteMany({ where: { id: MGR_OWNED_ENTRY_ID } });
+        await api.dispose();
+        await prisma.$disconnect();
+    });
+
+    test("POST /api/mobile/login — field crew happy path", async () => {
+        const res = await api.post("/api/mobile/login", { data: { email: FIELD_CREW_EMAIL, pinCode: FIELD_CREW_PIN } });
+        expect(res.ok(), await res.text()).toBeTruthy();
+        const body = await res.json();
+        expect(typeof body.token).toBe("string");
+        expect(body.token.length).toBeGreaterThan(0);
+        expect(body.user).toMatchObject({ email: FIELD_CREW_EMAIL, role: "FIELD_CREW" });
+        expect(body.user.id).toBeTruthy();
+    });
+
+    test("POST /api/mobile/login — manager happy path", async () => {
+        const res = await api.post("/api/mobile/login", { data: { email: MANAGER_EMAIL, pinCode: MANAGER_PIN } });
+        expect(res.ok(), await res.text()).toBeTruthy();
+        const body = await res.json();
+        expect(typeof body.token).toBe("string");
+        expect(body.user).toMatchObject({ email: MANAGER_EMAIL, role: "MANAGER" });
+    });
+
+    test("POST /api/mobile/login — wrong PIN -> 401", async () => {
+        const res = await api.post("/api/mobile/login", { data: { email: FIELD_CREW_EMAIL, pinCode: "000000" } });
+        expect(res.status()).toBe(401);
+    });
+
+    test("POST /api/mobile/login — unknown email -> 401", async () => {
+        const res = await api.post("/api/mobile/login", { data: { email: "nobody-e2e-tsug@test.local", pinCode: "123456" } });
+        expect(res.status()).toBe(401);
+    });
+
+    test("GET /api/mobile/me — field crew shape", async () => {
+        const res = await api.get("/api/mobile/me", { headers: { authorization: `Bearer ${fieldCrewToken}` } });
+        expect(res.ok(), await res.text()).toBeTruthy();
+        const body = await res.json();
+        expect(body.user).toMatchObject({ email: FIELD_CREW_EMAIL, role: "FIELD_CREW" });
+        expect(Array.isArray(body.assignedProjects)).toBe(true);
+        expect(body.assignedProjects.some((p: any) => p.id === PROJECT_ID)).toBe(true);
+        expect(body.permissions).toBeTruthy();
+    });
+
+    test("GET /api/mobile/me — no token -> 401", async () => {
+        const res = await api.get("/api/mobile/me");
+        expect(res.status()).toBe(401);
+    });
+
+    test("GET /api/mobile/me — garbage token -> 401", async () => {
+        const res = await api.get("/api/mobile/me", { headers: { authorization: "Bearer not-a-real-token" } });
+        expect(res.status()).toBe(401);
+    });
+
+    test("GET /api/time-entries — field crew sees only their own entries", async () => {
+        await prisma.timeEntry.create({
+            data: { id: MGR_ENTRY_ID, userId: managerId, projectId: PROJECT_ID, startTime: new Date() },
+        });
+
+        const res = await api.get(`/api/time-entries?projectId=${PROJECT_ID}`, {
+            headers: { authorization: `Bearer ${fieldCrewToken}` },
+        });
+        expect(res.ok(), await res.text()).toBeTruthy();
+        const entries = await res.json();
+        expect(entries.some((e: any) => e.id === MGR_ENTRY_ID)).toBe(false);
+    });
+
+    test("GET /api/time-entries — manager sees everyone's entries", async () => {
+        const res = await api.get(`/api/time-entries?projectId=${PROJECT_ID}`, {
+            headers: { authorization: `Bearer ${managerToken}` },
+        });
+        expect(res.ok(), await res.text()).toBeTruthy();
+        const entries = await res.json();
+        expect(entries.some((e: any) => e.id === MGR_ENTRY_ID)).toBe(true);
+
+        await prisma.timeEntry.delete({ where: { id: MGR_ENTRY_ID } });
+    });
+
+    test("POST then PUT — duration/laborCost/burdenCost math", async () => {
+        const start = new Date();
+        const postRes = await api.post("/api/time-entries", {
+            data: { projectId: PROJECT_ID, estimateItemId: MOBILE_ITEM_DEMO_ID, startTime: start.toISOString() },
+            headers: { authorization: `Bearer ${fieldCrewToken}` },
+        });
+        expect(postRes.ok(), await postRes.text()).toBeTruthy();
+        const created = await postRes.json();
+        createdEntryIds.add(created.id);
+
+        const end = new Date(start.getTime() + 2 * 60 * 60 * 1000);
+        const putRes = await api.put("/api/time-entries", {
+            data: { id: created.id, endTime: end.toISOString() },
+            headers: { authorization: `Bearer ${fieldCrewToken}` },
+        });
+        expect(putRes.ok(), await putRes.text()).toBeTruthy();
+        const updated = await putRes.json();
+
+        // laborCost/burdenCost are Prisma Decimal — JSON-serialized as strings.
+        expect(Number(updated.durationHours)).toBeCloseTo(2, 1);
+        expect(Number(updated.laborCost)).toBeCloseTo(100, 1); // field-crew hourlyRate 50 * 2h
+        expect(Number(updated.burdenCost)).toBeCloseTo(20, 1); // field-crew burdenRate 10 * 2h
+
+        await prisma.timeEntry.delete({ where: { id: created.id } });
+        createdEntryIds.delete(created.id);
+    });
+
+    test("PUT — FIELD_CREW cannot edit another user's entry -> 403", async () => {
+        await prisma.timeEntry.create({
+            data: { id: MGR_OWNED_ENTRY_ID, userId: managerId, projectId: PROJECT_ID, startTime: new Date() },
+        });
+
+        const res = await api.put("/api/time-entries", {
+            data: { id: MGR_OWNED_ENTRY_ID, endTime: new Date().toISOString() },
+            headers: { authorization: `Bearer ${fieldCrewToken}` },
+        });
+        expect(res.status()).toBe(403);
+
+        await prisma.timeEntry.delete({ where: { id: MGR_OWNED_ENTRY_ID } });
+    });
+
+    test("GET /api/mobile/schedule/today — field crew sees the drywall task with its cost code", async () => {
+        const res = await api.get("/api/mobile/schedule/today", { headers: { authorization: `Bearer ${fieldCrewToken}` } });
+        expect(res.ok(), await res.text()).toBeTruthy();
+        const body = await res.json();
+        const task = body.tasks.find((t: any) => t.id === MOBILE_TASK_DRYW_ID);
+        expect(task).toBeTruthy();
+        expect(task.costCode).toMatchObject({ code: "05-DRYW" });
+    });
+
+    test("GET /api/mobile/time-suggestion — missing projectId -> 400", async () => {
+        const res = await api.get("/api/mobile/time-suggestion", { headers: { authorization: `Bearer ${fieldCrewToken}` } });
+        expect(res.status()).toBe(400);
+    });
+});

--- a/e2e/mobile-app/auth.spec.ts
+++ b/e2e/mobile-app/auth.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+import { FIELD_CREW_EMAIL, FIELD_CREW_PIN, TOKEN_STORAGE_KEY, loginWithPin } from "./helpers";
+
+// Auth flow for the Expo-web build: PIN sign-in (components/Auth.tsx's "Use PIN instead"
+// form), token persistence across reload, and the 401 -> logout bounce that
+// setUnauthorizedHandler (lib/auth-store.ts) + app/_layout.tsx's routing effect wire up.
+
+test.describe.serial("Mobile auth", () => {
+    test("PIN happy path lands on the time-clock tab", async ({ page }) => {
+        await loginWithPin(page, FIELD_CREW_EMAIL, FIELD_CREW_PIN);
+        await expect(page.getByText("TIME CLOCK", { exact: true })).toBeVisible();
+    });
+
+    test("wrong PIN shows an error and stays on the login form", async ({ page }) => {
+        await page.goto("/");
+        await page.evaluate(() => window.localStorage.clear());
+        await page.goto("/");
+
+        await page.getByText("Use PIN instead").click();
+        await page.getByPlaceholder("you@company.com").fill(FIELD_CREW_EMAIL);
+        await page.getByPlaceholder("••••").fill("000000");
+        await page.getByText("Sign in with PIN", { exact: true }).click();
+
+        // Auth.tsx's onPinPress -> showDialog("Sign-in failed", "Invalid email or PIN.")
+        // on a 401 from /api/mobile/login.
+        await expect(page.getByText("Sign-in failed")).toBeVisible({ timeout: 15000 });
+        await expect(page.getByText("Invalid email or PIN.")).toBeVisible();
+        await page.getByText("OK", { exact: true }).click();
+
+        // Still on the login form, not routed to the tabs.
+        await expect(page.getByText("Sign in with PIN", { exact: true })).toBeVisible();
+        await expect(page.getByText("TIME CLOCK", { exact: true })).toHaveCount(0);
+    });
+
+    test("token persists across a page reload", async ({ page }) => {
+        await loginWithPin(page, FIELD_CREW_EMAIL, FIELD_CREW_PIN);
+        await page.reload();
+        // bootstrap() re-validates the stored token via /api/mobile/me and lands back on
+        // the same tab without requiring a fresh sign-in.
+        await expect(page.getByText("TIME CLOCK", { exact: true })).toBeVisible({ timeout: 20000 });
+    });
+
+    test("a corrupted token is rejected on the next API call and bounces to login", async ({ page }) => {
+        await loginWithPin(page, FIELD_CREW_EMAIL, FIELD_CREW_PIN);
+        await page.evaluate(
+            (key) => window.localStorage.setItem(key, "not-a-valid-jwt"),
+            TOKEN_STORAGE_KEY
+        );
+        // Reload triggers bootstrap() -> api.me() -> 401 (jwtVerify throws on a malformed
+        // token) -> user cleared -> login screen.
+        await page.reload();
+        await expect(page.getByText("Sign in with Google")).toBeVisible({ timeout: 20000 });
+        await expect(page.getByText("TIME CLOCK", { exact: true })).toHaveCount(0);
+    });
+});

--- a/e2e/mobile-app/expenses.spec.ts
+++ b/e2e/mobile-app/expenses.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+import { PrismaClient } from "@prisma/client";
+import { FIELD_CREW_EMAIL, FIELD_CREW_PIN, PROJECT_NAME, loginWithPin } from "./helpers";
+
+// (tabs)/expenses.tsx — a create-only form (no expense list on this screen; see the
+// report note in the spec inventory). Photo attach goes through expo-image-picker's web
+// shim (ExponentImagePicker.web.js), which appends a real, hidden <input type="file"
+// data-testid="file-input"> to <body> and dispatches a synthetic click on it to open the
+// native file chooser. Setting files directly on that located input (bypassing the native
+// chooser) was tried first and reliably timed out — Playwright never saw the element
+// resolve, most likely because the synthetic (non-trusted) click doesn't open a chooser
+// Playwright can special-case, and the element is torn down before a plain locator finds
+// it. `page.waitForEvent("filechooser")` is Playwright's documented, CDP-level mechanism for
+// exactly this shape (any input[type=file] activation, real or scripted) and is what
+// resolved it reliably. The receipt upload itself is a direct browser PUT to a Supabase
+// "signed" URL; under E2E_STORAGE_MOCK=1 the server hands back a URL pointing at a
+// non-serving mock host (see supabase-storage-mock.ts's own doc comment: this case — the
+// browser fetching/PUTing a storage URL directly — is explicitly NOT covered by that mock),
+// so the PUT itself is intercepted here via page.route.
+
+const prisma = new PrismaClient();
+
+// 1x1 white pixel JPEG — enough for the browser's <img> decode step in the web image
+// picker's metadata read (ExponentImagePicker.web.js's getImageMetadata).
+const TINY_JPEG_BASE64 =
+    "/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/2wBDAQMDAwQDBAgEBAgQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAn/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k=";
+
+test.describe.serial("Expenses", () => {
+    const createdExpenseIds: string[] = [];
+
+    test.afterAll(async () => {
+        if (createdExpenseIds.length > 0) {
+            await prisma.expense.deleteMany({ where: { id: { in: createdExpenseIds } } });
+        }
+        await prisma.$disconnect();
+    });
+
+    test("fill vendor/amount, attach a receipt, and save", async ({ page }) => {
+        await loginWithPin(page, FIELD_CREW_EMAIL, FIELD_CREW_PIN);
+        await page.getByText("Expenses", { exact: true }).click();
+        await expect(page.getByText("Photo a receipt or check")).toBeVisible({ timeout: 15000 });
+
+        // Only one active project is assigned to this fixture user, so it's the default
+        // selection already — assert it rather than driving the picker for a single option.
+        await expect(page.getByText(PROJECT_NAME, { exact: true })).toBeVisible();
+
+        // Mock the direct-to-storage PUT (see file header comment).
+        await page.route("**/storage/v1/object/upload/sign/**", async (route) => {
+            const corsHeaders = {
+                "access-control-allow-origin": "*",
+                "access-control-allow-methods": "PUT, OPTIONS",
+                "access-control-allow-headers": "*",
+            };
+            if (route.request().method() === "OPTIONS") {
+                await route.fulfill({ status: 204, headers: corsHeaders });
+            } else {
+                await route.fulfill({
+                    status: 200,
+                    headers: { ...corsHeaders, "content-type": "application/json" },
+                    body: "{}",
+                });
+            }
+        });
+
+        const vendor = `E2E Vendor ${Date.now()}`;
+        await page.getByPlaceholder("Home Depot, Hoppe, etc.").fill(vendor);
+        await page.getByPlaceholder("0.00").fill("42.50");
+
+        const [fileChooser] = await Promise.all([
+            page.waitForEvent("filechooser"),
+            page.getByText("🖼️ Gallery").click(),
+        ]);
+        await fileChooser.setFiles({
+            name: "receipt.jpg",
+            mimeType: "image/jpeg",
+            buffer: Buffer.from(TINY_JPEG_BASE64, "base64"),
+        });
+        await expect(page.getByText("X Remove")).toBeVisible({ timeout: 10000 });
+
+        await page.getByText("Save Expense", { exact: true }).click();
+        await expect(page.getByText("Saved")).toBeVisible({ timeout: 15000 });
+        await page.getByText("OK", { exact: true }).click();
+
+        const expense = await prisma.expense.findFirst({
+            where: { vendor },
+            orderBy: { createdAt: "desc" },
+        });
+        expect(expense).not.toBeNull();
+        createdExpenseIds.push(expense!.id);
+        expect(Number(expense!.amount)).toBeCloseTo(42.5, 2);
+        expect(expense!.receiptUrl).toBeTruthy();
+    });
+});

--- a/e2e/mobile-app/helpers.ts
+++ b/e2e/mobile-app/helpers.ts
@@ -1,0 +1,59 @@
+import { expect, type Page } from "@playwright/test";
+
+// Fixture ids seeded by e2e/data.setup.ts — see its "Mobile-app + suggestion spec
+// fixtures" section. Kept in one place so every mobile-app spec references the same
+// constants instead of re-typing them.
+export const PROJECT_ID = "cmml6vt3y000lpwrh0p9p3k12";
+export const PROJECT_NAME = "Test Project — DO NOT DELETE (used by e2e)";
+
+export const COST_CODE_DEMO_ID = "e2e-mob-cc-demo";
+export const COST_CODE_DRYW_ID = "e2e-mob-cc-dryw";
+
+export const MOBILE_ESTIMATE_ID = "e2e-mob-estimate";
+export const MOBILE_ITEM_DEMO_ID = "e2e-mob-item-demo";
+export const MOBILE_ITEM_DRYW_ID = "e2e-mob-item-dryw";
+export const MOBILE_TASK_DRYW_ID = "e2e-mob-task-dryw";
+export const MOBILE_DAILYLOG_ID = "e2e-mob-dailylog";
+export const MOBILE_TIME_ENTRY_HIST_ID = "e2e-mob-entry-hist";
+
+export const FIELD_CREW_EMAIL = "field-crew@test.local";
+export const FIELD_CREW_PIN = "246810";
+export const MANAGER_EMAIL = "manager@test.local";
+export const MANAGER_PIN = "135790";
+
+// Key secureToken.ts uses to persist the bearer JWT in localStorage on web.
+export const TOKEN_STORAGE_KEY = "probuild.mobileJwt";
+
+/** Short unique-enough suffix for spec-created rows (id/name collisions across runs). */
+export function runId(): string {
+    return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+}
+
+async function clearLocalStorage(page: Page) {
+    await page.evaluate(() => window.localStorage.clear());
+}
+
+/**
+ * Drives the real PIN sign-in form (Auth.tsx's "Use PIN instead" toggle) from a clean
+ * (logged-out) localStorage, and waits for the Time Clock tab to land. Every mobile-app
+ * spec should start from this instead of assuming session state left by another test.
+ */
+export async function loginWithPin(page: Page, email: string, pin: string): Promise<void> {
+    // A page must exist at the app's origin before localStorage is reachable — first load,
+    // then clear, then reload so the login form starts from a genuinely logged-out state.
+    await page.goto("/");
+    await clearLocalStorage(page);
+    await page.goto("/");
+
+    await page.getByText("Use PIN instead").click();
+    await page.getByPlaceholder("you@company.com").fill(email);
+    await page.getByPlaceholder("••••").fill(pin);
+    await page.getByText("Sign in with PIN", { exact: true }).click();
+
+    // BrandHeader's uppercase subtitle on the Time Clock tab — unique to that screen and
+    // stable regardless of clocked-in/break/off-clock badge state. Playwright's default
+    // getByText match is case-INsensitive substring, so without `exact: true` this also
+    // matches the card title "Time Clock" and the tab label "Time Clock" (strict-mode
+    // violation — 3 elements).
+    await expect(page.getByText("TIME CLOCK", { exact: true })).toBeVisible({ timeout: 20000 });
+}

--- a/e2e/mobile-app/history.spec.ts
+++ b/e2e/mobile-app/history.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "@playwright/test";
+import { PrismaClient } from "@prisma/client";
+import {
+    FIELD_CREW_EMAIL,
+    FIELD_CREW_PIN,
+    MANAGER_EMAIL,
+    MANAGER_PIN,
+    PROJECT_ID,
+    PROJECT_NAME,
+    loginWithPin,
+    runId,
+} from "./helpers";
+
+// (tabs)/history.tsx. Reality differs from a naive "crew can't edit" reading: tapping any
+// entry (crew's own or, for a manager, one they can see) opens the same edit modal for
+// EITHER role — PATCH /api/time-entries/[id] allows the owner OR a manager/admin
+// (src/app/api/time-entries/[id]/route.ts: `if (!isOwner && !isPrivileged) return 403`).
+// The only role-gated affordance inside that modal is "Delete entry" (client-checked via
+// isManager(), and DELETE is server-gated the same way). The screen is also always scoped
+// to the CALLER's own entries client-side (`all.filter(e => e.userId === user.id)` in
+// fetchHistory) regardless of role — a manager does NOT see crew's entries here, unlike the
+// separate Manager Dashboard. So the manager case below seeds its OWN time entry rather
+// than reusing the field-crew fixture entry.
+
+const prisma = new PrismaClient();
+
+test.describe.serial("Time history", () => {
+    const id = runId();
+    const managerEntryId = `e2e-mweb-hist-${id}`;
+
+    test.afterAll(async () => {
+        await prisma.timeEntry.deleteMany({ where: { id: managerEntryId } });
+        await prisma.$disconnect();
+    });
+
+    test("field crew can open the seeded entry but has no delete affordance", async ({ page }) => {
+        await loginWithPin(page, FIELD_CREW_EMAIL, FIELD_CREW_PIN);
+        await page.getByText("History", { exact: true }).click();
+
+        await expect(page.getByText(PROJECT_NAME, { exact: true }).first()).toBeVisible({
+            timeout: 15000,
+        });
+        await page.getByText(PROJECT_NAME, { exact: true }).first().click();
+
+        await expect(page.getByText("Edit time entry")).toBeVisible({ timeout: 10000 });
+        await expect(page.getByText("Delete entry")).toHaveCount(0);
+        await page.getByText("Cancel", { exact: true }).click();
+    });
+
+    test("manager sees the delete affordance on their own entry", async ({ page }) => {
+        const manager = await prisma.user.findUniqueOrThrow({
+            where: { email: MANAGER_EMAIL },
+            select: { id: true },
+        });
+        const start = new Date();
+        const end = new Date(start.getTime() + 60 * 60 * 1000);
+        await prisma.timeEntry.create({
+            data: {
+                id: managerEntryId,
+                userId: manager.id,
+                projectId: PROJECT_ID,
+                startTime: start,
+                endTime: end,
+                durationHours: 1,
+            },
+        });
+
+        await loginWithPin(page, MANAGER_EMAIL, MANAGER_PIN);
+        await page.getByText("History", { exact: true }).click();
+
+        await expect(page.getByText(PROJECT_NAME, { exact: true }).first()).toBeVisible({
+            timeout: 15000,
+        });
+        await page.getByText(PROJECT_NAME, { exact: true }).first().click();
+
+        await expect(page.getByText("Edit time entry")).toBeVisible({ timeout: 10000 });
+        await expect(page.getByText("Delete entry")).toBeVisible();
+        await page.getByText("Cancel", { exact: true }).click();
+    });
+});

--- a/e2e/mobile-app/leads.spec.ts
+++ b/e2e/mobile-app/leads.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from "@playwright/test";
+import { PrismaClient } from "@prisma/client";
+import { MANAGER_EMAIL, MANAGER_PIN, loginWithPin, runId } from "./helpers";
+
+// app/leads/*.tsx — ADMIN/MANAGER only (canWorkLeads() in
+// src/app/api/mobile/leads/route.ts). Lead creation is hermetically safe to exercise for
+// real: the Drive-folder step is best-effort and gated behind isDriveConnected(), which
+// resolves false (no network call) when no Google refresh token is configured — exactly the
+// case in this throwaway DB, so POST /api/mobile/leads succeeds without ever touching
+// Google. No `location` is filled in below to also skip the geocode call
+// (geocodeJobSiteAddress short-circuits on an empty address anyway, but this keeps the
+// request path obviously side-effect-free).
+
+const prisma = new PrismaClient();
+
+test.describe.serial("Leads", () => {
+    const id = runId();
+    const clientName = `E2E Mobile Web ${id}`;
+    let createdLeadId: string | null = null;
+    let createdClientId: string | null = null;
+
+    test.afterAll(async () => {
+        // Lead first — LeadNote cascades off it, and Client can't be deleted while a Lead
+        // still references it (Lead.clientId has no onDelete: Cascade on that side).
+        if (createdLeadId) {
+            await prisma.lead.deleteMany({ where: { id: createdLeadId } });
+        }
+        if (createdClientId) {
+            await prisma.client.deleteMany({ where: { id: createdClientId } });
+        }
+        await prisma.$disconnect();
+    });
+
+    test("manager creates a lead, sees it in the list, and adds a note", async ({ page }) => {
+        await loginWithPin(page, MANAGER_EMAIL, MANAGER_PIN);
+        await page.getByText("Manager", { exact: true }).click();
+        await page.getByText("Leads", { exact: true }).click();
+
+        // exact: true — the empty-leads-list hint paragraph literally contains the
+        // substring "New lead" ('Tap "New lead" when you meet a prospect...'), and this is
+        // the very first lead created, so the list starts empty.
+        await expect(page.getByText("New lead", { exact: true })).toBeVisible({ timeout: 15000 });
+        await page.getByText("New lead", { exact: true }).click();
+
+        await expect(page.getByPlaceholder("Jane Homeowner")).toBeVisible({ timeout: 10000 });
+        await page.getByPlaceholder("Jane Homeowner").fill(clientName);
+        await page.getByText("Create lead", { exact: true }).click();
+
+        // Lands on the lead detail page (router.replace) — the client card shows the
+        // exact name typed above (leadName gets a " - <projectType>" suffix server-side
+        // when a project type is picked; none was picked here, so lead.name === clientName).
+        await expect(page.getByText(clientName, { exact: true })).toBeVisible({ timeout: 15000 });
+
+        const lead = await prisma.lead.findFirst({ where: { name: clientName } });
+        expect(lead).not.toBeNull();
+        createdLeadId = lead!.id;
+        createdClientId = lead!.clientId;
+
+        const noteText = `E2E note ${id}`;
+        const noteInput = page.getByPlaceholder("Add a note...");
+        await noteInput.fill(noteText);
+        // No accessible name/testID on the send button (an icon-only TouchableOpacity) —
+        // it's the composer row's only other child, immediately after the note input.
+        await noteInput.locator("xpath=following-sibling::*[1]").click();
+        // The composer is a <textarea>, and Playwright's getByText also matches an
+        // input/textarea's current value — so a bare getByText(noteText) is already
+        // satisfied by the freshly-typed composer text, before addNote() even resolves
+        // (false positive: it'd pass even if the send silently failed). addNote() only
+        // clears the composer (setNoteText("")) after its POST succeeds, so wait for that
+        // first — from then on the only element left matching noteText is the real note
+        // row rendered from the reloaded lead.
+        await expect(noteInput).toHaveValue("");
+        await expect(page.getByText(noteText)).toBeVisible({ timeout: 15000 });
+
+        const note = await prisma.leadNote.findFirst({ where: { leadId: lead!.id, content: noteText } });
+        expect(note).not.toBeNull();
+
+        // "New lead" was pushed then replaced by the detail screen, so back lands on the
+        // Leads list (not the form) without a full page reload.
+        await page.goBack();
+        // The list row renders lead.name and lead.client.name as separate Text nodes — with
+        // no projectType picked, lead.name === clientName too, so both nodes hold the exact
+        // same string. .first() picks either; we only need to confirm the row exists.
+        await expect(page.getByText(clientName, { exact: true }).first()).toBeVisible({
+            timeout: 15000,
+        });
+    });
+});

--- a/e2e/mobile-app/manager-dashboard.spec.ts
+++ b/e2e/mobile-app/manager-dashboard.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from "@playwright/test";
+import { PrismaClient } from "@prisma/client";
+import { MANAGER_EMAIL, MANAGER_PIN, PROJECT_ID, PROJECT_NAME, loginWithPin, runId } from "./helpers";
+
+// components/ManagerDashboard.tsx's "Field compliance" section, computed by
+// /api/manager/dashboard (src/app/api/manager/dashboard/route.ts, ~line 279 on): a project
+// is "eligible" for the day only once it has a TimeEntry whose startTime falls in that day's
+// window; then noDailyLog = no DailyLog dated that day, noPhotos = a same-day DailyLog
+// exists but has zero DailyLogPhoto rows (noPhotos never fires alongside noDailyLog). The
+// seeded fixtures' daily log + entry are both dated "yesterday" (data.setup.ts), so today
+// starts with neither flag showing until this spec stages today's rows itself.
+
+const prisma = new PrismaClient();
+
+test.describe.serial("Manager dashboard — field compliance", () => {
+    const id = runId();
+    const entryId = `e2e-mweb-compliance-entry-${id}`;
+    const dailyLogId = `e2e-mweb-compliance-log-${id}`;
+
+    test.beforeAll(async () => {
+        const manager = await prisma.user.findUniqueOrThrow({
+            where: { email: MANAGER_EMAIL },
+            select: { id: true },
+        });
+        const now = new Date();
+        // Makes the project "eligible" for today's compliance computation — no other
+        // fields (costCodeId/estimateItemId) matter for this flag.
+        await prisma.timeEntry.create({
+            data: {
+                id: entryId,
+                userId: manager.id,
+                projectId: PROJECT_ID,
+                startTime: now,
+                endTime: new Date(now.getTime() + 60 * 60 * 1000),
+                durationHours: 1,
+            },
+        });
+    });
+
+    test.afterAll(async () => {
+        await prisma.dailyLog.deleteMany({ where: { id: dailyLogId } }); // cascades any photos
+        await prisma.timeEntry.deleteMany({ where: { id: entryId } });
+        await prisma.$disconnect();
+    });
+
+    test("flags no daily log today, then flips to no photos once one is logged", async ({ page }) => {
+        await loginWithPin(page, MANAGER_EMAIL, MANAGER_PIN);
+        await page.getByText("Manager", { exact: true }).click();
+        await expect(page.getByText("MANAGER DASHBOARD", { exact: true })).toBeVisible({ timeout: 15000 });
+
+        await expect(page.getByText("Field compliance")).toBeVisible({ timeout: 20000 });
+        // .first() — the project's own name also renders again in the "Active jobs" card
+        // further down (this fixture's staged TimeEntry makes it active today too); the
+        // compliance card renders first in the JSX, so .first() is the compliance row.
+        await expect(page.getByText(PROJECT_NAME, { exact: true }).first()).toBeVisible();
+        await expect(page.getByText("⚠ No daily log today")).toBeVisible();
+        await expect(page.getByText("⚠ Daily log has no photos")).toHaveCount(0);
+
+        const manager = await prisma.user.findUniqueOrThrow({
+            where: { email: MANAGER_EMAIL },
+            select: { id: true },
+        });
+        await prisma.dailyLog.create({
+            data: {
+                id: dailyLogId,
+                projectId: PROJECT_ID,
+                createdById: manager.id,
+                date: new Date(),
+                workPerformed: "E2E compliance check",
+                nextSteps: "n/a",
+            },
+        });
+
+        // Force a fresh fetch — the dashboard's own 30s poll would eventually pick this up,
+        // but a reload + re-navigate is deterministic for a test.
+        await page.reload();
+        await page.getByText("Manager", { exact: true }).click();
+        await expect(page.getByText("Field compliance")).toBeVisible({ timeout: 20000 });
+
+        await expect(page.getByText("⚠ Daily log has no photos")).toBeVisible({ timeout: 15000 });
+        await expect(page.getByText("⚠ No daily log today")).toHaveCount(0);
+    });
+});

--- a/e2e/mobile-app/role-gating.spec.ts
+++ b/e2e/mobile-app/role-gating.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+import { FIELD_CREW_EMAIL, FIELD_CREW_PIN, MANAGER_EMAIL, MANAGER_PIN, loginWithPin } from "./helpers";
+
+// (tabs)/_layout.tsx hides the Manager and Employees tabs entirely (href: null, not just
+// disabled) for anyone isManager(role) doesn't cover — FIELD_CREW here. MANAGER/ADMIN see
+// (and can open) both.
+
+test.describe.serial("Mobile role gating", () => {
+    test("field crew sees no Manager or Employees tabs", async ({ page }) => {
+        await loginWithPin(page, FIELD_CREW_EMAIL, FIELD_CREW_PIN);
+        await expect(page.getByText("Manager", { exact: true })).toHaveCount(0);
+        await expect(page.getByText("Employees", { exact: true })).toHaveCount(0);
+    });
+
+    test("manager sees both tabs and can open them", async ({ page }) => {
+        await loginWithPin(page, MANAGER_EMAIL, MANAGER_PIN);
+        await expect(page.getByText("Manager", { exact: true })).toBeVisible();
+        await expect(page.getByText("Employees", { exact: true })).toBeVisible();
+
+        // exact: true — the tab bar's own "Employees"/"Manager" labels stay on screen
+        // alongside each header's uppercase subtitle, and getByText's default match is
+        // case-insensitive substring (proven by an earlier "TIME CLOCK" vs "Time Clock"
+        // strict-mode collision here).
+        await page.getByText("Employees", { exact: true }).click();
+        await expect(page.getByText("EMPLOYEES", { exact: true })).toBeVisible({ timeout: 15000 });
+
+        await page.getByText("Manager", { exact: true }).click();
+        await expect(page.getByText("MANAGER DASHBOARD", { exact: true })).toBeVisible({ timeout: 15000 });
+    });
+});

--- a/e2e/mobile-app/run-mobile-e2e.mjs
+++ b/e2e/mobile-app/run-mobile-e2e.mjs
@@ -1,0 +1,37 @@
+// Launch-gate runner: build the mobile app's Expo web export, then run the
+// mobile-app Playwright suite against it. See playwright.config.mobile.ts.
+//
+//   set MOBILE_APP_DIR=C:\...\gtr-probuild-mobile   (required)
+//   npm run test:mobile-e2e
+//
+//   SKIP_MOBILE_BUILD=1  reuse an existing apps/mobile/dist export
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const mobileDir = process.env.MOBILE_APP_DIR;
+if (!mobileDir || !existsSync(mobileDir)) {
+    console.error("Set MOBILE_APP_DIR to the gtr-probuild-mobile checkout path.");
+    process.exit(1);
+}
+const appDir = path.join(mobileDir, "apps", "mobile");
+
+if (process.env.SKIP_MOBILE_BUILD !== "1") {
+    console.log(`Building Expo web export in ${appDir} ...`);
+    const build = spawnSync("npx", ["expo", "export", "--platform", "web"], {
+        cwd: appDir,
+        stdio: "inherit",
+        shell: true,
+    });
+    if (build.status !== 0) process.exit(build.status ?? 1);
+} else if (!existsSync(path.join(appDir, "dist", "index.html"))) {
+    console.error("SKIP_MOBILE_BUILD=1 but no dist/index.html export exists.");
+    process.exit(1);
+}
+
+const test = spawnSync("npx", ["playwright", "test", "-c", "playwright.config.mobile.ts"], {
+    stdio: "inherit",
+    shell: true,
+    env: process.env,
+});
+process.exit(test.status ?? 1);

--- a/e2e/mobile-app/schedule-tasks.spec.ts
+++ b/e2e/mobile-app/schedule-tasks.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from "@playwright/test";
+import { PrismaClient } from "@prisma/client";
+import {
+    FIELD_CREW_EMAIL,
+    FIELD_CREW_PIN,
+    MOBILE_TASK_DRYW_ID,
+    PROJECT_NAME,
+    loginWithPin,
+} from "./helpers";
+
+// (tabs)/schedule.tsx ("Today" tab) + task/[id].tsx comment composer.
+
+const prisma = new PrismaClient();
+
+test.describe.serial("Schedule + task detail", () => {
+    const createdCommentIds: string[] = [];
+
+    test.afterAll(async () => {
+        if (createdCommentIds.length > 0) {
+            await prisma.taskComment.deleteMany({ where: { id: { in: createdCommentIds } } });
+        }
+        await prisma.$disconnect();
+    });
+
+    test("today's schedule lists the seeded drywall task under its project", async ({ page }) => {
+        await loginWithPin(page, FIELD_CREW_EMAIL, FIELD_CREW_PIN);
+        await page.getByText("Today", { exact: true }).click();
+
+        await expect(page.getByText("Hang drywall in hall bath")).toBeVisible({ timeout: 15000 });
+        // exact: true — the field-crew fixture has a closed historical entry, so the Time
+        // Clock tab (visited first by loginWithPin) renders a "Resume Last Task" button whose
+        // detail line is "<project> — <phase> · <when>". React Navigation's bottom-tabs keeps
+        // that screen mounted (just hidden) after switching tabs, so a non-exact match on the
+        // bare project name also matches that leftover combined string (2 elements).
+        await expect(page.getByText(PROJECT_NAME, { exact: true })).toBeVisible();
+    });
+
+    test("opening the task and adding a comment renders it in the thread", async ({ page }) => {
+        await loginWithPin(page, FIELD_CREW_EMAIL, FIELD_CREW_PIN);
+        await page.getByText("Today", { exact: true }).click();
+        await expect(page.getByText("Hang drywall in hall bath")).toBeVisible({ timeout: 15000 });
+        await page.getByText("Hang drywall in hall bath").click();
+
+        const composer = page.getByPlaceholder("What's happening on site?");
+        await expect(composer).toBeVisible({ timeout: 15000 });
+
+        const commentText = `E2E schedule comment ${Date.now()}`;
+        await composer.fill(commentText);
+        await page.getByText("Send", { exact: true }).click();
+
+        // The composer is a <textarea>, and Playwright's getByText also matches an
+        // input/textarea's current value — so a bare getByText(commentText) is already
+        // satisfied by the freshly-typed composer text, before submit() even resolves
+        // (false positive: it'd pass even if the send silently failed). submit() only
+        // clears the composer (setText("")) after its POST succeeds, so wait for that
+        // first — from then on the only element left matching commentText is the real
+        // comment row rendered from the server response.
+        await expect(composer).toHaveValue("");
+        await expect(page.getByText(commentText)).toBeVisible({ timeout: 15000 });
+
+        const comment = await prisma.taskComment.findFirst({
+            where: { taskId: MOBILE_TASK_DRYW_ID, text: commentText },
+            orderBy: { createdAt: "desc" },
+        });
+        expect(comment).not.toBeNull();
+        createdCommentIds.push(comment!.id);
+    });
+});

--- a/e2e/mobile-app/serve-mobile-web.mjs
+++ b/e2e/mobile-app/serve-mobile-web.mjs
@@ -1,0 +1,98 @@
+// Static server + API proxy for the Expo web build of the ProBuild mobile app.
+//
+// Mirrors production's shape: on the web the mobile app calls
+// window.location.origin for every API request (a Vercel rewrite proxies /api
+// in prod), so tests serve the static export and proxy /api/* to the Next dev
+// server on :3000 — same-origin, no CORS, no change to the app's api client.
+//
+// Usage (playwright.config.mobile.ts webServer):
+//   node e2e/mobile-app/serve-mobile-web.mjs
+// Env:
+//   MOBILE_APP_DIR   path to the gtr-probuild-mobile checkout (required)
+//   MOBILE_WEB_PORT  listen port (default 19006)
+//   API_TARGET       backend origin (default http://localhost:3000)
+//
+// The Expo export must exist first (npm run test:mobile-e2e builds it):
+//   cd <MOBILE_APP_DIR>/apps/mobile && npx expo export --platform web
+import { createServer, request as httpRequest } from "node:http";
+import { existsSync, statSync, createReadStream } from "node:fs";
+import path from "node:path";
+
+const mobileDir = process.env.MOBILE_APP_DIR;
+if (!mobileDir) {
+    console.error("MOBILE_APP_DIR is required (path to the gtr-probuild-mobile checkout)");
+    process.exit(1);
+}
+const dist = path.join(mobileDir, "apps", "mobile", "dist");
+if (!existsSync(path.join(dist, "index.html"))) {
+    console.error(`No Expo web export at ${dist} — run: cd ${path.join(mobileDir, "apps", "mobile")} && npx expo export --platform web`);
+    process.exit(1);
+}
+
+const port = Number(process.env.MOBILE_WEB_PORT ?? 19006);
+const apiTarget = new URL(process.env.API_TARGET ?? "http://localhost:3000");
+
+const MIME = {
+    ".html": "text/html; charset=utf-8",
+    ".js": "text/javascript",
+    ".mjs": "text/javascript",
+    ".css": "text/css",
+    ".json": "application/json",
+    ".map": "application/json",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".svg": "image/svg+xml",
+    ".ico": "image/x-icon",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
+    ".ttf": "font/ttf",
+    ".wasm": "application/wasm",
+};
+
+const server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", `http://localhost:${port}`);
+
+    // API proxy — preserve method, headers (incl. Authorization), and body.
+    if (url.pathname.startsWith("/api/")) {
+        const upstream = httpRequest(
+            {
+                hostname: apiTarget.hostname,
+                port: apiTarget.port,
+                path: url.pathname + url.search,
+                method: req.method,
+                headers: { ...req.headers, host: apiTarget.host },
+            },
+            proxied => {
+                res.writeHead(proxied.statusCode ?? 502, proxied.headers);
+                proxied.pipe(res);
+            },
+        );
+        upstream.on("error", err => {
+            res.writeHead(502, { "content-type": "application/json" });
+            res.end(JSON.stringify({ error: `proxy: ${err.message}` }));
+        });
+        req.pipe(upstream);
+        return;
+    }
+
+    // Static file, else SPA fallback to index.html (expo-router client routing).
+    const safePath = path.normalize(decodeURIComponent(url.pathname)).replace(/^([/\\])+/, "");
+    let filePath = path.join(dist, safePath);
+    if (!filePath.startsWith(dist)) {
+        res.writeHead(403);
+        res.end();
+        return;
+    }
+    if (!existsSync(filePath) || statSync(filePath).isDirectory()) {
+        const htmlCandidate = `${filePath.replace(/[/\\]+$/, "")}.html`;
+        filePath = existsSync(htmlCandidate) ? htmlCandidate : path.join(dist, "index.html");
+    }
+    const ext = path.extname(filePath).toLowerCase();
+    res.writeHead(200, { "content-type": MIME[ext] ?? "application/octet-stream" });
+    createReadStream(filePath).pipe(res);
+});
+
+server.listen(port, () => {
+    console.log(`mobile-web: serving ${dist} on http://localhost:${port}, /api -> ${apiTarget.origin}`);
+});

--- a/e2e/mobile-app/timeclock.spec.ts
+++ b/e2e/mobile-app/timeclock.spec.ts
@@ -1,0 +1,191 @@
+import { test, expect } from "@playwright/test";
+import { PrismaClient, type TimeEntry } from "@prisma/client";
+import {
+    COST_CODE_DEMO_ID,
+    COST_CODE_DRYW_ID,
+    FIELD_CREW_EMAIL,
+    FIELD_CREW_PIN,
+    MOBILE_ITEM_DEMO_ID,
+    MOBILE_ITEM_DRYW_ID,
+    PROJECT_ID,
+    PROJECT_NAME,
+    loginWithPin,
+} from "./helpers";
+
+// Covers components/TimeClock.tsx's clock-in picker (phase-grouped by cost code),
+// the /api/mobile/time-suggestion chip (keyword-matched from the seeded daily log's
+// nextSteps — no AI call at request time, see src/lib/time-suggestion.ts), the
+// suggestion-mismatch confirm dialog, and the clock-in/out audit trail
+// (costCodeId, suggestionOverridden) written by POST /api/time-entries.
+
+const prisma = new PrismaClient();
+
+test.describe.serial("Time clock", () => {
+    // Geolocation isn't required for clock-in on this fixture (the seeded project has no
+    // locationLat/Lng, so TimeClock's geofence soft-check never fires) — granted anyway so
+    // the cold-start location warm-up (lib/location.ts) resolves quickly instead of hitting
+    // its 5s timeout/deny path.
+    test.use({
+        permissions: ["geolocation"],
+        geolocation: { latitude: 46.0645, longitude: -118.343 },
+    });
+
+    const createdEntryIds: string[] = [];
+
+    test.afterAll(async () => {
+        if (createdEntryIds.length > 0) {
+            await prisma.timeEntry.deleteMany({ where: { id: { in: createdEntryIds } } });
+        }
+        await prisma.$disconnect();
+    });
+
+    test("suggested drywall clock-in, then an overridden demo clock-in", async ({ page }) => {
+        const fieldCrew = await prisma.user.findUniqueOrThrow({
+            where: { email: FIELD_CREW_EMAIL },
+            select: { id: true },
+        });
+
+        // The Line Item selector button's own text isn't stable — it starts as the
+        // "Select a line item…" placeholder, but flips to the suggestion's label the moment
+        // the auto-preselect effect runs (see TimeClock.tsx), which can beat a click on that
+        // placeholder text. The button is reliably the LAST child of the "Line Item" label's
+        // container (label, then an optional suggestion chip, then the button), so open it via
+        // that structural position instead of its current label text.
+        const openItemPicker = () =>
+            page.getByText("Line Item", { exact: true }).locator("xpath=../*[last()]").click();
+
+        await loginWithPin(page, FIELD_CREW_EMAIL, FIELD_CREW_PIN);
+
+        // ---- select the project ----
+        await page.getByText("Select a project…").click();
+        await expect(page.getByText("Select Project")).toBeVisible({ timeout: 10000 });
+        await page.getByText(PROJECT_NAME, { exact: true }).click();
+
+        // ---- suggestion chip from the seeded daily log ----
+        await expect(page.getByText("Suggested: Hang drywall in hall bath")).toBeVisible({
+            timeout: 15000,
+        });
+
+        // ---- item picker: phase-grouped, 01-DEMO header before 05-DRYW header ----
+        await openItemPicker();
+        await expect(page.getByText("Select Line Item")).toBeVisible({ timeout: 10000 });
+        await expect(page.getByText("Demolition phase")).toBeVisible();
+        await expect(page.getByText("Drywall phase")).toBeVisible();
+
+        const demoHeader = page.getByText("01-DEMO — Demolition", { exact: true });
+        // "05-DRYW — Drywall" also renders as the (now-preselected) Line Item selector
+        // button text behind the modal overlay — .last() targets the modal's own portal
+        // content, which mounts after (and so sorts after in DOM order) the screen behind it.
+        const drywHeader = page.getByText("05-DRYW — Drywall", { exact: true }).last();
+        await expect(demoHeader).toBeVisible();
+        await expect(drywHeader).toBeVisible();
+        // The modal slides/fades in, so its rows are still moving for a couple of frames
+        // after they first become visible — two sequential boundingBox() calls can straddle
+        // that animation and briefly read an inverted order. Fetch both in one round trip
+        // (Promise.all, not two awaits) and poll until the animation settles on the final,
+        // correct order instead of asserting on a single (possibly mid-animation) snapshot.
+        await expect
+            .poll(async () => {
+                const [demoBox, drywBox] = await Promise.all([
+                    demoHeader.boundingBox(),
+                    drywHeader.boundingBox(),
+                ]);
+                if (!demoBox || !drywBox) return null;
+                return demoBox.y - drywBox.y;
+            })
+            .toBeLessThan(0);
+
+        // Drywall item is already preselected by the suggestion — close without picking.
+        await page.getByText("Close", { exact: true }).click();
+
+        // ---- clock in: matches the suggestion, no mismatch dialog ----
+        await page.getByText("Clock In", { exact: true }).click();
+        await expect(page.getByText("CLOCKED IN")).toBeVisible({ timeout: 15000 });
+
+        // performClockIn (TimeClock.tsx) flips to CLOCKED IN optimistically — with a
+        // client-only provisional entry — the instant the tap is handled, before the
+        // create POST it kicks off has resolved. So "CLOCKED IN" visible does not mean the
+        // row is in the DB yet; poll for it instead of querying once immediately after.
+        let active: TimeEntry | null = null;
+        await expect
+            .poll(
+                async () => {
+                    active = await prisma.timeEntry.findFirst({
+                        where: { userId: fieldCrew.id, projectId: PROJECT_ID, endTime: null },
+                        orderBy: { createdAt: "desc" },
+                    });
+                    return active;
+                },
+                { timeout: 15000 }
+            )
+            .not.toBeNull();
+        createdEntryIds.push(active!.id);
+        expect(active!.estimateItemId).toBe(MOBILE_ITEM_DRYW_ID);
+        expect(active!.costCodeId).toBe(COST_CODE_DRYW_ID);
+        expect(active!.suggestionOverridden).toBe(false);
+
+        // ---- clock out ----
+        await page.getByText("Clock Out", { exact: true }).click();
+        await expect(page.getByText("OFF CLOCK")).toBeVisible({ timeout: 15000 });
+
+        // Same optimistic-UI shape as clock-in (handleClockOut sets activeEntry null before
+        // the clock-out PATCH resolves) — poll until the row is actually closed server-side.
+        let closed: TimeEntry | null = null;
+        await expect
+            .poll(
+                async () => {
+                    closed = await prisma.timeEntry.findUniqueOrThrow({ where: { id: active!.id } });
+                    return closed.endTime;
+                },
+                { timeout: 15000 }
+            )
+            .not.toBeNull();
+        expect(closed!.durationHours).not.toBeNull();
+        expect(closed!.laborCost).not.toBeNull();
+
+        // ---- second clock-in: manually pick the DEMO item instead of the suggestion ----
+        // Clock-out resets selectedItemId to "" without re-running the auto-preselect
+        // effect (its deps — suggestion/items/itemManuallyPicked — didn't change), so the
+        // Line Item selector shows its placeholder again and needs a fresh pick.
+        await openItemPicker();
+        await expect(page.getByText("Select Line Item")).toBeVisible({ timeout: 10000 });
+        await page.getByText("Demolition phase", { exact: true }).click();
+
+        await page.getByText("Clock In", { exact: true }).click();
+
+        // Mismatch dialog: selected item (DEMO) disagrees with today's suggestion (DRYW).
+        await expect(page.getByText("Are you sure this is the correct task?")).toBeVisible({
+            timeout: 10000,
+        });
+        await expect(
+            page.getByText("Today's plan is Hang drywall in hall bath (05-DRYW — Drywall).")
+        ).toBeVisible();
+        await page.getByText("Keep my choice", { exact: true }).click();
+
+        await expect(page.getByText("CLOCKED IN")).toBeVisible({ timeout: 15000 });
+
+        // Same optimistic-UI race as the first clock-in above — poll rather than query once.
+        let overridden: TimeEntry | null = null;
+        await expect
+            .poll(
+                async () => {
+                    overridden = await prisma.timeEntry.findFirst({
+                        where: { userId: fieldCrew.id, projectId: PROJECT_ID, endTime: null },
+                        orderBy: { createdAt: "desc" },
+                    });
+                    return overridden;
+                },
+                { timeout: 15000 }
+            )
+            .not.toBeNull();
+        expect(overridden!.id).not.toBe(active!.id);
+        createdEntryIds.push(overridden!.id);
+        expect(overridden!.estimateItemId).toBe(MOBILE_ITEM_DEMO_ID);
+        expect(overridden!.costCodeId).toBe(COST_CODE_DEMO_ID);
+        expect(overridden!.suggestionOverridden).toBe(true);
+
+        // Leave the crew off the clock for whatever runs next.
+        await page.getByText("Clock Out", { exact: true }).click();
+        await expect(page.getByText("OFF CLOCK")).toBeVisible({ timeout: 15000 });
+    });
+});

--- a/e2e/time-suggestion.spec.ts
+++ b/e2e/time-suggestion.spec.ts
@@ -22,6 +22,8 @@ const FIELD_CREW_PIN = "246810";
 // Unique per run so reruns after a failed/aborted prior run never collide on IDs.
 const RUN = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
 const TSUG_TASK2_ID = `e2e-tsug-task2-${RUN}`;
+const TSUG_STALE_TASK_ID = `e2e-tsug-stale-${RUN}`;
+const TSUG_ITEM_NOCODE_ID = `e2e-tsug-nocode-${RUN}`;
 const TSUG_LOG_ID = `e2e-tsug-log-${RUN}`;
 const TSUG_PROJECT_AUTH_ID = `e2e-tsug-projauth-${RUN}`;
 const TSUG_CLIENT_AUTH_ID = `e2e-tsug-cliauth-${RUN}`;
@@ -46,6 +48,7 @@ test.describe.serial("Mobile clock-in time suggestion", () => {
     let api: APIRequestContext;
     let fieldCrewToken: string;
     let fieldCrewId: string;
+    const suiteStart = new Date();
 
     test.beforeAll(async ({ playwright }) => {
         api = await playwright.request.newContext({ baseURL: BASE_URL, storageState: { cookies: [], origins: [] } });
@@ -65,12 +68,15 @@ test.describe.serial("Mobile clock-in time suggestion", () => {
             where: { id: MOBILE_DAILYLOG_ID },
             data: { aiSuggestedTaskId: null, aiSuggestionReason: null },
         }).catch(() => {});
-        await prisma.scheduleTask.update({
-            where: { id: MOBILE_TASK_DRYW_ID },
-            data: { status: "In Progress" },
+        // Entries this file POSTed but failed to delete inline (assertion threw
+        // before the inline cleanup). The fixture history entry has an endTime,
+        // so open entries created since suite start are unambiguously ours.
+        await prisma.timeEntry.deleteMany({
+            where: { userId: fieldCrewId, projectId: PROJECT_ID, endTime: null, createdAt: { gte: suiteStart } },
         }).catch(() => {});
-        await prisma.taskAssignment.deleteMany({ where: { taskId: TSUG_TASK2_ID } });
-        await prisma.scheduleTask.deleteMany({ where: { id: TSUG_TASK2_ID } });
+        await prisma.taskAssignment.deleteMany({ where: { taskId: { in: [TSUG_TASK2_ID, TSUG_STALE_TASK_ID] } } });
+        await prisma.scheduleTask.deleteMany({ where: { id: { in: [TSUG_TASK2_ID, TSUG_STALE_TASK_ID] } } });
+        await prisma.estimateItem.deleteMany({ where: { id: TSUG_ITEM_NOCODE_ID } });
         await prisma.dailyLogPhoto.deleteMany({ where: { dailyLogId: TSUG_LOG_ID } });
         await prisma.dailyLog.deleteMany({ where: { id: TSUG_LOG_ID } });
         await prisma.dailyLog.deleteMany({ where: { workPerformed: DAILYLOG_MARKER } });
@@ -112,30 +118,42 @@ test.describe.serial("Mobile clock-in time suggestion", () => {
         });
     });
 
-    test("2. stale stored pick falls through when the task is Complete", async () => {
-        // The stored pick names the ONLY suggestable task on this project. Marking
-        // it Complete removes it from loadSuggestableTasks entirely (Complete tasks
-        // are excluded outright), so the candidate set is empty and
-        // suggestTaskForClockIn short-circuits to null before the daily-log lookup
-        // (and thus before the keyword fallback) ever runs.
+    test("2. stale stored pick (Complete task) falls through to the keyword match", async () => {
+        // The stored pick names a task that has since been Completed — it is no
+        // longer suggestable, so the engine must discard it and fall through to
+        // the keyword match over the same log (which finds the drywall task).
+        // Uses a throwaway Complete task rather than flipping the shared
+        // fixture task's status, so parallel suites never see a mutated fixture.
+        await prisma.scheduleTask.create({
+            data: {
+                id: TSUG_STALE_TASK_ID,
+                projectId: PROJECT_ID,
+                name: "Old finished punch work",
+                type: "task",
+                status: "Complete",
+                startDate: daysAgo(10),
+                endDate: daysAgo(5),
+            },
+        });
         await prisma.dailyLog.update({
             where: { id: MOBILE_DAILYLOG_ID },
-            data: { aiSuggestedTaskId: MOBILE_TASK_DRYW_ID, aiSuggestionReason: "Stale pick" },
+            data: { aiSuggestedTaskId: TSUG_STALE_TASK_ID, aiSuggestionReason: "Stale pick" },
         });
-        await prisma.scheduleTask.update({ where: { id: MOBILE_TASK_DRYW_ID }, data: { status: "Complete" } });
 
         const res = await api.get(`/api/mobile/time-suggestion?projectId=${PROJECT_ID}`, {
             headers: { authorization: `Bearer ${fieldCrewToken}` },
         });
         expect(res.ok(), await res.text()).toBeTruthy();
         const { suggestion } = await res.json();
-        expect(suggestion).toBeNull();
+        expect(suggestion).not.toBeNull();
+        expect(suggestion.source).toBe("daily_log");
+        expect(suggestion.scheduleTaskId).toBe(MOBILE_TASK_DRYW_ID); // keyword fallback, not the stale pick
 
-        await prisma.scheduleTask.update({ where: { id: MOBILE_TASK_DRYW_ID }, data: { status: "In Progress" } });
         await prisma.dailyLog.update({
             where: { id: MOBILE_DAILYLOG_ID },
             data: { aiSuggestedTaskId: null, aiSuggestionReason: null },
         });
+        await prisma.scheduleTask.delete({ where: { id: TSUG_STALE_TASK_ID } });
     });
 
     test("3. keyword match against the latest log picks the drywall task", async () => {
@@ -230,6 +248,9 @@ test.describe.serial("Mobile clock-in time suggestion", () => {
             data: {
                 projectId: PROJECT_ID,
                 estimateItemId: MOBILE_ITEM_DRYW_ID,
+                // Deliberately WRONG client cost code — the server must charge
+                // the estimate item's code, not this.
+                costCodeId: COST_CODE_DEMO_ID,
                 suggestedScheduleTaskId: MOBILE_TASK_DRYW_ID,
                 suggestedCostCodeId: COST_CODE_DRYW_ID,
                 suggestionSource: "daily_log",
@@ -253,7 +274,8 @@ test.describe.serial("Mobile clock-in time suggestion", () => {
 
     test("7. legacy POST without suggestion fields still derives the cost code", async () => {
         const res = await api.post("/api/time-entries", {
-            data: { projectId: PROJECT_ID, estimateItemId: MOBILE_ITEM_DEMO_ID },
+            // Explicit null costCodeId — exactly what the shipped mobile client sends.
+            data: { projectId: PROJECT_ID, estimateItemId: MOBILE_ITEM_DEMO_ID, costCodeId: null },
             headers: { authorization: `Bearer ${fieldCrewToken}` },
         });
         expect(res.ok(), await res.text()).toBeTruthy();
@@ -268,6 +290,35 @@ test.describe.serial("Mobile clock-in time suggestion", () => {
         expect(entry.suggestionSource).toBeNull();
 
         await prisma.timeEntry.delete({ where: { id: created.id } });
+    });
+
+    test("7b. codeless estimate item never inherits a client-sent cost code", async () => {
+        await prisma.estimateItem.create({
+            data: {
+                id: TSUG_ITEM_NOCODE_ID,
+                estimateId: "e2e-mob-estimate",
+                name: "Codeless phase",
+                parentId: null,
+                quantity: 1,
+                unitCost: 100,
+                total: 100,
+            },
+        });
+
+        const res = await api.post("/api/time-entries", {
+            data: { projectId: PROJECT_ID, estimateItemId: TSUG_ITEM_NOCODE_ID, costCodeId: COST_CODE_DEMO_ID },
+            headers: { authorization: `Bearer ${fieldCrewToken}` },
+        });
+        expect(res.ok(), await res.text()).toBeTruthy();
+        const created = await res.json();
+
+        const entry = await prisma.timeEntry.findUniqueOrThrow({ where: { id: created.id } });
+        // The item decides the charge; a codeless item means NO cost code — the
+        // client-sent one must not sneak in.
+        expect(entry.costCodeId).toBeNull();
+
+        await prisma.timeEntry.delete({ where: { id: created.id } });
+        await prisma.estimateItem.delete({ where: { id: TSUG_ITEM_NOCODE_ID } });
     });
 
     test("8. estimate item belonging to another project is rejected with 400", async () => {

--- a/e2e/time-suggestion.spec.ts
+++ b/e2e/time-suggestion.spec.ts
@@ -38,6 +38,19 @@ const prisma = new PrismaClient();
 const daysAgo = (n: number) => new Date(Date.now() - n * 24 * 60 * 60 * 1000);
 const daysFromNow = (n: number) => new Date(Date.now() + n * 24 * 60 * 60 * 1000);
 
+// DailyLog.date convention: every real writer (web form, MCP/chat bot) stores
+// UTC MIDNIGHT of the intended company-local calendar day — never a raw
+// timestamp. A raw `new Date()` in the UTC evening lands on tomorrow's date
+// and the engine rightly discards it as future-dated (this bit CI at 05:24
+// UTC). Company timezone matches src/lib/company-day.ts.
+const companyTodayDateOnly = () => {
+    const parts = new Intl.DateTimeFormat("en-CA", {
+        timeZone: "America/Los_Angeles", year: "numeric", month: "2-digit", day: "2-digit",
+    }).formatToParts(new Date());
+    const get = (type: string) => parts.find(p => p.type === type)?.value ?? "";
+    return new Date(`${get("year")}-${get("month")}-${get("day")}T00:00:00.000Z`);
+};
+
 async function mobileLogin(request: APIRequestContext, email: string, pinCode: string): Promise<string> {
     const res = await request.post("/api/mobile/login", { data: { email, pinCode } });
     expect(res.ok(), `login failed: ${await res.text()}`).toBeTruthy();
@@ -204,7 +217,7 @@ test.describe.serial("Mobile clock-in time suggestion", () => {
                 id: TSUG_LOG_ID,
                 projectId: PROJECT_ID,
                 createdById: fieldCrewId,
-                date: new Date(),
+                date: companyTodayDateOnly(),
                 workPerformed: "Ordered materials for next week delivery",
                 nextSteps: "Confirm supplier invoice totals",
             },
@@ -369,8 +382,10 @@ test.describe.serial("Mobile clock-in time suggestion", () => {
     test("9. daily log form submission triggers Stage A matching end-to-end", async ({ page }) => {
         // Uses the default (admin) storageState session — the daily-log form is a
         // staff-only server action, not a mobile-token endpoint.
-        await page.goto(`/projects/${PROJECT_ID}/dailylogs`, { waitUntil: "networkidle" });
-
+        // "load" + element auto-wait, not networkidle — the app shell keeps
+        // background requests going (polling), so idle may never arrive.
+        await page.goto(`/projects/${PROJECT_ID}/dailylogs`);
+        await expect(page.getByRole("button", { name: "Add Log", exact: true })).toBeVisible({ timeout: 20_000 });
         await page.getByRole("button", { name: "Add Log", exact: true }).click();
         await page.getByPlaceholder(/shorthand notes/i).fill(DAILYLOG_MARKER);
         await page.getByPlaceholder(/plan for tomorrow/i).fill("hang drywall in hall bath");

--- a/e2e/time-suggestion.spec.ts
+++ b/e2e/time-suggestion.spec.ts
@@ -1,0 +1,340 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import { PrismaClient } from "@prisma/client";
+
+// Clock-in task suggestion pipeline (Stage A daily-log matcher + Stage B
+// ranking in src/lib/time-suggestion.ts), exercised through the real HTTP
+// surface: POST /api/mobile/login for a bearer token, then
+// GET /api/mobile/time-suggestion. Serial — later tests rely on the daily
+// log's aiSuggestedTaskId being reset to null by earlier tests.
+
+const BASE_URL = "http://localhost:3000";
+
+const PROJECT_ID = "cmml6vt3y000lpwrh0p9p3k12";
+const COST_CODE_DEMO_ID = "e2e-mob-cc-demo";
+const COST_CODE_DRYW_ID = "e2e-mob-cc-dryw";
+const MOBILE_ITEM_DEMO_ID = "e2e-mob-item-demo";
+const MOBILE_ITEM_DRYW_ID = "e2e-mob-item-dryw";
+const MOBILE_TASK_DRYW_ID = "e2e-mob-task-dryw";
+const MOBILE_DAILYLOG_ID = "e2e-mob-dailylog";
+const FIELD_CREW_EMAIL = "field-crew@test.local";
+const FIELD_CREW_PIN = "246810";
+
+// Unique per run so reruns after a failed/aborted prior run never collide on IDs.
+const RUN = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+const TSUG_TASK2_ID = `e2e-tsug-task2-${RUN}`;
+const TSUG_LOG_ID = `e2e-tsug-log-${RUN}`;
+const TSUG_PROJECT_AUTH_ID = `e2e-tsug-projauth-${RUN}`;
+const TSUG_CLIENT_AUTH_ID = `e2e-tsug-cliauth-${RUN}`;
+const TSUG_PROJECT_X_ID = `e2e-tsug-projx-${RUN}`;
+const TSUG_CLIENT_X_ID = `e2e-tsug-clix-${RUN}`;
+const TSUG_ESTIMATE_X_ID = `e2e-tsug-estx-${RUN}`;
+const TSUG_ITEM_X_ID = `e2e-tsug-itemx-${RUN}`;
+const DAILYLOG_MARKER = `misc-e2e-tsug-${RUN}`;
+
+const prisma = new PrismaClient();
+
+const daysAgo = (n: number) => new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+const daysFromNow = (n: number) => new Date(Date.now() + n * 24 * 60 * 60 * 1000);
+
+async function mobileLogin(request: APIRequestContext, email: string, pinCode: string): Promise<string> {
+    const res = await request.post("/api/mobile/login", { data: { email, pinCode } });
+    expect(res.ok(), `login failed: ${await res.text()}`).toBeTruthy();
+    return ((await res.json()) as { token: string }).token;
+}
+
+test.describe.serial("Mobile clock-in time suggestion", () => {
+    let api: APIRequestContext;
+    let fieldCrewToken: string;
+    let fieldCrewId: string;
+
+    test.beforeAll(async ({ playwright }) => {
+        api = await playwright.request.newContext({ baseURL: BASE_URL, storageState: { cookies: [], origins: [] } });
+        fieldCrewToken = await mobileLogin(api, FIELD_CREW_EMAIL, FIELD_CREW_PIN);
+        const fieldCrew = await prisma.user.findUniqueOrThrow({
+            where: { email: FIELD_CREW_EMAIL },
+            select: { id: true },
+        });
+        fieldCrewId = fieldCrew.id;
+    });
+
+    test.afterAll(async () => {
+        // Safety net: restore fixture state and delete every row this file may
+        // have created, in case an earlier assertion failed mid-test and skipped
+        // its own inline cleanup.
+        await prisma.dailyLog.update({
+            where: { id: MOBILE_DAILYLOG_ID },
+            data: { aiSuggestedTaskId: null, aiSuggestionReason: null },
+        }).catch(() => {});
+        await prisma.scheduleTask.update({
+            where: { id: MOBILE_TASK_DRYW_ID },
+            data: { status: "In Progress" },
+        }).catch(() => {});
+        await prisma.taskAssignment.deleteMany({ where: { taskId: TSUG_TASK2_ID } });
+        await prisma.scheduleTask.deleteMany({ where: { id: TSUG_TASK2_ID } });
+        await prisma.dailyLogPhoto.deleteMany({ where: { dailyLogId: TSUG_LOG_ID } });
+        await prisma.dailyLog.deleteMany({ where: { id: TSUG_LOG_ID } });
+        await prisma.dailyLog.deleteMany({ where: { workPerformed: DAILYLOG_MARKER } });
+        await prisma.projectAccess.deleteMany({ where: { projectId: TSUG_PROJECT_AUTH_ID } });
+        await prisma.project.deleteMany({ where: { id: TSUG_PROJECT_AUTH_ID } });
+        await prisma.client.deleteMany({ where: { id: TSUG_CLIENT_AUTH_ID } });
+        await prisma.estimateItem.deleteMany({ where: { id: TSUG_ITEM_X_ID } });
+        await prisma.estimate.deleteMany({ where: { id: TSUG_ESTIMATE_X_ID } });
+        await prisma.project.deleteMany({ where: { id: TSUG_PROJECT_X_ID } });
+        await prisma.client.deleteMany({ where: { id: TSUG_CLIENT_X_ID } });
+
+        await api.dispose();
+        await prisma.$disconnect();
+    });
+
+    test("1. stored AI pick wins over everything else", async () => {
+        await prisma.dailyLog.update({
+            where: { id: MOBILE_DAILYLOG_ID },
+            data: { aiSuggestedTaskId: MOBILE_TASK_DRYW_ID, aiSuggestionReason: "Stored pick from AI" },
+        });
+
+        const res = await api.get(`/api/mobile/time-suggestion?projectId=${PROJECT_ID}`, {
+            headers: { authorization: `Bearer ${fieldCrewToken}` },
+        });
+        expect(res.ok(), await res.text()).toBeTruthy();
+        const { suggestion } = await res.json();
+
+        expect(suggestion).not.toBeNull();
+        expect(suggestion.source).toBe("daily_log");
+        expect(suggestion.confidence).toBe("high");
+        expect(suggestion.scheduleTaskId).toBe(MOBILE_TASK_DRYW_ID);
+        expect(suggestion.clockInEstimateItemId).toBe(MOBILE_ITEM_DRYW_ID);
+        expect(suggestion.costCodeId).toBe(COST_CODE_DRYW_ID);
+        expect(suggestion.reason).toBe("Stored pick from AI");
+
+        await prisma.dailyLog.update({
+            where: { id: MOBILE_DAILYLOG_ID },
+            data: { aiSuggestedTaskId: null, aiSuggestionReason: null },
+        });
+    });
+
+    test("2. stale stored pick falls through when the task is Complete", async () => {
+        // The stored pick names the ONLY suggestable task on this project. Marking
+        // it Complete removes it from loadSuggestableTasks entirely (Complete tasks
+        // are excluded outright), so the candidate set is empty and
+        // suggestTaskForClockIn short-circuits to null before the daily-log lookup
+        // (and thus before the keyword fallback) ever runs.
+        await prisma.dailyLog.update({
+            where: { id: MOBILE_DAILYLOG_ID },
+            data: { aiSuggestedTaskId: MOBILE_TASK_DRYW_ID, aiSuggestionReason: "Stale pick" },
+        });
+        await prisma.scheduleTask.update({ where: { id: MOBILE_TASK_DRYW_ID }, data: { status: "Complete" } });
+
+        const res = await api.get(`/api/mobile/time-suggestion?projectId=${PROJECT_ID}`, {
+            headers: { authorization: `Bearer ${fieldCrewToken}` },
+        });
+        expect(res.ok(), await res.text()).toBeTruthy();
+        const { suggestion } = await res.json();
+        expect(suggestion).toBeNull();
+
+        await prisma.scheduleTask.update({ where: { id: MOBILE_TASK_DRYW_ID }, data: { status: "In Progress" } });
+        await prisma.dailyLog.update({
+            where: { id: MOBILE_DAILYLOG_ID },
+            data: { aiSuggestedTaskId: null, aiSuggestionReason: null },
+        });
+    });
+
+    test("3. keyword match against the latest log picks the drywall task", async () => {
+        // aiSuggestedTaskId is null (reset by test 2). The fixture log's nextSteps
+        // — "Start hanging drywall in the hall bath" — tokenizes to
+        // {hanging, drywall, hall, bath} (weight 2), which matches the drywall
+        // task's name + cost code tokens {hang, drywall, hall, bath, dryw} for a
+        // score of 6 against the project's only candidate — an unambiguous, high
+        // confidence keyword hit.
+        const res = await api.get(`/api/mobile/time-suggestion?projectId=${PROJECT_ID}`, {
+            headers: { authorization: `Bearer ${fieldCrewToken}` },
+        });
+        expect(res.ok(), await res.text()).toBeTruthy();
+        const { suggestion } = await res.json();
+
+        expect(suggestion).not.toBeNull();
+        expect(suggestion.source).toBe("daily_log");
+        expect(suggestion.scheduleTaskId).toBe(MOBILE_TASK_DRYW_ID);
+        expect(suggestion.confidence).toBe("high");
+    });
+
+    test("4. two active assigned tasks with no keyword match falls through to null", async () => {
+        // Second suggestable task on the project's other free top-level item
+        // (e2e-mob-item-demo has no ScheduleTask yet — MOBILE_ITEM_DRYW_ID is
+        // already claimed by the fixture task via the @unique estimateItemId FK),
+        // assigned to the same field crew and active today.
+        await prisma.scheduleTask.create({
+            data: {
+                id: TSUG_TASK2_ID,
+                projectId: PROJECT_ID,
+                name: "Demo phase task",
+                type: "task",
+                status: "In Progress",
+                startDate: daysAgo(3),
+                endDate: daysFromNow(4),
+                estimateItemId: MOBILE_ITEM_DEMO_ID,
+            },
+        });
+        await prisma.taskAssignment.create({ data: { taskId: TSUG_TASK2_ID, userId: fieldCrewId } });
+
+        // A newer daily log (becomes "latest") whose text shares no tokens with
+        // either candidate's name/cost-code tokens, so keywordMatchTasks scores
+        // everything 0 and returns null.
+        await prisma.dailyLog.create({
+            data: {
+                id: TSUG_LOG_ID,
+                projectId: PROJECT_ID,
+                createdById: fieldCrewId,
+                date: new Date(),
+                workPerformed: "Ordered materials for next week delivery",
+                nextSteps: "Confirm supplier invoice totals",
+            },
+        });
+
+        const res = await api.get(`/api/mobile/time-suggestion?projectId=${PROJECT_ID}`, {
+            headers: { authorization: `Bearer ${fieldCrewToken}` },
+        });
+        expect(res.ok(), await res.text()).toBeTruthy();
+        const { suggestion } = await res.json();
+        // No keyword match -> two active assigned tasks (step 3 requires exactly
+        // one) -> the fixture's sole history entry has no scheduleTaskId, so step
+        // 4 also yields nothing -> null.
+        expect(suggestion).toBeNull();
+
+        await prisma.dailyLog.delete({ where: { id: TSUG_LOG_ID } });
+        await prisma.taskAssignment.deleteMany({ where: { taskId: TSUG_TASK2_ID } });
+        await prisma.scheduleTask.delete({ where: { id: TSUG_TASK2_ID } });
+    });
+
+    test("5a. no bearer token -> 401", async () => {
+        const res = await api.get(`/api/mobile/time-suggestion?projectId=${PROJECT_ID}`);
+        expect(res.status()).toBe(401);
+    });
+
+    test("5b. field crew on a project they are not assigned to -> 403", async () => {
+        await prisma.client.create({ data: { id: TSUG_CLIENT_AUTH_ID, name: "E2E TSUG Client Auth", initials: "TA" } });
+        await prisma.project.create({
+            data: { id: TSUG_PROJECT_AUTH_ID, name: "E2E TSUG Project Auth", clientId: TSUG_CLIENT_AUTH_ID, status: "In Progress" },
+        });
+
+        const res = await api.get(`/api/mobile/time-suggestion?projectId=${TSUG_PROJECT_AUTH_ID}`, {
+            headers: { authorization: `Bearer ${fieldCrewToken}` },
+        });
+        expect(res.status()).toBe(403);
+
+        await prisma.project.delete({ where: { id: TSUG_PROJECT_AUTH_ID } });
+        await prisma.client.delete({ where: { id: TSUG_CLIENT_AUTH_ID } });
+    });
+
+    test("6. POST /api/time-entries persists the suggestion audit fields", async () => {
+        const res = await api.post("/api/time-entries", {
+            data: {
+                projectId: PROJECT_ID,
+                estimateItemId: MOBILE_ITEM_DRYW_ID,
+                suggestedScheduleTaskId: MOBILE_TASK_DRYW_ID,
+                suggestedCostCodeId: COST_CODE_DRYW_ID,
+                suggestionSource: "daily_log",
+                suggestionOverridden: true,
+            },
+            headers: { authorization: `Bearer ${fieldCrewToken}` },
+        });
+        expect(res.ok(), await res.text()).toBeTruthy();
+        const created = await res.json();
+
+        const entry = await prisma.timeEntry.findUniqueOrThrow({ where: { id: created.id } });
+        expect(entry.costCodeId).toBe(COST_CODE_DRYW_ID); // derived from estimateItemId, not the client-sent value
+        expect(entry.suggestionOverridden).toBe(true);
+        expect(entry.suggestedScheduleTaskId).toBe(MOBILE_TASK_DRYW_ID);
+        expect(entry.suggestedTaskName).toBe("Hang drywall in hall bath");
+        expect(entry.suggestedCostCodeId).toBe(COST_CODE_DRYW_ID);
+        expect(entry.suggestionSource).toBe("daily_log");
+
+        await prisma.timeEntry.delete({ where: { id: created.id } });
+    });
+
+    test("7. legacy POST without suggestion fields still derives the cost code", async () => {
+        const res = await api.post("/api/time-entries", {
+            data: { projectId: PROJECT_ID, estimateItemId: MOBILE_ITEM_DEMO_ID },
+            headers: { authorization: `Bearer ${fieldCrewToken}` },
+        });
+        expect(res.ok(), await res.text()).toBeTruthy();
+        const created = await res.json();
+
+        const entry = await prisma.timeEntry.findUniqueOrThrow({ where: { id: created.id } });
+        expect(entry.costCodeId).toBe(COST_CODE_DEMO_ID);
+        expect(entry.suggestionOverridden).toBe(false);
+        expect(entry.suggestedScheduleTaskId).toBeNull();
+        expect(entry.suggestedTaskName).toBeNull();
+        expect(entry.suggestedCostCodeId).toBeNull();
+        expect(entry.suggestionSource).toBeNull();
+
+        await prisma.timeEntry.delete({ where: { id: created.id } });
+    });
+
+    test("8. estimate item belonging to another project is rejected with 400", async () => {
+        await prisma.client.create({ data: { id: TSUG_CLIENT_X_ID, name: "E2E TSUG Client X", initials: "TX" } });
+        await prisma.project.create({
+            data: { id: TSUG_PROJECT_X_ID, name: "E2E TSUG Project X", clientId: TSUG_CLIENT_X_ID, status: "In Progress" },
+        });
+        await prisma.estimate.create({
+            data: {
+                id: TSUG_ESTIMATE_X_ID,
+                title: "E2E TSUG Estimate X",
+                code: "EST-TSUG-X",
+                status: "Approved",
+                projectId: TSUG_PROJECT_X_ID,
+                totalAmount: 500,
+                balanceDue: 500,
+            },
+        });
+        await prisma.estimateItem.create({
+            data: {
+                id: TSUG_ITEM_X_ID,
+                estimateId: TSUG_ESTIMATE_X_ID,
+                name: "Other project item",
+                parentId: null,
+                quantity: 1,
+                unitCost: 500,
+                total: 500,
+            },
+        });
+
+        const res = await api.post("/api/time-entries", {
+            data: { projectId: PROJECT_ID, estimateItemId: TSUG_ITEM_X_ID },
+            headers: { authorization: `Bearer ${fieldCrewToken}` },
+        });
+        expect(res.status()).toBe(400);
+
+        await prisma.estimateItem.delete({ where: { id: TSUG_ITEM_X_ID } });
+        await prisma.estimate.delete({ where: { id: TSUG_ESTIMATE_X_ID } });
+        await prisma.project.delete({ where: { id: TSUG_PROJECT_X_ID } });
+        await prisma.client.delete({ where: { id: TSUG_CLIENT_X_ID } });
+    });
+
+    test("9. daily log form submission triggers Stage A matching end-to-end", async ({ page }) => {
+        // Uses the default (admin) storageState session — the daily-log form is a
+        // staff-only server action, not a mobile-token endpoint.
+        await page.goto(`/projects/${PROJECT_ID}/dailylogs`, { waitUntil: "networkidle" });
+
+        await page.getByRole("button", { name: "Add Log", exact: true }).click();
+        await page.getByPlaceholder(/shorthand notes/i).fill(DAILYLOG_MARKER);
+        await page.getByPlaceholder(/plan for tomorrow/i).fill("hang drywall in hall bath");
+        await page.getByRole("button", { name: "Save Log" }).click();
+
+        await expect(page.getByText("Daily log created!")).toBeVisible({ timeout: 15_000 });
+
+        // Stage A runs in a Next.js after() callback following the write, so it
+        // lands shortly AFTER the HTTP/toast response — poll rather than assert once.
+        await expect.poll(
+            async () => {
+                const log = await prisma.dailyLog.findFirst({
+                    where: { workPerformed: DAILYLOG_MARKER },
+                    select: { aiSuggestedTaskId: true },
+                });
+                return log?.aiSuggestedTaskId ?? null;
+            },
+            { timeout: 10_000 },
+        ).toBe(MOBILE_TASK_DRYW_ID);
+
+        await prisma.dailyLog.deleteMany({ where: { workPerformed: DAILYLOG_MARKER } });
+    });
+});

--- a/e2e/time-suggestion.spec.ts
+++ b/e2e/time-suggestion.spec.ts
@@ -48,7 +48,9 @@ test.describe.serial("Mobile clock-in time suggestion", () => {
     let api: APIRequestContext;
     let fieldCrewToken: string;
     let fieldCrewId: string;
-    const suiteStart = new Date();
+    // Every entry id this file creates via POST — the afterAll safety net
+    // deletes exactly these, nothing broader.
+    const createdEntryIds = new Set<string>();
 
     test.beforeAll(async ({ playwright }) => {
         api = await playwright.request.newContext({ baseURL: BASE_URL, storageState: { cookies: [], origins: [] } });
@@ -69,11 +71,11 @@ test.describe.serial("Mobile clock-in time suggestion", () => {
             data: { aiSuggestedTaskId: null, aiSuggestionReason: null },
         }).catch(() => {});
         // Entries this file POSTed but failed to delete inline (assertion threw
-        // before the inline cleanup). The fixture history entry has an endTime,
-        // so open entries created since suite start are unambiguously ours.
-        await prisma.timeEntry.deleteMany({
-            where: { userId: fieldCrewId, projectId: PROJECT_ID, endTime: null, createdAt: { gte: suiteStart } },
-        }).catch(() => {});
+        // before the inline cleanup). Exact IDs only — a time/user-scoped
+        // deleteMany could reap another parallel spec's in-flight entries.
+        if (createdEntryIds.size > 0) {
+            await prisma.timeEntry.deleteMany({ where: { id: { in: [...createdEntryIds] } } }).catch(() => {});
+        }
         await prisma.taskAssignment.deleteMany({ where: { taskId: { in: [TSUG_TASK2_ID, TSUG_STALE_TASK_ID] } } });
         await prisma.scheduleTask.deleteMany({ where: { id: { in: [TSUG_TASK2_ID, TSUG_STALE_TASK_ID] } } });
         await prisma.estimateItem.deleteMany({ where: { id: TSUG_ITEM_NOCODE_ID } });
@@ -260,6 +262,7 @@ test.describe.serial("Mobile clock-in time suggestion", () => {
         });
         expect(res.ok(), await res.text()).toBeTruthy();
         const created = await res.json();
+        createdEntryIds.add(created.id);
 
         const entry = await prisma.timeEntry.findUniqueOrThrow({ where: { id: created.id } });
         expect(entry.costCodeId).toBe(COST_CODE_DRYW_ID); // derived from estimateItemId, not the client-sent value
@@ -280,6 +283,7 @@ test.describe.serial("Mobile clock-in time suggestion", () => {
         });
         expect(res.ok(), await res.text()).toBeTruthy();
         const created = await res.json();
+        createdEntryIds.add(created.id);
 
         const entry = await prisma.timeEntry.findUniqueOrThrow({ where: { id: created.id } });
         expect(entry.costCodeId).toBe(COST_CODE_DEMO_ID);
@@ -311,6 +315,7 @@ test.describe.serial("Mobile clock-in time suggestion", () => {
         });
         expect(res.ok(), await res.text()).toBeTruthy();
         const created = await res.json();
+        createdEntryIds.add(created.id);
 
         const entry = await prisma.timeEntry.findUniqueOrThrow({ where: { id: created.id } });
         // The item decides the charge; a codeless item means NO cost code — the

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:qbo-expense-sync": "tsx --test tests/qbo-expense-sync.test.ts tests/qbo-expense-sync-route.test.ts tests/qbo-expense-sync-ui.test.tsx tests/qbo-purchase-changes.test.ts tests/qbo-expense-guard.test.ts",
     "test:qbo-receipt-push": "tsx --test tests/qbo-receipt-push.test.ts",
     "test:e2e": "playwright test",
+    "test:mobile-e2e": "node e2e/mobile-app/run-mobile-e2e.mjs",
     "test:qa": "npx playwright test e2e/quality-gate.spec.ts",
     "assets:download": "tsx scripts/download-assets.ts",
     "assets:download:dry": "tsx scripts/download-assets.ts --dry-run",

--- a/playwright.config.mobile.ts
+++ b/playwright.config.mobile.ts
@@ -1,0 +1,56 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Expo-web launch gate for the ProBuild mobile app. Runs LOCALLY (not in this
+// repo's CI — the mobile checkout lives in a separate repository):
+//
+//   set MOBILE_APP_DIR=C:\...\gtr-probuild-mobile
+//   npm run test:mobile-e2e
+//
+// Serves the mobile app's static Expo web export on :19006 with /api proxied
+// to the Next dev server (e2e/mobile-app/serve-mobile-web.mjs) — the same
+// same-origin shape production uses. Same hermetic-DB rules as the main
+// suite: point DATABASE_URL at a throwaway Postgres per docs/TESTING.md.
+//
+// workers: 1 on purpose — the mobile-app specs share one crew user/project
+// and mutate punches, entries, comments, and expenses; parallel workers would
+// race the fixtures. This is a pre-launch gate, not a speed benchmark.
+export default defineConfig({
+    testDir: "./e2e",
+    testMatch: "**/mobile-app/**/*.spec.ts",
+    fullyParallel: false,
+    workers: 1,
+    retries: 0,
+    reporter: "list",
+    timeout: 45_000,
+    expect: { timeout: 10_000 },
+    use: {
+        baseURL: "http://localhost:19006",
+        trace: "retain-on-failure",
+        screenshot: "only-on-failure",
+        ...devices["Desktop Chrome"],
+    },
+    projects: [
+        {
+            name: "data",
+            testMatch: /data\.setup\.ts/,
+        },
+        {
+            name: "mobile-web",
+            dependencies: ["data"],
+        },
+    ],
+    webServer: [
+        {
+            command: "npm run dev",
+            url: "http://localhost:3000",
+            reuseExistingServer: true,
+            timeout: 120_000,
+        },
+        {
+            command: "node e2e/mobile-app/serve-mobile-web.mjs",
+            url: "http://localhost:19006",
+            reuseExistingServer: true,
+            timeout: 30_000,
+        },
+    ],
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,9 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./e2e",
+  // Expo-web specs need the mobile checkout + its static export — they run
+  // via playwright.config.mobile.ts (npm run test:mobile-e2e), never here/CI.
+  testIgnore: "**/mobile-app/**",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -238,6 +238,7 @@ model Project {
   color               String?                      @default("#3b82f6") // Added color field
   paymentRemindersEnabled Boolean                  @default(false) // Settings → Client Dashboard: send automated payment-due reminder emails to the client. Opt-in — off by default, enabled per project.
   portalStageOverride String? // Staff-pinned current stage on the portal project route (a CLIENT_STAGES label); null = derive position from schedule tasks
+  chatWebhookUrl      String? // Google Chat incoming webhook for the project's team space — treated as a credential: manager-only, never serialized to field crew
   managerId           String?
   manager             User?                        @relation("ProjectManager", fields: [managerId], references: [id])
   estimates           Estimate[]
@@ -774,6 +775,13 @@ model TimeEntry {
 
   // Invoice linkage — set when pulled into a cost-plus invoice
   invoicedAt DateTime?
+
+  // Clock-in task suggestion audit (daily-log-driven accuracy feature)
+  suggestedScheduleTaskId String?
+  suggestedCostCodeId     String?
+  suggestedTaskName       String? // denormalized — survives task edits/deletes
+  suggestionSource        String? // "daily_log" | "today_schedule" | "user_history"
+  suggestionOverridden    Boolean @default(false)
 
   @@index([projectId])
   @@index([userId])
@@ -1908,6 +1916,9 @@ model DailyLog {
   workPerformed      String          @db.Text
   materialsDelivered String?         @db.Text
   issues             String?         @db.Text
+  nextSteps          String?         @db.Text // what's planned next — drives clock-in task suggestions
+  aiSuggestedTaskId  String? // ScheduleTask picked by the task matcher from this log's text + photos
+  aiSuggestionReason String?         @db.Text
   sharedToPortal     Boolean         @default(false)
   sharedContentHash  String?
   photos             DailyLogPhoto[]

--- a/scripts/apply-time-suggestion-schema.mjs
+++ b/scripts/apply-time-suggestion-schema.mjs
@@ -1,0 +1,48 @@
+// One-off additive migration for the daily-log-driven time-entry accuracy
+// feature. Safe to re-run while the previous build is live — every statement
+// is idempotent (ADD COLUMN IF NOT EXISTS). Additive DDL only — no deletes,
+// no drops, no destructive rewrites. Nullable columns on existing tables
+// only, so no RLS statements are needed (mirrors
+// scripts/apply-selection-order-tracking.mjs's convention).
+//
+// Run BEFORE deploying the build that ships this schema (see the pre-deploy
+// checklist in CLAUDE.md):
+//   node scripts/apply-time-suggestion-schema.mjs
+import { PrismaClient } from "@prisma/client";
+import { config } from "dotenv";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+config({ path: join(__dirname, "..", ".env.local") });
+config({ path: join(__dirname, "..", ".env") });
+
+const prisma = new PrismaClient({ datasources: { db: { url: process.env.DATABASE_URL } } });
+
+const statements = [
+    // ── DailyLog — next steps + AI task match ────────────────────────────
+    `ALTER TABLE "DailyLog" ADD COLUMN IF NOT EXISTS "nextSteps" TEXT`,
+    `ALTER TABLE "DailyLog" ADD COLUMN IF NOT EXISTS "aiSuggestedTaskId" TEXT`,
+    `ALTER TABLE "DailyLog" ADD COLUMN IF NOT EXISTS "aiSuggestionReason" TEXT`,
+    // ── Project — Chat post-back webhook (credential; manager-only) ──────
+    `ALTER TABLE "Project" ADD COLUMN IF NOT EXISTS "chatWebhookUrl" TEXT`,
+    // ── TimeEntry — clock-in suggestion audit ────────────────────────────
+    `ALTER TABLE "TimeEntry" ADD COLUMN IF NOT EXISTS "suggestedScheduleTaskId" TEXT`,
+    `ALTER TABLE "TimeEntry" ADD COLUMN IF NOT EXISTS "suggestedCostCodeId" TEXT`,
+    `ALTER TABLE "TimeEntry" ADD COLUMN IF NOT EXISTS "suggestedTaskName" TEXT`,
+    `ALTER TABLE "TimeEntry" ADD COLUMN IF NOT EXISTS "suggestionSource" TEXT`,
+    `ALTER TABLE "TimeEntry" ADD COLUMN IF NOT EXISTS "suggestionOverridden" BOOLEAN NOT NULL DEFAULT false`,
+];
+
+try {
+    for (const sql of statements) {
+        await prisma.$executeRawUnsafe(sql);
+        console.log("OK:", sql.split("\n")[0].slice(0, 80));
+    }
+    console.log("\nTime-suggestion schema applied successfully.");
+} catch (e) {
+    console.error("Migration failed:", e);
+    process.exit(1);
+} finally {
+    await prisma.$disconnect();
+}

--- a/scripts/verify-mcp-pm-tools.ts
+++ b/scripts/verify-mcp-pm-tools.ts
@@ -112,7 +112,7 @@ async function main() {
     // Static registry, security, migration, and no-Phase-2 contracts.
     assert.match(routeSource, /MCP_SECRET_RICHARD/);
     assert.match(routeSource, /timingSafeEqual/);
-    assert.match(routeSource, /serverInfo:\s*\{\s*name:\s*"probuild",\s*version:\s*"1\.15\.0"\s*\}/);
+    assert.match(routeSource, /serverInfo:\s*\{\s*name:\s*"probuild",\s*version:\s*"1\.16\.0"\s*\}/);
     for (const toolName of [
         "upload_file",
         "upload_files",

--- a/scripts/verify-time-suggestion.ts
+++ b/scripts/verify-time-suggestion.ts
@@ -1,0 +1,99 @@
+// Hermetic checks for the clock-in suggestion matcher (src/lib/time-suggestion.ts)
+// and the Chat webhook URL guard (src/lib/chat-webhook.ts). Pure-function only —
+// no DB, no AI. The ranking/DB layer is covered by e2e/time-suggestion.spec.ts.
+//
+//   npx tsx scripts/verify-time-suggestion.ts
+import assert from "node:assert/strict";
+import {
+    tokenizeForMatch,
+    keywordMatchTasks,
+    type KeywordCandidate,
+} from "../src/lib/time-suggestion";
+import { isValidChatWebhookUrl } from "../src/lib/chat-webhook";
+
+const CANDIDATES: KeywordCandidate[] = [
+    { taskId: "t-demo", taskName: "Demo hall bath", costCodeCode: "01-DEMO", costCodeName: "Demolition" },
+    { taskId: "t-dryw", taskName: "Hang drywall in hall bath", costCodeCode: "05-DRYW", costCodeName: "Drywall" },
+    { taskId: "t-conc", taskName: "Pour footing", costCodeCode: "29-CONCRETE", costCodeName: "Concrete" },
+];
+
+function verifyTokenize(): void {
+    // Lowercased, punctuation stripped, stopwords + short + numeric tokens dropped.
+    assert.deepEqual(tokenizeForMatch("Start hanging DRYWALL, in the hall-bath!"), ["hanging", "drywall", "hall", "bath"]);
+    assert.deepEqual(tokenizeForMatch(""), []);
+    assert.deepEqual(tokenizeForMatch(null), []);
+    assert.deepEqual(tokenizeForMatch("a an 12 99"), []);
+    console.log("PASS tokenize: normalization, stopwords, short/numeric drop");
+}
+
+function verifyNextStepsOutranksWorkPerformed(): void {
+    // workPerformed points at demo, nextSteps points at drywall — drywall must win
+    // (nextSteps tokens count double).
+    const match = keywordMatchTasks(
+        { workPerformed: "Demo complete in hall bath", nextSteps: "drywall delivery, start hanging drywall" },
+        CANDIDATES,
+    );
+    assert.ok(match);
+    assert.equal(match.taskId, "t-dryw");
+    console.log("PASS ranking: nextSteps outranks workPerformed");
+}
+
+function verifyPhotoCaptionsCount(): void {
+    const match = keywordMatchTasks(
+        { workPerformed: "long day on site", photoCaptions: ["concrete truck at footing", "pour finished"] },
+        CANDIDATES,
+    );
+    assert.ok(match);
+    assert.equal(match.taskId, "t-conc");
+    console.log("PASS ranking: photo captions participate in matching");
+}
+
+function verifyNoMatchAndTieReturnNull(): void {
+    assert.equal(keywordMatchTasks({ workPerformed: "picked up permits downtown" }, CANDIDATES), null);
+    assert.equal(keywordMatchTasks({ workPerformed: "" }, CANDIDATES), null);
+    // "hall bath" hits t-demo and t-dryw equally — a tie must NOT guess.
+    const tie = keywordMatchTasks({ workPerformed: "hall bath" }, [
+        { taskId: "a", taskName: "Demo hall bath", costCodeCode: null, costCodeName: null },
+        { taskId: "b", taskName: "Paint hall bath", costCodeCode: null, costCodeName: null },
+    ]);
+    assert.equal(tie, null);
+    console.log("PASS ranking: no-signal and tied-top both return null");
+}
+
+function verifyCostCodeTokensMatch(): void {
+    // The log naming the trade by its cost-code name alone should still match.
+    const match = keywordMatchTasks({ nextSteps: "demolition wrap-up" }, CANDIDATES);
+    assert.ok(match);
+    assert.equal(match.taskId, "t-demo");
+    console.log("PASS ranking: cost-code name tokens participate");
+}
+
+function verifyDuplicateTokensDontStack(): void {
+    // Repeating a word in the log must not multiply its score: candidate token
+    // sets are deduped, and each candidate token scores once.
+    const spam = keywordMatchTasks(
+        { workPerformed: "concrete concrete concrete", nextSteps: "hang drywall and tape drywall seams in hall bath" },
+        CANDIDATES,
+    );
+    assert.ok(spam);
+    assert.equal(spam.taskId, "t-dryw");
+    console.log("PASS ranking: repeated tokens don't stack per-candidate");
+}
+
+function verifyWebhookUrlGuard(): void {
+    assert.ok(isValidChatWebhookUrl("https://chat.googleapis.com/v1/spaces/AAQA123/messages?key=k&token=t"));
+    assert.ok(!isValidChatWebhookUrl("http://chat.googleapis.com/v1/spaces/AAQA123/messages")); // not https
+    assert.ok(!isValidChatWebhookUrl("https://evil.example.com/v1/spaces/AAQA123/messages")); // wrong host
+    assert.ok(!isValidChatWebhookUrl("https://chat.googleapis.com/other/path")); // wrong path
+    assert.ok(!isValidChatWebhookUrl("not a url"));
+    console.log("PASS chat-webhook: URL guard restricts to Google Chat webhooks");
+}
+
+verifyTokenize();
+verifyNextStepsOutranksWorkPerformed();
+verifyPhotoCaptionsCount();
+verifyNoMatchAndTieReturnNull();
+verifyCostCodeTokensMatch();
+verifyDuplicateTokensDontStack();
+verifyWebhookUrlGuard();
+console.log("\nverify-time-suggestion: all checks passed");

--- a/scripts/verify-time-suggestion.ts
+++ b/scripts/verify-time-suggestion.ts
@@ -68,6 +68,20 @@ function verifyCostCodeTokensMatch(): void {
     console.log("PASS ranking: cost-code name tokens participate");
 }
 
+function verifyDistinctTokenCount(): void {
+    // One hot nextSteps word = 1 distinct matched token (callers demote that to
+    // medium confidence); two agreeing words = 2.
+    const single = keywordMatchTasks({ nextSteps: "concrete order confirmed" }, CANDIDATES);
+    assert.ok(single);
+    assert.equal(single.taskId, "t-conc");
+    assert.equal(single.matchedTokens, 1);
+    const double = keywordMatchTasks({ nextSteps: "pour the concrete pad" }, CANDIDATES);
+    assert.ok(double);
+    assert.equal(double.taskId, "t-conc");
+    assert.equal(double.matchedTokens, 2);
+    console.log("PASS ranking: matchedTokens counts distinct hits for confidence");
+}
+
 function verifyDuplicateTokensDontStack(): void {
     // Repeating a word in the log must not multiply its score: candidate token
     // sets are deduped, and each candidate token scores once.
@@ -94,6 +108,7 @@ verifyNextStepsOutranksWorkPerformed();
 verifyPhotoCaptionsCount();
 verifyNoMatchAndTieReturnNull();
 verifyCostCodeTokensMatch();
+verifyDistinctTokenCount();
 verifyDuplicateTokensDontStack();
 verifyWebhookUrlGuard();
 console.log("\nverify-time-suggestion: all checks passed");

--- a/src/app/api/ai/daily-logs/route.ts
+++ b/src/app/api/ai/daily-logs/route.ts
@@ -91,7 +91,9 @@ Respond ONLY with valid JSON matching the schema provided.`;
         }
 
         const response = await ai.models.generateContent({
-            model: "gemini-3.0-flash-preview",
+            // "gemini-3.0-flash-preview" was never a real model id (ListModels
+            // verified 2026-08-06) — every call 404'd silently as a 500 here.
+            model: "gemini-3.5-flash",
             contents: { parts },
             config: {
                 responseMimeType: "application/json",

--- a/src/app/api/ai/daily-logs/route.ts
+++ b/src/app/api/ai/daily-logs/route.ts
@@ -19,12 +19,16 @@ const responseSchema = {
             type: "STRING",
             description: "Any issues, delays, or concerns mentioned. If none, return empty string."
         },
+        nextSteps: {
+            type: "STRING",
+            description: "What the crew should do next, based on the notes and photos (e.g. 'Install window trim on west wall; drywall inspection in the morning'). Empty string if unclear."
+        },
         weather: {
             type: "STRING",
             description: "Inferred weather conditions if mentioned, otherwise empty string. Must be a short string like 'Sunny, 80F' or 'Rainy'."
         }
     },
-    required: ["workPerformed", "materialsDelivered", "issues", "weather"],
+    required: ["workPerformed", "materialsDelivered", "issues", "nextSteps", "weather"],
 };
 
 export async function POST(req: NextRequest) {
@@ -68,6 +72,7 @@ Please extract and expand upon this information into the following structured fo
 - workPerformed: Detail what was done today. Make it read well.
 - materialsDelivered: Any materials.
 - issues: Any issues or delays.
+- nextSteps: What the crew should do next, based on the notes and photos.
 - weather: If any weather info is included.
 
 Respond ONLY with valid JSON matching the schema provided.`;

--- a/src/app/api/daily-logs/[projectId]/pdf/route.ts
+++ b/src/app/api/daily-logs/[projectId]/pdf/route.ts
@@ -221,6 +221,17 @@ export async function GET(
             y -= 6;
         }
 
+        // Next Steps
+        if (log.nextSteps) {
+            checkNewPage(60);
+            page.drawText("NEXT STEPS", {
+                x: margin + 4, y, size: 8, font: helveticaBold, color: colors.blue,
+            });
+            y -= 14;
+            y = drawWrappedText(log.nextSteps, margin + 4, y, contentWidth - 8, 9, helvetica, colors.textMain);
+            y -= 6;
+        }
+
         // Photos count
         if (log.photos.length > 0) {
             checkNewPage(40);

--- a/src/app/api/manager/dashboard/route.ts
+++ b/src/app/api/manager/dashboard/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { toNum } from "@/lib/prisma-helpers";
 import { authenticateMobileOrSession } from "@/lib/mobile-auth";
+import { toCompanyDayKey } from "@/lib/company-day";
 
 // One-shot dashboard payload for the mobile manager tab. Replaces ~4 prior client-side
 // Supabase queries + 2 realtime subscriptions; mobile polls this every 30s while focused.
@@ -275,6 +276,95 @@ export async function GET(req: Request) {
         (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
     );
 
+    // -------- Field compliance flags (open projects with a clock-in on the selected day) --------
+    const dayKey = toCompanyDayKey(dayStart);
+
+    const dayProjectGroups = await prisma.timeEntry.groupBy({
+        by: ["projectId"],
+        where: { startTime: { gte: dayStart, lt: dayEnd } },
+    });
+    const dayProjectIds = new Set(dayProjectGroups.map((g) => g.projectId));
+    const eligibleProjects = projects.filter((p) => dayProjectIds.has(p.id));
+    const eligibleProjectIds = eligibleProjects.map((p) => p.id);
+
+    let compliance: Array<{
+        projectId: string;
+        projectName: string;
+        noDailyLog: boolean;
+        noPhotos: boolean;
+        itemsMissingPhaseCode: number;
+    }> = [];
+
+    if (eligibleProjectIds.length > 0) {
+        const [dailyLogs, eligibleEstimates] = await Promise.all([
+            prisma.dailyLog.findMany({
+                where: { projectId: { in: eligibleProjectIds } },
+                select: { id: true, projectId: true, date: true },
+            }),
+            prisma.estimate.findMany({
+                where: {
+                    projectId: { in: eligibleProjectIds },
+                    status: { in: ["Approved", "Invoiced", "Partially Paid", "Paid"] },
+                    archivedAt: null,
+                },
+                select: { id: true, projectId: true },
+            }),
+        ]);
+
+        // Daily logs whose calendar day, in company-local time, matches the requested day.
+        const logsForDay = dailyLogs.filter((log) => toCompanyDayKey(log.date) === dayKey);
+        const logIdsForDay = logsForDay.map((l) => l.id);
+
+        const photoCounts = logIdsForDay.length
+            ? await prisma.dailyLogPhoto.groupBy({
+                  by: ["dailyLogId"],
+                  where: { dailyLogId: { in: logIdsForDay } },
+                  _count: { id: true },
+              })
+            : [];
+        const photoCountByLogId = new Map(photoCounts.map((p) => [p.dailyLogId, p._count.id]));
+
+        const logsForDayByProject = new Map<string, typeof logsForDay>();
+        for (const log of logsForDay) {
+            const arr = logsForDayByProject.get(log.projectId) ?? [];
+            arr.push(log);
+            logsForDayByProject.set(log.projectId, arr);
+        }
+
+        const estimateIds = eligibleEstimates.map((e) => e.id);
+        const missingPhaseGroups = estimateIds.length
+            ? await prisma.estimateItem.groupBy({
+                  by: ["estimateId"],
+                  where: { estimateId: { in: estimateIds }, parentId: null, costCodeId: null },
+                  _count: { id: true },
+              })
+            : [];
+        const estimateToProject = new Map(eligibleEstimates.map((e) => [e.id, e.projectId]));
+        const missingPhaseByProject = new Map<string, number>();
+        for (const g of missingPhaseGroups) {
+            const projectId = estimateToProject.get(g.estimateId);
+            if (!projectId) continue;
+            missingPhaseByProject.set(projectId, (missingPhaseByProject.get(projectId) ?? 0) + g._count.id);
+        }
+
+        compliance = eligibleProjects
+            .map((p) => {
+                const logsToday = logsForDayByProject.get(p.id) ?? [];
+                const noDailyLog = logsToday.length === 0;
+                const photosToday = logsToday.reduce((sum, l) => sum + (photoCountByLogId.get(l.id) ?? 0), 0);
+                const noPhotos = !noDailyLog && photosToday === 0;
+                const itemsMissingPhaseCode = missingPhaseByProject.get(p.id) ?? 0;
+                return {
+                    projectId: p.id,
+                    projectName: p.name,
+                    noDailyLog,
+                    noPhotos,
+                    itemsMissingPhaseCode,
+                };
+            })
+            .filter((c) => c.noDailyLog || c.noPhotos || c.itemsMissingPhaseCode > 0);
+    }
+
     return NextResponse.json({
         totalActiveWorkers: activeWorkers.length,
         weeklyTotalHours,
@@ -285,6 +375,7 @@ export async function GET(req: Request) {
         employeeStats,
         activity,
         employees: employees.map((u) => ({ id: u.id, name: u.name ?? u.email })),
+        compliance,
     });
 }
 

--- a/src/app/api/manager/jobs/[id]/route.ts
+++ b/src/app/api/manager/jobs/[id]/route.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { authenticateMobileOrSession } from "@/lib/mobile-auth";
 import { canonicalProjectStatus } from "@/lib/project-status";
 import { geocodeJobSiteAddress } from "@/lib/geocode";
+import { isValidChatWebhookUrl } from "@/lib/chat-webhook";
 
 const SELECT = {
     id: true,
@@ -14,6 +15,9 @@ const SELECT = {
     locationLng: true,
     geofenceRadiusMeters: true,
     clientId: true,
+    // Only safe here because this route is MANAGER/ADMIN-gated; the webhook URL
+    // is a credential and must never appear in crew-visible project responses.
+    chatWebhookUrl: true,
 } as const;
 
 export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -127,6 +131,19 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
         const geocoded = await geocodeJobSiteAddress(body.location);
         data.locationLat = geocoded?.lat ?? null;
         data.locationLng = geocoded?.lng ?? null;
+    }
+
+    if (body.chatWebhookUrl !== undefined) {
+        if (body.chatWebhookUrl === null || body.chatWebhookUrl === "") {
+            data.chatWebhookUrl = null;
+        } else if (typeof body.chatWebhookUrl === "string" && isValidChatWebhookUrl(body.chatWebhookUrl)) {
+            data.chatWebhookUrl = body.chatWebhookUrl.trim();
+        } else {
+            return NextResponse.json(
+                { error: "chatWebhookUrl must be a Google Chat incoming webhook (https://chat.googleapis.com/v1/spaces/...)" },
+                { status: 400 }
+            );
+        }
     }
 
     if (Object.keys(data).length === 0) {

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -1841,6 +1841,9 @@ function createHandler(actor: RouteMcpActor) {
                     workPerformed: z.string().trim().min(1).max(20_000),
                     materialsDelivered: z.string().max(20_000).optional(),
                     issues: z.string().max(20_000).optional(),
+                    nextSteps: z.string().max(20_000).optional().describe(
+                        "What's planned next / for tomorrow, if the chat mentions it—pull this from the conversation's \"next steps\" or \"tomorrow\" content."
+                    ),
                     photos: z.array(z.object({
                         fileId: z.string().max(50),
                         caption: z.string().max(500).optional(),
@@ -2606,7 +2609,7 @@ function createHandler(actor: RouteMcpActor) {
         );
     },
     {
-        serverInfo: { name: "probuild", version: "1.15.0" },
+        serverInfo: { name: "probuild", version: "1.16.0" },
         capabilities: { tools: {} },
         instructions:
             "ProBuild is Golden Touch Remodeling's construction management system. " +

--- a/src/app/api/mobile/time-suggestion/route.ts
+++ b/src/app/api/mobile/time-suggestion/route.ts
@@ -1,0 +1,33 @@
+export const dynamic = "force-dynamic";
+import { NextResponse } from "next/server";
+import { authenticateMobileOrSession, assertProjectAccess } from "@/lib/mobile-auth";
+import { suggestTaskForClockIn } from "@/lib/time-suggestion";
+
+// GET /api/mobile/time-suggestion?projectId=...
+// Suggested clock-in task for the caller on this project, derived from the
+// latest daily log (AI match, then keywords), today's schedule, then the
+// caller's own recent entries. Deterministic — no AI call happens here.
+// Hybrid auth: Bearer token (mobile) OR NextAuth session (web time clock).
+export async function GET(req: Request) {
+    const auth = await authenticateMobileOrSession(req);
+    if (!auth.ok) return NextResponse.json({ error: auth.error }, { status: auth.status });
+    const { user } = auth;
+
+    const { searchParams } = new URL(req.url);
+    const projectId = searchParams.get("projectId");
+    if (!projectId) {
+        return NextResponse.json({ error: "projectId is required" }, { status: 400 });
+    }
+
+    const fail = await assertProjectAccess(user, projectId);
+    if (fail) return fail;
+
+    try {
+        const suggestion = await suggestTaskForClockIn({ userId: user.id, projectId });
+        return NextResponse.json({ suggestion });
+    } catch (error) {
+        // A suggestion fault must never break the clock-in screen.
+        console.error("[time-suggestion] failed", { projectId, error });
+        return NextResponse.json({ suggestion: null });
+    }
+}

--- a/src/app/api/projects/[id]/estimate-items/route.ts
+++ b/src/app/api/projects/[id]/estimate-items/route.ts
@@ -35,6 +35,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ id: stri
             id: true,
             name: true,
             total: true,
+            costCodeId: true,
             costCode: { select: { code: true, name: true } },
         },
         orderBy: { order: 'asc' },

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -51,5 +51,8 @@ export async function GET(req: Request) {
         });
     }
 
-    return NextResponse.json(projects);
+    // chatWebhookUrl is a credential (Google Chat incoming webhook) — never
+    // serialize it to app clients; it's configured/read via manager-only routes.
+    const safe = projects.map(({ chatWebhookUrl: _chatWebhookUrl, ...rest }) => rest);
+    return NextResponse.json(safe);
 }

--- a/src/app/api/time-entries/route.ts
+++ b/src/app/api/time-entries/route.ts
@@ -26,7 +26,15 @@ export async function GET(req: Request) {
         where: whereClause,
         include: {
             user: true,
-            project: true,
+            // Explicit select — a full Project row would serialize
+            // chatWebhookUrl (a credential) to field crew.
+            project: {
+                select: {
+                    id: true, name: true, status: true, location: true,
+                    locationLat: true, locationLng: true, geofenceRadiusMeters: true,
+                    color: true, code: true, clientId: true,
+                },
+            },
             costCode: true
         },
         orderBy: {
@@ -61,7 +69,7 @@ export async function POST(req: Request) {
     // wins over whatever the client sent. Mobile historically sent
     // costCodeId: null, which is exactly how wrong/missing cost codes happened.
     let resolvedEstimateItemId: string | null = null;
-    let resolvedCostCodeId: string | null = costCodeId || null;
+    let resolvedCostCodeId: string | null = null;
     if (estimateItemId) {
         const item = await prisma.estimateItem.findFirst({
             where: {
@@ -78,7 +86,14 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Estimate item does not belong to an eligible estimate on this project" }, { status: 400 });
         }
         resolvedEstimateItemId = item.id;
-        if (item.costCodeId) resolvedCostCodeId = item.costCodeId;
+        // The item alone decides the charge — a client-sent costCodeId must not
+        // fill in for a codeless item, or crew can charge any code they like.
+        resolvedCostCodeId = item.costCodeId ?? null;
+    } else if (costCodeId && typeof costCodeId === "string") {
+        // True legacy path (no estimate item): keep the client's code, but only
+        // if it actually exists.
+        const code = await prisma.costCode.findUnique({ where: { id: costCodeId }, select: { id: true } });
+        resolvedCostCodeId = code?.id ?? null;
     }
 
     // Suggestion audit fields: trust nothing about the suggested task without

--- a/src/app/api/time-entries/route.ts
+++ b/src/app/api/time-entries/route.ts
@@ -43,7 +43,11 @@ export async function POST(req: Request) {
     const { user } = auth;
 
     const body = await req.json();
-    const { projectId, costCodeId, estimateItemId, startTime, latitude, longitude } = body;
+    const {
+        projectId, costCodeId, estimateItemId, startTime, latitude, longitude,
+        // Suggestion audit (newer clients only — older app versions omit all of these)
+        suggestedScheduleTaskId, suggestedCostCodeId, suggestionSource, suggestionOverridden,
+    } = body;
 
     if (!projectId) {
         return NextResponse.json({ error: "Project ID is required" }, { status: 400 });
@@ -52,24 +56,70 @@ export async function POST(req: Request) {
     const fail = await assertProjectAccess(user, projectId);
     if (fail) return fail;
 
+    // Cost attribution: the estimate item is what actually gets charged, so it
+    // must belong to this project (on an eligible estimate) and its cost code
+    // wins over whatever the client sent. Mobile historically sent
+    // costCodeId: null, which is exactly how wrong/missing cost codes happened.
+    let resolvedEstimateItemId: string | null = null;
+    let resolvedCostCodeId: string | null = costCodeId || null;
+    if (estimateItemId) {
+        const item = await prisma.estimateItem.findFirst({
+            where: {
+                id: estimateItemId,
+                estimate: {
+                    projectId,
+                    status: { in: ["Approved", "Invoiced", "Partially Paid", "Paid"] },
+                    archivedAt: null,
+                },
+            },
+            select: { id: true, costCodeId: true },
+        });
+        if (!item) {
+            return NextResponse.json({ error: "Estimate item does not belong to an eligible estimate on this project" }, { status: 400 });
+        }
+        resolvedEstimateItemId = item.id;
+        if (item.costCodeId) resolvedCostCodeId = item.costCodeId;
+    }
+
+    // Suggestion audit fields: trust nothing about the suggested task without
+    // re-checking it lives on this project (it feeds manager review, not cost).
+    let auditSuggestedTaskId: string | null = null;
+    let auditSuggestedTaskName: string | null = null;
+    if (suggestedScheduleTaskId && typeof suggestedScheduleTaskId === "string") {
+        const suggestedTask = await prisma.scheduleTask.findFirst({
+            where: { id: suggestedScheduleTaskId, projectId },
+            select: { id: true, name: true },
+        });
+        if (suggestedTask) {
+            auditSuggestedTaskId = suggestedTask.id;
+            auditSuggestedTaskName = suggestedTask.name;
+        }
+    }
+    const validSources = ["daily_log", "today_schedule", "user_history"];
+
     const entryStartTime = startTime ? new Date(startTime) : new Date();
     const scheduleTaskId = await resolveScheduleTaskIdForPunch({
         userId: user.id,
         projectId,
         dayKey: toCompanyDayKey(entryStartTime),
-        estimateItemId,
+        estimateItemId: resolvedEstimateItemId,
     });
 
     const timeEntry = await prisma.timeEntry.create({
         data: {
             userId: user.id,
             projectId,
-            costCodeId: costCodeId || null,
-            estimateItemId: estimateItemId || null,
+            costCodeId: resolvedCostCodeId,
+            estimateItemId: resolvedEstimateItemId,
             startTime: entryStartTime,
             latitude,
             longitude,
             scheduleTaskId,
+            suggestedScheduleTaskId: auditSuggestedTaskId,
+            suggestedTaskName: auditSuggestedTaskName,
+            suggestedCostCodeId: typeof suggestedCostCodeId === "string" ? suggestedCostCodeId : null,
+            suggestionSource: validSources.includes(suggestionSource) ? suggestionSource : null,
+            suggestionOverridden: suggestionOverridden === true,
         }
     });
 

--- a/src/app/projects/[id]/dailylogs/DailyLogsClient.tsx
+++ b/src/app/projects/[id]/dailylogs/DailyLogsClient.tsx
@@ -65,6 +65,7 @@ type DailyLog = {
     workPerformed: string;
     materialsDelivered: string | null;
     issues: string | null;
+    nextSteps: string | null;
     photos: DailyLogPhoto[];
     createdBy: { id: string; name: string | null; email: string };
     createdAt: string;
@@ -133,6 +134,7 @@ export default function DailyLogsClient({
     const [formWork, setFormWork] = useState("");
     const [formMaterials, setFormMaterials] = useState("");
     const [formIssues, setFormIssues] = useState("");
+    const [formNextSteps, setFormNextSteps] = useState("");
     const [formPhotos, setFormPhotos] = useState<File[]>([]);
     const [uploading, setUploading] = useState(false);
     const fileInputRef = useRef<HTMLInputElement>(null);
@@ -145,6 +147,7 @@ export default function DailyLogsClient({
         setFormWork("");
         setFormMaterials("");
         setFormIssues("");
+        setFormNextSteps("");
         setFormPhotos([]);
     };
 
@@ -224,6 +227,7 @@ export default function DailyLogsClient({
             if (data.workPerformed) setFormWork(data.workPerformed);
             if (data.materialsDelivered) setFormMaterials(data.materialsDelivered);
             if (data.issues) setFormIssues(data.issues);
+            if (data.nextSteps) setFormNextSteps(data.nextSteps);
             
             // If weather wasn't explicitly set by user, suggest it if AI found it
             if (!formWeather && !formTemp && data.weather) {
@@ -265,6 +269,7 @@ export default function DailyLogsClient({
                         workPerformed: formWork,
                         materialsDelivered: formMaterials || undefined,
                         issues: formIssues || undefined,
+                        nextSteps: formNextSteps || undefined,
                         photoUrls: photoUrls.length > 0 ? photoUrls : undefined,
                     });
                     toast.success("Daily log created!");
@@ -725,6 +730,16 @@ export default function DailyLogsClient({
                                                                         </div>
                                                                     )}
 
+                                                                    {/* Next Steps */}
+                                                                    {log.nextSteps && (
+                                                                        <div>
+                                                                            <p className="text-[10px] font-bold text-blue-600 uppercase tracking-wider mb-2">Next Steps</p>
+                                                                            <div className="text-sm text-hui-textMain whitespace-pre-wrap bg-blue-50/50 rounded-lg p-4 border border-blue-100">
+                                                                                {log.nextSteps}
+                                                                            </div>
+                                                                        </div>
+                                                                    )}
+
                                                                     {/* Photos */}
                                                                     {log.photos.length > 0 && (
                                                                         <div>
@@ -960,6 +975,18 @@ export default function DailyLogsClient({
                                     placeholder="Note any issues, delays, or concerns..."
                                     value={formIssues}
                                     onChange={e => setFormIssues(e.target.value)}
+                                    className="hui-input w-full"
+                                    rows={2}
+                                />
+                            </div>
+
+                            {/* Next Steps */}
+                            <div>
+                                <label className="block text-sm font-medium text-hui-textMain mb-1">Next Steps (optional)</label>
+                                <textarea
+                                    placeholder="What's the plan for tomorrow?"
+                                    value={formNextSteps}
+                                    onChange={e => setFormNextSteps(e.target.value)}
                                     className="hui-input w-full"
                                     rows={2}
                                 />

--- a/src/app/projects/[id]/timeclock/TimeClockClient.tsx
+++ b/src/app/projects/[id]/timeclock/TimeClockClient.tsx
@@ -20,6 +20,9 @@ type TimeEntryDetailed = {
     laborCost: number | null;
     user: { id: string; name: string | null; email: string };
     costCode: CostCodeBasic | null;
+    suggestionOverridden?: boolean;
+    suggestedTaskName?: string | null;
+    suggestionSource?: string | null;
 };
 
 interface TimeClockClientProps {
@@ -366,13 +369,23 @@ export default function TimeClockClient({
                                         </div>
                                     </td>
                                     <td className="px-5 py-3.5">
-                                        {entry.costCode ? (
-                                            <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-indigo-50 text-indigo-700 border border-indigo-100">
-                                                {entry.costCode.code} – {entry.costCode.name}
-                                            </span>
-                                        ) : (
-                                            <span className="text-slate-400 italic text-xs">Unassigned</span>
-                                        )}
+                                        <div className="flex flex-col items-start gap-1">
+                                            {entry.costCode ? (
+                                                <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-indigo-50 text-indigo-700 border border-indigo-100">
+                                                    {entry.costCode.code} – {entry.costCode.name}
+                                                </span>
+                                            ) : (
+                                                <span className="text-slate-400 italic text-xs">Unassigned</span>
+                                            )}
+                                            {entry.suggestionOverridden && (
+                                                <span
+                                                    className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-amber-100 text-amber-700"
+                                                    title={entry.suggestionSource ? `Suggestion source: ${entry.suggestionSource}` : undefined}
+                                                >
+                                                    Overrode suggestion: {entry.suggestedTaskName ?? "suggested task"}
+                                                </span>
+                                            )}
+                                        </div>
                                     </td>
                                     <td className="px-5 py-3.5 text-right font-semibold tabular-nums">
                                         {entry.durationHours === 0

--- a/src/app/time-clock/page.tsx
+++ b/src/app/time-clock/page.tsx
@@ -1,8 +1,19 @@
 "use client";
 export const dynamic = "force-dynamic";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useRouter } from "next/navigation";
+
+type ClockInSuggestion = {
+    scheduleTaskId: string;
+    clockInEstimateItemId: string;
+    costCodeId: string;
+    costCodeLabel: string;
+    taskName: string;
+    source: "daily_log" | "today_schedule" | "user_history";
+    confidence: "high" | "medium" | "low";
+    reason: string | null;
+};
 
 export default function TimeClockPage() {
     const router = useRouter();
@@ -16,6 +27,13 @@ export default function TimeClockPage() {
 
     const [budgetBuckets, setBudgetBuckets] = useState<any[]>([]);
     const [selectedBucket, setSelectedBucket] = useState<string>("");
+
+    const [suggestion, setSuggestion] = useState<ClockInSuggestion | null>(null);
+    // True once the user has picked a phase themselves — the suggestion preselect
+    // must never fight a manual choice.
+    const userPickedBucket = useRef(false);
+    // Set while the "are you sure?" mismatch dialog is showing.
+    const [confirmMismatch, setConfirmMismatch] = useState(false);
 
     const [projectsError, setProjectsError] = useState<string>("");
     const [timeEntriesError, setTimeEntriesError] = useState<string>("");
@@ -91,8 +109,13 @@ export default function TimeClockPage() {
         if (!selectedProject) {
             setBudgetBuckets([]);
             setSelectedBucket("");
+            setSuggestion(null);
+            userPickedBucket.current = false;
             return;
         }
+
+        userPickedBucket.current = false;
+        setSuggestion(null);
 
         fetch(`/api/projects/${selectedProject}/estimate-items`)
             .then(res => res.json())
@@ -106,7 +129,41 @@ export default function TimeClockPage() {
                 setBucketsError("Failed to load budget phases");
             });
 
+        // Suggested task for today (from the latest daily log / schedule).
+        // Best-effort: a failure here must never block clocking in.
+        fetch(`/api/mobile/time-suggestion?projectId=${selectedProject}`)
+            .then(res => res.ok ? res.json() : { suggestion: null })
+            .then(data => {
+                const s: ClockInSuggestion | null = data?.suggestion ?? null;
+                setSuggestion(s);
+                if (s && !userPickedBucket.current) {
+                    setSelectedBucket(s.clockInEstimateItemId);
+                }
+            })
+            .catch(() => setSuggestion(null));
+
     }, [selectedProject]);
+
+    // Phase-code-grouped picker: groups ordered by cost code; codeless items
+    // surface last, flagged — every estimate item is supposed to carry a phase code.
+    const bucketGroups = useMemo(() => {
+        const groups = new Map<string, { label: string; items: any[] }>();
+        for (const bucket of budgetBuckets) {
+            const key = bucket.costCode ? bucket.costCode.code : "~none";
+            const label = bucket.costCode
+                ? `${bucket.costCode.code} — ${bucket.costCode.name}`
+                : "No phase code (fix in estimate)";
+            if (!groups.has(key)) groups.set(key, { label, items: [] });
+            groups.get(key)!.items.push(bucket);
+        }
+        return [...groups.entries()]
+            .sort(([a], [b]) => {
+                if (a === "~none") return 1;
+                if (b === "~none") return -1;
+                return a.localeCompare(b, undefined, { numeric: true });
+            })
+            .map(([, group]) => group);
+    }, [budgetBuckets]);
 
     const getLocation = (): Promise<{ lat: number, lng: number }> => {
         return new Promise((resolve, reject) => {
@@ -125,8 +182,7 @@ export default function TimeClockPage() {
         });
     };
 
-    const handleClockInOut = async () => {
-        setError("");
+    const performClockIn = async (bucketId: string, overridden: boolean) => {
         let loc = null;
         try {
             loc = await getLocation();
@@ -135,32 +191,57 @@ export default function TimeClockPage() {
             setError(e);
         }
 
+        try {
+            const res = await fetch('/api/time-entries', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    projectId: selectedProject,
+                    estimateItemId: bucketId || null,
+                    latitude: loc?.lat,
+                    longitude: loc?.lng,
+                    ...(suggestion ? {
+                        suggestedScheduleTaskId: suggestion.scheduleTaskId,
+                        suggestedCostCodeId: suggestion.costCodeId,
+                        suggestionSource: suggestion.source,
+                        suggestionOverridden: overridden,
+                    } : {}),
+                })
+            });
+            const data = await res.json();
+            if (data.error) throw new Error(data.error);
+
+            setStatus("Clocked In");
+            setCurrentTimeEntryId(data.id);
+            if (bucketId !== selectedBucket) setSelectedBucket(bucketId);
+        } catch (err: any) {
+            setError(err.message);
+        }
+    };
+
+    const handleClockInOut = async () => {
+        setError("");
+
         if (status === "Clocked Out") {
             if (!selectedProject) {
                 setError("Please select a project before clocking in.");
                 return;
             }
 
-            try {
-                const res = await fetch('/api/time-entries', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        projectId: selectedProject,
-                        estimateItemId: selectedBucket || null,
-                        latitude: loc?.lat,
-                        longitude: loc?.lng
-                    })
-                });
-                const data = await res.json();
-                if (data.error) throw new Error(data.error);
-
-                setStatus("Clocked In");
-                setCurrentTimeEntryId(data.id);
-            } catch (err: any) {
-                setError(err.message);
+            // Red flag: picked something other than today's plan? Confirm first.
+            if (suggestion && selectedBucket !== suggestion.clockInEstimateItemId) {
+                setConfirmMismatch(true);
+                return;
             }
+            await performClockIn(selectedBucket, false);
         } else {
+            let loc = null;
+            try {
+                loc = await getLocation();
+                setLocation(loc);
+            } catch (e: any) {
+                setError(e);
+            }
             try {
                 if (!currentTimeEntryId) return;
 
@@ -217,23 +298,47 @@ export default function TimeClockPage() {
                             )}
                         </div>
 
+                        {suggestion && (
+                            <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
+                                <div className="text-sm text-blue-800 font-medium">
+                                    Suggested: {suggestion.taskName}
+                                </div>
+                                <div className="text-xs text-blue-700 mt-0.5">{suggestion.costCodeLabel}</div>
+                                {suggestion.reason && (
+                                    <div className="text-xs text-blue-600 mt-1">{suggestion.reason}</div>
+                                )}
+                            </div>
+                        )}
+
                         {budgetBuckets.length > 0 && (
                             <div>
                                 <label className="block text-sm font-medium text-slate-700 mb-2">Budget Bucket (Phase)</label>
                                 <select
                                     value={selectedBucket}
-                                    onChange={(e) => setSelectedBucket(e.target.value)}
+                                    onChange={(e) => {
+                                        userPickedBucket.current = true;
+                                        setSelectedBucket(e.target.value);
+                                    }}
                                     className="hui-input"
                                 >
                                     <option value="">Select a Phase...</option>
-                                    {budgetBuckets.map(b => (
-                                        <option key={b.id} value={b.id}>
-                                            {b.name}{b.costCode ? ` — ${b.costCode.code}` : ''}
-                                        </option>
+                                    {bucketGroups.map(group => (
+                                        <optgroup key={group.label} label={group.label}>
+                                            {group.items.map((b: any) => (
+                                                <option key={b.id} value={b.id}>
+                                                    {b.costCode ? `${b.costCode.code} — ` : ''}{b.name}
+                                                </option>
+                                            ))}
+                                        </optgroup>
                                     ))}
                                 </select>
                                 {bucketsError && (
                                     <p className="text-xs text-red-600 mt-1">{bucketsError}</p>
+                                )}
+                                {budgetBuckets.some((b: any) => !b.costCode) && (
+                                    <p className="text-xs text-amber-600 mt-1">
+                                        Some phases have no phase code — assign cost codes in the estimate.
+                                    </p>
                                 )}
                             </div>
                         )}
@@ -282,6 +387,46 @@ export default function TimeClockPage() {
                     </div>
                 )}
             </div>
+
+            {confirmMismatch && suggestion && (
+                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-6">
+                    <div className="hui-card w-full max-w-sm p-6 text-left">
+                        <h2 className="text-lg font-bold text-hui-textMain mb-2">
+                            Are you sure this is the correct task?
+                        </h2>
+                        <p className="text-sm text-slate-600 mb-5">
+                            Today&apos;s plan is <span className="font-semibold">{suggestion.taskName}</span> ({suggestion.costCodeLabel}).
+                        </p>
+                        <div className="space-y-2">
+                            <button
+                                className="hui-btn hui-btn-green w-full"
+                                onClick={async () => {
+                                    setConfirmMismatch(false);
+                                    userPickedBucket.current = true;
+                                    await performClockIn(suggestion.clockInEstimateItemId, false);
+                                }}
+                            >
+                                Use suggested task
+                            </button>
+                            <button
+                                className="hui-btn w-full"
+                                onClick={async () => {
+                                    setConfirmMismatch(false);
+                                    await performClockIn(selectedBucket, true);
+                                }}
+                            >
+                                Keep my choice
+                            </button>
+                            <button
+                                className="w-full py-2 text-sm text-slate-500 hover:text-slate-700"
+                                onClick={() => setConfirmMismatch(false)}
+                            >
+                                Cancel
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/src/app/time-clock/page.tsx
+++ b/src/app/time-clock/page.tsx
@@ -117,7 +117,11 @@ export default function TimeClockPage() {
         userPickedBucket.current = false;
         setSuggestion(null);
 
-        fetch(`/api/projects/${selectedProject}/estimate-items`)
+        // Abort both per-project fetches on project switch — a slow response
+        // for the previous project must not overwrite the current one's state.
+        const controller = new AbortController();
+
+        fetch(`/api/projects/${selectedProject}/estimate-items`, { signal: controller.signal })
             .then(res => res.json())
             .then(data => {
                 if (Array.isArray(data)) {
@@ -125,13 +129,14 @@ export default function TimeClockPage() {
                 }
             })
             .catch(e => {
+                if (e.name === "AbortError") return;
                 console.error("Could not fetch estimate items", e);
                 setBucketsError("Failed to load budget phases");
             });
 
         // Suggested task for today (from the latest daily log / schedule).
         // Best-effort: a failure here must never block clocking in.
-        fetch(`/api/mobile/time-suggestion?projectId=${selectedProject}`)
+        fetch(`/api/mobile/time-suggestion?projectId=${selectedProject}`, { signal: controller.signal })
             .then(res => res.ok ? res.json() : { suggestion: null })
             .then(data => {
                 const s: ClockInSuggestion | null = data?.suggestion ?? null;
@@ -140,8 +145,9 @@ export default function TimeClockPage() {
                     setSelectedBucket(s.clockInEstimateItemId);
                 }
             })
-            .catch(() => setSuggestion(null));
+            .catch(() => { /* aborted or failed — no suggestion */ });
 
+        return () => controller.abort();
     }, [selectedProject]);
 
     // Phase-code-grouped picker: groups ordered by cost code; codeless items

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -22,6 +22,7 @@ import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { appendPunchItemsInTransaction } from "./punch-items";
 import { runDailyLogTaskMatch } from "./daily-log-task-match";
 import { postDailyLogSummary } from "./chat-webhook";
+import { runAfterRequest } from "./after-request";
 import { enqueueMilestonePaid, drainPaymentNotifications } from "./payment-outbox";
 import { deleteChangeOrderCore, updateChangeOrderCore } from "./change-order-core";
 import { approveChangeOrderWithSignature } from "./change-order-approval";
@@ -12116,7 +12117,7 @@ export async function createDailyLog(projectId: string, data: {
     // Best-effort enrichment after the response: pin the AI task match on the
     // log, then post the summary (with tomorrow's task) to the project's Chat
     // space. Neither may block or fail the log write.
-    after(async () => {
+    runAfterRequest(async () => {
         await runDailyLogTaskMatch(log.id);
         await postDailyLogSummary(log.id);
     });
@@ -12163,7 +12164,7 @@ export async function updateDailyLog(id: string, data: {
     const narrativeChanged = data.workPerformed !== undefined
         || data.nextSteps !== undefined
         || data.issues !== undefined;
-    after(async () => {
+    runAfterRequest(async () => {
         await runDailyLogTaskMatch(log.id);
         if (narrativeChanged) await postDailyLogSummary(log.id);
     });
@@ -12199,7 +12200,7 @@ export async function addDailyLogPhotos(dailyLogId: string, photos: { url: strin
 
     // Photos are matcher evidence — refresh the pick. No Chat re-post for
     // photo-only mutations.
-    after(() => runDailyLogTaskMatch(dailyLogId));
+    runAfterRequest(() => runDailyLogTaskMatch(dailyLogId));
 
     revalidatePath(`/projects/${log.projectId}/dailylogs`);
     return { success: true };
@@ -12225,7 +12226,7 @@ export async function deleteDailyLogPhoto(photoId: string) {
     });
 
     // Photos are matcher evidence — refresh the pick after removal too.
-    after(() => runDailyLogTaskMatch(photo.dailyLog.id));
+    runAfterRequest(() => runDailyLogTaskMatch(photo.dailyLog.id));
 
     revalidatePath(`/projects/${photo.dailyLog.projectId}/dailylogs`);
     return { success: true };

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -12197,6 +12197,9 @@ export async function addDailyLogPhotos(dailyLogId: string, photos: { url: strin
             caption: p.caption || null,
         })),
     });
+    // Bump the log row: its updatedAt versions the content for the matcher's
+    // atomic stale-store guard, and photo rows alone don't touch it.
+    await prisma.dailyLog.update({ where: { id: dailyLogId }, data: { updatedAt: new Date() } });
 
     // Photos are matcher evidence — refresh the pick. No Chat re-post for
     // photo-only mutations.
@@ -12217,12 +12220,12 @@ export async function deleteDailyLogPhoto(photoId: string) {
 
     await prisma.$transaction(async tx => {
         await tx.dailyLogPhoto.delete({ where: { id: photoId } });
-        if (photo.sharedToPortal) {
-            await tx.dailyLog.update({
-                where: { id: photo.dailyLog.id },
-                data: { sharedContentHash: null },
-            });
-        }
+        // Bump the log row regardless: updatedAt versions the content for the
+        // matcher's atomic stale-store guard.
+        await tx.dailyLog.update({
+            where: { id: photo.dailyLog.id },
+            data: photo.sharedToPortal ? { sharedContentHash: null, updatedAt: new Date() } : { updatedAt: new Date() },
+        });
     });
 
     // Photos are matcher evidence — refresh the pick after removal too.

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -20,6 +20,8 @@ import { canUseDevAuthFallback, getCurrentUserWithPermissions, getUserWithPermis
 import { logActivity } from "./activity-log";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { appendPunchItemsInTransaction } from "./punch-items";
+import { runDailyLogTaskMatch } from "./daily-log-task-match";
+import { postDailyLogSummary } from "./chat-webhook";
 import { enqueueMilestonePaid, drainPaymentNotifications } from "./payment-outbox";
 import { deleteChangeOrderCore, updateChangeOrderCore } from "./change-order-core";
 import { approveChangeOrderWithSignature } from "./change-order-approval";
@@ -12100,6 +12102,7 @@ export async function createDailyLog(projectId: string, data: {
     workPerformed: string;
     materialsDelivered?: string;
     issues?: string;
+    nextSteps?: string;
     photoUrls?: { url: string; caption?: string }[];
 }) {
     // Hardened (dispatch-arc foundation): derive the author from an authorized staff session.
@@ -12108,6 +12111,14 @@ export async function createDailyLog(projectId: string, data: {
         projectId,
         actorUserId: author.id,
         ...data,
+    });
+
+    // Best-effort enrichment after the response: pin the AI task match on the
+    // log, then post the summary (with tomorrow's task) to the project's Chat
+    // space. Neither may block or fail the log write.
+    after(async () => {
+        await runDailyLogTaskMatch(log.id);
+        await postDailyLogSummary(log.id);
     });
 
     revalidatePath(`/projects/${projectId}/dailylogs`);
@@ -12121,6 +12132,7 @@ export async function updateDailyLog(id: string, data: {
     workPerformed?: string;
     materialsDelivered?: string;
     issues?: string;
+    nextSteps?: string;
 }) {
     // Hardened (dispatch-arc foundation): authorize against the persisted log project before updating.
     const target = await prisma.dailyLog.findUnique({ where: { id }, select: { projectId: true } });
@@ -12138,10 +12150,22 @@ export async function updateDailyLog(id: string, data: {
     }
     if (data.materialsDelivered !== undefined) updateData.materialsDelivered = data.materialsDelivered || null;
     if (data.issues !== undefined) updateData.issues = data.issues || null;
+    if (data.nextSteps !== undefined) updateData.nextSteps = data.nextSteps || null;
 
     const log = await prisma.dailyLog.update({
         where: { id },
         data: updateData,
+    });
+
+    // Re-run the task match on any edit; re-post to Chat only when the
+    // narrative fields changed (a weather/date touch-up shouldn't re-ping the
+    // whole crew space).
+    const narrativeChanged = data.workPerformed !== undefined
+        || data.nextSteps !== undefined
+        || data.issues !== undefined;
+    after(async () => {
+        await runDailyLogTaskMatch(log.id);
+        if (narrativeChanged) await postDailyLogSummary(log.id);
     });
 
     revalidatePath(`/projects/${log.projectId}/dailylogs`);
@@ -12173,6 +12197,10 @@ export async function addDailyLogPhotos(dailyLogId: string, photos: { url: strin
         })),
     });
 
+    // Photos are matcher evidence — refresh the pick. No Chat re-post for
+    // photo-only mutations.
+    after(() => runDailyLogTaskMatch(dailyLogId));
+
     revalidatePath(`/projects/${log.projectId}/dailylogs`);
     return { success: true };
 }
@@ -12195,6 +12223,10 @@ export async function deleteDailyLogPhoto(photoId: string) {
             });
         }
     });
+
+    // Photos are matcher evidence — refresh the pick after removal too.
+    after(() => runDailyLogTaskMatch(photo.dailyLog.id));
+
     revalidatePath(`/projects/${photo.dailyLog.projectId}/dailylogs`);
     return { success: true };
 }

--- a/src/lib/after-request.ts
+++ b/src/lib/after-request.ts
@@ -1,0 +1,14 @@
+import { after } from "next/server";
+
+// next/server's after() throws outside a request scope (verify scripts, CLI
+// tools importing server libs). Deferred best-effort work should degrade to a
+// detached run there, not crash the caller.
+export function runAfterRequest(task: () => Promise<unknown>): void {
+    try {
+        after(task);
+    } catch {
+        void task().catch(error => {
+            console.error("[after-request] detached task failed", error);
+        });
+    }
+}

--- a/src/lib/chat-webhook.ts
+++ b/src/lib/chat-webhook.ts
@@ -122,11 +122,24 @@ export async function postDailyLogSummary(dailyLogId: string): Promise<boolean> 
                 where: { id: log.aiSuggestedTaskId },
                 select: {
                     name: true,
-                    estimateItem: { select: { costCode: { select: { code: true, name: true } } } },
+                    // A leaf's item may be codeless with the code on its parent
+                    // bucket (the thing actually charged) — walk up for display.
+                    estimateItem: {
+                        select: {
+                            costCode: { select: { code: true, name: true } },
+                            parent: {
+                                select: {
+                                    costCode: { select: { code: true, name: true } },
+                                    parent: { select: { costCode: { select: { code: true, name: true } } } },
+                                },
+                            },
+                        },
+                    },
                 },
             });
             if (task) {
-                const costCode = task.estimateItem?.costCode;
+                const item = task.estimateItem;
+                const costCode = item?.costCode ?? item?.parent?.costCode ?? item?.parent?.parent?.costCode ?? null;
                 suggestedTask = {
                     taskName: task.name,
                     costCodeLabel: costCode ? `${costCode.code} — ${costCode.name}` : "",

--- a/src/lib/chat-webhook.ts
+++ b/src/lib/chat-webhook.ts
@@ -120,26 +120,27 @@ export async function postDailyLogSummary(dailyLogId: string): Promise<boolean> 
         if (log.aiSuggestedTaskId) {
             const task = await prisma.scheduleTask.findUnique({
                 where: { id: log.aiSuggestedTaskId },
-                select: {
-                    name: true,
-                    // A leaf's item may be codeless with the code on its parent
-                    // bucket (the thing actually charged) — walk up for display.
-                    estimateItem: {
-                        select: {
-                            costCode: { select: { code: true, name: true } },
-                            parent: {
-                                select: {
-                                    costCode: { select: { code: true, name: true } },
-                                    parent: { select: { costCode: { select: { code: true, name: true } } } },
-                                },
-                            },
-                        },
-                    },
-                },
+                select: { name: true, estimateItemId: true },
             });
             if (task) {
-                const item = task.estimateItem;
-                const costCode = item?.costCode ?? item?.parent?.costCode ?? item?.parent?.parent?.costCode ?? null;
+                // The charge lands on the TOP-LEVEL bucket, so the label must be
+                // that bucket's cost code — not the nearest coded ancestor.
+                // Same walk the suggestion mapper does (bounded hop count).
+                let costCode: { code: string; name: string } | null = null;
+                let itemId: string | null = task.estimateItemId;
+                for (let hops = 0; itemId && hops < 10; hops += 1) {
+                    const item: { parentId: string | null; costCode: { code: string; name: string } | null } | null =
+                        await prisma.estimateItem.findUnique({
+                            where: { id: itemId },
+                            select: { parentId: true, costCode: { select: { code: true, name: true } } },
+                        });
+                    if (!item) break;
+                    if (!item.parentId) {
+                        costCode = item.costCode;
+                        break;
+                    }
+                    itemId = item.parentId;
+                }
                 suggestedTask = {
                     taskName: task.name,
                     costCodeLabel: costCode ? `${costCode.code} — ${costCode.name}` : "",

--- a/src/lib/chat-webhook.ts
+++ b/src/lib/chat-webhook.ts
@@ -1,0 +1,150 @@
+import { prisma } from "@/lib/prisma";
+
+// Daily-log post-back to the project's Google Chat team space, via a per-space
+// incoming webhook (Project.chatWebhookUrl — a credential, manager-configured).
+//
+// One-way in v1: the crew sees the structured log + tomorrow's suggested task
+// the evening before, which is what makes the clock-in "are you sure?" nudge
+// trusted instead of noise. There is deliberately no "reply to correct"
+// invitation — a reply-driven correction loop needs thread correlation and an
+// update tool that don't exist yet.
+//
+// Callers AWAIT this (or run it inside next/server `after()`); it must never
+// throw into a daily-log write, so all failures resolve false and log.
+
+const WEBHOOK_HOST = "chat.googleapis.com";
+const POST_TIMEOUT_MS = 10_000;
+
+/**
+ * The server POSTs to this URL, so restrict it to Google Chat's webhook
+ * surface — anything else is an SSRF vector, not a configuration choice.
+ */
+export function isValidChatWebhookUrl(value: string): boolean {
+    try {
+        const url = new URL(value.trim());
+        return url.protocol === "https:"
+            && url.hostname === WEBHOOK_HOST
+            && url.pathname.startsWith("/v1/spaces/");
+    } catch {
+        return false;
+    }
+}
+
+export interface DailyLogPostBackInput {
+    projectId: string;
+    dateLabel: string; // "2026-08-06"
+    workPerformed: string;
+    nextSteps?: string | null;
+    issues?: string | null;
+    photoCount: number;
+    /** Stage A's pick, when it produced one — shown as tomorrow's task. */
+    suggestedTask?: { costCodeLabel: string; taskName: string } | null;
+}
+
+/**
+ * Post the structured daily-log summary to the project's Chat space.
+ * Resolves true when a post was delivered, false otherwise (no webhook
+ * configured, invalid URL, network failure). Never throws.
+ */
+export async function postDailyLogToChat(input: DailyLogPostBackInput): Promise<boolean> {
+    try {
+        const project = await prisma.project.findUnique({
+            where: { id: input.projectId },
+            select: { name: true, chatWebhookUrl: true },
+        });
+        const webhookUrl = project?.chatWebhookUrl;
+        if (!webhookUrl || !isValidChatWebhookUrl(webhookUrl)) return false;
+
+        const lines = [
+            `📋 *Daily log — ${input.dateLabel}*`,
+            ``,
+            `*What we did:* ${truncate(input.workPerformed)}`,
+        ];
+        if (input.nextSteps?.trim()) lines.push(`*Next steps:* ${truncate(input.nextSteps)}`);
+        if (input.issues?.trim()) lines.push(`*Issues:* ${truncate(input.issues)}`);
+        if (input.photoCount > 0) lines.push(`📷 ${input.photoCount} photo${input.photoCount === 1 ? "" : "s"}`);
+        if (input.suggestedTask) {
+            const label = input.suggestedTask.costCodeLabel
+                ? `${input.suggestedTask.costCodeLabel} — ${input.suggestedTask.taskName}`
+                : input.suggestedTask.taskName;
+            lines.push(``, `👉 *Tomorrow's task: ${label}*`);
+        }
+
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), POST_TIMEOUT_MS);
+        const res = await fetch(webhookUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json; charset=UTF-8" },
+            body: JSON.stringify({ text: lines.join("\n") }),
+            signal: controller.signal,
+        });
+        clearTimeout(timer);
+        if (!res.ok) {
+            console.error("[chat-webhook] post failed", { projectId: input.projectId, status: res.status });
+            return false;
+        }
+        return true;
+    } catch (error) {
+        console.error("[chat-webhook] post failed", { projectId: input.projectId, error });
+        return false;
+    }
+}
+
+function truncate(text: string, max = 600): string {
+    const trimmed = text.trim();
+    return trimmed.length <= max ? trimmed : `${trimmed.slice(0, max - 1)}…`;
+}
+
+/**
+ * Load a daily log (incl. the Stage A task pick, so call this AFTER
+ * runDailyLogTaskMatch) and post its summary to the project's Chat space.
+ * Never throws.
+ */
+export async function postDailyLogSummary(dailyLogId: string): Promise<boolean> {
+    try {
+        const log = await prisma.dailyLog.findUnique({
+            where: { id: dailyLogId },
+            select: {
+                projectId: true,
+                date: true,
+                workPerformed: true,
+                nextSteps: true,
+                issues: true,
+                aiSuggestedTaskId: true,
+                photos: { select: { id: true } },
+            },
+        });
+        if (!log) return false;
+
+        let suggestedTask: { costCodeLabel: string; taskName: string } | null = null;
+        if (log.aiSuggestedTaskId) {
+            const task = await prisma.scheduleTask.findUnique({
+                where: { id: log.aiSuggestedTaskId },
+                select: {
+                    name: true,
+                    estimateItem: { select: { costCode: { select: { code: true, name: true } } } },
+                },
+            });
+            if (task) {
+                const costCode = task.estimateItem?.costCode;
+                suggestedTask = {
+                    taskName: task.name,
+                    costCodeLabel: costCode ? `${costCode.code} — ${costCode.name}` : "",
+                };
+            }
+        }
+
+        return await postDailyLogToChat({
+            projectId: log.projectId,
+            dateLabel: log.date.toISOString().slice(0, 10),
+            workPerformed: log.workPerformed,
+            nextSteps: log.nextSteps,
+            issues: log.issues,
+            photoCount: log.photos.length,
+            suggestedTask,
+        });
+    } catch (error) {
+        console.error("[chat-webhook] summary post failed", { dailyLogId, error });
+        return false;
+    }
+}

--- a/src/lib/daily-log-core.ts
+++ b/src/lib/daily-log-core.ts
@@ -11,6 +11,7 @@ export type CreateDailyLogCoreInput = {
     workPerformed: string;
     materialsDelivered?: string;
     issues?: string;
+    nextSteps?: string;
     photoUrls?: Array<{ url: string; caption?: string }>;
 };
 
@@ -29,6 +30,7 @@ export async function createDailyLogCore(
         workPerformed,
         materialsDelivered,
         issues,
+        nextSteps,
         photoUrls,
     } = input;
     return tx.dailyLog.create({
@@ -40,6 +42,7 @@ export async function createDailyLogCore(
             workPerformed,
             materialsDelivered: materialsDelivered || null,
             issues: issues || null,
+            nextSteps: nextSteps || null,
             createdById: actorUserId,
             photos: photoUrls && photoUrls.length > 0 ? {
                 create: photoUrls.map(photo => ({

--- a/src/lib/daily-log-task-match.ts
+++ b/src/lib/daily-log-task-match.ts
@@ -1,0 +1,186 @@
+import { GoogleGenAI, type Part } from "@google/genai";
+import { prisma } from "@/lib/prisma";
+import { loadSuggestableTasks, keywordMatchTasks } from "@/lib/time-suggestion";
+
+// Stage A of the daily-log accuracy pipeline: when a daily log is written (or
+// its photos change), match the log's TEXT AND PHOTOS against the project's
+// open schedule tasks and pin the pick on the log
+// (DailyLog.aiSuggestedTaskId/aiSuggestionReason). Clock-in (Stage B,
+// time-suggestion.ts) reads that stored pick — no AI runs at clock-in.
+//
+// Lifecycle contract:
+//   - a SUCCESSFUL run that finds no match CLEARS any stored suggestion
+//     (the log changed; the old pick no longer has evidence behind it)
+//   - a TRANSIENT failure (AI/transport error) PRESERVES what's stored
+//   - nothing here ever throws into a log write — this is best-effort
+//     enrichment beside the write, never a gate on it.
+
+const MAX_PHOTOS = 4;
+const PHOTO_FETCH_TIMEOUT_MS = 5_000;
+const MAX_PHOTO_BYTES = 4 * 1024 * 1024;
+
+/** Set DAILY_LOG_MATCH_AI_MOCK=1 to force the deterministic keyword path (CI). */
+function aiMocked(): boolean {
+    return process.env.DAILY_LOG_MATCH_AI_MOCK === "1";
+}
+
+const matchResponseSchema = {
+    type: "OBJECT",
+    properties: {
+        taskId: {
+            type: "STRING",
+            description: "The id of the single task this log's work/next-steps most clearly points to. Empty string if no task is a clear match.",
+        },
+        reason: {
+            type: "STRING",
+            description: "One short sentence of evidence, citing what in the text or photos supports the pick. Empty string if no match.",
+        },
+    },
+    required: ["taskId", "reason"],
+};
+
+async function fetchPhotoInline(url: string): Promise<Part | null> {
+    try {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), PHOTO_FETCH_TIMEOUT_MS);
+        const res = await fetch(url, { signal: controller.signal });
+        clearTimeout(timer);
+        if (!res.ok) return null;
+        const contentType = res.headers.get("content-type") ?? "image/jpeg";
+        if (!contentType.startsWith("image/")) return null;
+        const buf = Buffer.from(await res.arrayBuffer());
+        if (buf.byteLength === 0 || buf.byteLength > MAX_PHOTO_BYTES) return null;
+        return { inlineData: { mimeType: contentType, data: buf.toString("base64") } };
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Recompute the AI task match for a daily log. Call after any log mutation
+ * (create, edit, photo add/remove). Never throws.
+ */
+export async function runDailyLogTaskMatch(dailyLogId: string): Promise<void> {
+    try {
+        const log = await prisma.dailyLog.findUnique({
+            where: { id: dailyLogId },
+            select: {
+                id: true,
+                projectId: true,
+                createdById: true,
+                workPerformed: true,
+                nextSteps: true,
+                issues: true,
+                aiSuggestedTaskId: true,
+                photos: { select: { url: true, caption: true } },
+            },
+        });
+        if (!log) return;
+
+        const candidates = await loadSuggestableTasks(log.projectId, log.createdById);
+        if (candidates.length === 0) {
+            await storeMatch(log.id, null, null);
+            return;
+        }
+
+        const keywordFallback = () => {
+            const match = keywordMatchTasks(
+                {
+                    nextSteps: log.nextSteps,
+                    workPerformed: log.workPerformed,
+                    photoCaptions: log.photos.map(photo => photo.caption ?? "").filter(Boolean),
+                },
+                candidates.map(task => ({
+                    taskId: task.taskId,
+                    taskName: task.taskName,
+                    costCodeCode: task.costCodeCode,
+                    costCodeName: task.costCodeName,
+                })),
+            );
+            return match
+                ? { taskId: match.taskId, reason: "Keyword match against the log text" }
+                : null;
+        };
+
+        const apiKey = process.env.GEMINI_API_KEY;
+        if (aiMocked() || !apiKey) {
+            const picked = keywordFallback();
+            await storeMatch(log.id, picked?.taskId ?? null, picked?.reason ?? null);
+            return;
+        }
+
+        // doneWhen gives the model the task's completion criteria — good
+        // disambiguation material ("drywall hung" vs "drywall taped").
+        const doneWhens = await prisma.scheduleTask.findMany({
+            where: { id: { in: candidates.map(task => task.taskId) } },
+            select: { id: true, doneWhen: true },
+        });
+        const doneWhenById = new Map(doneWhens.map(task => [task.id, task.doneWhen]));
+
+        const taskLines = candidates.map(task => {
+            const doneWhen = doneWhenById.get(task.taskId);
+            return `- id: ${task.taskId} | ${task.costCodeLabel} | ${task.taskName}${doneWhen ? ` | done when: ${doneWhen}` : ""}`;
+        }).join("\n");
+
+        const prompt = `You are matching a construction daily log to the schedule task the crew should charge time to.
+
+Open tasks on this project:
+${taskLines}
+
+Daily log:
+Work performed: ${log.workPerformed || "(none)"}
+Next steps: ${log.nextSteps || "(none)"}
+Issues: ${log.issues || "(none)"}
+${log.photos.length > 0 ? `\n${Math.min(log.photos.length, MAX_PHOTOS)} site photo(s) attached. Use what the photos show (materials, trade, room, stage of work) as evidence.` : ""}
+
+Pick the ONE task that "next steps" (preferred) or the most recent work points to. If the log doesn't clearly point at one task, return an empty taskId — a wrong pick misfiles labor hours, so only answer when confident.
+
+Respond ONLY with valid JSON matching the schema.`;
+
+        const parts: Part[] = [{ text: prompt }];
+        for (const photo of log.photos.slice(0, MAX_PHOTOS)) {
+            const inline = await fetchPhotoInline(photo.url);
+            if (inline) parts.push(inline);
+        }
+
+        const ai = new GoogleGenAI({ apiKey });
+        const response = await ai.models.generateContent({
+            model: "gemini-3.0-flash-preview",
+            contents: { parts },
+            config: {
+                responseMimeType: "application/json",
+                responseSchema: matchResponseSchema as any,
+                temperature: 0.1,
+            },
+        });
+        if (!response.text) throw new Error("empty AI response");
+        const parsed = JSON.parse(response.text) as { taskId?: string; reason?: string };
+
+        const pickedId = typeof parsed.taskId === "string" ? parsed.taskId.trim() : "";
+        if (!pickedId) {
+            // The model ran and declined — that's a successful no-match: clear.
+            await storeMatch(log.id, null, null);
+            return;
+        }
+        const valid = candidates.find(task => task.taskId === pickedId);
+        if (!valid) {
+            // Hallucinated id — treat as no confident match rather than storing garbage.
+            await storeMatch(log.id, null, null);
+            return;
+        }
+        const reason = typeof parsed.reason === "string" && parsed.reason.trim()
+            ? parsed.reason.trim().slice(0, 500)
+            : null;
+        await storeMatch(log.id, valid.taskId, reason);
+    } catch (error) {
+        // Transient failure: preserve whatever is stored.
+        console.error("[daily-log-task-match] failed", { dailyLogId, error });
+    }
+}
+
+async function storeMatch(dailyLogId: string, taskId: string | null, reason: string | null): Promise<void> {
+    await prisma.dailyLog.update({
+        where: { id: dailyLogId },
+        data: { aiSuggestedTaskId: taskId, aiSuggestionReason: taskId ? reason : null },
+    });
+}

--- a/src/lib/daily-log-task-match.ts
+++ b/src/lib/daily-log-task-match.ts
@@ -18,6 +18,28 @@ import { loadSuggestableTasks, keywordMatchTasks } from "@/lib/time-suggestion";
 const MAX_PHOTOS = 4;
 const PHOTO_FETCH_TIMEOUT_MS = 5_000;
 const MAX_PHOTO_BYTES = 4 * 1024 * 1024;
+const AI_CALL_TIMEOUT_MS = 25_000; // after() shares the route's maxDuration budget — never let the AI call eat it all
+
+// Verified against ListModels with the production key (2026-08-06); the
+// previously used "gemini-3.0-flash-preview" does not exist and every call
+// with it 404s.
+const GEMINI_MODEL = "gemini-3.5-flash";
+
+/**
+ * Photos are fetched server-side for Gemini vision, so only URLs on our own
+ * Supabase storage are eligible — anything else is an SSRF vector. (Both photo
+ * write paths store Supabase URLs; foreign URLs simply aren't fetched.)
+ */
+function isOwnStorageUrl(value: string): boolean {
+    const base = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+    if (!base) return false;
+    try {
+        const url = new URL(value);
+        return url.protocol === "https:" && url.hostname === new URL(base).hostname;
+    } catch {
+        return false;
+    }
+}
 
 /** Set DAILY_LOG_MATCH_AI_MOCK=1 to force the deterministic keyword path (CI). */
 function aiMocked(): boolean {
@@ -40,17 +62,40 @@ const matchResponseSchema = {
 };
 
 async function fetchPhotoInline(url: string): Promise<Part | null> {
+    if (!isOwnStorageUrl(url)) return null;
     try {
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), PHOTO_FETCH_TIMEOUT_MS);
-        const res = await fetch(url, { signal: controller.signal });
-        clearTimeout(timer);
-        if (!res.ok) return null;
+        const res = await fetch(url, { signal: controller.signal, redirect: "error" });
+        if (!res.ok || !res.body) {
+            clearTimeout(timer);
+            return null;
+        }
         const contentType = res.headers.get("content-type") ?? "image/jpeg";
-        if (!contentType.startsWith("image/")) return null;
-        const buf = Buffer.from(await res.arrayBuffer());
-        if (buf.byteLength === 0 || buf.byteLength > MAX_PHOTO_BYTES) return null;
-        return { inlineData: { mimeType: contentType, data: buf.toString("base64") } };
+        const declaredLength = Number(res.headers.get("content-length") ?? 0);
+        if (!contentType.startsWith("image/") || declaredLength > MAX_PHOTO_BYTES) {
+            clearTimeout(timer);
+            controller.abort();
+            return null;
+        }
+        // Stream with a hard byte cap — content-length is advisory.
+        const reader = res.body.getReader();
+        const chunks: Uint8Array[] = [];
+        let received = 0;
+        for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            received += value.byteLength;
+            if (received > MAX_PHOTO_BYTES) {
+                controller.abort();
+                clearTimeout(timer);
+                return null;
+            }
+            chunks.push(value);
+        }
+        clearTimeout(timer);
+        if (received === 0) return null;
+        return { inlineData: { mimeType: contentType, data: Buffer.concat(chunks).toString("base64") } };
     } catch {
         return null;
     }
@@ -68,18 +113,23 @@ export async function runDailyLogTaskMatch(dailyLogId: string): Promise<void> {
                 id: true,
                 projectId: true,
                 createdById: true,
+                updatedAt: true,
                 workPerformed: true,
                 nextSteps: true,
                 issues: true,
                 aiSuggestedTaskId: true,
-                photos: { select: { url: true, caption: true } },
+                photos: { select: { id: true, url: true, caption: true } },
             },
         });
         if (!log) return;
+        // Snapshot for the stale-store guard: two matcher runs can race (edit +
+        // photo add each schedule one); only the run that saw the CURRENT log
+        // content may store, so a slow older run never clobbers a newer result.
+        const contentStamp = `${log.updatedAt.getTime()}:${log.photos.map(photo => photo.id).sort().join(",")}`;
 
         const candidates = await loadSuggestableTasks(log.projectId, log.createdById);
         if (candidates.length === 0) {
-            await storeMatch(log.id, null, null);
+            await storeMatch(log.id, null, null, contentStamp);
             return;
         }
 
@@ -105,7 +155,7 @@ export async function runDailyLogTaskMatch(dailyLogId: string): Promise<void> {
         const apiKey = process.env.GEMINI_API_KEY;
         if (aiMocked() || !apiKey) {
             const picked = keywordFallback();
-            await storeMatch(log.id, picked?.taskId ?? null, picked?.reason ?? null);
+            await storeMatch(log.id, picked?.taskId ?? null, picked?.reason ?? null, contentStamp);
             return;
         }
 
@@ -144,41 +194,59 @@ Respond ONLY with valid JSON matching the schema.`;
         }
 
         const ai = new GoogleGenAI({ apiKey });
-        const response = await ai.models.generateContent({
-            model: "gemini-3.0-flash-preview",
-            contents: { parts },
-            config: {
-                responseMimeType: "application/json",
-                responseSchema: matchResponseSchema as any,
-                temperature: 0.1,
-            },
-        });
+        const response = await Promise.race([
+            ai.models.generateContent({
+                model: GEMINI_MODEL,
+                contents: { parts },
+                config: {
+                    responseMimeType: "application/json",
+                    responseSchema: matchResponseSchema as any,
+                    temperature: 0.1,
+                },
+            }),
+            new Promise<never>((_, reject) =>
+                setTimeout(() => reject(new Error("AI call timed out")), AI_CALL_TIMEOUT_MS)),
+        ]);
         if (!response.text) throw new Error("empty AI response");
         const parsed = JSON.parse(response.text) as { taskId?: string; reason?: string };
 
         const pickedId = typeof parsed.taskId === "string" ? parsed.taskId.trim() : "";
         if (!pickedId) {
             // The model ran and declined — that's a successful no-match: clear.
-            await storeMatch(log.id, null, null);
+            await storeMatch(log.id, null, null, contentStamp);
             return;
         }
         const valid = candidates.find(task => task.taskId === pickedId);
         if (!valid) {
             // Hallucinated id — treat as no confident match rather than storing garbage.
-            await storeMatch(log.id, null, null);
+            await storeMatch(log.id, null, null, contentStamp);
             return;
         }
         const reason = typeof parsed.reason === "string" && parsed.reason.trim()
             ? parsed.reason.trim().slice(0, 500)
             : null;
-        await storeMatch(log.id, valid.taskId, reason);
+        await storeMatch(log.id, valid.taskId, reason, contentStamp);
     } catch (error) {
         // Transient failure: preserve whatever is stored.
         console.error("[daily-log-task-match] failed", { dailyLogId, error });
     }
 }
 
-async function storeMatch(dailyLogId: string, taskId: string | null, reason: string | null): Promise<void> {
+async function storeMatch(
+    dailyLogId: string,
+    taskId: string | null,
+    reason: string | null,
+    contentStamp: string,
+): Promise<void> {
+    // Stale-store guard: skip if the log changed while this run was in flight —
+    // the mutation that changed it scheduled a fresh run that owns the store.
+    const current = await prisma.dailyLog.findUnique({
+        where: { id: dailyLogId },
+        select: { updatedAt: true, photos: { select: { id: true } } },
+    });
+    if (!current) return;
+    const currentStamp = `${current.updatedAt.getTime()}:${current.photos.map(photo => photo.id).sort().join(",")}`;
+    if (currentStamp !== contentStamp) return;
     await prisma.dailyLog.update({
         where: { id: dailyLogId },
         data: { aiSuggestedTaskId: taskId, aiSuggestionReason: taskId ? reason : null },

--- a/src/lib/daily-log-task-match.ts
+++ b/src/lib/daily-log-task-match.ts
@@ -122,10 +122,12 @@ export async function runDailyLogTaskMatch(dailyLogId: string): Promise<void> {
             },
         });
         if (!log) return;
-        // Snapshot for the stale-store guard: two matcher runs can race (edit +
-        // photo add each schedule one); only the run that saw the CURRENT log
-        // content may store, so a slow older run never clobbers a newer result.
-        const contentStamp = `${log.updatedAt.getTime()}:${log.photos.map(photo => photo.id).sort().join(",")}`;
+        // Stale-store guard: two matcher runs can race (edit + photo add each
+        // schedule one); only the run that saw the CURRENT log row may store.
+        // Photo mutations bump the log row's updatedAt (see addDailyLogPhotos /
+        // deleteDailyLogPhoto), so updatedAt alone versions the content and the
+        // store can be a single atomic conditional write.
+        const contentStamp = log.updatedAt;
 
         const candidates = await loadSuggestableTasks(log.projectId, log.createdById);
         if (candidates.length === 0) {
@@ -188,25 +190,39 @@ Pick the ONE task that "next steps" (preferred) or the most recent work points t
 Respond ONLY with valid JSON matching the schema.`;
 
         const parts: Part[] = [{ text: prompt }];
-        for (const photo of log.photos.slice(0, MAX_PHOTOS)) {
-            const inline = await fetchPhotoInline(photo.url);
+        // Parallel fetch keeps worst-case photo time at ONE per-fetch timeout,
+        // not four — this whole pipeline runs inside after()'s shared duration
+        // budget.
+        const inlines = await Promise.all(
+            log.photos.slice(0, MAX_PHOTOS).map(photo => fetchPhotoInline(photo.url)),
+        );
+        for (const inline of inlines) {
             if (inline) parts.push(inline);
         }
 
         const ai = new GoogleGenAI({ apiKey });
-        const response = await Promise.race([
-            ai.models.generateContent({
-                model: GEMINI_MODEL,
-                contents: { parts },
-                config: {
-                    responseMimeType: "application/json",
-                    responseSchema: matchResponseSchema as any,
-                    temperature: 0.1,
-                },
-            }),
-            new Promise<never>((_, reject) =>
-                setTimeout(() => reject(new Error("AI call timed out")), AI_CALL_TIMEOUT_MS)),
-        ]);
+        // Bounds the await, not the SDK's underlying request (it has no abort
+        // hook) — the orphaned promise resolves into nothing.
+        let aiTimer: ReturnType<typeof setTimeout> | undefined;
+        let response;
+        try {
+            response = await Promise.race([
+                ai.models.generateContent({
+                    model: GEMINI_MODEL,
+                    contents: { parts },
+                    config: {
+                        responseMimeType: "application/json",
+                        responseSchema: matchResponseSchema as any,
+                        temperature: 0.1,
+                    },
+                }),
+                new Promise<never>((_, reject) => {
+                    aiTimer = setTimeout(() => reject(new Error("AI call timed out")), AI_CALL_TIMEOUT_MS);
+                }),
+            ]);
+        } finally {
+            clearTimeout(aiTimer);
+        }
         if (!response.text) throw new Error("empty AI response");
         const parsed = JSON.parse(response.text) as { taskId?: string; reason?: string };
 
@@ -236,19 +252,14 @@ async function storeMatch(
     dailyLogId: string,
     taskId: string | null,
     reason: string | null,
-    contentStamp: string,
+    contentStamp: Date,
 ): Promise<void> {
-    // Stale-store guard: skip if the log changed while this run was in flight —
-    // the mutation that changed it scheduled a fresh run that owns the store.
-    const current = await prisma.dailyLog.findUnique({
-        where: { id: dailyLogId },
-        select: { updatedAt: true, photos: { select: { id: true } } },
-    });
-    if (!current) return;
-    const currentStamp = `${current.updatedAt.getTime()}:${current.photos.map(photo => photo.id).sort().join(",")}`;
-    if (currentStamp !== contentStamp) return;
-    await prisma.dailyLog.update({
-        where: { id: dailyLogId },
+    // Atomic compare-and-write: the row must still carry the updatedAt this run
+    // read, or the write is silently skipped — the mutation that changed the
+    // log scheduled a fresh run that owns the store. (updateMany allows non-id
+    // filters; count 0 simply means we lost the race.)
+    await prisma.dailyLog.updateMany({
+        where: { id: dailyLogId, updatedAt: contentStamp },
         data: { aiSuggestedTaskId: taskId, aiSuggestionReason: taskId ? reason : null },
     });
 }

--- a/src/lib/mcp-pm-tools.ts
+++ b/src/lib/mcp-pm-tools.ts
@@ -1,6 +1,6 @@
 import type { Prisma } from "@prisma/client";
-import { after } from "next/server";
 
+import { runAfterRequest } from "./after-request";
 import { postDailyLogSummary } from "./chat-webhook";
 import { createDailyLogCore } from "./daily-log-core";
 import { runDailyLogTaskMatch } from "./daily-log-task-match";
@@ -583,7 +583,7 @@ export async function createDailyLogWithConfirmation(
     // tool result.
     if (result && typeof result === "object" && "dailyLogId" in result) {
         const dailyLogId = (result as { dailyLogId: string }).dailyLogId;
-        after(async () => {
+        runAfterRequest(async () => {
             await runDailyLogTaskMatch(dailyLogId);
             await postDailyLogSummary(dailyLogId);
         });

--- a/src/lib/mcp-pm-tools.ts
+++ b/src/lib/mcp-pm-tools.ts
@@ -1,6 +1,9 @@
 import type { Prisma } from "@prisma/client";
+import { after } from "next/server";
 
+import { postDailyLogSummary } from "./chat-webhook";
 import { createDailyLogCore } from "./daily-log-core";
+import { runDailyLogTaskMatch } from "./daily-log-task-match";
 import {
     executeConfirmed,
     issueConfirmation,
@@ -431,6 +434,7 @@ export async function listDailyLogs(input: {
             workPerformed: true,
             materialsDelivered: true,
             issues: true,
+            nextSteps: true,
             sharedToPortal: true,
             _count: { select: { photos: true } },
         },
@@ -445,6 +449,7 @@ export async function listDailyLogs(input: {
             workPerformed: log.workPerformed,
             materialsDelivered: log.materialsDelivered,
             issues: log.issues,
+            nextSteps: log.nextSteps,
             photoCount: log._count.photos,
             sharedToPortal: log.sharedToPortal,
         })),
@@ -459,6 +464,7 @@ type CreateDailyLogInput = {
     workPerformed: string;
     materialsDelivered?: string;
     issues?: string;
+    nextSteps?: string;
     photos?: Array<{ fileId: string; caption?: string }>;
     confirmToken?: string;
 };
@@ -513,6 +519,7 @@ export async function createDailyLogWithConfirmation(
         workPerformed,
         materialsDelivered: input.materialsDelivered?.trim() || undefined,
         issues: input.issues?.trim() || undefined,
+        nextSteps: input.nextSteps?.trim() || undefined,
         photos: photos.map(photo => ({
             fileId: photo.fileId,
             caption: photo.caption?.trim() || undefined,
@@ -528,11 +535,11 @@ export async function createDailyLogWithConfirmation(
         return issueConfirmation(
             "create_daily_log",
             args,
-            `Create the ${input.date} daily log on "${project.name}" with ${resolvedPhotos.length} photo${resolvedPhotos.length === 1 ? "" : "s"}: ${workPerformed}`,
+            `Create the ${input.date} daily log on "${project.name}" with ${resolvedPhotos.length} photo${resolvedPhotos.length === 1 ? "" : "s"}: ${workPerformed}${args.nextSteps ? ` Next steps: ${args.nextSteps}` : ""}`,
             actor.actorLabel,
         );
     }
-    return executePmConfirmed("create_daily_log", args, input.confirmToken, actor, async tx => {
+    const result = await executePmConfirmed("create_daily_log", args, input.confirmToken, actor, async tx => {
         const project = await tx.project.findUnique({
             where: { id: input.projectId },
             select: { id: true, name: true },
@@ -548,6 +555,7 @@ export async function createDailyLogWithConfirmation(
             workPerformed: args.workPerformed,
             materialsDelivered: args.materialsDelivered,
             issues: args.issues,
+            nextSteps: args.nextSteps,
             photoUrls: resolvedPhotos.map(photo => ({
                 url: photo.url,
                 caption: photo.caption,
@@ -569,6 +577,18 @@ export async function createDailyLogWithConfirmation(
             sharedToPortal: log.sharedToPortal,
         };
     });
+    // After commit (this is the chat-ingest path — the primary daily-log
+    // source): pin the AI task match, then post the summary with tomorrow's
+    // task back to the project's Chat space. Best-effort; never blocks the
+    // tool result.
+    if (result && typeof result === "object" && "dailyLogId" in result) {
+        const dailyLogId = (result as { dailyLogId: string }).dailyLogId;
+        after(async () => {
+            await runDailyLogTaskMatch(dailyLogId);
+            await postDailyLogSummary(dailyLogId);
+        });
+    }
+    return result;
 }
 
 export async function listPunchItems(input: {

--- a/src/lib/time-suggestion.ts
+++ b/src/lib/time-suggestion.ts
@@ -1,0 +1,342 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { isTaskActiveOnDay } from "@/app/company-dashboard/schedule-board/dispatch-exceptions";
+import { toCompanyDayKey, daysBetweenDayKeys } from "@/lib/company-day";
+
+// Clock-in task suggestion (Stage B of the daily-log accuracy pipeline).
+//
+// Deterministic and fast — no AI call happens at clock-in. The AI runs earlier,
+// at daily-log write time (daily-log-task-match.ts), and stores its pick on the
+// log. This module ranks: that stored pick, then a keyword match over the same
+// log, then today's schedule, then the user's own recent history.
+//
+// Every suggestion must resolve to something the clock-in picker can actually
+// select: a TOP-LEVEL estimate item (budget phase) on an eligible estimate,
+// with a cost code. A suggestion the picker can't express — or whose leaf task
+// cost code disagrees with the bucket that would actually be charged — is
+// worse than none, so those are excluded rather than approximated.
+
+export type TimeSuggestionSource = "daily_log" | "today_schedule" | "user_history";
+
+export interface TimeSuggestion {
+    scheduleTaskId: string;
+    /** Top-level estimate item the picker should preselect — the thing that gets charged. */
+    clockInEstimateItemId: string;
+    costCodeId: string;
+    costCodeLabel: string; // "01-DEMO — Demolition"
+    taskName: string;
+    source: TimeSuggestionSource;
+    confidence: "high" | "medium" | "low";
+    reason: string | null;
+}
+
+// Statuses under which an estimate's items appear in the clock-in picker
+// (mirrors /api/projects/[id]/estimate-items).
+const ELIGIBLE_ESTIMATE_STATUSES = ["Approved", "Invoiced", "Partially Paid", "Paid"];
+
+const DAILY_LOG_LOOKBACK_DAYS = 7;
+const HISTORY_LOOKBACK_DAYS = 3;
+
+// ── Pure text matching (exercised directly by scripts/verify-time-suggestion.ts) ──
+
+const STOPWORDS = new Set([
+    "the", "and", "for", "with", "was", "were", "are", "have", "has", "had",
+    "will", "then", "than", "that", "this", "them", "they", "there", "out",
+    "our", "all", "any", "but", "not", "did", "done", "get", "got", "today",
+    "tomorrow", "next", "steps", "day", "days", "morning", "afternoon",
+    "finish", "finished", "start", "started", "continue", "continued",
+    "work", "worked", "working", "crew", "site", "job", "more", "some",
+]);
+
+/** Lowercase word tokens, punctuation stripped, stopwords and short tokens dropped. */
+export function tokenizeForMatch(text: string | null | undefined): string[] {
+    if (!text) return [];
+    return text
+        .toLowerCase()
+        .replace(/[^a-z0-9\s]/g, " ")
+        .split(/\s+/)
+        .filter(token => token.length >= 3 && !STOPWORDS.has(token) && !/^\d+$/.test(token));
+}
+
+export interface KeywordCandidate {
+    taskId: string;
+    taskName: string;
+    costCodeCode: string | null;
+    costCodeName: string | null;
+}
+
+export interface KeywordMatch {
+    taskId: string;
+    score: number;
+}
+
+/**
+ * Score candidate tasks against log text. `nextSteps` tokens count double —
+ * a stated plan for tomorrow outweighs a description of finished work.
+ * Returns the sole best match, or null when nothing scores or the top is tied
+ * (a tie means the log doesn't disambiguate; guessing would misfile hours).
+ */
+export function keywordMatchTasks(
+    input: { nextSteps?: string | null; workPerformed?: string | null; photoCaptions?: string[] },
+    candidates: KeywordCandidate[],
+): KeywordMatch | null {
+    const weighted = new Map<string, number>();
+    for (const token of tokenizeForMatch(input.nextSteps)) {
+        weighted.set(token, 2);
+    }
+    const singleWeight = [
+        ...tokenizeForMatch(input.workPerformed),
+        ...(input.photoCaptions ?? []).flatMap(caption => tokenizeForMatch(caption)),
+    ];
+    for (const token of singleWeight) {
+        if (!weighted.has(token)) weighted.set(token, 1);
+    }
+    if (weighted.size === 0) return null;
+
+    let best: KeywordMatch | null = null;
+    let tied = false;
+    for (const candidate of candidates) {
+        const candidateTokens = new Set([
+            ...tokenizeForMatch(candidate.taskName),
+            ...tokenizeForMatch(candidate.costCodeName),
+            ...tokenizeForMatch(candidate.costCodeCode?.replace(/[-_]/g, " ")),
+        ]);
+        let score = 0;
+        for (const token of candidateTokens) {
+            score += weighted.get(token) ?? 0;
+        }
+        if (score === 0) continue;
+        if (!best || score > best.score) {
+            best = { taskId: candidate.taskId, score };
+            tied = false;
+        } else if (score === best.score) {
+            tied = true;
+        }
+    }
+    if (!best || tied) return null;
+    return best;
+}
+
+// ── Candidate loading + picker mapping ──────────────────────────────────────
+
+type DbClient = PrismaClient | Prisma.TransactionClient;
+
+interface EligibleItem {
+    id: string;
+    parentId: string | null;
+    costCodeId: string | null;
+    costCode: { code: string; name: string } | null;
+}
+
+export interface SuggestableTask {
+    taskId: string;
+    taskName: string;
+    status: string;
+    startDate: Date;
+    endDate: Date;
+    type: string;
+    assignedToUser: boolean;
+    /** Top-level estimate item this task charges to. */
+    clockInEstimateItemId: string;
+    costCodeId: string;
+    costCodeLabel: string;
+    costCodeCode: string;
+    costCodeName: string;
+}
+
+/**
+ * Load the project's leaf tasks that a suggestion is allowed to name:
+ * non-Complete `type === "task"` leaves whose estimate item maps up to a
+ * top-level item on an eligible estimate, where the bucket has a cost code
+ * and the leaf's own cost code (if any) agrees with it.
+ */
+export async function loadSuggestableTasks(
+    projectId: string,
+    userId: string,
+    db: DbClient = prisma,
+): Promise<SuggestableTask[]> {
+    const [tasks, items] = await Promise.all([
+        db.scheduleTask.findMany({
+            where: { projectId },
+            select: {
+                id: true,
+                name: true,
+                parentId: true,
+                estimateItemId: true,
+                startDate: true,
+                endDate: true,
+                status: true,
+                type: true,
+                assignments: { where: { userId }, select: { id: true } },
+            },
+        }),
+        db.estimateItem.findMany({
+            where: {
+                estimate: { projectId, status: { in: ELIGIBLE_ESTIMATE_STATUSES }, archivedAt: null },
+            },
+            select: {
+                id: true,
+                parentId: true,
+                costCodeId: true,
+                costCode: { select: { code: true, name: true } },
+            },
+        }),
+    ]);
+
+    const itemById = new Map<string, EligibleItem>(items.map(item => [item.id, item]));
+    const parentIds = new Set(tasks.map(task => task.parentId).filter((id): id is string => !!id));
+
+    const toTopLevel = (itemId: string): EligibleItem | null => {
+        let current = itemById.get(itemId);
+        let hops = 0;
+        while (current && current.parentId && hops < 10) {
+            current = itemById.get(current.parentId);
+            hops += 1;
+        }
+        return current && !current.parentId ? current : null;
+    };
+
+    const out: SuggestableTask[] = [];
+    for (const task of tasks) {
+        if (task.type !== "task") continue;
+        if (task.status === "Complete") continue;
+        if (parentIds.has(task.id)) continue; // never suggest a phase parent
+        if (!task.estimateItemId) continue;
+        const leafItem = itemById.get(task.estimateItemId);
+        if (!leafItem) continue; // item not on an eligible estimate
+        const top = toTopLevel(task.estimateItemId);
+        if (!top || !top.costCodeId || !top.costCode) continue; // picker can't charge it
+        // The picker charges the bucket's cost code; a leaf that codes elsewhere
+        // must not be suggested as if it billed to this bucket.
+        if (leafItem.costCodeId && leafItem.costCodeId !== top.costCodeId) continue;
+        out.push({
+            taskId: task.id,
+            taskName: task.name,
+            status: task.status,
+            startDate: task.startDate,
+            endDate: task.endDate,
+            type: task.type,
+            assignedToUser: task.assignments.length > 0,
+            clockInEstimateItemId: top.id,
+            costCodeId: top.costCodeId,
+            costCodeCode: top.costCode.code,
+            costCodeName: top.costCode.name,
+            costCodeLabel: `${top.costCode.code} — ${top.costCode.name}`,
+        });
+    }
+    return out;
+}
+
+// ── Ranking ─────────────────────────────────────────────────────────────────
+
+export async function suggestTaskForClockIn(
+    input: { userId: string; projectId: string; now?: Date },
+    db: DbClient = prisma,
+): Promise<TimeSuggestion | null> {
+    const { userId, projectId } = input;
+    const now = input.now ?? new Date();
+    const todayKey = toCompanyDayKey(now);
+
+    const suggestable = await loadSuggestableTasks(projectId, userId, db);
+    if (suggestable.length === 0) return null;
+    const byTaskId = new Map(suggestable.map(task => [task.taskId, task]));
+
+    const toSuggestion = (
+        task: SuggestableTask,
+        source: TimeSuggestionSource,
+        confidence: TimeSuggestion["confidence"],
+        reason: string | null,
+    ): TimeSuggestion => ({
+        scheduleTaskId: task.taskId,
+        clockInEstimateItemId: task.clockInEstimateItemId,
+        costCodeId: task.costCodeId,
+        costCodeLabel: task.costCodeLabel,
+        taskName: task.taskName,
+        source,
+        confidence,
+        reason,
+    });
+
+    // 1 + 2 — the latest daily log (within lookback), AI pick first, keywords second.
+    const latestLog = await db.dailyLog.findFirst({
+        where: { projectId },
+        orderBy: [{ date: "desc" }, { createdAt: "desc" }],
+        select: {
+            date: true,
+            nextSteps: true,
+            workPerformed: true,
+            aiSuggestedTaskId: true,
+            aiSuggestionReason: true,
+            photos: { select: { caption: true } },
+        },
+    });
+    const logIsFresh = latestLog
+        ? Math.abs(daysBetweenDayKeys(toCompanyDayKey(latestLog.date), todayKey)) <= DAILY_LOG_LOOKBACK_DAYS
+        : false;
+
+    if (latestLog && logIsFresh) {
+        if (latestLog.aiSuggestedTaskId) {
+            const task = byTaskId.get(latestLog.aiSuggestedTaskId);
+            if (task) {
+                return toSuggestion(task, "daily_log", "high", latestLog.aiSuggestionReason ?? null);
+            }
+            // Stored pick points at a task that is gone/complete/unmappable — fall through.
+        }
+        const match = keywordMatchTasks(
+            {
+                nextSteps: latestLog.nextSteps,
+                workPerformed: latestLog.workPerformed,
+                photoCaptions: latestLog.photos.map(photo => photo.caption ?? "").filter(Boolean),
+            },
+            suggestable.map(task => ({
+                taskId: task.taskId,
+                taskName: task.taskName,
+                costCodeCode: task.costCodeCode,
+                costCodeName: task.costCodeName,
+            })),
+        );
+        if (match) {
+            const task = byTaskId.get(match.taskId);
+            if (task) {
+                return toSuggestion(
+                    task,
+                    "daily_log",
+                    match.score >= 2 ? "high" : "medium",
+                    "Matched from the latest daily log",
+                );
+            }
+        }
+    }
+
+    // 3 — sole assigned task active today.
+    const activeToday = suggestable.filter(task =>
+        task.assignedToUser
+        && isTaskActiveOnDay(
+            { startDate: task.startDate.toISOString(), endDate: task.endDate.toISOString(), type: task.type },
+            todayKey,
+        ));
+    if (activeToday.length === 1) {
+        return toSuggestion(activeToday[0], "today_schedule", "medium", "Your only scheduled task today");
+    }
+
+    // 4 — the user's most recent closed entry on this project, if its task still qualifies.
+    const historyCutoff = new Date(now.getTime() - HISTORY_LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
+    const lastEntry = await db.timeEntry.findFirst({
+        where: {
+            userId,
+            projectId,
+            endTime: { not: null, gte: historyCutoff },
+            scheduleTaskId: { not: null },
+        },
+        orderBy: { endTime: "desc" },
+        select: { scheduleTaskId: true },
+    });
+    if (lastEntry?.scheduleTaskId) {
+        const task = byTaskId.get(lastEntry.scheduleTaskId);
+        if (task) {
+            return toSuggestion(task, "user_history", "low", "You clocked into this task last");
+        }
+    }
+
+    return null;
+}

--- a/src/lib/time-suggestion.ts
+++ b/src/lib/time-suggestion.ts
@@ -68,6 +68,8 @@ export interface KeywordCandidate {
 export interface KeywordMatch {
     taskId: string;
     score: number;
+    /** How many DISTINCT log tokens hit the winner — confidence needs breadth, not one hot word. */
+    matchedTokens: number;
 }
 
 /**
@@ -102,12 +104,15 @@ export function keywordMatchTasks(
             ...tokenizeForMatch(candidate.costCodeCode?.replace(/[-_]/g, " ")),
         ]);
         let score = 0;
+        let matchedTokens = 0;
         for (const token of candidateTokens) {
-            score += weighted.get(token) ?? 0;
+            const weight = weighted.get(token) ?? 0;
+            score += weight;
+            if (weight > 0) matchedTokens += 1;
         }
         if (score === 0) continue;
         if (!best || score > best.score) {
-            best = { taskId: candidate.taskId, score };
+            best = { taskId: candidate.taskId, score, matchedTokens };
             tied = false;
         } else if (score === best.score) {
             tied = true;
@@ -257,9 +262,13 @@ export async function suggestTaskForClockIn(
         reason,
     });
 
-    // 1 + 2 — the latest daily log (within lookback), AI pick first, keywords second.
+    // 1 + 2 — the latest daily log (within lookback), AI pick first, keywords
+    // second. DailyLog.date is stored as UTC midnight of a date-only input, so
+    // the intended calendar day is the ISO date part — running it through a
+    // timezone conversion would shift it back a day. Future-dated logs are
+    // excluded outright: tomorrow's plan can't be evidence for today.
     const latestLog = await db.dailyLog.findFirst({
-        where: { projectId },
+        where: { projectId, date: { lte: new Date(`${todayKey}T23:59:59.999Z`) } },
         orderBy: [{ date: "desc" }, { createdAt: "desc" }],
         select: {
             date: true,
@@ -270,9 +279,9 @@ export async function suggestTaskForClockIn(
             photos: { select: { caption: true } },
         },
     });
-    const logIsFresh = latestLog
-        ? Math.abs(daysBetweenDayKeys(toCompanyDayKey(latestLog.date), todayKey)) <= DAILY_LOG_LOOKBACK_DAYS
-        : false;
+    const logDayKey = latestLog ? latestLog.date.toISOString().slice(0, 10) : null;
+    const logAge = logDayKey ? daysBetweenDayKeys(logDayKey, todayKey) : null;
+    const logIsFresh = logAge !== null && logAge >= 0 && logAge <= DAILY_LOG_LOOKBACK_DAYS;
 
     if (latestLog && logIsFresh) {
         if (latestLog.aiSuggestedTaskId) {
@@ -298,10 +307,12 @@ export async function suggestTaskForClockIn(
         if (match) {
             const task = byTaskId.get(match.taskId);
             if (task) {
+                // "High" needs breadth: two distinct tokens agreeing, not one
+                // hot word that happened to sit in nextSteps.
                 return toSuggestion(
                     task,
                     "daily_log",
-                    match.score >= 2 ? "high" : "medium",
+                    match.matchedTokens >= 2 ? "high" : "medium",
                     "Matched from the latest daily log",
                 );
             }


### PR DESCRIPTION
## What this is

Two workstreams for next week's mobile launch (approved plan):

### Time entry accuracy (the Mesplay retro fix)
- **Daily logs drive clock-in**: a two-stage pipeline — an AI matcher (Gemini vision over log text AND photos, from the chat-ingested logs) pins the recommended task on each daily log at write time; clock-in ranks that pick → keyword match (nextSteps weighted) → today's schedule → recent history, always mapped to a selectable top-level phase bucket whose cost code agrees.
- **Red flag on mismatch**: web + mobile clock-in preselect the suggestion and soft-confirm "Are you sure this is the correct task?" when the crew picks something else; overrides are recorded (`suggestionOverridden` + audit fields) for manager review.
- **Cost attribution fix**: `POST /api/time-entries` now validates the estimate item against eligible estimates and derives `costCodeId` server-side — client-sent codes can no longer misfile labor.
- **Phase-code-grouped picker**: estimate items grouped/ordered by phase code; codeless items flagged.
- **Daily log next steps**: threaded through web form, AI draft, MCP `create_daily_log` (chat bot), PDF; MCP v1.15.0 → 1.16.0 (all three pins).
- **Chat post-back**: log summary + "Tomorrow's task" posted to the project's Chat space via per-project webhook (manager-only credential, SSRF-guarded, stripped from crew-visible responses).
- **Manager visibility**: override badges on project timeclock; compliance flags (time-with-no-log / log-without-photos / items missing phase codes) on the manager dashboard.
- Also fixes the pre-existing invalid Gemini model id (`gemini-3.0-flash-preview` never existed — verified via ListModels) that silently broke AI daily-log drafts.

### Launch test suite
- `e2e/mobile-api.spec.ts` — mobile API contract tests (auth matrix, role authz, cost math) — runs in CI.
- `e2e/time-suggestion.spec.ts` — 11 tests pinning the suggestion pipeline incl. Stage A end-to-end through the daily-log form.
- `e2e/mobile-app/` — 8 Expo-web field-flow specs behind a static-export + `/api`-proxy harness (`npm run test:mobile-e2e`, local launch gate; excluded from CI — separate repo checkout). **These caught a real launch blocker**: signed-URL uploads (receipts/lead media/scans) were broken in the web build; fixed in the mobile repo.
- Fixtures, `DAILY_LOG_MATCH_AI_MOCK` CI wiring, `docs/MOBILE-TESTING.md`.

## Review
Codex peer review, 2 rounds: 4 blockers + 6 real issues found and fixed (model id, webhook credential leak, SSRF/memory bound, codeless-item cost-code hole, tz/future-date day keys, atomic stale-store, duration budget, test hardening). Defenses accepted for project-wide ranking and audit-claim fields.

## Verification
- Full e2e (hermetic Postgres, CI mode): 357 passed; 1 failure in `selections-ai-sort` is Windows-local-env only — files byte-identical to main, passes in Linux CI.
- `npm run test:mobile-e2e`: 15/15. Mobile unit tests: 29/29. `run-verify-all`: green. `npm run build`: clean.

## Deploy notes (in order)
1. `node scripts/apply-time-suggestion-schema.mjs` against prod BEFORE deploying (additive, idempotent).
2. `vercel --prod` from the canonical checkout.
3. Mobile: `eas update` on the TestFlight channel (companion branch `feat/time-entry-suggestions` in gtr-probuild-mobile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)