### PR TITLE
feat(estimates): multiple POs per line item + undo for deleted line items

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -491,8 +491,12 @@ model EstimateItem {
   costType      CostType?      @relation(fields: [costTypeId], references: [id])
   approvalStatus String?        // pending, approved, rejected
   approvalNote   String?
+  /// @deprecated legacy single-PO link. Superseded by purchaseOrderLinks; kept
+  /// dual-written (syncLegacyPoLink) so a rollback to the pre-many-to-many build
+  /// still reads correctly. Drop in a follow-up once this has been stable on prod.
   purchaseOrderId  String?
   purchaseOrder    PurchaseOrder? @relation(fields: [purchaseOrderId], references: [id], onDelete: SetNull)
+  purchaseOrderLinks EstimateItemPurchaseOrder[]
   budgetQuantity   Float?
   budgetUnit       String?
   budgetRate       Decimal?
@@ -1570,13 +1574,29 @@ model PurchaseOrder {
   files    PurchaseOrderFile[]
   expenses Expense[]
   messages PurchaseOrderMessage[]
+  /// @deprecated back-relation for the legacy single-PO link. See EstimateItem.purchaseOrderId.
   estimateItems EstimateItem[]
+  estimateItemLinks EstimateItemPurchaseOrder[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
   @@index([projectId])
   @@index([vendorId])
+}
+
+/// Join table letting one estimate line item carry several purchase orders.
+/// Replaces the one-PO-per-item cap of EstimateItem.purchaseOrderId.
+model EstimateItemPurchaseOrder {
+  id              String        @id @default(cuid())
+  estimateItemId  String
+  estimateItem    EstimateItem  @relation(fields: [estimateItemId], references: [id], onDelete: Cascade)
+  purchaseOrderId String
+  purchaseOrder   PurchaseOrder @relation(fields: [purchaseOrderId], references: [id], onDelete: Cascade)
+  createdAt       DateTime      @default(now())
+
+  @@unique([estimateItemId, purchaseOrderId])
+  @@index([purchaseOrderId])
 }
 
 model PurchaseOrderMessage {

--- a/scripts/apply-estimate-item-po-links.mjs
+++ b/scripts/apply-estimate-item-po-links.mjs
@@ -1,0 +1,91 @@
+// One-off additive migration for multiple purchase orders per estimate line item.
+// Creates the EstimateItemPurchaseOrder join table that replaces the one-PO-per-item
+// cap of EstimateItem.purchaseOrderId.
+//
+// DDL ONLY — no data is written here. The backfill lives in a SEPARATE script that
+// must run AFTER the deploy (scripts/backfill-estimate-item-po-links.mjs): while the
+// old build is still live it writes only the legacy scalar column, so backfilling
+// before the cutover would leave stale rows behind any unlink/replace that happens in
+// the deploy window. Splitting the two means exactly one writer exists at any moment.
+//
+// Safe to re-run while the previous build is live — every statement is idempotent
+// (IF NOT EXISTS / guarded DO $$ blocks). Additive only — no deletes, no drops.
+//
+// Run BEFORE deploying the build that ships this schema (see the pre-deploy checklist
+// in CLAUDE.md):
+//   node scripts/apply-estimate-item-po-links.mjs
+import { PrismaClient } from "@prisma/client";
+import { config } from "dotenv";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+config({ path: join(__dirname, "..", ".env.local") });
+config({ path: join(__dirname, "..", ".env") });
+
+const prisma = new PrismaClient({ datasources: { db: { url: process.env.DATABASE_URL } } });
+
+const statements = [
+    `CREATE TABLE IF NOT EXISTS "EstimateItemPurchaseOrder" (
+        "id" TEXT PRIMARY KEY,
+        "estimateItemId" TEXT NOT NULL,
+        "purchaseOrderId" TEXT NOT NULL,
+        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )`,
+    // Cascade on both sides mirrors today's behavior: deleting a PO dropped the link
+    // (it was ON DELETE SET NULL on the scalar), and deleting an item took its link
+    // with it. Undo restores these rows explicitly via restoreEstimateItemAssociations.
+    `DO $$ BEGIN
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'EstimateItemPurchaseOrder_estimateItemId_fkey'
+              AND conrelid = '"EstimateItemPurchaseOrder"'::regclass
+        ) THEN
+            ALTER TABLE "EstimateItemPurchaseOrder"
+                ADD CONSTRAINT "EstimateItemPurchaseOrder_estimateItemId_fkey"
+                FOREIGN KEY ("estimateItemId") REFERENCES "EstimateItem"("id")
+                ON DELETE CASCADE ON UPDATE CASCADE;
+        END IF;
+    END $$`,
+    `DO $$ BEGIN
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'EstimateItemPurchaseOrder_purchaseOrderId_fkey'
+              AND conrelid = '"EstimateItemPurchaseOrder"'::regclass
+        ) THEN
+            ALTER TABLE "EstimateItemPurchaseOrder"
+                ADD CONSTRAINT "EstimateItemPurchaseOrder_purchaseOrderId_fkey"
+                FOREIGN KEY ("purchaseOrderId") REFERENCES "PurchaseOrder"("id")
+                ON DELETE CASCADE ON UPDATE CASCADE;
+        END IF;
+    END $$`,
+    // The unique index is what makes every link write idempotent (createMany with
+    // skipDuplicates, and the backfill's ON CONFLICT DO NOTHING).
+    `CREATE UNIQUE INDEX IF NOT EXISTS "EstimateItemPurchaseOrder_estimateItemId_purchaseOrderId_key"
+        ON "EstimateItemPurchaseOrder" ("estimateItemId", "purchaseOrderId")`,
+    `CREATE INDEX IF NOT EXISTS "EstimateItemPurchaseOrder_purchaseOrderId_idx"
+        ON "EstimateItemPurchaseOrder" ("purchaseOrderId")`,
+    // Server-only table. RLS with no policies denies direct anon/authenticated Data API
+    // access; server-side Prisma uses the owner role. Matches the convention in
+    // scripts/apply-selections-playground.mjs.
+    `ALTER TABLE "EstimateItemPurchaseOrder" ENABLE ROW LEVEL SECURITY`,
+];
+
+try {
+    for (const sql of statements) {
+        await prisma.$executeRawUnsafe(sql);
+        console.log("OK:", sql.split("\n")[0].slice(0, 90));
+    }
+
+    const [{ count: pending }] = await prisma.$queryRawUnsafe(
+        `SELECT count(*)::int AS count FROM "EstimateItem" WHERE "purchaseOrderId" IS NOT NULL`
+    );
+    console.log(`\nEstimateItemPurchaseOrder schema applied successfully.`);
+    console.log(`${pending} existing scalar PO link(s) awaiting backfill.`);
+    console.log(`NEXT: deploy, then run  node scripts/backfill-estimate-item-po-links.mjs`);
+} catch (e) {
+    console.error("Migration failed:", e);
+    process.exit(1);
+} finally {
+    await prisma.$disconnect();
+}

--- a/scripts/backfill-estimate-item-po-links.mjs
+++ b/scripts/backfill-estimate-item-po-links.mjs
@@ -1,0 +1,100 @@
+// Data backfill for multiple purchase orders per estimate line item.
+// Copies every legacy EstimateItem.purchaseOrderId into the EstimateItemPurchaseOrder
+// join table created by scripts/apply-estimate-item-po-links.mjs.
+//
+// RUN THIS *AFTER* THE DEPLOY, not before. The old build writes only the legacy scalar
+// column, so backfilling while it is still serving traffic would leave a stale join row
+// behind any unlink or PO replacement that happens in the deploy window — an insert-only
+// sweep can never detect those. Running after the cutover means the scalar column is the
+// undisputed source of truth for every pre-existing link at the moment we read it.
+//
+// Nothing is lost in the gap between deploy and backfill: the new build falls back to the
+// legacy scalar when an item has no join rows, and every link-write path migrates the
+// legacy scalar into the join table first (migrate-on-write).
+//
+// Processes one EstimateItem at a time, each in its own transaction that locks the item row
+// FOR UPDATE and re-reads the scalar before inserting — the same per-item locking protocol
+// every server action uses (see lockEstimateItemLinks in src/lib/actions.ts). Without it, a
+// live unlink running concurrently with this backfill could delete a join row that doesn't
+// exist yet, the backfill's bulk insert could then recreate it from the (about-to-be-nulled)
+// scalar, and the unlink's own mirror resync could re-materialize it — silently undoing the
+// unlink. Locking the row first means whichever side gets there first (this script or a live
+// unlink/link transaction) fully completes, including the mirror resync, before the other
+// proceeds.
+//
+// Idempotent — safe to run late, twice, or after users have already added links:
+//   node scripts/backfill-estimate-item-po-links.mjs
+import { PrismaClient } from "@prisma/client";
+import { config } from "dotenv";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+config({ path: join(__dirname, "..", ".env.local") });
+config({ path: join(__dirname, "..", ".env") });
+
+const prisma = new PrismaClient({ datasources: { db: { url: process.env.DATABASE_URL } } });
+
+// Counts legacy scalar links that have no matching join row. This is the assertion that
+// matters — NOT "rows inserted by this run", which is legitimately 0 on a rerun and can
+// also be short by however many rows migrate-on-write already created.
+const COVERAGE_SQL = `
+    SELECT count(*)::int AS count
+    FROM "EstimateItem" e
+    WHERE e."purchaseOrderId" IS NOT NULL
+      AND NOT EXISTS (
+          SELECT 1 FROM "EstimateItemPurchaseOrder" j
+          WHERE j."estimateItemId" = e."id"
+            AND j."purchaseOrderId" = e."purchaseOrderId"
+      )`;
+
+try {
+    const [{ count: scalarLinks }] = await prisma.$queryRawUnsafe(
+        `SELECT count(*)::int AS count FROM "EstimateItem" WHERE "purchaseOrderId" IS NOT NULL`
+    );
+    const [{ count: before }] = await prisma.$queryRawUnsafe(COVERAGE_SQL);
+    console.log(`${scalarLinks} legacy scalar link(s); ${before} not yet in the join table.`);
+
+    // Sorted so this script's per-item lock acquisition order matches the app's
+    // (Estimate → sorted EstimateItem ids), even though each row here gets its own
+    // transaction — consistent ordering avoids unnecessary lock-wait pileups.
+    const candidates = await prisma.$queryRawUnsafe(
+        `SELECT "id" FROM "EstimateItem" WHERE "purchaseOrderId" IS NOT NULL ORDER BY "id" ASC`
+    );
+
+    let inserted = 0;
+    for (const { id } of candidates) {
+        inserted += await prisma.$transaction(async (tx) => {
+            const rows = await tx.$queryRawUnsafe(
+                `SELECT "purchaseOrderId", "createdAt" FROM "EstimateItem" WHERE "id" = $1 FOR UPDATE`,
+                id,
+            );
+            const current = rows[0];
+            if (!current?.purchaseOrderId) return 0; // unlinked since the initial scan above
+            return tx.$executeRawUnsafe(
+                `INSERT INTO "EstimateItemPurchaseOrder" ("id", "estimateItemId", "purchaseOrderId", "createdAt")
+                 VALUES (gen_random_uuid()::text, $1, $2, COALESCE($3, NOW()))
+                 ON CONFLICT ("estimateItemId", "purchaseOrderId") DO NOTHING`,
+                id, current.purchaseOrderId, current.createdAt,
+            );
+        });
+    }
+    console.log(`Inserted ${inserted} join row(s) across ${candidates.length} candidate item(s).`);
+
+    const [{ count: after }] = await prisma.$queryRawUnsafe(COVERAGE_SQL);
+    if (after !== 0) {
+        console.error(`\nFAILED: ${after} legacy link(s) still have no join row. No data was removed — investigate before proceeding.`);
+        process.exit(1);
+    }
+
+    const [{ count: total }] = await prisma.$queryRawUnsafe(
+        `SELECT count(*)::int AS count FROM "EstimateItemPurchaseOrder"`
+    );
+    console.log(`\nBackfill complete. Coverage check passed (0 legacy links missing a join row).`);
+    console.log(`${total} total link row(s) now in EstimateItemPurchaseOrder.`);
+} catch (e) {
+    console.error("Backfill failed:", e);
+    process.exit(1);
+} finally {
+    await prisma.$disconnect();
+}

--- a/src/app/projects/[id]/estimates/[estimateId]/BudgetStrip.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/BudgetStrip.tsx
@@ -19,7 +19,7 @@ interface BudgetStripProps {
     contextType: "project" | "lead";
     onLinkPO: (itemId: string) => void;
     onCreatePO: (itemId: string) => void;
-    onUnlinkPO: (itemId: string) => void;
+    onUnlinkPO: (itemId: string, poId: string) => void;
     onViewPO: (poId: string) => void;
 }
 
@@ -27,7 +27,7 @@ export default function BudgetStrip({
     item, index, updateItem, contextType, onLinkPO, onCreatePO, onUnlinkPO, onViewPO
 }: BudgetStripProps) {
     const [showUnitDropdown, setShowUnitDropdown] = useState(false);
-    const [showPOPopover, setShowPOPopover] = useState(false);
+    const [openPopoverPoId, setOpenPopoverPoId] = useState<string | null>(null);
 
     const budgetQty = item.budgetQuantity ?? item.quantity ?? 0;
     const budgetRateVal = item.budgetRate ?? item.baseCost ?? "";
@@ -45,9 +45,9 @@ export default function BudgetStrip({
         baseCost: item.baseCost,
     });
 
-    const po = item.purchaseOrder;
+    const links = item.purchaseOrderLinks ?? [];
     const isLead = contextType === "lead";
-    const isPoLocked = item.purchaseOrderId != null;
+    const isPoLocked = links.length > 0;
     const sellPrice = parseFloat(item.unitCost) || 0;
 
     return (
@@ -56,7 +56,7 @@ export default function BudgetStrip({
             {isPoLocked && (
                 <span
                     className="flex items-center justify-center w-5 h-5 text-slate-500 flex-shrink-0"
-                    title={`Budget protected by PO${po?.code ? ` ${po.code}` : ""}`}
+                    title={`Budget protected by PO${links.length ? ` ${links.map((l: any) => l.purchaseOrder.code).join(", ")}` : ""}`}
                 >
                     <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
                         <rect x="3" y="11" width="18" height="11" rx="2" />
@@ -177,36 +177,40 @@ export default function BudgetStrip({
             <div className="w-px h-5 bg-indigo-200" />
 
             {/* PO Section */}
-            <div className="flex items-center gap-2 ml-auto">
-                {po ? (
-                    <div className="relative">
-                        <button
-                            onClick={() => setShowPOPopover(!showPOPopover)}
-                            className="flex items-center gap-1.5 bg-white border border-indigo-200 rounded-full px-2.5 py-0.5 text-xs font-medium text-indigo-700 hover:border-indigo-400 transition"
-                        >
-                            <span className="w-1.5 h-1.5 rounded-full bg-indigo-400" />
-                            {po.code} — {po.vendor?.name || "Vendor"} — {formatCurrency(Number(po.totalAmount))}
-                        </button>
-                        {showPOPopover && (
-                            <div className="absolute top-full right-0 mt-1 bg-white border border-slate-200 rounded-lg shadow-lg z-30 w-40 py-1">
-                                <button
-                                    onClick={() => { onViewPO(po.id); setShowPOPopover(false); }}
-                                    className="w-full text-left px-3 py-1.5 text-xs hover:bg-slate-50 transition flex items-center gap-2"
-                                >
-                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6M15 3h6v6M10 14L21 3" /></svg>
-                                    View PO
-                                </button>
-                                <button
-                                    onClick={() => { onUnlinkPO(item.id); setShowPOPopover(false); }}
-                                    className="w-full text-left px-3 py-1.5 text-xs text-red-600 hover:bg-red-50 transition flex items-center gap-2"
-                                >
-                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6 6 18M6 6l12 12" /></svg>
-                                    Unlink
-                                </button>
-                            </div>
-                        )}
-                    </div>
-                ) : isLead ? (
+            <div className="flex items-center gap-2 ml-auto flex-wrap justify-end">
+                {links.map((link: any) => {
+                    const linkPo = link.purchaseOrder;
+                    return (
+                        <div key={linkPo.id} className="relative">
+                            <button
+                                onClick={() => setOpenPopoverPoId(openPopoverPoId === linkPo.id ? null : linkPo.id)}
+                                className="flex items-center gap-1.5 bg-white border border-indigo-200 rounded-full px-2.5 py-0.5 text-xs font-medium text-indigo-700 hover:border-indigo-400 transition"
+                            >
+                                <span className="w-1.5 h-1.5 rounded-full bg-indigo-400" />
+                                {linkPo.code} — {linkPo.vendor?.name || "Vendor"} — {formatCurrency(Number(linkPo.totalAmount))}
+                            </button>
+                            {openPopoverPoId === linkPo.id && (
+                                <div className="absolute top-full right-0 mt-1 bg-white border border-slate-200 rounded-lg shadow-lg z-30 w-40 py-1">
+                                    <button
+                                        onClick={() => { onViewPO(linkPo.id); setOpenPopoverPoId(null); }}
+                                        className="w-full text-left px-3 py-1.5 text-xs hover:bg-slate-50 transition flex items-center gap-2"
+                                    >
+                                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6M15 3h6v6M10 14L21 3" /></svg>
+                                        View PO
+                                    </button>
+                                    <button
+                                        onClick={() => { onUnlinkPO(item.id, linkPo.id); setOpenPopoverPoId(null); }}
+                                        className="w-full text-left px-3 py-1.5 text-xs text-red-600 hover:bg-red-50 transition flex items-center gap-2"
+                                    >
+                                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6 6 18M6 6l12 12" /></svg>
+                                        Unlink
+                                    </button>
+                                </div>
+                            )}
+                        </div>
+                    );
+                })}
+                {isLead ? (
                     <span className="text-slate-400 italic text-[10px]" title="Convert to project to create purchase orders">
                         Requires project
                     </span>

--- a/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
@@ -40,9 +40,92 @@ function recalcMilestoneAmounts(schedules: any[], total: number): any[] {
     return cloned;
 }
 
+/** A PO-link / schedule-task restore payload left pending after an undo or history revert
+ *  whose item-row save succeeded but whose association restore failed (or hasn't run yet). */
+type PendingAssociationRestore = {
+    links: { estimateItemId: string; purchaseOrderId: string; createdAt?: string }[];
+    scheduleTasks: { scheduleTaskId: string; estimateItemId: string }[];
+    /** Bounded-retry counter — see MAX_PENDING_RESTORE_ATTEMPTS/attemptPendingRestore below.
+     *  Persisted alongside the payload so a browser refresh/remount doesn't reset the budget
+     *  and let a permanently-failing restore retry forever. */
+    attempts?: number;
+};
+
+/** After this many failed attempts, stop retrying a pending restore automatically and tell
+ *  the user once instead of silently looping on every future save. */
+const MAX_PENDING_RESTORE_ATTEMPTS = 5;
+
+/** Errors that retrying won't fix — the caller lacks permission, or the estimate/PO/schedule
+ *  target no longer exists. Give up on these immediately rather than burning the attempt
+ *  budget on a request that will never succeed. */
+function isPermanentRestoreError(e: any): boolean {
+    const msg = e?.message || "";
+    return /forbidden/i.test(msg) || /not found/i.test(msg) || /requires a project/i.test(msg);
+}
+
+/** sessionStorage key for a pending restore, scoped per estimate — so a browser refresh or
+ *  component remount between the row-recreation save and the association restore doesn't
+ *  silently lose the payload (see pendingAssociationRestoreRef comment in the component). */
+function pendingRestoreStorageKey(estimateId: string) {
+    return `probuild:estimate-pending-restore:${estimateId}`;
+}
+
+function loadPendingRestore(estimateId: string): PendingAssociationRestore | null {
+    if (typeof window === "undefined") return null;
+    try {
+        const raw = window.sessionStorage.getItem(pendingRestoreStorageKey(estimateId));
+        return raw ? JSON.parse(raw) : null;
+    } catch {
+        return null;
+    }
+}
+
+function persistPendingRestore(estimateId: string, payload: PendingAssociationRestore | null) {
+    if (typeof window === "undefined") return;
+    try {
+        const key = pendingRestoreStorageKey(estimateId);
+        if (!payload || (payload.links.length === 0 && payload.scheduleTasks.length === 0)) {
+            window.sessionStorage.removeItem(key);
+        } else {
+            window.sessionStorage.setItem(key, JSON.stringify(payload));
+        }
+    } catch {
+        // sessionStorage unavailable (private browsing, quota) — the in-memory ref still
+        // covers the same-session cases; only the across-remount case degrades.
+    }
+}
+
+/** Merge a new restore payload into whatever's already pending, deduped by
+ *  (estimateItemId, purchaseOrderId) for links and by scheduleTaskId for schedule tasks, so
+ *  two restores queued before either resolves don't clobber each other. */
+function mergePendingRestore(existing: PendingAssociationRestore | null, addition: PendingAssociationRestore): PendingAssociationRestore {
+    const linkMap = new Map((existing?.links ?? []).map(l => [`${l.estimateItemId}:${l.purchaseOrderId}`, l] as const));
+    for (const l of addition.links) linkMap.set(`${l.estimateItemId}:${l.purchaseOrderId}`, l);
+    const taskMap = new Map((existing?.scheduleTasks ?? []).map(t => [t.scheduleTaskId, t] as const));
+    for (const t of addition.scheduleTasks) taskMap.set(t.scheduleTaskId, t);
+    // Reset the attempt counter — merging in new links/tasks is meaningfully different work
+    // from whatever may have already failed a few times, so it gets a fresh bounded-retry
+    // budget instead of inheriting a near-exhausted count from an unrelated prior restore.
+    return { links: Array.from(linkMap.values()), scheduleTasks: Array.from(taskMap.values()), attempts: 0 };
+}
+
+/** Remove entries matching the given (estimateItemId, purchaseOrderId) pairs from a pending
+ *  restore payload. Used whenever a later user action explicitly removes a link (a manual
+ *  unlink, or a "replace"-mode revert's own stale-link cleanup) — without this, a still-pending
+ *  restore queued before that removal could replay afterward and resurrect the link the user
+ *  just deliberately removed, since mergePendingRestore only ever unions entries in. */
+function removePendingLinks(existing: PendingAssociationRestore | null, toRemove: { estimateItemId: string; purchaseOrderId: string }[]): PendingAssociationRestore | null {
+    if (!existing || toRemove.length === 0) return existing;
+    const removeKeys = new Set(toRemove.map(l => `${l.estimateItemId}:${l.purchaseOrderId}`));
+    const links = existing.links.filter(l => !removeKeys.has(`${l.estimateItemId}:${l.purchaseOrderId}`));
+    if (links.length === existing.links.length) return existing;
+    return { ...existing, links };
+}
+
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import dynamic from "next/dynamic";
-import { saveEstimate, createInvoiceFromEstimate, deleteEstimate, duplicateEstimate, saveEstimateAsTemplate, uploadEstimateFile, deleteEstimateFile, getEstimateFiles, saveItemsAsAssembly, getEstimateTemplates, deleteAssembly, updateItemApproval, bulkUpdateItemApproval, linkPOToEstimateItem, unlinkPOFromEstimateItem, getProjectPurchaseOrdersForLinking, recordEstimatePayment, sendEstimatePaymentReceipt, unrecordEstimatePayment, getDocumentTemplates, createDocumentTemplate } from "@/lib/actions";
+import { saveEstimate, createInvoiceFromEstimate, deleteEstimate, duplicateEstimate, saveEstimateAsTemplate, uploadEstimateFile, deleteEstimateFile, getEstimateFiles, saveItemsAsAssembly, getEstimateTemplates, deleteAssembly, updateItemApproval, bulkUpdateItemApproval, linkPOToEstimateItem, unlinkPOFromEstimateItem, restoreEstimateItemAssociations, getProjectPurchaseOrdersForLinking, recordEstimatePayment, sendEstimatePaymentReceipt, unrecordEstimatePayment, getDocumentTemplates, createDocumentTemplate } from "@/lib/actions";
+import type { RestoreEstimateItemAssociationsResult } from "@/lib/actions";
 import RichTextEditor from "@/components/RichTextEditor";
 import { useRouter } from "next/navigation";
 import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
@@ -84,6 +167,7 @@ const POQuickCreateModal = dynamic(() => import("./POQuickCreateModal"), { ssr: 
 const UndoPaymentModal = dynamic(() => import("@/components/UndoPaymentModal"), { ssr: false });
 
 import { internalBudget, derivedMarginPct } from "@/lib/budget-math";
+import { normalizeItemPoLinks } from "@/lib/estimate-item-po-links";
 
 // Prompt the user copies into ChatGPT so its output imports cleanly via "Import from ChatGPT".
 // Mirrors the JSON shape that /api/ai-estimate/import + transformPhasesToItems expect.
@@ -119,7 +203,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
     const [title, setTitle] = useState(initialEstimate.title);
     const [code, setCode] = useState(initialEstimate.code);
     const [status, setStatus] = useState(initialEstimate.status);
-    const [items, setItems] = useState<any[]>(initialEstimate.items || []);
+    const [items, setItems] = useState<any[]>(() => (initialEstimate.items || []).map(normalizeItemPoLinks));
     const [paymentSchedules, setPaymentSchedules] = useState<any[]>(initialEstimate.paymentSchedules || []);
     // Invoice generated from this estimate (if any) — milestone edits here do not
     // cascade to it, so the schedule UI warns when one exists.
@@ -230,17 +314,81 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
 
     const lastSavedStateRef = useRef<string>("");
 
-    const getEstimateSnapshot = useCallback(() => {
-        const activeTax = taxOptions.find(t => t.name === selectedTaxName) || defaultTaxRate;
+    // Mirrors `items` so undo/restore code can read the just-restored array immediately —
+    // `items` itself is frozen inside whatever render's closure captured it (e.g. a toast's
+    // onClick from a stale render), so it can't be trusted for that. Kept in sync for the
+    // normal case by the effect below; restoreItems also writes it directly so handleSave
+    // sees the restored rows synchronously, before that effect has a chance to run.
+    const itemsRef = useRef(items);
+    useEffect(() => { itemsRef.current = items; }, [items]);
+
+    // Mirrors every estimate-level field that runSave persists alongside items (title, tax,
+    // notes, payment schedules, etc.) — same reason as itemsRef: a save triggered from a
+    // stale render's closure (e.g. the delete-undo toast's onClick, bound at delete time)
+    // must send whatever the user has typed/changed SINCE, not whatever was current when
+    // that closure was created. Kept in sync every render by the effect below.
+    const fieldsRef = useRef({
+        title, code, status, processingFeeMarkup, hideProcessingFee, expirationDate,
+        memo, termsAndConditions, overviewEnabled, overviewTitle, overviewBody,
+        notesEnabled, notesTitle, notesBody, notesPlacement, signatureUrl, targetMargin,
+        taxExempt, selectedTaxName, paymentSchedules,
+    });
+    useEffect(() => {
+        fieldsRef.current = {
+            title, code, status, processingFeeMarkup, hideProcessingFee, expirationDate,
+            memo, termsAndConditions, overviewEnabled, overviewTitle, overviewBody,
+            notesEnabled, notesTitle, notesBody, notesPlacement, signatureUrl, targetMargin,
+            taxExempt, selectedTaxName, paymentSchedules,
+        };
+    }, [
+        title, code, status, processingFeeMarkup, hideProcessingFee, expirationDate,
+        memo, termsAndConditions, overviewEnabled, overviewTitle, overviewBody,
+        notesEnabled, notesTitle, notesBody, notesPlacement, signatureUrl, targetMargin,
+        taxExempt, selectedTaxName, paymentSchedules,
+    ]);
+
+    // Serializes every call to handleSave so overlapping saves (e.g. the blur-triggered
+    // autosave racing the delete-undo's own restore save) always execute in enqueue order
+    // instead of concurrently, where whichever server request happened to land last would
+    // silently win and could re-delete a just-restored item. Each call chains onto whatever
+    // is already in flight and waits for it to settle (success or failure) before starting.
+    const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
+
+    // Holds a PO-link/schedule-task restore payload after step 2 (the item save) of undo
+    // has succeeded but step 3 (restoreEstimateItemAssociations) has failed. Kept here —
+    // not just reported as a one-off error — so the next save (or the toast's Retry action)
+    // can retry it; without this, lastSavedStateRef already marks the item state saved and a
+    // later save would silently early-return, permanently losing the associations. Also
+    // mirrored to sessionStorage (see loadPendingRestore/persistPendingRestore) so a browser
+    // refresh or component remount between step 2 and step 3 doesn't lose it either.
+    const pendingAssociationRestoreRef = useRef<PendingAssociationRestore | null>(null);
+
+    // Recover a pending restore left over from a previous session/tab that never resolved —
+    // e.g. the row-recreation save succeeded but the tab closed before the association
+    // restore ran. retryAssociationRestore is a stable function declaration (hoisted) that
+    // reads the ref fresh at call time, so referencing it here before its definition is fine.
+    useEffect(() => {
+        const saved = loadPendingRestore(initialEstimate.id);
+        if (saved && (saved.links.length > 0 || saved.scheduleTasks.length > 0)) {
+            pendingAssociationRestoreRef.current = saved;
+            retryAssociationRestore();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only recovery
+    }, []);
+
+    const getEstimateSnapshot = useCallback((itemsOverride?: any[], fieldsOverride?: Partial<typeof fieldsRef.current>) => {
+        const srcItems = itemsOverride ?? itemsRef.current;
+        const f = { ...fieldsRef.current, ...fieldsOverride };
+        const activeTax = taxOptions.find(t => t.name === f.selectedTaxName) || defaultTaxRate;
 
         const childTotals = new Map<string, number>();
-        for (const item of items) {
+        for (const item of srcItems) {
             if (item.parentId) {
                 childTotals.set(item.parentId, (childTotals.get(item.parentId) || 0) + rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0)));
             }
         }
-        const mappedItems = items.map((item, index) => {
-            const isSection = !item.parentId && items.some((i: any) => i.parentId === item.id);
+        const mappedItems = srcItems.map((item, index) => {
+            const isSection = !item.parentId && srcItems.some((i: any) => i.parentId === item.id);
             const computedTotal = isSection
                 ? (childTotals.get(item.id) || 0)
                 : rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0));
@@ -261,7 +409,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
             };
         });
 
-        const mappedSchedules = paymentSchedules.map((schedule, index) => ({
+        const mappedSchedules = f.paymentSchedules.map((schedule: any, index: number) => ({
             id: schedule.id || null,
             name: schedule.name || "",
             amount: String(schedule.amount || "0"),
@@ -275,36 +423,30 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
         }));
 
         return {
-            title: title || "",
-            code: code || "",
-            status: status || "Draft",
-            processingFeeMarkup: Number(processingFeeMarkup) || 0,
-            hideProcessingFee: !!hideProcessingFee,
-            expirationDate: expirationDate ? new Date(expirationDate).toISOString().split("T")[0] : null,
-            memo: memo || null,
-            termsAndConditions: termsAndConditions || null,
-            overviewEnabled: !!overviewEnabled,
-            overviewTitle: overviewTitle || null,
-            overviewBody: overviewBody || null,
-            notesEnabled: !!notesEnabled,
-            notesTitle: notesTitle || null,
-            notesBody: notesBody || null,
-            notesPlacement,
-            signatureUrl: signatureUrl || null,
-            targetMarginPercent: parseFloat(targetMargin) || 25,
-            taxExempt: !!taxExempt,
-            taxRateName: taxExempt ? null : (activeTax?.name || null),
-            taxRatePercent: taxExempt ? null : (activeTax?.rate ?? null),
+            title: f.title || "",
+            code: f.code || "",
+            status: f.status || "Draft",
+            processingFeeMarkup: Number(f.processingFeeMarkup) || 0,
+            hideProcessingFee: !!f.hideProcessingFee,
+            expirationDate: f.expirationDate ? new Date(f.expirationDate).toISOString().split("T")[0] : null,
+            memo: f.memo || null,
+            termsAndConditions: f.termsAndConditions || null,
+            overviewEnabled: !!f.overviewEnabled,
+            overviewTitle: f.overviewTitle || null,
+            overviewBody: f.overviewBody || null,
+            notesEnabled: !!f.notesEnabled,
+            notesTitle: f.notesTitle || null,
+            notesBody: f.notesBody || null,
+            notesPlacement: f.notesPlacement,
+            signatureUrl: f.signatureUrl || null,
+            targetMarginPercent: parseFloat(f.targetMargin) || 25,
+            taxExempt: !!f.taxExempt,
+            taxRateName: f.taxExempt ? null : (activeTax?.name || null),
+            taxRatePercent: f.taxExempt ? null : (activeTax?.rate ?? null),
             items: mappedItems,
             paymentSchedules: mappedSchedules,
         };
-    }, [
-        title, code, status, processingFeeMarkup, hideProcessingFee, expirationDate,
-        memo, termsAndConditions, overviewEnabled, overviewTitle, overviewBody,
-        notesEnabled, notesTitle, notesBody, notesPlacement,
-        signatureUrl, targetMargin, taxExempt, selectedTaxName,
-        taxOptions, defaultTaxRate, items, paymentSchedules
-    ]);
+    }, [taxOptions, defaultTaxRate]);
 
     useEffect(() => {
         lastSavedStateRef.current = JSON.stringify(getEstimateSnapshot());
@@ -757,78 +899,133 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
     const totalMarkup = subtotal - totalBaseCost;
     const profitMargin = subtotal > 0 ? ((totalMarkup / subtotal) * 100) : 0;
 
-    async function handleSave({ silent = false, skipRefresh = false } = {}) {
-        captureHistory(new Date().toLocaleString());
+    async function handleSave(opts: { silent?: boolean; skipRefresh?: boolean; itemsOverride?: any[]; fieldsOverride?: Partial<typeof fieldsRef.current>; skipHistoryCapture?: boolean } = {}) {
+        // Chain this save behind whatever is already in flight (see saveQueueRef comment
+        // above) so saves always run one at a time, in the order they were requested. The
+        // queue promise itself must never reject — that would break the chain for every
+        // future caller — so failures are swallowed there; this call's own promise (`run`)
+        // still resolves/rejects normally for its caller.
+        const run = saveQueueRef.current.catch(() => {}).then(() => runSave(opts));
+        saveQueueRef.current = run.then(() => undefined, () => undefined);
+        return run;
+    }
+
+    async function runSave({ silent = false, skipRefresh = false, itemsOverride, fieldsOverride, skipHistoryCapture = false }: { silent?: boolean; skipRefresh?: boolean; itemsOverride?: any[]; fieldsOverride?: Partial<typeof fieldsRef.current>; skipHistoryCapture?: boolean } = {}) {
+        // `itemsOverride`/`fieldsOverride` let restoreItems (undo / history revert) pass the
+        // just-restored items and any fields it wants to force explicitly. Everything else
+        // is read from fieldsRef/itemsRef rather than this function's own closure — that
+        // closure is frozen to whatever render created it, which is stale for a caller like
+        // the delete-undo toast's onClick (bound at delete time, possibly long before the
+        // user clicks Undo and edits the title/tax/notes in between).
+        const sourceItems = itemsOverride ?? itemsRef.current;
+        const f = { ...fieldsRef.current, ...fieldsOverride };
+        // Skipped when restoreItems already captured the pre-swap state itself (see its
+        // comment) — otherwise this would capture itemsRef.current AFTER restoreItems has
+        // already swapped it to the restored/reverted target, recording the wrong snapshot.
+        if (!skipHistoryCapture) captureHistory(new Date().toLocaleString());
 
         // Check if there are actual changes before saving
-        const currentSnapshot = getEstimateSnapshot();
+        const currentSnapshot = getEstimateSnapshot(itemsOverride, fieldsOverride);
         const currentSnapshotStr = JSON.stringify(currentSnapshot);
-        if (currentSnapshotStr === lastSavedStateRef.current) {
-            if (!silent) {
-                toast.success("Estimate saved successfully");
-            }
-            return;
-        }
+        const hasChanges = currentSnapshotStr !== lastSavedStateRef.current;
 
-        if (!silent) setIsSaving(true);
-        try {
-            // Recompute section header totals from children before saving
-            const childTotals = new Map<string, number>();
-            for (const item of items) {
-                if (item.parentId) {
-                    childTotals.set(item.parentId, (childTotals.get(item.parentId) || 0) + rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0)));
+        if (hasChanges) {
+            if (!silent) setIsSaving(true);
+            try {
+                // Recompute section header totals from children before saving
+                const childTotals = new Map<string, number>();
+                for (const item of sourceItems) {
+                    if (item.parentId) {
+                        childTotals.set(item.parentId, (childTotals.get(item.parentId) || 0) + rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0)));
+                    }
                 }
-            }
-            const mappedItems = items.map((item, index) => {
-                const isSection = !item.parentId && items.some((i: any) => i.parentId === item.id);
-                const computedTotal = isSection
-                    ? (childTotals.get(item.id) || 0)
-                    : rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0));
-                return { ...item, order: index, total: computedTotal, ...(isSection ? { unitCost: computedTotal } : {}) };
-            });
-            const mappedSchedules = paymentSchedules.map((schedule, index) => ({
-                ...schedule,
-                order: index
-            }));
+                const mappedItems = sourceItems.map((item, index) => {
+                    const isSection = !item.parentId && sourceItems.some((i: any) => i.parentId === item.id);
+                    const computedTotal = isSection
+                        ? (childTotals.get(item.id) || 0)
+                        : rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0));
+                    return { ...item, order: index, total: computedTotal, ...(isSection ? { unitCost: computedTotal } : {}) };
+                });
+                const mappedSchedules = f.paymentSchedules.map((schedule: any, index: number) => ({
+                    ...schedule,
+                    order: index
+                }));
 
-            await saveEstimate(initialEstimate.id, context.id, context.type, {
-                title, code, status, totalAmount: total, paymentSchedules: mappedSchedules,
-                processingFeeMarkup, hideProcessingFee,
-                expirationDate: expirationDate ? new Date(expirationDate).toISOString() : null,
-                memo: memo || null,
-                termsAndConditions: termsAndConditions || null,
-                overviewEnabled,
-                overviewTitle: overviewTitle || null,
-                overviewBody: overviewBody || null,
-                notesEnabled,
-                notesTitle: notesTitle || null,
-                notesBody: notesBody || null,
-                notesPlacement,
-                signatureUrl: signatureUrl || null,
-                targetMarginPercent: parseFloat(targetMargin) || 25,
-                taxExempt,
-                taxRateName: taxExempt ? null : (activeTax?.name || null),
-                taxRatePercent: taxExempt ? null : (activeTax?.rate ?? null),
-            }, mappedItems);
+                // Recompute the sell subtotal/total (and tax) from `sourceItems`/`f` rather than
+                // the render's `total`/`taxRate` consts, which are equally frozen to the stale
+                // render for a caller with a stale closure.
+                const sourceSubtotal = sourceItems.reduce((acc: number, item: any) => {
+                    if (item.parentId) return acc + rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0));
+                    if (!sourceItems.some((i: any) => i.parentId === item.id)) return acc + rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0));
+                    return acc;
+                }, 0);
+                const activeTax = taxOptions.find(t => t.name === f.selectedTaxName) || defaultTaxRate;
+                const sourceTaxRate = f.taxExempt ? 0 : (activeTax ? activeTax.rate / 100 : 0.088);
+                const sourceProcessingFee = f.processingFeeMarkup > 0 ? rm(sourceSubtotal * (f.processingFeeMarkup / 100)) : 0;
+                const sourceTax = rm(sourceSubtotal * sourceTaxRate);
+                const sourceTotal = rm(sourceSubtotal + sourceTax + sourceProcessingFee);
 
-            // Update the last saved state ref to the new state
-            lastSavedStateRef.current = currentSnapshotStr;
+                await saveEstimate(initialEstimate.id, context.id, context.type, {
+                    title: f.title, code: f.code, status: f.status, totalAmount: sourceTotal, paymentSchedules: mappedSchedules,
+                    processingFeeMarkup: f.processingFeeMarkup, hideProcessingFee: f.hideProcessingFee,
+                    expirationDate: f.expirationDate ? new Date(f.expirationDate).toISOString() : null,
+                    memo: f.memo || null,
+                    termsAndConditions: f.termsAndConditions || null,
+                    overviewEnabled: f.overviewEnabled,
+                    overviewTitle: f.overviewTitle || null,
+                    overviewBody: f.overviewBody || null,
+                    notesEnabled: f.notesEnabled,
+                    notesTitle: f.notesTitle || null,
+                    notesBody: f.notesBody || null,
+                    notesPlacement: f.notesPlacement,
+                    signatureUrl: f.signatureUrl || null,
+                    targetMarginPercent: parseFloat(f.targetMargin) || 25,
+                    taxExempt: f.taxExempt,
+                    taxRateName: f.taxExempt ? null : (activeTax?.name || null),
+                    taxRatePercent: f.taxExempt ? null : (activeTax?.rate ?? null),
+                }, mappedItems);
 
-            if (!silent) {
-                toast.success("Estimate saved successfully");
+                // Update the last saved state ref to the new state
+                lastSavedStateRef.current = currentSnapshotStr;
+            } catch (e: any) {
+                console.error("[EstimateEditor] Failed to save estimate:", e);
+                if (!silent) {
+                    toast.error(e?.message || "Failed to save estimate. Please try again.");
+                }
+                throw e;
+            } finally {
+                if (!silent) setIsSaving(false);
             }
-            if (!skipRefresh) {
-                router.refresh();
-            }
-        } catch (e: any) {
-            console.error("[EstimateEditor] Failed to save estimate:", e);
-            if (!silent) {
-                toast.error(e?.message || "Failed to save estimate. Please try again.");
-            }
-            throw e;
-        } finally {
-            if (!silent) setIsSaving(false);
         }
+
+        // Retry any association restore left pending from a previous undo/revert whose step 3
+        // (restoreEstimateItemAssociations) failed after step 2 (the row save) already
+        // committed — see pendingAssociationRestoreRef comment. This runs AFTER the row save
+        // above, not before: the payload may belong to THIS very save (restoreItems sets it
+        // right before calling handleSave to recreate deleted rows), and the associated rows
+        // don't exist again until saveEstimate resolves. Running it at the top of runSave (as
+        // this used to) would replay against not-yet-existent rows — which the server treats
+        // as a harmless no-op success — clearing the payload before the row save even had a
+        // chance to fail, permanently losing the one thing the payload exists to protect.
+        // If the row save above threw, we never reach here, so the payload is left untouched
+        // for the next attempt.
+        //
+        // The status is returned (handleSave resolves to whatever runSave returns) so a
+        // caller that specifically wants to know how the replay went — retryAssociationRestore,
+        // driving the manual "Retry" action and mount-time recovery — doesn't have to guess
+        // from ref state alone or invoke a second, redundant restore call of its own.
+        let pendingRestoreStatus: "success" | "retrying" | "gave-up" | undefined;
+        if (pendingAssociationRestoreRef.current) {
+            pendingRestoreStatus = await attemptPendingRestore(pendingAssociationRestoreRef.current);
+        }
+
+        if (!silent) {
+            toast.success("Estimate saved successfully");
+        }
+        if (hasChanges && !skipRefresh) {
+            router.refresh();
+        }
+        return pendingRestoreStatus;
     }
 
     async function handleCreateInvoice() {
@@ -906,13 +1103,258 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
     }
 
     function captureHistory(label: string) {
-        setHistory(prev => [{ ts: Date.now(), label, snapshot: JSON.parse(JSON.stringify(items)) }, ...prev.slice(0, 49)]);
+        // Reads itemsRef rather than the `items` closure so a capture triggered from inside
+        // handleSave (a normal save) snapshots the actually-current items, not whatever
+        // render created this particular closure. restoreItems calls this itself BEFORE
+        // swapping itemsRef to a restored/reverted target (and tells runSave to skip its own
+        // automatic capture) so this always records the state being left, not the state
+        // being restored to.
+        setHistory(prev => [{ ts: Date.now(), label, snapshot: JSON.parse(JSON.stringify(itemsRef.current)) }, ...prev.slice(0, 49)]);
     }
 
-    function revertToHistory(entry: { ts: number; label: string; snapshot: any[] }) {
-        setItems(entry.snapshot);
-        setExpandedHistoryTs(null);
-        toast.success(`Reverted to ${entry.label}`);
+    // Shared by the delete-undo toast (B2/B3) and the History panel (B4). Runs three steps,
+    // in order: local state, then the save that recreates the rows (with their original ids),
+    // then re-attaching the PO links / schedule task that only the save step could not restore
+    // (they were severed at the DB level when the row was deleted). Step 3 must come after
+    // step 2 — the item row doesn't exist again until the save completes.
+    //
+    // `mode` distinguishes the two callers: delete-undo ("additive") only ever needs to
+    // re-add what THIS delete severed, since nothing else changed underneath it. History
+    // revert ("replace") can jump back across other edits that happened after the snapshot
+    // was taken, so it also needs to strip associations that don't belong in the target
+    // state — see the linksToRemove block below.
+    async function restoreItems({ nextItems, links, scheduleTasks, mode = "additive", label }: {
+        nextItems: any[];
+        links: { estimateItemId: string; purchaseOrderId: string; createdAt?: string }[];
+        scheduleTasks: { scheduleTaskId: string; estimateItemId: string }[];
+        mode?: "additive" | "replace";
+        label: string;
+    }) {
+        // Capture the state we're LEAVING before swapping itemsRef to nextItems below.
+        // captureHistory reads itemsRef.current, so capturing after the swap (as this used
+        // to) records the state we're restoring TO, not the one we're restoring FROM — making
+        // it impossible to undo an undo or revert a revert. runSave's own automatic capture
+        // is skipped for this save (skipHistoryCapture) so it doesn't immediately overwrite
+        // this with the target state again.
+        captureHistory(label);
+
+        // "replace" mode: strip any PO link that exists on the CURRENT (pre-revert) items but
+        // isn't part of the target snapshot — e.g. a link added after this history entry was
+        // captured. Computed from itemsRef.current before it gets swapped below.
+        //
+        // NOTE: schedule-task detachment can't be replayed the same way — the server action
+        // (restoreEstimateItemAssociations) only ever attaches/repoints a ScheduleTask, it
+        // never detaches one, so a task attached to an item AFTER this snapshot (or moved to
+        // a different item) stays attached. That needs a server-side "replace" mode we don't
+        // have; flagging as a known gap rather than working around it with an unrelated action.
+        let linksToRemove: { estimateItemId: string; purchaseOrderId: string }[] = [];
+        if (mode === "replace") {
+            const targetLinkKeys = new Set(links.map(l => `${l.estimateItemId}:${l.purchaseOrderId}`));
+            linksToRemove = itemsRef.current.flatMap((it: any) =>
+                (it.purchaseOrderLinks ?? [])
+                    .map((l: any) => ({ estimateItemId: it.id, purchaseOrderId: l.purchaseOrder.id }))
+                    .filter((l: any) => !targetLinkKeys.has(`${l.estimateItemId}:${l.purchaseOrderId}`))
+            );
+        }
+
+        // Recorded (merged with anything already pending, deduped) BEFORE attempting the row
+        // save below — previously this was only set after that save succeeded, so if the row
+        // save itself failed, the links/schedule-task payload was lost forever: a later manual
+        // save would recreate the rows but never re-attach them. Also persisted to
+        // sessionStorage so a remount/refresh between now and step 3 doesn't lose it either.
+        let mergedPending: PendingAssociationRestore | null = null;
+        if (links.length > 0 || scheduleTasks.length > 0) {
+            mergedPending = mergePendingRestore(pendingAssociationRestoreRef.current, { links, scheduleTasks });
+            pendingAssociationRestoreRef.current = mergedPending;
+            persistPendingRestore(initialEstimate.id, mergedPending);
+        }
+
+        itemsRef.current = nextItems;
+        setItems(nextItems);
+        // The row save below (via runSave) also replays whatever's currently pending in
+        // pendingAssociationRestoreRef AFTER it commits — including the payload just set
+        // above for this very restore, now that the rows exist again (see runSave comment).
+        await handleSave({ silent: true, itemsOverride: nextItems, skipHistoryCapture: true });
+
+        if (linksToRemove.length > 0) {
+            await Promise.all(linksToRemove.map(l =>
+                unlinkPOFromEstimateItem(l.estimateItemId, l.purchaseOrderId)
+                    .then(() => {
+                        // Supersede: a link this revert deliberately strips must not be
+                        // resurrected by some OTHER still-pending restore that happens to
+                        // reference the same (item, PO) pair (mergePendingRestore only
+                        // unions, so without this an unrelated pending payload could replay
+                        // the very link we just removed).
+                        const updated = removePendingLinks(pendingAssociationRestoreRef.current, [{ estimateItemId: l.estimateItemId, purchaseOrderId: l.purchaseOrderId }]);
+                        if (updated !== pendingAssociationRestoreRef.current) {
+                            pendingAssociationRestoreRef.current = updated;
+                            persistPendingRestore(initialEstimate.id, updated);
+                        }
+                    })
+                    .catch(() => {
+                        console.error(`[EstimateEditor] Failed to unlink stale PO ${l.purchaseOrderId} from item ${l.estimateItemId} during history revert`);
+                    })
+            ));
+        }
+
+        // If mergedPending is still pending on the ref at this point, the replay inside the
+        // row save above either hasn't fully succeeded yet (still retrying, bounded) or gave
+        // up permanently (already told the user — see attemptPendingRestore). Either way,
+        // surface that this restore isn't fully done rather than reporting full success.
+        if (mergedPending && pendingAssociationRestoreRef.current) {
+            throw new Error("Row restored, but its purchase order / schedule links could not be reattached yet.");
+        }
+    }
+
+    // Attempts one pending association restore and diffs the server's structured result
+    // (RestoreEstimateItemAssociationsResult) against what was sent, so the payload is only
+    // ever cleared for entries the server actually confirms — either restored, or reported as
+    // PERMANENTLY impossible (its PO/ScheduleTask target is gone or out of scope). Anything the
+    // server reports as RETRYABLE (missing.itemIds — the EstimateItem itself isn't back yet)
+    // stays pending untouched. This replaces the old "any non-throwing response == full
+    // success" assumption, which is what let a call that silently skipped every entry (because
+    // the item wasn't recreated yet) still clear the whole payload.
+    //
+    // A thrown exception here is a genuine server-side failure (auth, estimate/project gone) —
+    // no longer how "stale id" skips are reported — so it keeps the same permanent-vs-bounded-
+    // retry handling as before.
+    async function attemptPendingRestore(pending: PendingAssociationRestore): Promise<"success" | "retrying" | "gave-up"> {
+        let result: RestoreEstimateItemAssociationsResult;
+        try {
+            result = await restoreEstimateItemAssociations({ estimateId: initialEstimate.id, links: pending.links, scheduleTasks: pending.scheduleTasks });
+        } catch (e: any) {
+            const attempts = (pending.attempts ?? 0) + 1;
+            const permanent = isPermanentRestoreError(e);
+            if (permanent || attempts >= MAX_PENDING_RESTORE_ATTEMPTS) {
+                pendingAssociationRestoreRef.current = null;
+                persistPendingRestore(initialEstimate.id, null);
+                toast.error(
+                    permanent
+                        ? `Could not restore purchase order / schedule links: ${e?.message || "not permitted"}. Please re-link manually.`
+                        : "Failed to restore purchase order / schedule links after repeated attempts. Please re-link manually."
+                );
+                return "gave-up";
+            }
+            const updated = { ...pending, attempts };
+            pendingAssociationRestoreRef.current = updated;
+            persistPendingRestore(initialEstimate.id, updated);
+            return "retrying";
+        }
+
+        const restoredLinkKeys = new Set(result.restoredLinks.map(l => `${l.estimateItemId}:${l.purchaseOrderId}`));
+        const permanentPoIds = new Set(result.missing.purchaseOrderIds);
+        const retryableItemIds = new Set(result.missing.itemIds);
+        // A link entry is kept pending unless the server confirms it restored, or confirms its
+        // PO target is permanently gone — an item reported retryable-missing always stays,
+        // even if its purchaseOrderId also happens to appear in `permanentPoIds` for some OTHER
+        // (already-existing) item's entry.
+        const remainingLinks = pending.links.filter(l => {
+            if (restoredLinkKeys.has(`${l.estimateItemId}:${l.purchaseOrderId}`)) return false;
+            if (retryableItemIds.has(l.estimateItemId)) return true;
+            if (permanentPoIds.has(l.purchaseOrderId)) return false;
+            return true;
+        });
+
+        const restoredTaskIds = new Set(result.restoredScheduleTasks.map(t => t.scheduleTaskId));
+        const permanentTaskIds = new Set(result.missing.scheduleTaskIds);
+        const remainingScheduleTasks = pending.scheduleTasks.filter(st => {
+            if (restoredTaskIds.has(st.scheduleTaskId)) return false;
+            if (retryableItemIds.has(st.estimateItemId)) return true;
+            if (permanentTaskIds.has(st.scheduleTaskId)) return false;
+            return true;
+        });
+
+        if (remainingLinks.length === 0 && remainingScheduleTasks.length === 0) {
+            pendingAssociationRestoreRef.current = null;
+            persistPendingRestore(initialEstimate.id, null);
+            return "success";
+        }
+
+        // Something is still pending (retryable). Only spend a unit of the attempt budget when
+        // this call made literally zero progress (nothing restored, nothing permanently
+        // resolved) — a call that DID clear some entries but left others waiting on a
+        // not-yet-recreated row is forward progress, not a failure, so it shouldn't count
+        // toward giving up. In practice this keeps the manual Retry / mount-recovery paths
+        // (which now trigger a real row save first — see retryAssociationRestore) from burning
+        // through MAX_PENDING_RESTORE_ATTEMPTS purely because a row simply isn't back yet.
+        // The attempt budget exists to stop us retrying a call that keeps FAILING — not to time
+        // out work the server has explicitly told us to come back for. When every remaining
+        // entry is one the server reported as retryable-missing (its EstimateItem row simply
+        // isn't back yet), retain the payload without spending any budget: the remedy is a
+        // successful row save, which may legitimately be several user actions away, and
+        // dropping the payload on a countdown would silently lose the very links this mechanism
+        // exists to protect. The budget is spent only by a thrown transient failure (the catch
+        // path above) or by a call that resolved nothing and explained nothing.
+        const allRemainingRetryable =
+            remainingLinks.every(l => retryableItemIds.has(l.estimateItemId)) &&
+            remainingScheduleTasks.every(st => retryableItemIds.has(st.estimateItemId));
+
+        const totalBefore = pending.links.length + pending.scheduleTasks.length;
+        const totalAfter = remainingLinks.length + remainingScheduleTasks.length;
+        const madeProgress = totalAfter < totalBefore;
+        const attempts = (madeProgress || allRemainingRetryable)
+            ? (pending.attempts ?? 0)
+            : (pending.attempts ?? 0) + 1;
+
+        if (!madeProgress && !allRemainingRetryable && attempts >= MAX_PENDING_RESTORE_ATTEMPTS) {
+            pendingAssociationRestoreRef.current = null;
+            persistPendingRestore(initialEstimate.id, null);
+            toast.error("Failed to restore purchase order / schedule links after repeated attempts. Please re-link manually.");
+            return "gave-up";
+        }
+
+        const updated: PendingAssociationRestore = { links: remainingLinks, scheduleTasks: remainingScheduleTasks, attempts };
+        pendingAssociationRestoreRef.current = updated;
+        persistPendingRestore(initialEstimate.id, updated);
+        return "retrying";
+    }
+
+    // Retries a pending association restore on demand (wired to the error toast's Retry
+    // action, and to the mount-time recovery effect above). Drives it through handleSave
+    // rather than calling attemptPendingRestore in isolation — the actual remedy for a
+    // RETRYABLE (item-missing) entry is a normal save that recreates the row, and calling the
+    // restore directly (as this used to) replayed against rows that weren't back yet, which
+    // read as "nothing to do" and (under the old server contract) cleared the payload for
+    // good. handleSave recreates the row when there are pending changes and, once that
+    // succeeds, itself runs the same replay afterward (see runSave) and returns its outcome —
+    // so a caller here never duplicates that call.
+    async function retryAssociationRestore() {
+        if (!pendingAssociationRestoreRef.current) return;
+        let status: "success" | "retrying" | "gave-up" | undefined;
+        try {
+            status = await handleSave({ silent: true });
+        } catch {
+            // The row save itself failed — runSave already toasted that error and never
+            // reached the replay step (see its comment), so the pending payload is untouched.
+            // Nothing further to report here.
+            return;
+        }
+        if (status === "success") toast.success("Purchase order / schedule links restored");
+        else if (status === "retrying") toast.error("Still failed to restore purchase order / schedule links — will retry on next save.");
+        // "gave-up" already showed its own toast inside attemptPendingRestore; `undefined`
+        // means there was nothing pending by the time runSave got there — nothing to report.
+    }
+
+    async function revertToHistory(entry: { ts: number; label: string; snapshot: any[] }) {
+        const nextItems = entry.snapshot;
+        const links = nextItems.flatMap((it: any) =>
+            (it.purchaseOrderLinks ?? []).map((l: any) => ({ estimateItemId: it.id, purchaseOrderId: l.purchaseOrder.id, createdAt: l.createdAt }))
+        );
+        const scheduleTasks = nextItems
+            .filter((it: any) => it.scheduleTask?.id)
+            .map((it: any) => ({ scheduleTaskId: it.scheduleTask.id, estimateItemId: it.id }));
+        try {
+            await restoreItems({ nextItems, links, scheduleTasks, mode: "replace", label: `Before reverting to ${entry.label}` });
+            setExpandedHistoryTs(null);
+            toast.success(`Reverted to ${entry.label}`);
+        } catch (e: any) {
+            setExpandedHistoryTs(null);
+            toast.error(e?.message || "Reverted locally, but failed to save — please review and save manually.", {
+                action: pendingAssociationRestoreRef.current
+                    ? { label: "Retry", onClick: () => retryAssociationRestore() }
+                    : undefined,
+            });
+        }
     }
 
     function diffSnapshots(prev: any[], curr: any[]) {
@@ -1043,7 +1485,11 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
             ? [...paymentSchedules, ...data.paymentMilestones]
             : paymentSchedules;
 
-        // Update UI immediately — don't wait for save
+        // Update UI immediately — don't wait for save. itemsRef is set synchronously (not
+        // just via the effect that mirrors `items`) so a save queued right behind this one
+        // sees the merged items immediately, and so this save's own captureHistory call
+        // records them correctly.
+        itemsRef.current = newItems;
         setItems(newItems);
         if (data.paymentMilestones && data.paymentMilestones.length > 0) {
             setPaymentSchedules(newSchedules);
@@ -1051,92 +1497,14 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
         onMerged?.();
         toast.success(`${verb} ${data.count} items (est. ${formatCurrency(Number(data.totalEstimate || 0))})`);
 
-        // Auto-save in background — set isSaving to block concurrent blur-triggered save
-        setIsSaving(true);
+        // Auto-save in background, routed through the same save queue as every other write
+        // (see saveQueueRef comment). This used to call saveEstimate directly, bypassing the
+        // queue — a save already in flight (e.g. a blur autosave) could land afterwards with
+        // a stale items array and silently wipe out the just-generated/imported lines.
+        setIsSaving(true); // blocks the onBlur-triggered autosave guard while this is in flight
         try {
-            // Recompute section header totals from children before saving
-            const childTotals = new Map<string, number>();
-            for (const item of newItems) {
-                if (item.parentId) {
-                    childTotals.set(item.parentId, (childTotals.get(item.parentId) || 0) + rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0)));
-                }
-            }
-            const mappedItems = newItems.map((item: any, index: number) => {
-                const isSect = !item.parentId && newItems.some((i: any) => i.parentId === item.id);
-                const ct = isSect ? (childTotals.get(item.id) || 0) : rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0));
-                return { ...item, order: index, total: ct, ...(isSect ? { unitCost: ct } : {}) };
-            });
-            const mappedSchedules = newSchedules.map((schedule, index) => ({
-                ...schedule,
-                order: index
-            }));
-            // Subtotal from leaf items only (sections would double-count)
-            const newSubtotal = newItems.reduce((acc: number, item: any) => {
-                if (item.parentId) return acc + rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0));
-                if (!newItems.some((i: any) => i.parentId === item.id)) return acc + rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0));
-                return acc;
-            }, 0);
-            const newTotal = rm(newSubtotal + rm(newSubtotal * taxRate));
-            await saveEstimate(initialEstimate.id, context.id, context.type, {
-                title, code, status, totalAmount: newTotal, paymentSchedules: mappedSchedules, taxExempt,
-                taxRateName: taxExempt ? null : (activeTax?.name || null),
-                taxRatePercent: taxExempt ? null : (activeTax?.rate ?? null),
-            }, mappedItems);
+            await handleSave({ silent: true, itemsOverride: newItems, fieldsOverride: { paymentSchedules: newSchedules } });
             toast.success("Estimate auto-saved");
-
-            // Update lastSavedStateRef so subsequent blur saves are skipped
-            const savedSnapshot = {
-                title: title || "",
-                code: code || "",
-                status: status || "Draft",
-                processingFeeMarkup: Number(processingFeeMarkup) || 0,
-                hideProcessingFee: !!hideProcessingFee,
-                expirationDate: expirationDate ? new Date(expirationDate).toISOString().split("T")[0] : null,
-                memo: memo || null,
-                termsAndConditions: termsAndConditions || null,
-                overviewEnabled,
-                overviewTitle: overviewTitle || null,
-                overviewBody: overviewBody || null,
-                notesEnabled,
-                notesTitle: notesTitle || null,
-                notesBody: notesBody || null,
-                notesPlacement,
-                signatureUrl: signatureUrl || null,
-                targetMarginPercent: parseFloat(targetMargin) || 25,
-                taxExempt: !!taxExempt,
-                taxRateName: taxExempt ? null : (activeTax?.name || null),
-                taxRatePercent: taxExempt ? null : (activeTax?.rate ?? null),
-                items: mappedItems.map((item: any, index: number) => ({
-                    id: item.id || null,
-                    parentId: item.parentId || null,
-                    name: item.name || "",
-                    description: item.description || "",
-                    type: item.type || "Material",
-                    quantity: String(item.quantity || "0"),
-                    unitCost: String(item.unitCost || "0"),
-                    costCodeId: item.costCodeId || null,
-                    costTypeId: item.costTypeId || null,
-                    vendorId: item.vendorId || null,
-                    approvalStatus: item.approvalStatus || null,
-                    order: index,
-                    total: item.total,
-                })),
-                paymentSchedules: mappedSchedules.map((schedule: any, index: number) => ({
-                    id: schedule.id || null,
-                    name: schedule.name || "",
-                    amount: String(schedule.amount || "0"),
-                    dueDate: schedule.dueDate ? new Date(schedule.dueDate).toISOString().split("T")[0] : null,
-                    status: schedule.status || "Pending",
-                    paymentMethod: schedule.paymentMethod || null,
-                    paymentReference: schedule.paymentReference || null,
-                    percentage: String(schedule.percentage || "0"),
-                    type: schedule.type || null,
-                    order: index
-                })),
-            };
-            lastSavedStateRef.current = JSON.stringify(savedSnapshot);
-
-            router.refresh();
         } catch (saveErr) {
             console.error("Auto-save after estimate merge failed:", saveErr);
             toast.error("Items added — but auto-save failed. Click Save to persist.");
@@ -1193,10 +1561,93 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
         setItems(newItems);
     }
 
+    // Re-inserts each removed row at its original index, for the case where other edits
+    // happened to `current` while the undo toast was up (so we can't just restore `preDelete`
+    // wholesale — that would also discard those other edits).
+    function spliceBackByIndex(current: any[], removed: Array<{ item: any; index: number }>) {
+        const next = [...current];
+        const sorted = [...removed].sort((a, b) => a.index - b.index);
+        for (const { item, index } of sorted) {
+            next.splice(Math.min(index, next.length), 0, item);
+        }
+        return next;
+    }
+
     function removeItem(index: number) {
         const itemToRemove = items[index];
-        // Also remove children if it's a parent
-        setItems(items.filter((item, i) => i !== index && item.parentId !== itemToRemove.id));
+        const children = items.filter(i => i.parentId === itemToRemove.id);
+        const group = [itemToRemove, ...children];
+
+        // B1: block outright if the item or any sub-item has logged time/expenses —
+        // saveEstimate hard-rejects deleting those server-side, so a local delete here
+        // would just wedge the editor unable to save.
+        const hasProtectedData = group.some(it => (it._count?.timeEntries ?? 0) > 0 || (it.expenses?.length ?? 0) > 0);
+        if (hasProtectedData) {
+            toast.error(`"${itemToRemove.name || "This item"}" can't be deleted — it has logged time entries or expenses attached. Remove those first.`);
+            return;
+        }
+
+        // B1: confirm if PO links or a schedule task would be severed.
+        const poLinks = group.flatMap(it => it.purchaseOrderLinks ?? []);
+        const scheduleTasks = group.filter(it => it.scheduleTask);
+        if (poLinks.length > 0 || scheduleTasks.length > 0) {
+            const parts: string[] = [];
+            if (poLinks.length > 0) parts.push(`${poLinks.length} purchase order${poLinks.length !== 1 ? "s" : ""}`);
+            if (scheduleTasks.length > 0) parts.push(`${scheduleTasks.length} schedule task${scheduleTasks.length !== 1 ? "s" : ""}`);
+            const ok = window.confirm(`"${itemToRemove.name || "This item"}" has ${parts.join(" and ")} attached. Delete anyway?`);
+            if (!ok) return;
+        }
+
+        captureHistory(`Before deleting "${itemToRemove.name || "item"}"`);
+        const preDelete = items;
+        const postDelete = items.filter((it, i) => i !== index && it.parentId !== itemToRemove.id);
+        const removed = group.map(it => ({ item: it, index: items.indexOf(it) }));
+        setItems(postDelete);
+        itemsRef.current = postDelete;
+
+        toast(`Deleted "${itemToRemove.name || "item"}"${children.length ? ` and ${children.length} sub-item(s)` : ""}`, {
+            action: { label: "Undo", onClick: () => undoDelete({ preDelete, postDelete, removed }) },
+            duration: 10000,
+        });
+    }
+
+    async function undoDelete({ preDelete, postDelete, removed }: {
+        preDelete: any[];
+        postDelete: any[];
+        removed: Array<{ item: any; index: number }>;
+    }) {
+        // Compute nextItems synchronously from itemsRef.current — the canonical current
+        // state — BEFORE calling setItems. A functional setItems(current => ...) updater is
+        // not guaranteed to run before this handler continues (React can defer it to the
+        // render phase), so extracting the computed array out of the updater via a captured
+        // variable previously reached restoreItems as `[]`, which saveEstimate interprets as
+        // "delete every line item" — a catastrophic false undo. itemsRef.current is safe to
+        // read here directly because it was set synchronously in removeItem right after the
+        // delete (and by restoreItems on every prior restore), so it always reflects the
+        // actual current items regardless of render timing.
+        const current = itemsRef.current;
+        const nextItems = current === postDelete ? preDelete : spliceBackByIndex(current, removed);
+
+        const links = removed.flatMap(r =>
+            (r.item.purchaseOrderLinks ?? []).map((l: any) => ({ estimateItemId: r.item.id, purchaseOrderId: l.purchaseOrder.id, createdAt: l.createdAt }))
+        );
+        const scheduleTasks = removed
+            .filter(r => r.item.scheduleTask?.id)
+            .map(r => ({ scheduleTaskId: r.item.scheduleTask.id, estimateItemId: r.item.id }));
+
+        try {
+            await restoreItems({
+                nextItems, links, scheduleTasks, mode: "additive",
+                label: `Before undoing delete of "${removed[0]?.item?.name || "item"}"`,
+            });
+            toast.success("Item restored");
+        } catch (e: any) {
+            toast.error(e?.message || "Restored locally, but failed to save — please review and save manually.", {
+                action: pendingAssociationRestoreRef.current
+                    ? { label: "Retry", onClick: () => retryAssociationRestore() }
+                    : undefined,
+            });
+        }
     }
 
     async function handleLinkPO(itemId: string) {
@@ -1210,29 +1661,55 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
         finally { setLoadingPOs(false); }
     }
 
+    // Appends/removes a single item's purchaseOrderLinks inside one functional setItems
+    // update, deduplicated by PO id. Rapid-fire clicks (link A, then B, then C before any
+    // request resolves) each call this from their own event handler with whatever `items`
+    // their render closure captured — reading/writing through the closure directly would
+    // have each call overwrite the others' additions with a stale array. Routing every
+    // mutation through the same functional updater means each one applies on top of
+    // whatever the previous one just committed, and itemsRef is kept in sync inside the
+    // same update (not via the separate effect, which could still be pending).
+    function applyPoLinkChange(itemId: string, mutate: (links: any[]) => any[]) {
+        setItems(prev => {
+            const next = prev.map((it: any) => {
+                if (it.id !== itemId) return it;
+                return { ...it, purchaseOrderLinks: mutate(it.purchaseOrderLinks ?? []) };
+            });
+            itemsRef.current = next;
+            return next;
+        });
+    }
+
     async function handleSelectPO(itemId: string, po: any) {
         try {
             await linkPOToEstimateItem(itemId, po.id);
-            const idx = items.findIndex((i: any) => i.id === itemId);
-            if (idx >= 0) updateItem(idx, "purchaseOrderId", po.id);
-            if (idx >= 0) updateItem(idx, "purchaseOrder", po);
+            applyPoLinkChange(itemId, links =>
+                links.some((l: any) => l.purchaseOrder.id === po.id) ? links : [...links, { purchaseOrder: po }]
+            );
             toast.success(`Linked ${po.code}`);
         } catch (err: any) { toast.error(err.message); }
-        finally { setPOLinkItemId(null); }
     }
 
-    async function handleUnlinkPO(itemId: string) {
+    async function handleUnlinkPO(itemId: string, poId: string) {
         try {
-            await unlinkPOFromEstimateItem(itemId);
-            const idx = items.findIndex((i: any) => i.id === itemId);
-            if (idx >= 0) { updateItem(idx, "purchaseOrderId", null); updateItem(idx, "purchaseOrder", null); }
+            await unlinkPOFromEstimateItem(itemId, poId);
+            applyPoLinkChange(itemId, links => links.filter((l: any) => l.purchaseOrder.id !== poId));
+            // Supersede: this is a deliberate, explicit user action — if some earlier undo/
+            // revert still has this exact (item, PO) pair queued for restore, that queued
+            // restore must not be allowed to replay it back in on the next save.
+            const updated = removePendingLinks(pendingAssociationRestoreRef.current, [{ estimateItemId: itemId, purchaseOrderId: poId }]);
+            if (updated !== pendingAssociationRestoreRef.current) {
+                pendingAssociationRestoreRef.current = updated;
+                persistPendingRestore(initialEstimate.id, updated);
+            }
             toast.success("PO unlinked");
         } catch (err: any) { toast.error(err.message); }
     }
 
     function handlePOCreated(itemId: string, po: any) {
-        const idx = items.findIndex((i: any) => i.id === itemId);
-        if (idx >= 0) { updateItem(idx, "purchaseOrderId", po.id); updateItem(idx, "purchaseOrder", po); }
+        applyPoLinkChange(itemId, links =>
+            links.some((l: any) => l.purchaseOrder.id === po.id) ? links : [...links, { purchaseOrder: po }]
+        );
     }
 
     async function handleAiFillAll({ overwriteExisting: overwrite }: { overwriteExisting: boolean }) {
@@ -1244,7 +1721,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
 
         // Lock partition. PO-locked items are ALWAYS skipped regardless of overwrite flag —
         // a cut purchase order is a real dollar commitment, not a suggestion.
-        const isPoLocked = (it: any) => it.purchaseOrderId != null;
+        const isPoLocked = (it: any) => (it.purchaseOrderLinks?.length ?? 0) > 0;
         const hasBudget = (it: any) => {
             const n = parseFloat(it.budgetRate);
             return Number.isFinite(n) && n > 0;
@@ -1332,7 +1809,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                         budgetUnit: s.budgetUnit || next[idx].budgetUnit,
                         budgetQuantity: sellQty,
                         markupPercent: derivedMarginPct(rate, sellPrice),
-                        // DO NOT touch: unitCost, quantity, total, purchaseOrderId
+                        // DO NOT touch: unitCost, quantity, total, purchaseOrderLinks
                     };
                     filled++;
                 }
@@ -1417,7 +1894,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
         if (!window.confirm("Clear all budget values? Items with purchase orders will be preserved.")) return;
         const resetMargin = Math.max(0, Math.min(70, parseFloat(targetMargin) || 25));
         setItems(prev => prev.map(it => {
-            if (it.purchaseOrderId != null) return it;                            // PO-locked, never touch
+            if ((it.purchaseOrderLinks?.length ?? 0) > 0) return it;               // PO-locked, never touch
             if (!it.parentId && prev.some((c: any) => c.parentId === it.id)) return it; // category header
             return {
                 ...it,
@@ -3689,16 +4166,34 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                                 <div className="text-sm text-slate-400 text-center py-4">Loading...</div>
                             ) : projectPOs.length === 0 ? (
                                 <div className="text-sm text-slate-400 text-center py-4">No purchase orders found</div>
-                            ) : projectPOs.map(po => (
-                                <button
-                                    key={po.id}
-                                    onClick={() => handleSelectPO(poLinkItemId, po)}
-                                    className="w-full text-left px-3 py-2 text-sm hover:bg-indigo-50 transition flex justify-between items-center"
-                                >
-                                    <span className="font-medium">{po.code} — {po.vendor?.name}</span>
-                                    <span className="text-slate-500">{formatCurrency(Number(po.totalAmount))}</span>
-                                </button>
-                            ))}
+                            ) : projectPOs.map(po => {
+                                const currentItem = items.find((i: any) => i.id === poLinkItemId);
+                                const alreadyLinked = (currentItem?.purchaseOrderLinks ?? []).some((l: any) => l.purchaseOrder.id === po.id);
+                                return (
+                                    <button
+                                        key={po.id}
+                                        disabled={alreadyLinked}
+                                        onClick={() => handleSelectPO(poLinkItemId, po)}
+                                        className="w-full text-left px-3 py-2 text-sm hover:bg-indigo-50 transition flex justify-between items-center disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                                    >
+                                        <span className="font-medium flex items-center gap-1.5">
+                                            {alreadyLinked && (
+                                                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="text-green-600 flex-shrink-0"><path d="M20 6 9 17l-5-5" /></svg>
+                                            )}
+                                            {po.code} — {po.vendor?.name}
+                                        </span>
+                                        <span className="text-slate-500">{formatCurrency(Number(po.totalAmount))}</span>
+                                    </button>
+                                );
+                            })}
+                        </div>
+                        <div className="px-6 py-4 border-t border-slate-100 bg-slate-50 flex justify-end">
+                            <button
+                                onClick={() => setPOLinkItemId(null)}
+                                className="hui-btn hui-btn-primary"
+                            >
+                                Done
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/src/app/projects/[id]/estimates/[estimateId]/ExpensesTab.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/ExpensesTab.tsx
@@ -6,6 +6,12 @@ import { formatCurrency } from "@/lib/utils";
 import { internalBudget, bufferPercent, bufferColor, bufferBgColor } from "@/lib/budget-math";
 
 export default function ExpensesTab({ estimateId, projectId, items }: { estimateId: string, projectId: string, items: any[] }) {
+    // `items` comes straight from EstimateEditor's live `items` state, which is already
+    // normalized once at load (see normalizeItemPoLinks in EstimateEditor.tsx) and kept
+    // normalized thereafter by the PO-link handlers — do not re-normalize here. Re-running
+    // normalizeItemPoLinks against already-normalized state would resurrect a stale legacy
+    // `item.purchaseOrder` scalar (never cleared on unlink) even after purchaseOrderLinks
+    // was emptied by unlinking the last PO, making an intentionally-unlinked PO reappear.
     const [expenses, setExpenses] = useState<any[]>(items.flatMap(item => item.expenses || []));
     const [isUploading, setIsUploading] = useState(false);
     const [uploadError, setUploadError] = useState("");
@@ -182,9 +188,19 @@ export default function ExpensesTab({ estimateId, projectId, items }: { estimate
             budgetRate: item.budgetRate,
             baseCost: item.baseCost,
         });
-        const poAmount = item.purchaseOrder ? Number(item.purchaseOrder.totalAmount) : null;
-        const poCode = item.purchaseOrder?.code || null;
-        const poVendor = item.purchaseOrder?.vendor?.name || null;
+        const poLinks = item.purchaseOrderLinks ?? [];
+        const poAmount = poLinks.length > 0
+            ? poLinks.reduce((sum: number, l: any) => sum + Number(l.purchaseOrder.totalAmount || 0), 0)
+            : null;
+        const poCode = poLinks.length > 0
+            ? poLinks.map((l: any) => l.purchaseOrder.code).join(", ")
+            : null;
+        const poVendor = (() => {
+            if (poLinks.length === 0) return null;
+            const vendorNames = Array.from(new Set(poLinks.map((l: any) => l.purchaseOrder.vendor?.name).filter(Boolean)));
+            if (vendorNames.length === 0) return null;
+            return vendorNames.length === 1 ? vendorNames[0] : `${vendorNames.length} vendors`;
+        })();
 
         acc.push({
             ...item,
@@ -203,6 +219,20 @@ export default function ExpensesTab({ estimateId, projectId, items }: { estimate
     const totalActual = varianceByItem.reduce((sum: number, item: any) => sum + item.actualCost, 0);
     const totalBudget = varianceByItem.reduce((sum: number, item: any) => sum + item.budgetedCost, 0);
     const totalVariance = totalBudget - totalActual;
+
+    // Distinct-PO total for the headline: a PO linked to two line items must count once,
+    // not once per row — summing item.poAmount (per-row display, left as-is) double-counts
+    // any PO shared across items.
+    const distinctPoCommittedTotal = (() => {
+        const seen = new Map<string, number>();
+        for (const item of varianceByItem) {
+            for (const link of item.purchaseOrderLinks ?? []) {
+                const po = link.purchaseOrder;
+                if (po?.id && !seen.has(po.id)) seen.set(po.id, Number(po.totalAmount || 0));
+            }
+        }
+        return Array.from(seen.values()).reduce((sum, v) => sum + v, 0);
+    })();
 
     // Graph Data
     const budgetUtilization = totalBudget > 0 ? (totalActual / totalBudget) * 100 : (totalActual > 0 ? 100 : 0);
@@ -251,7 +281,7 @@ export default function ExpensesTab({ estimateId, projectId, items }: { estimate
                     <div className="bg-slate-50 p-6 rounded-xl border border-slate-100">
                         <p className="text-[11px] uppercase tracking-widest font-bold text-slate-400 mb-1">PO Committed</p>
                         <p className="text-3xl font-extrabold text-slate-800">
-                            {formatCurrency(varianceByItem.reduce((sum: number, item: any) => sum + (item.poAmount || 0), 0))}
+                            {formatCurrency(distinctPoCommittedTotal)}
                         </p>
                     </div>
                     <div className="bg-slate-50 p-6 rounded-xl border border-slate-100">

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1545,6 +1545,12 @@ export const getEstimate = cache(async function getEstimate(id: string) {
                         costCode: true,
                         costType: true,
                         purchaseOrder: { include: { vendor: true } },
+                        purchaseOrderLinks: {
+                            orderBy: { createdAt: "asc" },
+                            include: { purchaseOrder: { include: { vendor: true } } },
+                        },
+                        scheduleTask: { select: { id: true, name: true } },
+                        _count: { select: { timeEntries: true, expenses: true } },
                     },
                 },
                 paymentSchedules: { orderBy: { order: "asc" } },
@@ -1577,6 +1583,15 @@ export const getEstimate = cache(async function getEstimate(id: string) {
                         purchaseOrderId: true,
                         budgetQuantity: true, budgetUnit: true, budgetRate: true,
                         purchaseOrder: { select: { id: true, code: true, totalAmount: true, status: true, vendor: { select: { id: true, name: true } } } },
+                        purchaseOrderLinks: {
+                            orderBy: { createdAt: "asc" },
+                            select: {
+                                purchaseOrderId: true,
+                                purchaseOrder: { select: { id: true, code: true, totalAmount: true, status: true, vendor: { select: { id: true, name: true } } } },
+                            },
+                        },
+                        scheduleTask: { select: { id: true, name: true } },
+                        _count: { select: { timeEntries: true, expenses: true } },
                     },
                 },
                 paymentSchedules: { orderBy: { order: "asc" } },
@@ -3072,7 +3087,8 @@ export async function saveEstimate(estimateId: string, contextId: string, contex
             parentId: item.parentId || null,
             costCodeId: item.costCodeId || null,
             costTypeId: item.costTypeId || null,
-            purchaseOrderId: item.purchaseOrderId || null,
+            // purchaseOrderId is intentionally NOT set here — links live in
+            // EstimateItemPurchaseOrder and are maintained exclusively by syncLegacyPoLink.
             budgetQuantity: item.budgetQuantity != null ? (parseFloat(item.budgetQuantity) || null) : null,
             budgetUnit: item.budgetUnit || null,
             budgetRate: item.budgetRate != null ? (parseFloat(item.budgetRate) || null) : null,
@@ -9473,43 +9489,91 @@ export async function createPurchaseOrderFromEstimate(projectId: string, estimat
     const selectedItems = estimate.items.filter((item: any) => itemIds.includes(item.id));
     if (selectedItems.length === 0) throw new Error("No valid items found");
 
+    // itemIds must exactly match a validated in-estimate selection — never trust the raw
+    // argument for the PO-link step below, or a caller could link cross-estimate/cross-project
+    // items by passing arbitrary ids alongside valid ones.
+    const dedupedItemIds = Array.from(new Set(itemIds));
+    if (dedupedItemIds.length !== selectedItems.length) {
+        throw new Error("Selected items do not match a valid set of items on this estimate");
+    }
+
     const totalAmount = selectedItems.reduce((acc: number, item: any) => acc + ((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0)), 0);
 
-    // Get project PO count for the code
-    const count = await prisma.purchaseOrder.count({ where: { projectId } });
-    const nextNum = (count + 1).toString().padStart(3, '0');
-
-    // Create the PO
-    const newPo = await prisma.purchaseOrder.create({
-        data: {
-            projectId,
-            vendorId,
-            code: `PO-${nextNum}`,
-            status: "Draft",
-            totalAmount,
-            notes: `Auto-generated from Estimate: ${estimate.title}\n\nReview line items and update costs/quantities as needed.`,
-            memos: "",
-            terms: "Standard Subcontractor/Vendor terms apply unless overridden.",
-            items: {
-                create: selectedItems.map((item: any, idx: number) => {
-                    // Preserve an explicit zero quantity (optional/alternate estimate
-                    // lines are shown at $0) — only a missing/unparseable quantity
-                    // falls back to 1. `|| 1` would reprice a $0 option into the PO.
-                    const parsedQty = parseFloat(item.quantity);
-                    const qty = Number.isFinite(parsedQty) ? parsedQty : 1;
-                    return {
-                        description: item.name + (item.description ? ` - ${item.description}` : ""),
-                        quantity: qty,
-                        unitCost: parseFloat(item.unitCost) || 0,
-                        total: qty * (parseFloat(item.unitCost) || 0),
-                        order: idx,
-                        costCodeId: item.costCodeId,
-                        costTypeId: item.costTypeId
-                    };
-                })
-            }
+    // Create the PO, its PurchaseOrderItems, the PO<->item join rows, and the legacy mirror
+    // resync all inside ONE retried transaction (mirrors quickCreatePOAndLink's fix) — the PO
+    // used to commit in its own transaction before the link step ran separately, so a failure in
+    // the link step left an orphaned, unlinked PO behind, and a retry after the fact created a
+    // second one instead of resuming the first. The attempt loop keeps the same PO-code
+    // collision retry quickCreatePOAndLink uses: a P2002 on the code aborts that attempt's
+    // transaction cleanly (nothing committed), so the next attempt starts clean.
+    let newPo: any;
+    for (let attempt = 0; attempt < 5; attempt++) {
+        try {
+            newPo = await withTxRetry(() => prisma.$transaction(async (tx) => {
+                // Selected items are pre-validated against the in-estimate selection above —
+                // never the raw itemIds argument.
+                await lockEstimateItemLinks(tx, estimateId, selectedItems.map((item: any) => item.id));
+                const count = await tx.purchaseOrder.count({ where: { projectId } });
+                const code = `PO-${(count + 1 + attempt).toString().padStart(3, "0")}`;
+                const created = await tx.purchaseOrder.create({
+                    data: {
+                        projectId,
+                        vendorId,
+                        code,
+                        status: "Draft",
+                        totalAmount,
+                        notes: `Auto-generated from Estimate: ${estimate.title}\n\nReview line items and update costs/quantities as needed.`,
+                        memos: "",
+                        terms: "Standard Subcontractor/Vendor terms apply unless overridden.",
+                        items: {
+                            create: selectedItems.map((item: any, idx: number) => {
+                                // Preserve an explicit zero quantity (optional/alternate estimate
+                                // lines are shown at $0) — only a missing/unparseable quantity
+                                // falls back to 1. `|| 1` would reprice a $0 option into the PO.
+                                const parsedQty = parseFloat(item.quantity);
+                                const qty = Number.isFinite(parsedQty) ? parsedQty : 1;
+                                return {
+                                    description: item.name + (item.description ? ` - ${item.description}` : ""),
+                                    quantity: qty,
+                                    unitCost: parseFloat(item.unitCost) || 0,
+                                    total: qty * (parseFloat(item.unitCost) || 0),
+                                    order: idx,
+                                    costCodeId: item.costCodeId,
+                                    costTypeId: item.costTypeId
+                                };
+                            })
+                        }
+                    }
+                });
+                for (const item of selectedItems) {
+                    await migrateLegacyPoLink(tx, item.id);
+                }
+                await tx.estimateItemPurchaseOrder.createMany({
+                    data: selectedItems.map((item: any) => ({ estimateItemId: item.id, purchaseOrderId: created.id })),
+                    skipDuplicates: true,
+                });
+                for (const item of selectedItems) {
+                    await syncLegacyPoLink(tx, item.id);
+                }
+                return created;
+            }));
+            break;
+        } catch (e: any) {
+            // Unique constraint violation on code — retry with the next number. Any other
+            // error (including a deadlock withTxRetry already exhausted its own retries on)
+            // propagates immediately. Check e.meta?.target too, not just e.code, so a P2002 on
+            // some unrelated constraint inside this same transaction doesn't get mistaken for a
+            // code collision and silently retried instead of surfaced.
+            // NOTE: PurchaseOrder.code has no unique constraint in the schema yet (see
+            // prisma/schema.prisma ~1553), so this P2002 branch may never actually fire, and
+            // concurrent creates from different estimates can still produce duplicate codes —
+            // that gap needs its own migration + duplicate-cleanup plan, out of scope here.
+            const target = e?.meta?.target;
+            const isCodeCollision = e?.code === "P2002"
+                && (Array.isArray(target) ? target.includes("code") : typeof target === "string" && target.includes("code"));
+            if (!isCodeCollision || attempt === 4) throw e;
         }
-    });
+    }
 
     revalidatePath(`/projects/${projectId}/purchase-orders`);
     return newPo;
@@ -9566,7 +9630,56 @@ export async function deletePurchaseOrder(id: string) {
     const po = await prisma.purchaseOrder.findUnique({ where: { id } });
     if (!po) return;
     assertFinancialProjectScope(user, po.projectId);
-    await prisma.purchaseOrder.delete({ where: { id } });
+
+    await withTxRetry(() => prisma.$transaction(async (tx) => {
+        // Lock this PurchaseOrder row FIRST, before discovering which items are currently
+        // linked to it. Without this, the "affected" snapshot below is a bare read that races
+        // a concurrent link/quick-create/legacy-migrate: that operation could commit a brand
+        // new join row (or migrate the legacy scalar mirror onto this PO) in the gap between
+        // our snapshot and the delete, so our resync loop — built from the stale, possibly-empty
+        // snapshot — would never touch that item's legacy mirror, leaving it dangling once the
+        // PO it names has been deleted out from under it.
+        //
+        // Every PO-link writer (linkPOToEstimateItem, unlinkPOFromEstimateItem, and
+        // restoreEstimateItemAssociations) locks its target PurchaseOrder id(s) through
+        // lockEstimateItemLinks BEFORE the Estimate/EstimateItem locks — see that function's
+        // doc comment for why PurchaseOrder leads the order. Locking it here, first, keeps this
+        // path consistent with that same order (PurchaseOrder → Estimate → EstimateItem below).
+        await tx.$queryRaw`SELECT id FROM "PurchaseOrder" WHERE id = ${id} FOR UPDATE`;
+
+        // Collect affected items BEFORE the delete cascades their join rows away, so their
+        // legacy scalar mirrors can be resynced even when other links survive (the FK alone
+        // would only null out the mirror for items whose one-and-only link was this PO).
+        const affected = await tx.estimateItemPurchaseOrder.findMany({
+            where: { purchaseOrderId: id },
+            select: { estimateItemId: true },
+        });
+        if (affected.length > 0) {
+            const items = await tx.estimateItem.findMany({
+                where: { id: { in: affected.map((a) => a.estimateItemId) } },
+                select: { id: true, estimateId: true },
+            });
+            // Group by estimate and lock each group in sorted order so this commutes with
+            // every other path's Estimate → sorted-EstimateItem lock order instead of
+            // deadlocking against it. This PO is already locked above — passing it again here
+            // is a harmless re-lock (same transaction already holds it) that keeps every
+            // lockEstimateItemLinks call site symmetric.
+            const byEstimate = new Map<string, string[]>();
+            for (const it of items) {
+                const arr = byEstimate.get(it.estimateId) ?? [];
+                arr.push(it.id);
+                byEstimate.set(it.estimateId, arr);
+            }
+            for (const [estId, itemIds] of Array.from(byEstimate.entries()).sort(([a], [b]) => a.localeCompare(b))) {
+                await lockEstimateItemLinks(tx, estId, itemIds, [id]);
+            }
+        }
+        await tx.purchaseOrder.delete({ where: { id } });
+        for (const link of affected) {
+            await syncLegacyPoLink(tx, link.estimateItemId);
+        }
+    }));
+
     revalidatePath(`/projects/${po.projectId}/purchase-orders`);
 }
 
@@ -13138,6 +13251,80 @@ export async function bulkUpdateItemApproval(itemIds: string[], status: "approve
     return { success: true, count: itemIds.length }
 }
 
+// Keeps the deprecated EstimateItem.purchaseOrderId mirror pointing at the oldest surviving
+// link (or null) so a rollback to the pre-many-to-many build stays correct. Secondary `id`
+// ordering makes the pick deterministic when two rows share the identical `createdAt` (e.g. a
+// migrated legacy row and a brand-new link inserted in the same transaction both get the same
+// CURRENT_TIMESTAMP from Postgres) — without it, ordering by `createdAt` alone could pick the
+// NEW link as the mirror instead of the original.
+async function syncLegacyPoLink(tx: Prisma.TransactionClient, estimateItemId: string) {
+    const oldest = await tx.estimateItemPurchaseOrder.findFirst({
+        where: { estimateItemId },
+        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+        select: { purchaseOrderId: true },
+    });
+    await tx.estimateItem.update({
+        where: { id: estimateItemId },
+        data: { purchaseOrderId: oldest?.purchaseOrderId ?? null },
+    });
+}
+
+// If the item still carries a non-null legacy scalar link with no matching join row (predates
+// the join table, or the backfill hasn't run yet), create that join row first so it isn't
+// silently dropped when a new link is added. Safe to call unconditionally — no-ops otherwise.
+//
+// Uses createMany + skipDuplicates rather than a bare create with a P2002 catch: a unique
+// violation from a bare create aborts the whole surrounding Postgres transaction, so every
+// later statement in the same tx — including syncLegacyPoLink — would fail too, even though
+// "the row already exists" is exactly the no-op case this function exists to handle.
+//
+// Backdates the migrated row to the item's own `createdAt` (not "now") so it is genuinely the
+// oldest link and syncLegacyPoLink's findFirst deterministically picks it as the mirror.
+async function migrateLegacyPoLink(tx: Prisma.TransactionClient, estimateItemId: string) {
+    const item = await tx.estimateItem.findUnique({
+        where: { id: estimateItemId },
+        select: { purchaseOrderId: true, createdAt: true },
+    });
+    if (!item?.purchaseOrderId) return;
+    await tx.estimateItemPurchaseOrder.createMany({
+        data: [{ estimateItemId, purchaseOrderId: item.purchaseOrderId, createdAt: item.createdAt }],
+        skipDuplicates: true,
+    });
+}
+
+// Locks the affected PurchaseOrder row(s), then the parent Estimate, then the affected
+// EstimateItem row(s) FOR UPDATE — all in a stable (sorted) id order within each type — before
+// any read or write of purchaseOrderLinks / the legacy scalar mirror. Every path that mutates
+// PO<->item links takes these same locks in this same order so concurrent link/unlink/backfill
+// operations serialize instead of racing — without it, two concurrent unlinks on the same item
+// can each read the other's uncommitted delete and pick the wrong "oldest surviving link" in
+// syncLegacyPoLink, resurrecting a link the user just removed.
+//
+// PurchaseOrder leads (rather than following Estimate) because deletePurchaseOrder must lock its
+// own PO row before it can even discover which estimate(s)/item(s) are currently linked to it
+// (that discovery is itself a snapshot read racing against concurrent links) — putting
+// PurchaseOrder after Estimate would force deletePurchaseOrder to lock Estimate rows it hasn't
+// identified yet, which isn't possible without re-introducing that race. Every caller that knows
+// its target PurchaseOrder id(s) upfront (link/unlink/restore/delete) passes them here so this
+// stays the one global order; callers creating a brand-new PO (quickCreatePOAndLink,
+// createPurchaseOrderFromEstimate) have no existing row to lock and pass none.
+async function lockEstimateItemLinks(
+    tx: Prisma.TransactionClient,
+    estimateId: string,
+    estimateItemIds: string[],
+    purchaseOrderIds: string[] = [],
+) {
+    const sortedPoIds = Array.from(new Set(purchaseOrderIds)).sort();
+    for (const id of sortedPoIds) {
+        await tx.$queryRaw`SELECT id FROM "PurchaseOrder" WHERE id = ${id} FOR UPDATE`;
+    }
+    await lockMoneyParents(tx, { estimateId });
+    const sortedIds = Array.from(new Set(estimateItemIds)).sort();
+    for (const id of sortedIds) {
+        await tx.$queryRaw`SELECT id FROM "EstimateItem" WHERE id = ${id} FOR UPDATE`;
+    }
+}
+
 export async function linkPOToEstimateItem(estimateItemId: string, purchaseOrderId: string) {
     const user = await assertFinancialPermission();
 
@@ -13153,15 +13340,21 @@ export async function linkPOToEstimateItem(estimateItemId: string, purchaseOrder
     if (!po) throw new Error("Purchase order not found");
     if (po.projectId !== item.estimate.projectId) throw new Error("PO must belong to the same project");
 
-    await prisma.estimateItem.update({
-        where: { id: estimateItemId },
-        data: { purchaseOrderId },
-    });
+    await withTxRetry(() => prisma.$transaction(async (tx) => {
+        await lockEstimateItemLinks(tx, item.estimateId, [estimateItemId], [purchaseOrderId]);
+        await migrateLegacyPoLink(tx, estimateItemId);
+        await tx.estimateItemPurchaseOrder.createMany({
+            data: [{ estimateItemId, purchaseOrderId }],
+            skipDuplicates: true,
+        });
+        await syncLegacyPoLink(tx, estimateItemId);
+    }));
+
     revalidatePath(`/projects/${item.estimate.projectId}/estimates`);
     return po;
 }
 
-export async function unlinkPOFromEstimateItem(estimateItemId: string) {
+export async function unlinkPOFromEstimateItem(estimateItemId: string, purchaseOrderId: string) {
     const user = await assertFinancialPermission();
 
     const item = await prisma.estimateItem.findUnique({
@@ -13171,10 +13364,15 @@ export async function unlinkPOFromEstimateItem(estimateItemId: string) {
     if (!item) throw new Error("Estimate item not found");
     if (!item.estimate.projectId) throw new Error("Purchase orders require a project");
     assertFinancialProjectScope(user, item.estimate.projectId);
-    await prisma.estimateItem.update({
-        where: { id: estimateItemId },
-        data: { purchaseOrderId: null },
-    });
+
+    await withTxRetry(() => prisma.$transaction(async (tx) => {
+        await lockEstimateItemLinks(tx, item.estimateId, [estimateItemId], [purchaseOrderId]);
+        await tx.estimateItemPurchaseOrder.deleteMany({
+            where: { estimateItemId, purchaseOrderId },
+        });
+        await syncLegacyPoLink(tx, estimateItemId);
+    }));
+
     if (item?.estimate.projectId) {
         revalidatePath(`/projects/${item.estimate.projectId}/estimates`);
     }
@@ -13193,38 +13391,259 @@ export async function quickCreatePOAndLink(estimateItemId: string, data: { vendo
     const projectId = item.estimate.projectId;
     assertFinancialProjectScope(user, projectId);
 
-    // Retry loop to handle TOCTOU race: two concurrent creates could pick the same count
+    // Retry loop to handle TOCTOU race: two concurrent creates could pick the same count.
+    // Each attempt is its own retried transaction that creates the PO AND its join row AND
+    // resyncs the legacy mirror atomically. A P2002 on the code aborts that attempt's
+    // transaction cleanly (nothing committed) so the next attempt retries clean — the PO was
+    // previously created in a separate transaction from its link, which meant a retry after
+    // the fact left an orphaned, unlinked PO behind and created a second one.
     let po: any;
     for (let attempt = 0; attempt < 5; attempt++) {
-        const count = await prisma.purchaseOrder.count({ where: { projectId } });
-        const code = `PO-${(count + 1 + attempt).toString().padStart(3, "0")}`;
         try {
-            po = await prisma.purchaseOrder.create({
-                data: {
-                    projectId,
-                    vendorId: data.vendorId,
-                    code,
-                    totalAmount: data.amount,
-                    notes: data.notes || null,
-                    status: "Draft",
-                },
-                include: { vendor: true },
-            });
+            po = await withTxRetry(() => prisma.$transaction(async (tx) => {
+                await lockEstimateItemLinks(tx, item.estimateId, [estimateItemId]);
+                const count = await tx.purchaseOrder.count({ where: { projectId } });
+                const code = `PO-${(count + 1 + attempt).toString().padStart(3, "0")}`;
+                const created = await tx.purchaseOrder.create({
+                    data: {
+                        projectId,
+                        vendorId: data.vendorId,
+                        code,
+                        totalAmount: data.amount,
+                        notes: data.notes || null,
+                        status: "Draft",
+                    },
+                    include: { vendor: true },
+                });
+                await migrateLegacyPoLink(tx, estimateItemId);
+                await tx.estimateItemPurchaseOrder.createMany({
+                    data: [{ estimateItemId, purchaseOrderId: created.id }],
+                    skipDuplicates: true,
+                });
+                await syncLegacyPoLink(tx, estimateItemId);
+                return created;
+            }));
             break;
         } catch (e: any) {
-            // Unique constraint violation on code — retry with next number
-            if (attempt === 4) throw e;
+            // Unique constraint violation on code — retry with the next number. Any other
+            // error (including a deadlock withTxRetry already exhausted its own retries on)
+            // propagates immediately.
+            if (e?.code !== "P2002" || attempt === 4) throw e;
         }
     }
-
-    await prisma.estimateItem.update({
-        where: { id: estimateItemId },
-        data: { purchaseOrderId: po.id },
-    });
 
     revalidatePath(`/projects/${projectId}/purchase-orders`);
     revalidatePath(`/projects/${projectId}/estimates`);
     return po;
+}
+
+// Result of restoreEstimateItemAssociations — reports exactly what was (and wasn't) restored
+// so the caller can distinguish "nothing left to do" from "nothing happened yet". Two skip
+// reasons are classified separately because they call for opposite caller behavior:
+//   - missing.itemIds is RETRYABLE: the EstimateItem itself doesn't exist yet (e.g. its
+//     row-recreation save hasn't landed, or hasn't happened at all). It may come back on a
+//     later save, so the caller should keep these entries pending and retry.
+//   - missing.purchaseOrderIds / missing.scheduleTaskIds are PERMANENT: the target itself is
+//     gone, out of this estimate's project scope, or (for a ScheduleTask) already owned by a
+//     different EstimateItem. Retrying can never fix these — the caller should drop them.
+export type RestoreEstimateItemAssociationsResult = {
+    restoredLinks: { estimateItemId: string; purchaseOrderId: string }[];
+    restoredScheduleTasks: { scheduleTaskId: string; estimateItemId: string }[];
+    missing: {
+        itemIds: string[];
+        purchaseOrderIds: string[];
+        scheduleTaskIds: string[];
+    };
+};
+
+// Backs the durable delete-undo (Part B). Re-creates join rows and re-points schedule tasks
+// severed when an estimate item was deleted (both cascade/SetNull at the DB level), and
+// resyncs the legacy scalar mirror. Idempotent — skips ids that no longer exist rather than
+// throwing, so a partial restore (e.g. a PO deleted in the meantime) still succeeds. Reports
+// exactly what it restored vs. skipped (see RestoreEstimateItemAssociationsResult) instead of
+// a bare success — the caller cannot tell "restored everything" from "restored nothing" any
+// other way, and treating both as plain success risks clearing a still-needed retry payload.
+export async function restoreEstimateItemAssociations({
+    estimateId,
+    links,
+    scheduleTasks,
+}: {
+    estimateId: string;
+    links: { estimateItemId: string; purchaseOrderId: string; createdAt?: string | Date }[];
+    scheduleTasks: { scheduleTaskId: string; estimateItemId: string }[];
+}): Promise<RestoreEstimateItemAssociationsResult> {
+    // This restores TWO independent kinds of association from an undo snapshot: PO<->item
+    // links (financial data) and estimateItemId<->ScheduleTask repoints (schedule data). They
+    // are authorized separately by payload — per permissions.ts, FINANCE has no "schedules"
+    // permission, so a FINANCE user must not be able to repoint ScheduleTask rows just because
+    // they're restoring PO links in the same undo call, and a schedule-only user must not need
+    // financial access just to restore a task link. A payload the caller isn't permitted to
+    // touch throws (rather than being silently skipped) — consistent with every other auth
+    // assertion in this file, and it keeps an undo from ever reporting "done" while quietly
+    // leaving part of the restore undone.
+    const user = await assertActiveStaff();
+
+    const estimate = await prisma.estimate.findUnique({
+        where: { id: estimateId },
+        select: { projectId: true },
+    });
+    if (!estimate) throw new Error("Estimate not found");
+    if (!estimate.projectId) throw new Error("Purchase orders require a project");
+    const projectId = estimate.projectId;
+
+    if (links.length > 0) {
+        if (!hasPermission(user, "financialReports")) throw new Error("Forbidden: restoring purchase-order links requires financial access");
+        assertFinancialProjectScope(user, projectId);
+    }
+    if (scheduleTasks.length > 0) {
+        if (!hasPermission(user, "schedules") || !canAccessProject(user, projectId)) {
+            throw new Error("Forbidden: restoring schedule-task links requires schedule access");
+        }
+    }
+
+    const result = await withTxRetry(() => prisma.$transaction(async (tx) => {
+        // PO-item ids are only those referenced by the `links` payload — the financial
+        // permission asserted above authorizes the legacy PO mirror ONLY for these items. An
+        // item that appears solely in `scheduleTasks` is authorized under the schedules
+        // permission and must never reach migrateLegacyPoLink/syncLegacyPoLink below, or a
+        // schedules-only caller could pass a valid EstimateItem id (paired with even a
+        // nonexistent ScheduleTask id) and clobber that item's financial PO link.
+        const poItemIds = new Set(links.map(l => l.estimateItemId));
+        const candidateItemIds = Array.from(new Set([
+            ...links.map(l => l.estimateItemId),
+            ...scheduleTasks.map(s => s.estimateItemId),
+        ]));
+        // Purchase-order ids are known upfront from the undo snapshot, so lock them now too —
+        // PurchaseOrder → Estimate → EstimateItem is the global order every PO-link path obeys
+        // (see lockEstimateItemLinks's doc comment). Lock the full candidate set (PO items AND
+        // schedule-only items) since both are read/written below and must serialize against
+        // concurrent link/delete operations — only the migrate/sync calls further down are
+        // restricted to PO items.
+        await lockEstimateItemLinks(tx, estimateId, candidateItemIds, links.map(l => l.purchaseOrderId));
+
+        const existingItems = candidateItemIds.length
+            ? await tx.estimateItem.findMany({
+                where: { id: { in: candidateItemIds }, estimateId },
+                select: { id: true },
+            })
+            : [];
+        const existingItemIds = new Set(existingItems.map(i => i.id));
+
+        // RETRYABLE: the EstimateItem itself isn't back yet. Collected from both payloads —
+        // an item id can appear in `links`, `scheduleTasks`, or both.
+        const missingItemIds = new Set<string>();
+        for (const l of links) if (!existingItemIds.has(l.estimateItemId)) missingItemIds.add(l.estimateItemId);
+        for (const st of scheduleTasks) if (!existingItemIds.has(st.estimateItemId)) missingItemIds.add(st.estimateItemId);
+
+        // Materialize any pre-existing legacy scalar link into the join table BEFORE creating
+        // the restored links below, so the final syncLegacyPoLink pass sees the full set of
+        // links (legacy + restored) instead of racing its own migration. PO items only.
+        for (const itemId of existingItemIds) {
+            if (poItemIds.has(itemId)) {
+                await migrateLegacyPoLink(tx, itemId);
+            }
+        }
+
+        const validLinks = links.filter(l => existingItemIds.has(l.estimateItemId));
+        const restoredLinks: { estimateItemId: string; purchaseOrderId: string }[] = [];
+        // PERMANENT: the PO itself is gone or out of this project — retrying can't fix it.
+        const missingPurchaseOrderIds = new Set<string>();
+        if (validLinks.length > 0) {
+            // A PO must belong to the SAME project as this estimate — otherwise a caller
+            // authorized for this estimate could pass an id belonging to another project's PO
+            // (or ScheduleTask, below) and have it linked here.
+            const existingPos = await tx.purchaseOrder.findMany({
+                where: { id: { in: validLinks.map(l => l.purchaseOrderId) }, projectId },
+                select: { id: true },
+            });
+            const existingPoIds = new Set(existingPos.map(p => p.id));
+            const linksToCreate = validLinks
+                .filter(l => existingPoIds.has(l.purchaseOrderId))
+                .map(l => ({
+                    estimateItemId: l.estimateItemId,
+                    purchaseOrderId: l.purchaseOrderId,
+                    // Preserve the original link's timestamp when the caller has it (e.g. an
+                    // undo snapshot), so syncLegacyPoLink's oldest-link ordering stays correct
+                    // instead of treating a restored link as brand new.
+                    ...(l.createdAt ? { createdAt: new Date(l.createdAt) } : {}),
+                }));
+            if (linksToCreate.length > 0) {
+                await tx.estimateItemPurchaseOrder.createMany({
+                    data: linksToCreate,
+                    skipDuplicates: true,
+                });
+            }
+            for (const l of validLinks) {
+                if (existingPoIds.has(l.purchaseOrderId)) {
+                    restoredLinks.push({ estimateItemId: l.estimateItemId, purchaseOrderId: l.purchaseOrderId });
+                } else {
+                    missingPurchaseOrderIds.add(l.purchaseOrderId);
+                }
+            }
+        }
+
+        if (scheduleTasks.length > 0) {
+            // Schedule-task repointing writes ScheduleTask rows, so it must take the Project
+            // row lock FIRST — the same order lockTaskAssignmentParent establishes for every
+            // other ScheduleTask writer in schedule-core.ts (Project → ScheduleTask; see its
+            // doc comment there). Taking it here — after the PurchaseOrder/Estimate/EstimateItem
+            // locks above, before any ScheduleTask lock below — makes this function's full lock
+            // chain (PurchaseOrder → Estimate → EstimateItem → Project → ScheduleTask) a strict
+            // extension of both established orders, so it can't invert against either family of
+            // writer. (schedule-core.ts itself never acquires a PurchaseOrder, Estimate, or
+            // EstimateItem lock, so there's no reciprocal ordering constraint on that side to
+            // reconcile — no follow-up change to schedule-core.ts is needed for this.)
+            await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${projectId} FOR UPDATE`;
+        }
+
+        // Sort so two concurrent restores lock ScheduleTask rows in the same global order.
+        const sortedScheduleTasks = [...scheduleTasks].sort((a, b) => a.scheduleTaskId.localeCompare(b.scheduleTaskId));
+        const restoredScheduleTasks: { scheduleTaskId: string; estimateItemId: string }[] = [];
+        // PERMANENT: the ScheduleTask is gone, out of project scope, or owned by a different
+        // item — retrying can't fix any of these (item-missing is tracked separately above).
+        const missingScheduleTaskIds = new Set<string>();
+        for (const st of sortedScheduleTasks) {
+            if (!existingItemIds.has(st.estimateItemId)) continue;
+            const rows = await tx.$queryRaw<{ id: string; projectId: string | null; estimateItemId: string | null }[]>`
+                SELECT id, "projectId", "estimateItemId" FROM "ScheduleTask" WHERE id = ${st.scheduleTaskId} FOR UPDATE
+            `;
+            const task = rows[0];
+            if (!task) { missingScheduleTaskIds.add(st.scheduleTaskId); continue; }
+            // Same-project + no-theft guard: a ScheduleTask must belong to this estimate's
+            // project, and must be either unlinked or already pointing at the target item —
+            // never repoint a task that belongs to a different estimate item (schedule-task
+            // theft across items or projects).
+            if (task.projectId !== projectId) { missingScheduleTaskIds.add(st.scheduleTaskId); continue; }
+            if (task.estimateItemId && task.estimateItemId !== st.estimateItemId) { missingScheduleTaskIds.add(st.scheduleTaskId); continue; }
+            await tx.scheduleTask.update({
+                where: { id: st.scheduleTaskId },
+                data: { estimateItemId: st.estimateItemId },
+            });
+            restoredScheduleTasks.push({ scheduleTaskId: st.scheduleTaskId, estimateItemId: st.estimateItemId });
+        }
+
+        // Resync the legacy mirror only for PO items — never for schedule-only candidates (see
+        // poItemIds above); a schedules-only caller has no financial permission and must not be
+        // able to reach this write.
+        for (const itemId of existingItemIds) {
+            if (poItemIds.has(itemId)) {
+                await syncLegacyPoLink(tx, itemId);
+            }
+        }
+
+        return {
+            restoredLinks,
+            restoredScheduleTasks,
+            missing: {
+                itemIds: Array.from(missingItemIds),
+                purchaseOrderIds: Array.from(missingPurchaseOrderIds),
+                scheduleTaskIds: Array.from(missingScheduleTaskIds),
+            },
+        };
+    }));
+
+    revalidatePath(`/projects/${projectId}/estimates`);
+    return result;
 }
 
 export async function getProjectPurchaseOrdersForLinking(projectId: string) {

--- a/src/lib/estimate-item-po-links.ts
+++ b/src/lib/estimate-item-po-links.ts
@@ -1,0 +1,23 @@
+// Shared normalization for the item <-> purchase order relationship on estimate items.
+// EstimateItem.purchaseOrderId/purchaseOrder is the deprecated single-PO mirror; the
+// many-to-many source of truth is item.purchaseOrderLinks. Until every item has been
+// backfilled into the join table, an item may still only carry the legacy scalar link.
+// This normalizes both shapes into one so every consumer (budget strip, AI lock, delete
+// snapshot, expenses tab) can read `item.purchaseOrderLinks` and `link.purchaseOrder.id`
+// uniformly, whether the link came from the join table or the legacy fallback.
+
+/**
+ * If `item.purchaseOrderLinks` is empty/absent and the legacy `item.purchaseOrder` scalar
+ * mirror is set, synthesize a single-entry `purchaseOrderLinks` array from it. Must be
+ * applied once at load (wherever server item data enters client state) — not at render
+ * time — so every consumer (including snapshots taken for undo/AI-lock purposes) sees the
+ * link.
+ */
+export function normalizeItemPoLinks<T extends { purchaseOrderLinks?: any[] | null; purchaseOrder?: any }>(item: T): T {
+    if ((item.purchaseOrderLinks?.length ?? 0) > 0) return item;
+    if (!item.purchaseOrder) return item;
+    return {
+        ...item,
+        purchaseOrderLinks: [{ purchaseOrder: item.purchaseOrder }],
+    };
+}

--- a/src/lib/gpt-estimate.ts
+++ b/src/lib/gpt-estimate.ts
@@ -422,6 +422,7 @@ export async function updateEstimateFromPhases(input: UpdateEstimateInput): Prom
                         estimateId: existing.id,
                         OR: [
                             { purchaseOrderId: { not: null } },
+                            { purchaseOrderLinks: { some: {} } },
                             { timeEntries: { some: {} } },
                             { expenses: { some: {} } },
                             { scheduleTask: { isNot: null } },


### PR DESCRIPTION
## What

Estimate line items were capped at **one** purchase order each (`EstimateItem.purchaseOrderId` scalar FK) — the budget strip even hid the Link/Create buttons once a PO was attached. Jobs that split a budget line across two suppliers had nowhere to put the second PO. This makes item↔PO many-to-many via an `EstimateItemPurchaseOrder` join table.

Also adds **undo for accidentally deleted line items**, which previously vanished silently with no confirmation and could reach the DB via the blur autosave.

## Data safety

The legacy scalar column is **retained and dual-written** as a rollback mirror — nothing is dropped. The migration is split so exactly one writer exists at any moment:

1. `scripts/apply-estimate-item-po-links.mjs` — additive DDL, **before** the deploy (already applied to prod)
2. `scripts/backfill-estimate-item-po-links.mjs` — data copy, **after** the deploy

A read fallback and migrate-on-write cover the gap between the two, so no link is invisible or lost in the window. The backfill asserts *coverage* (zero legacy links lacking a join row), not rows-inserted, so it is safe to run late or twice.

## Undo

Delete now branches three ways: **blocks** when expenses/time entries are attached (`saveEstimate` rejects those server-side anyway, so a local delete just wedged the editor), **confirms** when POs or a schedule task are attached, otherwise deletes with a 10s undo toast. Undo is durable — it restores local state, awaits the row-recreating save (items come back with their original ids), then reattaches the PO links and schedule task the delete severed at the DB level. The History panel's revert goes through the same path.

## Review

Hardened over three rounds of Codex peer review, which caught among others:
- an undo that could save an **empty** items array, deleting every line on the estimate
- a blur-autosave race that silently re-deleted a restored row while reporting success
- a schedules-only caller able to null the financial mirror
- lock-order inversions across the PO / estimate / schedule paths
- `createPurchaseOrderFromEstimate` linking raw `itemIds` (cross-project link)

Final Codex verdict: safe to deploy.

## Verified on the Shop test project

Two POs linked to one line item (confirmed as two join rows on the same `estimateItemId`); unlinking the first left the second intact and resynced the mirror; a **persisted** delete (verified gone from the DB) was fully recovered by undo — original item id and PO link both restored. Test POs cleaned up afterward; legacy scalar count back to its original 11.

## Follow-ups filed separately

- estimate dirty-check omits budget fields, so budget-only edits can silently no-op (**pre-existing on main**)
- vendor deletion cascades POs without resync (pre-existing)
- `PurchaseOrder.code` has no unique constraint
- schedule-task detach in history-replace mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)