### PR TITLE
fix(estimates): budget edits silently failed to save

### DIFF
--- a/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
@@ -6,6 +6,7 @@ import {
     normalizeSectionTypes,
     rm,
     serializeEstimateItemsForSave,
+    normalizeEstimateItemForSave,
 } from "@/lib/estimate-item-payload";
 
 /** Recalculate milestone amounts: percentage-driven get amounts from %, fixed keep theirs, last absorbs residual */
@@ -386,25 +387,12 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
         const f = { ...fieldsRef.current, ...fieldsOverride };
         const activeTax = taxOptions.find(t => t.name === f.selectedTaxName) || defaultTaxRate;
 
-        const srcTotals = computeEstimateItemTotals(srcItems);
-        const mappedItems = srcItems.map((item, index) => {
-            const computedTotal = srcTotals[index].total;
-            return {
-                id: item.id || null,
-                parentId: item.parentId || null,
-                name: item.name || "",
-                description: item.description || "",
-                type: item.type || "Material",
-                quantity: String(item.quantity || "0"),
-                unitCost: String(item.unitCost || "0"),
-                costCodeId: item.costCodeId || null,
-                costTypeId: item.costTypeId || null,
-                vendorId: item.vendorId || null,
-                approvalStatus: item.approvalStatus || null,
-                order: index,
-                total: computedTotal,
-            };
-        });
+        // Exactly what a save would write, field for field: serialize (order, section
+        // roll-up, unitCost mirror) then project through the same function saveEstimate's
+        // toItemData uses. Hand-rolling a shorter list here is what made budget-only edits
+        // invisible to the change check, so the save reported success and wrote nothing.
+        const mappedItems = serializeEstimateItemsForSave(srcItems)
+            .map((item, index) => normalizeEstimateItemForSave(item, index));
 
         const mappedSchedules = f.paymentSchedules.map((schedule: any, index: number) => ({
             id: schedule.id || null,
@@ -490,7 +478,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
             if (res.ok) {
                 const data = await res.json();
                 if (data.description) {
-                    updateItem(itemIndex, "description", data.description);
+                    updateItemById(item.id, "description", data.description);
                     toast.success("AI description added");
                 }
             }
@@ -941,8 +929,9 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
         if (hasChanges) {
             if (!silent) setIsSaving(true);
             try {
-                // Recompute section header totals from children before saving
-                const mappedItems = serializeEstimateItemsForSave(sourceItems);
+                // The rows the change check just compared — reusing them is what keeps the
+                // comparison and the write from ever describing different things.
+                const mappedItems = currentSnapshot.items;
                 const mappedSchedules = f.paymentSchedules.map((schedule: any, index: number) => ({
                     ...schedule,
                     order: index
@@ -1569,10 +1558,28 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
         }
     }
 
+    /**
+     * Must use the functional setState form: several callers (BudgetStrip's rate and margin
+     * inputs) fire two or three updateItem calls from one event. Building from the
+     * render-closure `items` made each call overwrite the previous, so a rate edit persisted
+     * only markupPercent and a margin edit only baseCost — the rest were silently dropped.
+     */
     function updateItem(index: number, field: string, value: any) {
-        const newItems = [...items];
-        newItems[index] = { ...newItems[index], [field]: value };
-        setItems(newItems);
+        setItems(prev => {
+            const newItems = [...prev];
+            newItems[index] = { ...newItems[index], [field]: value };
+            return newItems;
+        });
+    }
+
+    /**
+     * Index-free variant for callers that resolve their row BEFORE an await (AI description
+     * fill, approve/reject). Rows can be reordered, added or deleted while the request is in
+     * flight, so a position captured beforehand may point at a different row — or past the
+     * end — by the time the updater runs. Matching on id is stable across all of those.
+     */
+    function updateItemById(itemId: string, field: string, value: any) {
+        setItems(prev => prev.map(item => item.id === itemId ? { ...item, [field]: value } : item));
     }
 
     // Re-inserts each removed row at its original index, for the case where other edits
@@ -2700,21 +2707,21 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                                                                     </div>
                                                                     <div className="w-24 flex items-center justify-end gap-0.5 flex-shrink-0">
                                                                         {item.approvalStatus === "approved" ? (
-                                                                            <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-semibold bg-green-50 text-green-700 border border-green-200 cursor-pointer" onClick={async () => { await updateItemApproval(item.id, null); updateItem(index, "approvalStatus", null); }}>
+                                                                            <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-semibold bg-green-50 text-green-700 border border-green-200 cursor-pointer" onClick={async () => { await updateItemApproval(item.id, null); updateItemById(item.id, "approvalStatus", null); }}>
                                                                                 <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
                                                                                 Approved
                                                                             </span>
                                                                         ) : item.approvalStatus === "rejected" ? (
-                                                                            <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-semibold bg-red-50 text-red-700 border border-red-200 cursor-pointer" onClick={async () => { await updateItemApproval(item.id, null); updateItem(index, "approvalStatus", null); }}>
+                                                                            <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-semibold bg-red-50 text-red-700 border border-red-200 cursor-pointer" onClick={async () => { await updateItemApproval(item.id, null); updateItemById(item.id, "approvalStatus", null); }}>
                                                                                 <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
                                                                                 Rejected
                                                                             </span>
                                                                         ) : (
                                                                             <span className="opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto transition flex gap-0.5 [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto">
-                                                                                <button onClick={async () => { await updateItemApproval(item.id, "approved"); updateItem(index, "approvalStatus", "approved"); toast.success("Item approved"); }} className="p-1 rounded hover:bg-green-50 text-slate-400 hover:text-green-600 transition focus-visible:opacity-100 focus-visible:pointer-events-auto" title="Approve">
+                                                                                <button onClick={async () => { await updateItemApproval(item.id, "approved"); updateItemById(item.id, "approvalStatus", "approved"); toast.success("Item approved"); }} className="p-1 rounded hover:bg-green-50 text-slate-400 hover:text-green-600 transition focus-visible:opacity-100 focus-visible:pointer-events-auto" title="Approve">
                                                                                     <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
                                                                                 </button>
-                                                                                <button onClick={async () => { await updateItemApproval(item.id, "rejected"); updateItem(index, "approvalStatus", "rejected"); toast.success("Item rejected"); }} className="p-1 rounded hover:bg-red-50 text-slate-400 hover:text-red-500 transition focus-visible:opacity-100 focus-visible:pointer-events-auto" title="Reject">
+                                                                                <button onClick={async () => { await updateItemApproval(item.id, "rejected"); updateItemById(item.id, "approvalStatus", "rejected"); toast.success("Item rejected"); }} className="p-1 rounded hover:bg-red-50 text-slate-400 hover:text-red-500 transition focus-visible:opacity-100 focus-visible:pointer-events-auto" title="Reject">
                                                                                     <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
                                                                                 </button>
                                                                             </span>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -16,6 +16,7 @@ import { resolveSessionClientId } from "./portal-auth";
 import { persistOwnedSignature } from "./signature-storage";
 import { parseProductUrl, MAX_PRICE as PRODUCT_PARSE_MAX_PRICE } from "./product-parse";
 import { isHttpUrl } from "./url-safety";
+import { normalizeEstimateItemForSave } from "./estimate-item-payload";
 import { canUseDevAuthFallback, getCurrentUserWithPermissions, getUserWithPermissionsByEmail, hasPermission, canAccessProject, PortalAuthError } from "./permissions";
 import { logActivity } from "./activity-log";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
@@ -3076,26 +3077,12 @@ export async function saveEstimate(estimateId: string, contextId: string, contex
             });
         }
 
+        // The field list lives in lib/estimate-item-payload, shared with the editor's
+        // change-detection snapshot so the two can't drift (a snapshot missing a field
+        // saveEstimate writes makes edits to it invisible, and the save silently no-ops).
         const toItemData = (item: any, fallbackOrder: number) => ({
-            id: item.id,
+            ...normalizeEstimateItemForSave(item, fallbackOrder),
             estimateId,
-            name: item.name,
-            description: item.description || "",
-            type: item.type,
-            quantity: parseFloat(item.quantity) || 0,
-            baseCost: item.baseCost != null ? (parseFloat(item.baseCost) || 0) : null,
-            markupPercent: parseFloat(item.markupPercent) || 25,
-            unitCost: parseFloat(item.unitCost) || 0,
-            total: parseFloat(item.total) || 0,
-            order: item.order ?? fallbackOrder,
-            parentId: item.parentId || null,
-            costCodeId: item.costCodeId || null,
-            costTypeId: item.costTypeId || null,
-            // purchaseOrderId is intentionally NOT set here — links live in
-            // EstimateItemPurchaseOrder and are maintained exclusively by syncLegacyPoLink.
-            budgetQuantity: item.budgetQuantity != null ? (parseFloat(item.budgetQuantity) || null) : null,
-            budgetUnit: item.budgetUnit || null,
-            budgetRate: item.budgetRate != null ? (parseFloat(item.budgetRate) || null) : null,
         });
 
         const parentItems = items.filter((i: any) => !i.parentId);

--- a/src/lib/estimate-item-payload.ts
+++ b/src/lib/estimate-item-payload.ts
@@ -192,3 +192,64 @@ export function serializeEstimateItemsForSave<T extends EstimateItemLike>(
         ...(totals[index].isSection ? { type: "Section", unitCost: totals[index].total } : {}),
     }));
 }
+
+/** Parse to a number, falling back only when the value is absent or unparseable — an explicit 0 survives. */
+function numberOr(value: unknown, fallback: number): number {
+    if (value == null || value === "") return fallback;
+    const parsed = typeof value === "number" ? value : parseFloat(String(value));
+    return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+/** Same, for optional columns: absent or unparseable is null, an explicit 0 stays 0. */
+function nullableNumber(value: unknown): number | null {
+    if (value == null || value === "") return null;
+    const parsed = typeof value === "number" ? value : parseFloat(String(value));
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * The exact set of item fields `saveEstimate` persists (everything `toItemData` writes
+ * except `estimateId`). Exported so a test can assert the projection below stays in step.
+ */
+export const ESTIMATE_ITEM_SAVE_FIELDS = [
+    "id", "name", "description", "type", "quantity", "baseCost", "markupPercent",
+    "unitCost", "total", "order", "parentId", "costCodeId", "costTypeId",
+    "budgetQuantity", "budgetUnit", "budgetRate",
+] as const;
+
+/**
+ * Project a row down to exactly what gets written to the database.
+ *
+ * `saveEstimate`'s `toItemData` is this function, and the editor's change-detection
+ * snapshot runs its rows through it too. That shared projection is the point: the snapshot
+ * used to hand-roll a shorter list that omitted baseCost, markupPercent and the budget*
+ * columns, so an edit touching only those fields produced an identical snapshot and the
+ * save early-returned "no changes" — reporting success without ever writing.
+ *
+ * Fallbacks apply only to absent or unparseable values, never to an explicit 0. A zero
+ * margin is real (derivedMarginPct clamps to 0) and a zero budget is real — and for
+ * budgetQuantity, null does not mean zero, it means "fall back to the sell quantity".
+ *
+ * purchaseOrderId is deliberately absent: PO links live in EstimateItemPurchaseOrder and
+ * are maintained exclusively by syncLegacyPoLink.
+ */
+export function normalizeEstimateItemForSave(item: any, fallbackOrder: number) {
+    return {
+        id: item.id,
+        name: item.name,
+        description: item.description || "",
+        type: item.type,
+        quantity: numberOr(item.quantity, 0),
+        baseCost: item.baseCost != null && item.baseCost !== "" ? numberOr(item.baseCost, 0) : null,
+        markupPercent: numberOr(item.markupPercent, 25),
+        unitCost: numberOr(item.unitCost, 0),
+        total: numberOr(item.total, 0),
+        order: item.order ?? fallbackOrder,
+        parentId: item.parentId || null,
+        costCodeId: item.costCodeId || null,
+        costTypeId: item.costTypeId || null,
+        budgetQuantity: nullableNumber(item.budgetQuantity),
+        budgetUnit: item.budgetUnit || null,
+        budgetRate: nullableNumber(item.budgetRate),
+    };
+}

--- a/tests/estimate-item-payload.test.ts
+++ b/tests/estimate-item-payload.test.ts
@@ -8,6 +8,8 @@ import {
     normalizeSectionTypes,
     rm,
     serializeEstimateItemsForSave,
+    ESTIMATE_ITEM_SAVE_FIELDS,
+    normalizeEstimateItemForSave,
 } from "../src/lib/estimate-item-payload";
 
 type Row = {
@@ -315,4 +317,82 @@ test("an orphaned child (parent row deleted) is still billed as a leaf", () => {
 test("an empty estimate has a zero subtotal", () => {
     assert.deepEqual(computeEstimateItemTotals([]), []);
     assert.equal(computeEstimateSubtotal([]), 0);
+});
+
+
+// --- the persisted-field projection ----------------------------------------------
+// Regression cover for the change-detection drift: the editor's snapshot used to
+// hand-roll a shorter field list than saveEstimate writes, so an edit touching only
+// the omitted fields produced an identical snapshot and the save silently no-opped.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const persistable = {
+    id: "item-1", name: "Cabinets", description: "Uppers", type: "Material",
+    quantity: 2, baseCost: 100, markupPercent: 25, unitCost: 125, total: 250,
+    parentId: null, costCodeId: null, costTypeId: null,
+    budgetQuantity: null, budgetUnit: null, budgetRate: null,
+};
+
+test("the projection emits exactly the fields saveEstimate persists", () => {
+    assert.deepEqual(
+        Object.keys(normalizeEstimateItemForSave(persistable, 0)).sort(),
+        [...ESTIMATE_ITEM_SAVE_FIELDS].sort(),
+    );
+});
+
+test("every budget field is visible to the change check", () => {
+    const before = JSON.stringify(serializeEstimateItemsForSave([persistable]).map((i, n) => normalizeEstimateItemForSave(i, n)));
+    for (const edit of [
+        { budgetQuantity: 3 }, { budgetUnit: "sf" }, { budgetRate: 42 },
+        { baseCost: 90 }, { markupPercent: 40 },
+    ]) {
+        const after = JSON.stringify(serializeEstimateItemsForSave([{ ...persistable, ...edit }]).map((i, n) => normalizeEstimateItemForSave(i, n)));
+        assert.notEqual(after, before, `editing ${Object.keys(edit)[0]} must be visible to the change check`);
+    }
+});
+
+test("an explicit zero survives; only an unset value falls back", () => {
+    // A zero margin is real (derivedMarginPct clamps to 0) and a zero budget is real.
+    // For budgetQuantity, null does not mean zero - it means "use the sell quantity".
+    for (const zero of [0, "0", "0.00"]) {
+        const row = normalizeEstimateItemForSave({ ...persistable, markupPercent: zero, budgetQuantity: zero, budgetRate: zero }, 0);
+        assert.equal(row.markupPercent, 0, `markupPercent ${JSON.stringify(zero)}`);
+        assert.equal(row.budgetQuantity, 0, `budgetQuantity ${JSON.stringify(zero)}`);
+        assert.equal(row.budgetRate, 0, `budgetRate ${JSON.stringify(zero)}`);
+    }
+    for (const unset of [null, undefined, "", "  ", "abc", NaN, Infinity]) {
+        const row = normalizeEstimateItemForSave({ ...persistable, markupPercent: unset, budgetQuantity: unset, budgetRate: unset }, 0);
+        assert.equal(row.markupPercent, 25, `markupPercent ${String(unset)}`);
+        assert.equal(row.budgetQuantity, null, `budgetQuantity ${String(unset)}`);
+        assert.equal(row.budgetRate, null, `budgetRate ${String(unset)}`);
+    }
+});
+
+test("string and numeric spellings of the same value compare equal", () => {
+    assert.equal(
+        JSON.stringify(normalizeEstimateItemForSave({ ...persistable, quantity: "2", unitCost: "125", baseCost: "100" }, 0)),
+        JSON.stringify(normalizeEstimateItemForSave(persistable, 0)),
+    );
+});
+
+test("PO links are not part of the save projection", () => {
+    // They live in EstimateItemPurchaseOrder, maintained solely by syncLegacyPoLink;
+    // writing the legacy scalar from here would fight that.
+    assert.ok(!("purchaseOrderId" in normalizeEstimateItemForSave({ ...persistable, purchaseOrderId: "po-1" }, 0)));
+});
+
+test("saveEstimate and the editor both go through the shared projection", () => {
+    // Guards the drift this module exists to prevent.
+    const root = path.join(__dirname, "..");
+    const actions = readFileSync(path.join(root, "src/lib/actions.ts"), "utf8");
+    assert.match(actions, /normalizeEstimateItemForSave\(item, fallbackOrder\)/);
+    const editor = readFileSync(path.join(root, "src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx"), "utf8");
+    assert.match(editor, /normalizeEstimateItemForSave\(item, index\)/);
+    // and updateItem must stay on the functional setState form
+    const body = editor.slice(editor.indexOf("function updateItem(index: number"));
+    const fn = body.slice(0, body.indexOf("\n    }") + 6);
+    assert.match(fn, /setItems\(prev =>/);
+    assert.doesNotMatch(fn, /\[\.\.\.items\]/);
 });


### PR DESCRIPTION
## The bug

`getEstimateSnapshot` built the save dirty-check mapping by hand, and that mapping omitted five fields `saveEstimate` actually persists: `baseCost`, `markupPercent`, `budgetQuantity`, `budgetUnit`, `budgetRate`.

Those are exactly the fields the BudgetStrip budget/margin inputs write. So a budget-only edit produced an identical snapshot, `handleSave` took its "no changes" early return, showed a success toast, and never wrote. Pre-existing on main.

## The fix

One canonical serializer (`src/lib/estimate-item-payload.ts`) now produces the item shape for **both** the dirty comparison and the save payload, and `toItemData` in `saveEstimate` delegates to it. The two field lists can't drift again. This also removed a third hand-rolled copy of the snapshot in the AI-import auto-save path.

## Three more defects, found across two rounds of Codex review

All pre-existing, all the same user-visible symptom, and the first two would have left the budget workflow broken even with the fix above.

- **`updateItem` clobbering.** It built its new array from the render-closure `items`, so the 2-3 calls BudgetStrip fires per keystroke each overwrote the previous — last write wins. A rate edit persisted only `markupPercent`; a margin edit only `baseCost`. It also hit the PO handlers, where the paired `purchaseOrderId`/`purchaseOrder` calls meant `purchaseOrderId` lost, so a later save wrote `null` and silently undid a completed PO link. Now uses the functional `setItems(prev => …)` form.
- **Stale row indexes across awaits.** Callers that resolve a row position *before* an await — AI description fill, PO link/unlink/create, approve/reject — could land on the wrong row if the list was reordered or a row deleted while the request was in flight. They now update by item id via a new `updateItemById`.
- **Explicit zeros discarded.** `parseFloat(x) || 25` rewrote a zero margin to 25%, and `parseFloat(x) || null` turned a deliberate zero `budgetQuantity`/`budgetRate` into "unset" — and for `budgetQuantity`, `null` means "fall back to the sell quantity", so that silently substituted a different number. Zero is now preserved; the fallback applies only to absent or unparseable values. Reachable today from the BudgetStrip margin input, whose `derivedMarginPct` clamps to 0.

## Deliberate behavior changes

- The save payload is now only the canonical fields, not a full `{...item}` spread. Verified `saveEstimate` reads items solely via `toItemData` plus `item.id` for the delete diff.
- `vendorId` and `approvalStatus` left the dirty check. Neither is persisted by `saveEstimate` (they're written by `updateItemApproval` and the PO actions), so this only removes false-positive dirtiness.
- Snapshot values are now parsed numbers rather than strings. Both sides use the same function, so comparisons stay sound.

## Testing

`npm run test:estimate-item-payload` — 8 tests: field-list match, budget-only edits visible, explicit-zero margin, explicit-zero budget, stable serialization, section rollup, plus source guards on `toItemData` and `updateItem` so neither can regress to a hand-rolled form.

`npm run typecheck` clean, `npm run build:next` passes.

## Not addressed here

Six pre-existing issues the reviews surfaced that are out of scope for this diff, each spun off separately: AI-import auto-save sends a narrower payload than it marks saved (and its `totalAmount` omits the processing fee); section rollups don't handle nesting; `purchaseOrderId` can be stale-overwritten across actors; `markupPercent` is written as a true markup by one path and read as a gross margin by another; the AI takeoff pipeline drops `baseCost`/`markupPercent` entirely so every generated line lands at a flat 25%; and the margin input clamps at 99 for its rate calculation but persists the raw value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
