### PR TITLE
fix(security): vendor delete no longer cascade-destroys purchase orders

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1607,7 +1607,10 @@ model PurchaseOrder {
   projectId   String
   project     Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
   vendorId    String
-  vendor      Vendor  @relation(fields: [vendorId], references: [id], onDelete: Cascade)
+  // Restrict, not Cascade: deleting a vendor must never silently destroy its
+  // purchase orders (and their items, files, messages) behind the app's back.
+  // deleteVendor blocks with a count; this is the backstop for every other caller.
+  vendor      Vendor  @relation(fields: [vendorId], references: [id], onDelete: Restrict)
   status      String  @default("Draft") // Draft, Sent, Received, Cancelled
   totalAmount Decimal   @default(0)
   notes       String?

--- a/scripts/apply-vendor-po-restrict.mjs
+++ b/scripts/apply-vendor-po-restrict.mjs
@@ -1,0 +1,166 @@
+// Changes PurchaseOrder.vendorId's FK from ON DELETE CASCADE to ON DELETE RESTRICT.
+//
+// Why: deleting a Vendor used to cascade-delete every one of its PurchaseOrders
+// at the database level, which also cascaded to PurchaseOrderItem,
+// PurchaseOrderFile and PurchaseOrderMessage, and severed Expense.purchaseOrderId.
+// All of that bypassed deletePurchaseOrder() and its permission + scope checks.
+//
+// Idempotent: re-reads the current delete_rule under lock and no-ops if it is
+// already RESTRICT. Safe to run against prod while the old build is live — the
+// old build never intentionally relied on the cascade, and the rule only tightens.
+//
+// Lock behaviour: DROP + ADD CONSTRAINT takes ACCESS EXCLUSIVE on PurchaseOrder.
+// Adding the FK as NOT VALID keeps that lock brief (no table scan); the separate
+// VALIDATE CONSTRAINT pass then re-checks existing rows under a weaker
+// SHARE UPDATE EXCLUSIVE lock that does not block reads or writes. lock_timeout
+// makes the script fail fast rather than queue behind a long transaction and
+// stall every query on the table behind it.
+//
+// Usage: node scripts/apply-vendor-po-restrict.mjs
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+// DATABASE_URL (the pooler) on purpose, matching every sibling apply-*.mjs.
+// Supabase generally recommends DIRECT_URL for migrations, but port 5432 is not
+// reachable on this project's tier, so preferring it would just fail to connect.
+// pgbouncer's transaction mode pins one server connection for the duration of a
+// transaction, so the interactive transaction below is safe over the pooler.
+// Set MIGRATION_DATABASE_URL to override (e.g. to use DIRECT_URL where it works).
+function resolveDatabaseUrl() {
+    const fromEnv = process.env.MIGRATION_DATABASE_URL || process.env.DATABASE_URL;
+    if (fromEnv) return fromEnv;
+    for (const file of [".env", ".env.local"]) {
+        if (!fs.existsSync(file)) continue;
+        const match = fs.readFileSync(file, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+        if (match) return match[1];
+    }
+    throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const url = resolveDatabaseUrl();
+const prisma = new PrismaClient({ datasources: { db: { url } } });
+
+// Resolve the FK from pg_catalog rather than information_schema: constraint
+// names are only unique per-schema, and information_schema joins on name alone,
+// so a same-named constraint in another schema can produce a bogus match. This
+// pins the schema, table, referenced table and exact column list.
+const FIND_FK = `
+    SELECT c.conname                            AS name,
+           c.confdeltype                        AS delete_type,
+           c.confupdtype                        AS update_type,
+           c.convalidated                       AS validated
+      FROM pg_constraint c
+      JOIN pg_class      t ON t.oid = c.conrelid
+      JOIN pg_namespace  n ON n.oid = t.relnamespace
+      JOIN pg_class      f ON f.oid = c.confrelid
+      JOIN pg_namespace fn ON fn.oid = f.relnamespace
+     WHERE c.contype = 'f'
+       AND n.nspname = 'public' AND t.relname = 'PurchaseOrder'
+       AND fn.nspname = 'public' AND f.relname = 'Vendor'
+       AND (SELECT array_agg(a.attname ORDER BY a.attname)
+              FROM unnest(c.conkey) AS k(attnum)
+              JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum)
+           = ARRAY['vendorId']
+       -- confkey too, not just conkey: without this, schema drift could match an
+       -- FK pointing at some other unique Vendor column, which the rebuild below
+       -- would then silently repoint at Vendor.id.
+       AND (SELECT array_agg(a.attname ORDER BY a.attname)
+              FROM unnest(c.confkey) AS k(attnum)
+              JOIN pg_attribute a ON a.attrelid = c.confrelid AND a.attnum = k.attnum)
+           = ARRAY['id'];
+`;
+
+// pg_constraint stores the actions as single chars, not words.
+const ACTION_BY_CODE = { a: "NO ACTION", r: "RESTRICT", c: "CASCADE", n: "SET NULL", d: "SET DEFAULT" };
+
+async function findVendorFk(client = prisma) {
+    const rows = await client.$queryRawUnsafe(FIND_FK);
+    if (rows.length !== 1) {
+        throw new Error(`Expected exactly 1 PurchaseOrder.vendorId -> Vendor FK, found ${rows.length}`);
+    }
+    const row = rows[0];
+    return {
+        name: row.name,
+        deleteAction: ACTION_BY_CODE[row.delete_type] ?? row.delete_type,
+        updateAction: ACTION_BY_CODE[row.update_type] ?? row.update_type,
+        validated: row.validated,
+    };
+}
+
+async function main() {
+    console.log(`Applying to ${url.replace(/:[^:@]*@/, ":****@")}`);
+
+    const fk = await findVendorFk();
+    console.log(`  found FK ${fk.name}: ON DELETE ${fk.deleteAction}, ON UPDATE ${fk.updateAction}`);
+
+    // Only done if it is BOTH restricted and validated. A first run that commits
+    // the swap then dies before VALIDATE would otherwise leave the constraint
+    // NOT VALID forever, with every rerun skipping straight past the fix.
+    if (fk.deleteAction === "RESTRICT" && fk.validated) {
+        console.log("Already RESTRICT and validated — nothing to do.");
+        return;
+    }
+
+    if (fk.deleteAction === "RESTRICT") {
+        console.log("  already RESTRICT but NOT VALID — resuming at validation.");
+    } else {
+        const [{ count: poCount }] = await prisma.$queryRawUnsafe(
+            `SELECT COUNT(*)::int AS count FROM "PurchaseOrder";`,
+        );
+        console.log(`  ${poCount} purchase orders protected by this change`);
+    }
+
+    // One transaction: take the lock, re-check under it so two concurrent runs
+    // cannot both rebuild the constraint, then swap the delete rule.
+    // update action is carried over verbatim — only the delete rule changes.
+    // Skipped entirely on the resume path so we don't take ACCESS EXCLUSIVE on a
+    // live table just to discover there is nothing to swap.
+    if (fk.deleteAction !== "RESTRICT") await prisma.$transaction(async tx => {
+        await tx.$executeRawUnsafe(`SET LOCAL lock_timeout = '5s';`);
+        await tx.$executeRawUnsafe(`LOCK TABLE "public"."PurchaseOrder" IN ACCESS EXCLUSIVE MODE;`);
+
+        const current = await findVendorFk(tx);
+        if (current.deleteAction === "RESTRICT") {
+            console.log("  another run got there first — nothing to do.");
+            return;
+        }
+
+        await tx.$executeRawUnsafe(`ALTER TABLE "public"."PurchaseOrder" DROP CONSTRAINT "${current.name}";`);
+        await tx.$executeRawUnsafe(
+            `ALTER TABLE "public"."PurchaseOrder"
+               ADD CONSTRAINT "${current.name}"
+               FOREIGN KEY ("vendorId") REFERENCES "public"."Vendor"("id")
+               ON DELETE RESTRICT ON UPDATE ${current.updateAction}
+               NOT VALID;`,
+        );
+    });
+
+    // Separate statement, weaker lock: re-checks existing rows without blocking
+    // reads or writes. Every row already satisfied the old FK, so this cannot fail.
+    const after = await findVendorFk();
+    if (!after.validated) {
+        console.log("  validating existing rows...");
+        await prisma.$executeRawUnsafe(
+            `ALTER TABLE "public"."PurchaseOrder" VALIDATE CONSTRAINT "${after.name}";`,
+        );
+    }
+
+    const final = await findVendorFk();
+    if (final.deleteAction !== "RESTRICT") {
+        throw new Error(`Verification failed: ON DELETE is ${final.deleteAction}, expected RESTRICT`);
+    }
+    if (final.updateAction !== fk.updateAction) {
+        throw new Error(`Verification failed: ON UPDATE changed from ${fk.updateAction} to ${final.updateAction}`);
+    }
+    if (!final.validated) {
+        throw new Error("Verification failed: constraint is still NOT VALID");
+    }
+    console.log(`${final.name} verified: ON DELETE RESTRICT, ON UPDATE ${final.updateAction}, validated.`);
+}
+
+main()
+    .catch(error => {
+        console.error(error);
+        process.exitCode = 1;
+    })
+    .finally(() => prisma.$disconnect());

--- a/scripts/apply-vendor-po-restrict.mjs
+++ b/scripts/apply-vendor-po-restrict.mjs
@@ -57,17 +57,19 @@ const FIND_FK = `
      WHERE c.contype = 'f'
        AND n.nspname = 'public' AND t.relname = 'PurchaseOrder'
        AND fn.nspname = 'public' AND f.relname = 'Vendor'
-       AND (SELECT array_agg(a.attname ORDER BY a.attname)
+       -- attname is of type name, not text — cast explicitly or the comparison
+       -- fails with 42883 "operator does not exist: name[] = text[]".
+       AND (SELECT array_agg(a.attname::text ORDER BY a.attname::text)
               FROM unnest(c.conkey) AS k(attnum)
               JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum)
-           = ARRAY['vendorId']
+           = ARRAY['vendorId']::text[]
        -- confkey too, not just conkey: without this, schema drift could match an
        -- FK pointing at some other unique Vendor column, which the rebuild below
        -- would then silently repoint at Vendor.id.
-       AND (SELECT array_agg(a.attname ORDER BY a.attname)
+       AND (SELECT array_agg(a.attname::text ORDER BY a.attname::text)
               FROM unnest(c.confkey) AS k(attnum)
               JOIN pg_attribute a ON a.attrelid = c.confrelid AND a.attnum = k.attnum)
-           = ARRAY['id'];
+           = ARRAY['id']::text[];
 `;
 
 // pg_constraint stores the actions as single chars, not words.

--- a/src/app/api/vendors/route.ts
+++ b/src/app/api/vendors/route.ts
@@ -1,12 +1,23 @@
 import { NextResponse } from "next/server";
 import { getVendors, createVendor } from "@/lib/actions";
 
+// Don't report a rejected request as a server fault. Validation errors carry an
+// explicit `status`; the shared auth helpers throw bare "Unauthorized"/"Forbidden"
+// Errors, so those two still have to be matched by message.
+function errorResponse(error: any) {
+    const message = error?.message || "Request failed";
+    if (typeof error?.status === "number") return NextResponse.json({ error: message }, { status: error.status });
+    if (message === "Unauthorized") return NextResponse.json({ error: message }, { status: 401 });
+    if (message === "Forbidden") return NextResponse.json({ error: message }, { status: 403 });
+    return NextResponse.json({ error: message }, { status: 500 });
+}
+
 export async function GET() {
     try {
         const vendors = await getVendors();
         return NextResponse.json(vendors);
     } catch (error: any) {
-        return NextResponse.json({ error: error.message }, { status: 500 });
+        return errorResponse(error);
     }
 }
 
@@ -16,6 +27,6 @@ export async function POST(req: Request) {
         const vendor = await createVendor(data);
         return NextResponse.json(vendor);
     } catch (error: any) {
-        return NextResponse.json({ error: error.message }, { status: 500 });
+        return errorResponse(error);
     }
 }

--- a/src/app/company/vendors/VendorsClient.tsx
+++ b/src/app/company/vendors/VendorsClient.tsx
@@ -536,12 +536,30 @@ export default function VendorsClient({ initialVendors, initialTags }: { initial
                                                     <button onClick={() => { setRowActionMenuVendorId(null); openVendorModal(v); }} className="w-full text-left px-4 py-2 text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2"><Edit2 className="w-3.5 h-3.5"/> Edit Record</button>
                                                     <button onClick={async () => {
                                                         setRowActionMenuVendorId(null);
-                                                        if (confirm("Delete this vendor permanently?")) {
-                                                            await deleteVendor(v.id);
-                                                            setVendors(vendors.filter(vx => vx.id !== v.id));
-                                                            toast.success("Vendor deleted");
-                                                            router.refresh();
+                                                        // The loaded count only shapes the prompt — the server decides.
+                                                        // Blocking on it here would strand a vendor whose POs were
+                                                        // reassigned elsewhere since this list was rendered.
+                                                        const knownPoCount = v._count?.purchaseOrders ?? 0;
+                                                        const prompt = knownPoCount > 0
+                                                            ? `This vendor has ${knownPoCount} purchase order${knownPoCount === 1 ? "" : "s"} and probably cannot be deleted. Try anyway?`
+                                                            : "Delete this vendor permanently?";
+                                                        if (!confirm(prompt)) return;
+                                                        let result;
+                                                        try {
+                                                            result = await deleteVendor(v.id);
+                                                        } catch {
+                                                            toast.error("Could not delete vendor");
+                                                            return;
                                                         }
+                                                        if (!result?.ok) {
+                                                            const n = result?.count ?? 0;
+                                                            toast.error(`This vendor has ${n} purchase order${n === 1 ? "" : "s"}. Delete or reassign them first.`);
+                                                            router.refresh();
+                                                            return;
+                                                        }
+                                                        setVendors(vendors.filter(vx => vx.id !== v.id));
+                                                        toast.success("Vendor deleted");
+                                                        router.refresh();
                                                     }} className="w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-red-50">Delete Vendor</button>
                                                 </div>
                                             )}

--- a/src/app/projects/[id]/estimates/[estimateId]/SelectVendorModal.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/SelectVendorModal.tsx
@@ -36,7 +36,10 @@ export default function SelectVendorModal({ onSelect, onClose }: SelectVendorMod
         if (statusFilter !== "ALL" && v.status !== statusFilter) return false;
         if (search) {
             const q = search.toLowerCase();
-            return v.name.toLowerCase().includes(q) || (v.type && v.type.toLowerCase().includes(q));
+            // Trade lives in vendor tags — v.type never existed, so searching by
+            // trade silently matched nothing.
+            return v.name.toLowerCase().includes(q)
+                || (v.tags || []).some((t: any) => t.name?.toLowerCase().includes(q));
         }
         return true;
     });
@@ -161,9 +164,11 @@ export default function SelectVendorModal({ onSelect, onClose }: SelectVendorMod
                                                     <span className="text-[10px] bg-slate-100 text-slate-500 font-bold px-2 py-0.5 rounded-full uppercase tracking-wider">Inactive</span>
                                                 )}
                                             </div>
-                                            {(v.type || v.email) && (
+                                            {((v.tags?.length ?? 0) > 0 || v.email) && (
                                                 <div className="text-xs text-slate-500 space-y-0.5">
-                                                    {v.type && <p>{v.type}</p>}
+                                                    {(v.tags?.length ?? 0) > 0 && (
+                                                        <p className="line-clamp-1">{v.tags.map((t: any) => t.name).join(", ")}</p>
+                                                    )}
                                                     {v.email && <p className="truncate text-slate-400">{v.email}</p>}
                                                 </div>
                                             )}

--- a/src/app/projects/[id]/estimates/[estimateId]/SelectVendorModal.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/SelectVendorModal.tsx
@@ -52,7 +52,9 @@ export default function SelectVendorModal({ onSelect, onClose }: SelectVendorMod
             const newVendor = await createVendor({
                 name: newName,
                 email: newEmail,
-                type: newType,
+                // Trade becomes a vendor tag — that's what the vendors list filters
+                // on. There is no "type" column; sending one used to throw.
+                tagNames: newType || undefined,
                 status: "ACTIVE"
             });
             toast.success("Vendor created successfully");

--- a/src/app/projects/[id]/purchase-orders/[poId]/PurchaseOrderEditor.tsx
+++ b/src/app/projects/[id]/purchase-orders/[poId]/PurchaseOrderEditor.tsx
@@ -209,7 +209,9 @@ export default function PurchaseOrderEditor({ context, initialData }: { context:
                         name: pendingNewVendor.name,
                         email: pendingNewVendor.email || undefined,
                         phone: pendingNewVendor.phone || undefined,
-                        address: pendingNewVendor.address || undefined,
+                        // Vendor's column is address1 — "address" was never a real
+                        // field, so the extracted address was being lost here.
+                        address1: pendingNewVendor.address || undefined,
                     });
                     finalVendorId = newVendor.id;
                 }

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -4070,7 +4070,7 @@ async function assertActiveStaff(): Promise<any> {
     throw new Error("Unauthorized");
 }
 
-async function assertStaffPermission(permission: "estimates" | "invoices" | "changeOrders" | "financialReports" | "companySettings" | "contracts") {
+async function assertStaffPermission(permission: "estimates" | "invoices" | "changeOrders" | "financialReports" | "companySettings" | "contracts" | "manageVendors") {
     const user = await assertActiveStaff();
     if (!hasPermission(user, permission)) throw new Error("Forbidden");
     return user;
@@ -4151,6 +4151,22 @@ async function assertFinancialProjectAccess(projectId: string) {
 
 async function assertCompanySettingsPermission() {
     return assertStaffPermission("companySettings");
+}
+
+async function assertVendorPermission() {
+    return assertStaffPermission("manageVendors");
+}
+
+// Creating a vendor is also part of the PO flow — SelectVendorModal and
+// POQuickCreateModal let an estimator add one inline, and those screens gate on
+// financialReports (see quickCreatePOAndLink). So either permission is enough to
+// create; editing and deleting still require manageVendors.
+async function assertVendorCreatePermission() {
+    const user = await assertActiveStaff();
+    if (!hasPermission(user, "manageVendors") && !hasPermission(user, "financialReports")) {
+        throw new Error("Forbidden");
+    }
+    return user;
 }
 
 async function assertEstimateStaffOrPortalAccess(estimateId: string) {
@@ -9221,22 +9237,95 @@ export async function subPortalDeleteCOI() {
 // ==========================================
 export async function getVendors() {
     "use server";
-    return prisma.vendor.findMany({ 
+    // Vendor rows carry EIN, account numbers, contacts and file URLs — this was
+    // reachable unauthenticated. The PO-flow modals need it too, so gate on
+    // active staff and let the two write permissions stay narrower.
+    await assertVendorCreatePermission();
+    return prisma.vendor.findMany({
         orderBy: { name: "asc" },
         include: { tags: true, files: true, _count: { select: { purchaseOrders: true } } }
     });
 }
 
+// Vendor columns a caller is allowed to write. Anything not listed here — most
+// importantly the `purchaseOrders` relation — is dropped. Spreading the raw
+// payload into Prisma let a caller pass nested relation writes such as
+// { purchaseOrders: { deleteMany: {} } }, which deletes POs directly and so
+// never trips the vendor FK's ON DELETE RESTRICT or deletePurchaseOrder's checks.
+const VENDOR_WRITABLE_FIELDS = [
+    "name", "website", "description", "firstName", "lastName", "email", "phone",
+    "fax", "address1", "address2", "city", "state", "zipCode", "country",
+    "paymentTerms", "chargesTax", "accountNumber", "ein", "notes", "status",
+] as const;
+
+function pickVendorFields(data: any) {
+    const out: Record<string, any> = {};
+    for (const key of VENDOR_WRITABLE_FIELDS) {
+        if (data?.[key] !== undefined) out[key] = data[key];
+    }
+    return out;
+}
+
+// Same reasoning for vendor files — map the scalars explicitly rather than
+// handing Prisma a caller-shaped object.
+function pickVendorFiles(files: any[]) {
+    return files.map((f: any) => ({
+        name: f.name,
+        url: f.url,
+        size: f.size,
+        type: f.type,
+    }));
+}
+
+// Free-text trade labels ("Supplier, Lumber") normalised into VendorTag names.
+// Tags are how the vendors list filters, so a trade typed during inline vendor
+// creation belongs here rather than buried in a text column.
+function parseTagNames(tagNames: any): string[] {
+    if (!tagNames) return [];
+    const raw = Array.isArray(tagNames) ? tagNames : [tagNames];
+    const seen = new Set<string>();
+    for (const entry of raw) {
+        if (typeof entry !== "string") continue;
+        for (const part of entry.split(",")) {
+            const name = part.trim();
+            if (name) seen.add(name);
+        }
+    }
+    return [...seen];
+}
+
 export async function createVendor(data: any) {
     "use server";
-    const { tagIds, files, ...vendorData } = data;
+    await assertVendorCreatePermission();
+    const { tagIds, tagNames, files } = data ?? {};
+    const newTagNames = parseTagNames(tagNames);
 
-    const v = await prisma.vendor.create({ 
+    // name is the one required Vendor column — the allowlist above can't prove
+    // to the type system that it survived, so check it rather than cast it away.
+    const fields = pickVendorFields(data);
+    const name = typeof fields.name === "string" ? fields.name.trim() : "";
+    if (!name) {
+        // status lets the API route answer 400 without matching on the message.
+        const err: any = new Error("Vendor name is required");
+        err.status = 400;
+        throw err;
+    }
+
+    const v = await prisma.vendor.create({
         data: {
-            ...vendorData,
-            tags: tagIds?.length ? { connect: tagIds.map((id: string) => ({ id })) } : undefined,
-            files: files?.length ? { create: files } : undefined
-        }
+            ...fields,
+            name,
+            tags: (tagIds?.length || newTagNames.length) ? {
+                connect: tagIds?.length ? tagIds.map((id: string) => ({ id })) : undefined,
+                // connectOrCreate so an existing trade tag is reused rather than
+                // colliding on VendorTag.name's unique constraint.
+                connectOrCreate: newTagNames.length
+                    ? newTagNames.map(tagName => ({ where: { name: tagName }, create: { name: tagName } }))
+                    : undefined,
+            } : undefined,
+            files: files?.length ? { create: pickVendorFiles(files) } : undefined
+        },
+        include: { tags: true, files: true, _count: { select: { purchaseOrders: true } } }
     });
     revalidatePath("/company/vendors");
     return v;
@@ -9244,25 +9333,20 @@ export async function createVendor(data: any) {
 
 export async function updateVendor(id: string, data: any) {
     "use server";
-    const { tagIds, files, ...vendorData } = data;
+    await assertVendorPermission();
+    const { tagIds, files } = data ?? {};
 
-    const v = await prisma.vendor.update({ 
-        where: { id }, 
+    const v = await prisma.vendor.update({
+        where: { id },
         data: {
-            ...vendorData,
+            ...pickVendorFields(data),
             tags: tagIds ? { set: tagIds.map((id: string) => ({ id })) } : undefined,
         }
     });
 
     if (files && files.length > 0) {
         await prisma.vendorFile.createMany({
-            data: files.map((f: any) => ({
-                name: f.name,
-                url: f.url,
-                size: f.size,
-                type: f.type,
-                vendorId: id
-            }))
+            data: pickVendorFiles(files).map(f => ({ ...f, vendorId: id }))
         });
     }
 
@@ -9272,12 +9356,41 @@ export async function updateVendor(id: string, data: any) {
 
 export async function deleteVendor(id: string) {
     "use server";
-    await prisma.vendor.delete({ where: { id } });
+    await assertVendorPermission();
+
+    // Purchase orders are financial records — a vendor that still has any must
+    // not be deletable. The FK is ON DELETE RESTRICT, so the database is the
+    // real guard; the count here only turns that into a message naming how many
+    // POs are in the way. The two are not atomic, hence the P2003 catch below.
+    //
+    // This returns a result rather than throwing, because a production Next
+    // build redacts thrown Server Function messages — a throw would reach the
+    // user as a generic error with the count stripped out. Authorization still
+    // throws: being denied is not an expected outcome worth rendering.
+    const poCount = await prisma.purchaseOrder.count({ where: { vendorId: id } });
+    if (poCount > 0) {
+        return { ok: false as const, reason: "HAS_PURCHASE_ORDERS" as const, count: poCount };
+    }
+
+    try {
+        await prisma.vendor.delete({ where: { id } });
+    } catch (error: any) {
+        // P2003 = FK constraint failure, i.e. a PO was attached between the
+        // count above and this delete.
+        if (error?.code === "P2003") {
+            const recount = await prisma.purchaseOrder.count({ where: { vendorId: id } });
+            return { ok: false as const, reason: "HAS_PURCHASE_ORDERS" as const, count: recount };
+        }
+        throw error;
+    }
+
     revalidatePath("/company/vendors");
+    return { ok: true as const };
 }
 
 export async function deleteVendorFile(id: string) {
     "use server";
+    await assertVendorPermission();
     await prisma.vendorFile.delete({ where: { id } });
     revalidatePath("/company/vendors");
 }
@@ -9289,6 +9402,7 @@ export async function getVendorTags() {
 
 export async function createVendorTag(name: string) {
     "use server";
+    await assertVendorPermission();
     const tag = await prisma.vendorTag.create({ data: { name } });
     revalidatePath("/company/vendors");
     return tag;
@@ -9296,6 +9410,7 @@ export async function createVendorTag(name: string) {
 
 export async function updateVendorTag(id: string, name: string) {
     "use server";
+    await assertVendorPermission();
     const tag = await prisma.vendorTag.update({ where: { id }, data: { name } });
     revalidatePath("/company/vendors");
     return tag;
@@ -9303,6 +9418,7 @@ export async function updateVendorTag(id: string, name: string) {
 
 export async function deleteVendorTag(id: string) {
     "use server";
+    await assertVendorPermission();
     await prisma.vendorTag.delete({ where: { id } });
     revalidatePath("/company/vendors");
 }

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -9280,6 +9280,9 @@ function pickVendorFiles(files: any[]) {
 // Free-text trade labels ("Supplier, Lumber") normalised into VendorTag names.
 // Tags are how the vendors list filters, so a trade typed during inline vendor
 // creation belongs here rather than buried in a text column.
+const MAX_TAG_NAME_LENGTH = 40;
+const MAX_NEW_TAGS = 10;
+
 function parseTagNames(tagNames: any): string[] {
     if (!tagNames) return [];
     const raw = Array.isArray(tagNames) ? tagNames : [tagNames];
@@ -9287,8 +9290,9 @@ function parseTagNames(tagNames: any): string[] {
     for (const entry of raw) {
         if (typeof entry !== "string") continue;
         for (const part of entry.split(",")) {
-            const name = part.trim();
+            const name = part.trim().slice(0, MAX_TAG_NAME_LENGTH);
             if (name) seen.add(name);
+            if (seen.size >= MAX_NEW_TAGS) return [...seen];
         }
     }
     return [...seen];
@@ -9311,22 +9315,43 @@ export async function createVendor(data: any) {
         throw err;
     }
 
-    const v = await prisma.vendor.create({
+    const tagWrite = {
+        ...(tagIds?.length ? { connect: tagIds.map((id: string) => ({ id })) } : {}),
+        // connectOrCreate so an existing trade tag is reused rather than
+        // colliding on VendorTag.name's unique constraint.
+        ...(newTagNames.length
+            ? { connectOrCreate: newTagNames.map(tagName => ({ where: { name: tagName }, create: { name: tagName } })) }
+            : {}),
+    };
+
+    const createArgs = {
         data: {
             ...fields,
             name,
-            tags: (tagIds?.length || newTagNames.length) ? {
-                connect: tagIds?.length ? tagIds.map((id: string) => ({ id })) : undefined,
-                // connectOrCreate so an existing trade tag is reused rather than
-                // colliding on VendorTag.name's unique constraint.
-                connectOrCreate: newTagNames.length
-                    ? newTagNames.map(tagName => ({ where: { name: tagName }, create: { name: tagName } }))
-                    : undefined,
-            } : undefined,
-            files: files?.length ? { create: pickVendorFiles(files) } : undefined
+            ...(Object.keys(tagWrite).length ? { tags: tagWrite } : {}),
+            ...(files?.length ? { files: { create: pickVendorFiles(files) } } : {}),
         },
         include: { tags: true, files: true, _count: { select: { purchaseOrders: true } } }
-    });
+    };
+
+    let v;
+    try {
+        v = await prisma.vendor.create(createArgs);
+    } catch (error: any) {
+        // connectOrCreate is a check-then-create, so two vendors naming the same
+        // new tag at once can race and one loses on VendorTag.name. The retry
+        // finds the tag the winner just created and connects to it instead.
+        const rawTarget = error?.meta?.target;
+        const targets: string[] = Array.isArray(rawTarget)
+            ? rawTarget.map(String)
+            : rawTarget ? [String(rawTarget)] : [];
+        const isTagNameRace = error?.code === "P2002"
+            && targets.includes("name")
+            && newTagNames.length > 0;
+        if (!isTagNameRace) throw error;
+        v = await prisma.vendor.create(createArgs);
+    }
+
     revalidatePath("/company/vendors");
     return v;
 }


### PR DESCRIPTION
## What was wrong

`PurchaseOrder.vendor` was declared `onDelete: Cascade`. Deleting a Vendor hard-deleted **every one of its purchase orders** at the database level — along with their items, files and messages, and nulling `Expense.purchaseOrderId`. All of it bypassed `deletePurchaseOrder()` and its permission and project-scope checks. Approved and Received POs were not exempt.

Vendors are deletable in one click from `/company/vendors`.

And every vendor server action was **unauthenticated** — `createVendor`, `updateVendor`, `deleteVendor`, `deleteVendorFile`, `getVendors` and the three vendorTag actions were bare `"use server"` functions with no gate. Any authenticated user, FIELD_CREW included, could destroy every PO in the company with a direct call. The `manageVendors` permission already existed, with a checkbox in the team-member UI, enforced nowhere.

Raised by a Codex peer review on 2026-08-06 during the multiple-POs-per-line-item work.

## What changed

- **FK `Cascade` → `Restrict`**, plus `scripts/apply-vendor-po-restrict.mjs` to swap the delete rule: `pg_catalog` lookup pinned on schema/table/`conkey`/`confkey`, `lock_timeout`, `ADD ... NOT VALID` then a separate `VALIDATE`, resumable and idempotent
- **Authorization**: `manageVendors` on update/delete/file/tag; `manageVendors OR financialReports` on `createVendor`/`getVendors`, since the PO-flow modals call them and a FINANCE user has only `financialReports`
- **Field allowlist**. Spreading the caller's payload into Prisma let a nested write like `{ purchaseOrders: { deleteMany: {} } }` delete POs *directly*, never touching the vendor row and so never tripping the new FK
- **`deleteVendor` returns `{ ok: false, reason, count }`** rather than throwing — a production Next build redacts thrown Server Function messages, so the count would never reach the user

### Pre-existing bugs found along the way

- The PO PDF importer sent `address`; Vendor's column is `address1`. Prisma was rejecting it, so extracted addresses were lost
- The estimate screen's **Create Vendor was broken outright** — it sent a `type` field that doesn't exist, so Prisma threw `Unknown arg`
- Vendor **search by trade silently matched nothing**, and the trade line never rendered, because both read `v.type`

Trade now creates a `VendorTag` (what the vendors list actually filters on), with a `P2002` retry for the concurrent-first-use race and bounded tag names.

## Deploy order

Schema change — run **before** deploying, or vendor pages throw until it's applied:

```bash
node scripts/apply-vendor-po-restrict.mjs
```

Touches zero rows. Reversible by re-adding the constraint with `ON DELETE CASCADE`.

## Verification

`npm run build` green. Three Codex review rounds (`blocker` → `real-issues` → `real-issues`, no Highs outstanding).

**Not verified in a running app.** Local dev's `DATABASE_URL` points at the prod pooler, so the only meaningful UI test — pressing Delete Vendor — is the destructive one. Worth noting that all three pre-existing bugs above were found by reading, not running; a throwaway-Postgres pass over vendor create/delete and the estimate modal would be the honest next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)