### PR TITLE
fix(estimates): section roll-up, emptied-section charges, and cent rounding

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint",
     "test:qbo-expense-sync": "tsx --test tests/qbo-expense-sync.test.ts tests/qbo-expense-sync-route.test.ts tests/qbo-expense-sync-ui.test.tsx tests/qbo-purchase-changes.test.ts tests/qbo-expense-guard.test.ts",
     "test:qbo-receipt-push": "tsx --test tests/qbo-receipt-push.test.ts",
+    "test:estimate-item-payload": "tsx --test tests/estimate-item-payload.test.ts",
     "test:e2e": "playwright test",
     "test:mobile-e2e": "node e2e/mobile-app/run-mobile-e2e.mjs",
     "test:qa": "npx playwright test e2e/quality-gate.spec.ts",

--- a/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
@@ -1,7 +1,12 @@
 "use client";
 
-/** Round to 2 decimal places to avoid IEEE 754 penny drift in money calculations */
-const rm = (n: number) => Math.round(n * 100) / 100;
+import {
+    computeEstimateItemTotals,
+    computeEstimateSubtotal,
+    normalizeSectionTypes,
+    rm,
+    serializeEstimateItemsForSave,
+} from "@/lib/estimate-item-payload";
 
 /** Recalculate milestone amounts: percentage-driven get amounts from %, fixed keep theirs, last absorbs residual */
 function recalcMilestoneAmounts(schedules: any[], total: number): any[] {
@@ -381,17 +386,9 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
         const f = { ...fieldsRef.current, ...fieldsOverride };
         const activeTax = taxOptions.find(t => t.name === f.selectedTaxName) || defaultTaxRate;
 
-        const childTotals = new Map<string, number>();
-        for (const item of srcItems) {
-            if (item.parentId) {
-                childTotals.set(item.parentId, (childTotals.get(item.parentId) || 0) + rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0)));
-            }
-        }
+        const srcTotals = computeEstimateItemTotals(srcItems);
         const mappedItems = srcItems.map((item, index) => {
-            const isSection = !item.parentId && srcItems.some((i: any) => i.parentId === item.id);
-            const computedTotal = isSection
-                ? (childTotals.get(item.id) || 0)
-                : rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0));
+            const computedTotal = srcTotals[index].total;
             return {
                 id: item.id || null,
                 parentId: item.parentId || null,
@@ -452,19 +449,18 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
         lastSavedStateRef.current = JSON.stringify(getEstimateSnapshot());
     }, []);
 
-    // Derived: sum of children totals per section header
+    // Derived: rolled-up total per section header, aggregating through nested sections
     const sectionTotals = useMemo(() => {
+        const totals = computeEstimateItemTotals(items);
         const map = new Map<string, number>();
-        for (const item of items) {
-            if (item.parentId) {
-                map.set(item.parentId, (map.get(item.parentId) || 0) + rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0)));
-            }
-        }
+        items.forEach((item, index) => {
+            if (totals[index].isSection && item.id) map.set(item.id, totals[index].total);
+        });
         return map;
     }, [items]);
 
-    // A row is a section header if it has no parentId and at least one child references it
-    const sectionIds = useMemo(() => new Set(items.filter(i => i.parentId).map((i: any) => i.parentId)), [items]);
+    // A row is a section header if it is typed as one or at least one child references it
+    const sectionIds = useMemo(() => new Set(sectionTotals.keys()), [sectionTotals]);
 
     // Auto-expand textarea ref handler
     const autoExpand = useCallback((el: HTMLTextAreaElement | null) => {
@@ -853,12 +849,10 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
             .catch((err) => console.error("[EstimateEditor] Failed to load cost codes:", err));
     }, []);
 
+    // Section flags / rolled-up totals, shared by the subtotal and the margin math below
+    const itemTotals = useMemo(() => computeEstimateItemTotals(items), [items]);
     // Subtotal from leaf items only (sections would double-count)
-    const subtotal = items.reduce((acc, item) => {
-        if (item.parentId) return acc + rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0));
-        if (!items.some((i: any) => i.parentId === item.id)) return acc + rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0));
-        return acc;
-    }, 0);
+    const subtotal = computeEstimateSubtotal(items);
     const activeTax = taxOptions.find(t => t.name === selectedTaxName) || defaultTaxRate;
     const taxRate = taxExempt ? 0 : (activeTax ? activeTax.rate / 100 : 0.088);
     const taxRateDisplay = activeTax ? Number(parseFloat(String(activeTax.rate)).toFixed(4)) : null;
@@ -887,14 +881,13 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
 
     // Internal margin calculations
     // Base cost from leaf items only (sections would double-count)
-    const totalBaseCost = items.reduce((acc, item) => {
+    const totalBaseCost = items.reduce((acc, item, index) => {
+        if (itemTotals[index].isSection) return acc;
         const rate = (item.budgetRate !== null && item.budgetRate !== undefined && item.budgetRate !== "")
             ? parseFloat(item.budgetRate)
             : (parseFloat(item.baseCost) || 0);
         const qty = item.budgetQuantity ?? (parseFloat(item.quantity) || 0);
-        if (item.parentId) return acc + (qty * rate);
-        if (!items.some((i: any) => i.parentId === item.id)) return acc + (qty * rate);
-        return acc;
+        return acc + (qty * rate);
     }, 0);
     const totalMarkup = subtotal - totalBaseCost;
     const profitMargin = subtotal > 0 ? ((totalMarkup / subtotal) * 100) : 0;
@@ -933,19 +926,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
             if (!silent) setIsSaving(true);
             try {
                 // Recompute section header totals from children before saving
-                const childTotals = new Map<string, number>();
-                for (const item of sourceItems) {
-                    if (item.parentId) {
-                        childTotals.set(item.parentId, (childTotals.get(item.parentId) || 0) + rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0)));
-                    }
-                }
-                const mappedItems = sourceItems.map((item, index) => {
-                    const isSection = !item.parentId && sourceItems.some((i: any) => i.parentId === item.id);
-                    const computedTotal = isSection
-                        ? (childTotals.get(item.id) || 0)
-                        : rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0));
-                    return { ...item, order: index, total: computedTotal, ...(isSection ? { unitCost: computedTotal } : {}) };
-                });
+                const mappedItems = serializeEstimateItemsForSave(sourceItems);
                 const mappedSchedules = f.paymentSchedules.map((schedule: any, index: number) => ({
                     ...schedule,
                     order: index
@@ -954,11 +935,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                 // Recompute the sell subtotal/total (and tax) from `sourceItems`/`f` rather than
                 // the render's `total`/`taxRate` consts, which are equally frozen to the stale
                 // render for a caller with a stale closure.
-                const sourceSubtotal = sourceItems.reduce((acc: number, item: any) => {
-                    if (item.parentId) return acc + rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0));
-                    if (!sourceItems.some((i: any) => i.parentId === item.id)) return acc + rm((parseFloat(item.quantity) || 0) * (parseFloat(item.unitCost) || 0));
-                    return acc;
-                }, 0);
+                const sourceSubtotal = computeEstimateSubtotal(sourceItems);
                 const activeTax = taxOptions.find(t => t.name === f.selectedTaxName) || defaultTaxRate;
                 const sourceTaxRate = f.taxExempt ? 0 : (activeTax ? activeTax.rate / 100 : 0.088);
                 const sourceProcessingFee = f.processingFeeMarkup > 0 ? rm(sourceSubtotal * (f.processingFeeMarkup / 100)) : 0;
@@ -984,6 +961,14 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                     taxRateName: f.taxExempt ? null : (activeTax?.name || null),
                     taxRatePercent: f.taxExempt ? null : (activeTax?.rate ?? null),
                 }, mappedItems);
+
+                // Mirror the section tags we just persisted back into local state. Serialization
+                // is non-mutating, so without this a legacy section (detected only via its
+                // children) stays untagged in memory: delete its last child in this same session
+                // and it bills its mirrored unitCost again, and the next save overwrites the tag
+                // that was just written.
+                setItems(prev => normalizeSectionTypes(prev));
+                itemsRef.current = normalizeSectionTypes(itemsRef.current);
 
                 // Update the last saved state ref to the new state
                 lastSavedStateRef.current = currentSnapshotStr;
@@ -1910,10 +1895,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
     }
 
     async function handleAiAssignPhases() {
-        const eligibleItems = items.filter(item => {
-            const isSection = !item.parentId && items.some((i: any) => i.parentId === item.id);
-            return !isSection;
-        });
+        const eligibleItems = items.filter((_item, index) => !itemTotals[index].isSection);
 
         if (eligibleItems.length === 0) {
             toast.info("No items found to assign phases.");
@@ -2577,7 +2559,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                                         <div {...provided.droppableProps} ref={provided.innerRef} className="divide-y divide-slate-100">
                                             {items.map((item, index) => {
                                                 const isSubItem = !!item.parentId;
-                                                const isSection = !item.parentId && sectionIds.has(item.id);
+                                                const isSection = sectionIds.has(item.id);
                                                 // Hide children of collapsed sections
                                                 if (isSubItem && collapsedSections.has(item.parentId)) return null;
                                                 const sectionTotal = isSection ? (sectionTotals.get(item.id) || 0) : 0;

--- a/src/lib/estimate-item-payload.ts
+++ b/src/lib/estimate-item-payload.ts
@@ -1,0 +1,194 @@
+/**
+ * Estimate line-item serialization — the single place that decides which rows are
+ * section headers, what a section's total is, and what gets sent to `saveEstimate`.
+ *
+ * This logic used to be copy-pasted three times inside EstimateEditor (the change-detection
+ * snapshot, the save payload, and the subtotal), which let the three copies drift. Three
+ * defects came out of that shared ancestry:
+ *
+ *  1. Section detection was `!item.parentId && hasChildren`, so only ONE level of nesting
+ *     rolled up: a nested section was treated as a plain billable row and its own children
+ *     were ignored (and double-counted by the subtotal).
+ *  2. Section detection was keyed off "has children", so deleting a section's last child
+ *     turned the row back into a billable line — still carrying the mirrored former child
+ *     total in `unitCost`, so it kept charging the deleted amount.
+ *  3. Child totals were accumulated without a final rounding pass, so 0.10 + 0.20 produced
+ *     0.30000000000000004.
+ *
+ * A row is a section if `type === "Section"` OR it has children. The `type` half is what
+ * fixes (2) — every path that creates a section sets `type: "Section"` (Add Category,
+ * saved assemblies, multi-phase templates, the AI transform), and both the MCP route and
+ * Budget generation in `approveEstimate` already treat `type === "Section"` as
+ * authoritative. The has-children half is kept so legacy rows that predate the type tag
+ * still roll up. A legacy section that has no children and no type tag is indistinguishable
+ * from a line item and is still treated as one — that is not recoverable from the data.
+ */
+
+/** Round to 2 decimal places to avoid IEEE 754 penny drift in money calculations */
+export const rm = (n: number) => Math.round(n * 100) / 100;
+
+/** The subset of an estimate item this module reads. Callers pass their own richer rows through. */
+export type EstimateItemLike = {
+    id?: string | null;
+    parentId?: string | null;
+    type?: string | null;
+    quantity?: unknown;
+    unitCost?: unknown;
+};
+
+export type EstimateItemTotal = {
+    /** True when this row is a section header: its total is rolled up, not billed directly. */
+    isSection: boolean;
+    /** Rolled-up child total for sections, `qty * unitCost` for leaves. Always cent-rounded. */
+    total: number;
+};
+
+function num(value: unknown): number {
+    const parsed = typeof value === "number" ? value : parseFloat(String(value ?? ""));
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/**
+ * Per-row `{ isSection, total }`, index-aligned with `items`.
+ *
+ * Section totals aggregate recursively, so a section nested inside another section
+ * contributes its own rolled-up total to its parent. Cyclic `parentId` data (which should
+ * be impossible, but is not enforced at the DB level) is treated as contributing 0 rather
+ * than recursing forever.
+ */
+export function computeEstimateItemTotals<T extends EstimateItemLike>(items: readonly T[]): EstimateItemTotal[] {
+    const childIndexesByParent = new Map<string, number[]>();
+    const indexById = new Map<string, number>();
+
+    items.forEach((item, index) => {
+        const id = item.id ? String(item.id) : null;
+        // Later duplicates lose; ids are unique in practice, this just keeps lookup total.
+        if (id && !indexById.has(id)) indexById.set(id, index);
+        const parentId = item.parentId ? String(item.parentId) : null;
+        if (!parentId) return;
+        const siblings = childIndexesByParent.get(parentId);
+        if (siblings) siblings.push(index);
+        else childIndexesByParent.set(parentId, [index]);
+    });
+
+    const isSectionAt = (index: number): boolean => {
+        const item = items[index];
+        if (item.type === "Section") return true;
+        const id = item.id ? String(item.id) : null;
+        return !!id && childIndexesByParent.has(id);
+    };
+
+    // Rows whose parent chain loops instead of terminating at a root. Resolved up front so
+    // the outcome does not depend on the order rows happen to appear in: every row in (or
+    // hanging off) a cycle totals 0 and contributes 0, whichever end we start walking from.
+    const ROOTED = 1;
+    const UNROOTED = 2;
+    const rootedness = new Array<number>(items.length).fill(0);
+    for (let start = 0; start < items.length; start++) {
+        if (rootedness[start] !== 0) continue;
+        const path: number[] = [];
+        const onPath = new Set<number>();
+        let cursor: number | undefined = start;
+        let verdict = ROOTED;
+        while (cursor !== undefined) {
+            if (onPath.has(cursor)) { verdict = UNROOTED; break; }
+            if (rootedness[cursor] !== 0) { verdict = rootedness[cursor]; break; }
+            path.push(cursor);
+            onPath.add(cursor);
+            const parentId: string | null = items[cursor].parentId ? String(items[cursor].parentId) : null;
+            cursor = parentId ? indexById.get(parentId) : undefined;
+        }
+        for (const index of path) rootedness[index] = verdict;
+    }
+
+    const resolved = new Array<number | undefined>(items.length);
+
+    const totalAt = (index: number): number => {
+        const cached = resolved[index];
+        if (cached !== undefined) return cached;
+        // Reserve a value before recursing so a cycle can never re-enter this row.
+        resolved[index] = 0;
+        if (rootedness[index] === UNROOTED) return 0;
+
+        const item = items[index];
+        let total: number;
+        if (isSectionAt(index)) {
+            const id = item.id ? String(item.id) : null;
+            const childIndexes = id ? childIndexesByParent.get(id) : undefined;
+            // Round the accumulated sum, not just each product: 0.10 + 0.20 must be 0.30.
+            total = rm((childIndexes ?? []).reduce((sum, childIndex) => sum + totalAt(childIndex), 0));
+        } else {
+            total = rm(num(item.quantity) * num(item.unitCost));
+        }
+
+        resolved[index] = total;
+        return total;
+    };
+
+    return items.map((_item, index) => ({ isSection: isSectionAt(index), total: totalAt(index) }));
+}
+
+/**
+ * Whether a single row is a section header, using the same rule as
+ * `computeEstimateItemTotals`. Exported for consumers that read *stored* totals off a saved
+ * estimate (the PDF) rather than recomputing them, so every reader agrees on which rows are
+ * headers and which are billable.
+ */
+export function isEstimateSectionRow<T extends EstimateItemLike>(item: T, items: readonly T[]): boolean {
+    if (item.type === "Section") return true;
+    return !!item.id && items.some(other => other.parentId && String(other.parentId) === String(item.id));
+}
+
+/**
+ * Tag every detected section with `type: "Section"`, leaving all other rows untouched.
+ *
+ * `serializeEstimateItemsForSave` normalizes the rows it *persists*, but it is deliberately
+ * non-mutating, so the editor's in-memory rows keep whatever type they loaded with. For a
+ * legacy row recognized as a section only because it has children, that gap is a money bug:
+ * delete its last child in the same session and the stale in-memory row looks like a leaf
+ * again, bills its mirrored unitCost, and the next save overwrites the tag that was just
+ * persisted. Editors call this after a successful save so local state matches the database.
+ *
+ * Idempotent, and safe to apply to a `setState` updater's `prev` value.
+ */
+export function normalizeSectionTypes<T extends EstimateItemLike>(items: readonly T[]): T[] {
+    const totals = computeEstimateItemTotals(items);
+    return items.map((item, index) =>
+        totals[index].isSection && item.type !== "Section" ? { ...item, type: "Section" } : item,
+    );
+}
+
+/**
+ * Estimate subtotal: leaf rows only. Section rows are excluded because their total is the
+ * sum of rows already counted here.
+ */
+export function computeEstimateSubtotal<T extends EstimateItemLike>(items: readonly T[]): number {
+    const totals = computeEstimateItemTotals(items);
+    return rm(totals.reduce((sum, entry) => (entry.isSection ? sum : sum + entry.total), 0));
+}
+
+/**
+ * The item payload for `saveEstimate`: every input field preserved, plus the row's list
+ * `order` and its computed `total`. Section rows additionally get `unitCost` mirrored to
+ * their rolled-up total, which is what the PDF and downstream readers display — so a
+ * section that has lost all of its children mirrors to 0 rather than keeping the stale
+ * total of the deleted children.
+ *
+ * Detected sections are also normalized to `type: "Section"`. Without this, a legacy row
+ * recognized as a section only because it has children would silently become a billable
+ * line the moment its last child is deleted — still carrying the mirrored child total.
+ * Persisting the tag makes the row self-healing on its next save, and matches what the
+ * consumers that filter strictly on type already expect (Budget generation in
+ * `approveEstimate`, the MCP route).
+ */
+export function serializeEstimateItemsForSave<T extends EstimateItemLike>(
+    items: readonly T[],
+): (T & { order: number; total: number })[] {
+    const totals = computeEstimateItemTotals(items);
+    return items.map((item, index) => ({
+        ...item,
+        order: index,
+        total: totals[index].total,
+        ...(totals[index].isSection ? { type: "Section", unitCost: totals[index].total } : {}),
+    }));
+}

--- a/src/lib/pdf.ts
+++ b/src/lib/pdf.ts
@@ -6,6 +6,7 @@ import { isOwnSignatureStorageUrl } from './signature-storage';
 import { isSecureRef, downloadDocBytes } from './secure-storage';
 import { coTaxRate, coTaxLabel } from './co-tax';
 import { drawRichHtml, drawWrappedText, measureWrappedLines, type RichTextCtx } from './pdf-richtext';
+import { isEstimateSectionRow, rm } from './estimate-item-payload';
 
 /** pdf-lib only supports PNG/JPG; SignaturePad always emits PNG, so a failed PNG embed
  *  falls through to a JPG attempt (no content-type header is available once bytes come
@@ -413,7 +414,11 @@ export async function generateEstimatePdf(estimateId: string): Promise<Buffer> {
     for (const item of estimate.items) {
         checkNewPage(100);
 
-        const isSection = !item.parentId && estimate.items.some(i => i.parentId === item.id);
+        // Shared with serializeEstimateItemsForSave: a row is a section if it is typed as one
+        // or has children. Keying off children alone rendered an emptied section (and any
+        // nested section) as a billable line with qty/unit-cost columns, even though its
+        // stored total is a rolled-up figure that does not equal qty * unitCost.
+        const isSection = isEstimateSectionRow(item, estimate.items);
         const isSubItem = !!item.parentId;
         const nameX = isSubItem ? cols.name + 16 : cols.name;
         const nameFont = isSection || !isSubItem ? helveticaBold : helvetica;
@@ -476,11 +481,18 @@ export async function generateEstimatePdf(estimateId: string): Promise<Buffer> {
     });
     y -= 20;
 
-    const subtotal = estimate.items.reduce((acc, item) => {
-        if (item.parentId) return acc + toNum(item.total);
-        if (!estimate.items.some(i => i.parentId === item.id)) return acc + toNum(item.total);
-        return acc;
-    }, 0);
+    // Leaf rows only, using the same predicate as the rows above. Keying off `parentId`
+    // added a nested section's rolled-up total on top of the child totals it already
+    // contains, inflating the subtotal (and therefore tax and the grand total).
+    // `rm` on the accumulated sum matches computeEstimateSubtotal: without it the raw float
+    // sum can land a hair under the canonical figure and drag tax, the processing fee and
+    // the grand total a cent below what the editor showed.
+    const subtotal = rm(
+        estimate.items.reduce(
+            (acc, item) => (isEstimateSectionRow(item, estimate.items) ? acc : acc + toNum(item.total)),
+            0,
+        ),
+    );
 
     const taxRatePercent = toNum(estimate.taxRatePercent);
     const taxExempt = !!estimate.taxExempt;

--- a/tests/estimate-item-payload.test.ts
+++ b/tests/estimate-item-payload.test.ts
@@ -1,0 +1,318 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+    computeEstimateItemTotals,
+    computeEstimateSubtotal,
+    isEstimateSectionRow,
+    normalizeSectionTypes,
+    rm,
+    serializeEstimateItemsForSave,
+} from "../src/lib/estimate-item-payload";
+
+type Row = {
+    id: string;
+    parentId?: string | null;
+    type?: string | null;
+    quantity?: unknown;
+    unitCost?: unknown;
+};
+
+const leaf = (id: string, parentId: string | null, quantity: unknown, unitCost: unknown, type = "Material"): Row =>
+    ({ id, parentId, type, quantity, unitCost });
+
+const section = (id: string, parentId: string | null = null, unitCost: unknown = 0): Row =>
+    ({ id, parentId, type: "Section", quantity: 1, unitCost });
+
+// --- baseline: the behaviour that already worked ---------------------------------
+
+test("leaf rows bill quantity * unitCost, rounded to cents", () => {
+    const items = [leaf("a", null, "3", "19.999"), leaf("b", null, 2, 10)];
+    const totals = computeEstimateItemTotals(items);
+
+    assert.deepEqual(totals, [
+        { isSection: false, total: 60 },
+        { isSection: false, total: 20 },
+    ]);
+    assert.equal(computeEstimateSubtotal(items), 80);
+});
+
+test("a section rolls up its children and is excluded from the subtotal", () => {
+    const items = [section("s"), leaf("c1", "s", 2, 100), leaf("c2", "s", 1, 50)];
+
+    assert.deepEqual(computeEstimateItemTotals(items), [
+        { isSection: true, total: 250 },
+        { isSection: false, total: 200 },
+        { isSection: false, total: 50 },
+    ]);
+    // 250 counted once via its children, not twice
+    assert.equal(computeEstimateSubtotal(items), 250);
+});
+
+test("an untyped legacy section is still detected via its children", () => {
+    const items = [leaf("s", null, 1, 999, "Material"), leaf("c", "s", 2, 25)];
+    const totals = computeEstimateItemTotals(items);
+
+    assert.equal(totals[0].isSection, true);
+    assert.equal(totals[0].total, 50, "the stale 999 unitCost must not survive the roll-up");
+    assert.equal(computeEstimateSubtotal(items), 50);
+});
+
+// --- defect 1: nested sections ---------------------------------------------------
+
+test("defect 1: a nested section aggregates its own children into its parent", () => {
+    const items = [
+        section("outer"),
+        section("inner", "outer", 999), // stale mirrored unitCost from a previous save
+        leaf("g1", "inner", 2, 100),
+        leaf("g2", "inner", 1, 50),
+        leaf("direct", "outer", 1, 25),
+    ];
+    const totals = computeEstimateItemTotals(items);
+
+    assert.equal(totals[1].isSection, true, "a section with a parentId is still a section");
+    assert.equal(totals[1].total, 250, "grandchildren aggregate into the nested section");
+    assert.equal(totals[0].total, 275, "the nested section's roll-up flows up to the outer section");
+    // Only the three leaves are billed: 200 + 50 + 25
+    assert.equal(computeEstimateSubtotal(items), 275);
+});
+
+test("defect 1: three levels of nesting still roll up", () => {
+    const items = [
+        section("l1"),
+        section("l2", "l1"),
+        section("l3", "l2"),
+        leaf("deep", "l3", 4, 12.5),
+    ];
+    const totals = computeEstimateItemTotals(items);
+
+    assert.deepEqual(totals.map(t => t.total), [50, 50, 50, 50]);
+    assert.equal(computeEstimateSubtotal(items), 50, "the leaf is billed once, not once per ancestor");
+});
+
+// --- defect 2: a section that lost its last child --------------------------------
+
+test("defect 2: an emptied section stops charging the deleted children's total", () => {
+    // The section previously held $250 of children, so unitCost was mirrored to 250.
+    const items = [section("s", null, 250), leaf("survivor", null, 1, 40)];
+    const totals = computeEstimateItemTotals(items);
+
+    assert.equal(totals[0].isSection, true, "type === 'Section' keeps it a section with no children");
+    assert.equal(totals[0].total, 0);
+    assert.equal(computeEstimateSubtotal(items), 40, "the deleted $250 is not billed");
+});
+
+test("defect 2: serializing an emptied section zeroes its mirrored unitCost", () => {
+    const items = [section("s", null, 250)];
+    const [serialized] = serializeEstimateItemsForSave(items);
+
+    assert.equal(serialized.total, 0);
+    assert.equal(serialized.unitCost, 0, "stale mirror must be cleared, not carried forward");
+});
+
+// --- defect 3: rounding the accumulated sum --------------------------------------
+
+test("defect 3: accumulated child totals are cent-rounded", () => {
+    const items = [section("s"), leaf("c1", "s", 1, 0.1), leaf("c2", "s", 1, 0.2)];
+    const totals = computeEstimateItemTotals(items);
+
+    assert.equal(totals[0].total, 0.3, "0.10 + 0.20 must not be 0.30000000000000004");
+    assert.equal(computeEstimateSubtotal(items), 0.3);
+});
+
+test("defect 3: rounding holds across many children and through nesting", () => {
+    const children = Array.from({ length: 10 }, (_v, i) => leaf(`c${i}`, "inner", 1, 0.1));
+    const items = [section("outer"), section("inner", "outer"), ...children];
+    const totals = computeEstimateItemTotals(items);
+
+    assert.equal(totals[1].total, 1);
+    assert.equal(totals[0].total, 1);
+    assert.equal(computeEstimateSubtotal(items), 1);
+});
+
+// --- serialization contract ------------------------------------------------------
+
+test("serializeEstimateItemsForSave assigns order and preserves unknown fields", () => {
+    const items = [
+        { ...section("s"), name: "Framing", costCodeId: "cc1" },
+        { ...leaf("c", "s", 2, 30), name: "Studs", costCodeId: "cc2" },
+    ];
+    const serialized = serializeEstimateItemsForSave(items);
+
+    assert.deepEqual(serialized.map(i => i.order), [0, 1]);
+    assert.equal(serialized[0].name, "Framing");
+    assert.equal(serialized[0].costCodeId, "cc1");
+    assert.equal(serialized[0].total, 60);
+    assert.equal(serialized[0].unitCost, 60, "section unitCost mirrors the rolled-up total");
+    assert.equal(serialized[1].total, 60);
+    assert.equal(serialized[1].unitCost, 30, "leaf unitCost is left untouched");
+});
+
+test("serializeEstimateItemsForSave does not mutate its input", () => {
+    const items = [section("s", null, 250)];
+    serializeEstimateItemsForSave(items);
+
+    assert.equal(items[0].unitCost, 250);
+});
+
+// --- defensive: bad data ---------------------------------------------------------
+
+test("non-numeric quantities and unit costs degrade to zero", () => {
+    const items = [leaf("a", null, "", ""), leaf("b", null, "abc", "12"), leaf("c", null, null, undefined)];
+
+    assert.deepEqual(computeEstimateItemTotals(items).map(t => t.total), [0, 0, 0]);
+    assert.equal(computeEstimateSubtotal(items), 0);
+});
+
+test("a parentId cycle terminates instead of recursing forever", () => {
+    const items = [
+        { id: "a", parentId: "b", type: "Section", quantity: 1, unitCost: 5 },
+        { id: "b", parentId: "a", type: "Section", quantity: 1, unitCost: 5 },
+    ];
+
+    const totals = computeEstimateItemTotals(items);
+    assert.deepEqual(totals.map(t => t.total), [0, 0]);
+    assert.equal(computeEstimateSubtotal(items), 0);
+});
+
+test("cycle handling does not depend on row order", () => {
+    // A leaf hangs off a two-node cycle. Whichever end of the cycle we walk from, the whole
+    // unrooted component must total 0 — an order-dependent result would mean the same saved
+    // estimate could total differently after a drag-reorder.
+    const build = (order: string[]) => {
+        const byId: Record<string, Row> = {
+            a: { id: "a", parentId: "b", type: "Section", quantity: 1, unitCost: 5 },
+            b: { id: "b", parentId: "a", type: "Section", quantity: 1, unitCost: 5 },
+            leaf: leaf("leaf", "a", 1, 10),
+        };
+        return order.map(id => byId[id]);
+    };
+
+    const forward = computeEstimateItemTotals(build(["a", "b", "leaf"]));
+    const swapped = computeEstimateItemTotals(build(["b", "a", "leaf"]));
+
+    assert.deepEqual(forward.map(t => t.total), [0, 0, 0]);
+    assert.deepEqual(swapped.map(t => t.total), [0, 0, 0]);
+    assert.equal(computeEstimateSubtotal(build(["a", "b", "leaf"])), 0);
+    assert.equal(computeEstimateSubtotal(build(["b", "a", "leaf"])), 0);
+});
+
+// --- legacy rows: the has-children-only transition -------------------------------
+
+test("serializing normalizes a detected legacy section to type 'Section'", () => {
+    const items = [leaf("s", null, 1, 999, "Material"), leaf("c", "s", 2, 25)];
+    const serialized = serializeEstimateItemsForSave(items);
+
+    assert.equal(serialized[0].type, "Section", "the tag must persist so the row survives losing its children");
+    assert.equal(serialized[0].total, 50);
+    assert.equal(serialized[0].unitCost, 50);
+    assert.equal(serialized[1].type, "Material", "leaves keep their own type");
+});
+
+test("a normalized legacy section stops charging once its last child is deleted", () => {
+    // Round 1: legacy row detected via children, normalized and mirrored to 50.
+    const withChild = [leaf("s", null, 1, 999, "Material"), leaf("c", "s", 2, 25)];
+    const saved = serializeEstimateItemsForSave(withChild);
+    assert.equal(computeEstimateSubtotal(withChild), 50);
+
+    // Round 2: the child is deleted. The row reloads carrying the tag round 1 persisted.
+    const afterDelete = [saved[0]];
+    assert.equal(isEstimateSectionRow(afterDelete[0], afterDelete), true);
+    assert.equal(computeEstimateSubtotal(afterDelete), 0, "the deleted child's $50 is not billed");
+    assert.equal(serializeEstimateItemsForSave(afterDelete)[0].unitCost, 0);
+});
+
+// --- the standalone predicate (used by the PDF against stored rows) --------------
+
+test("isEstimateSectionRow agrees with computeEstimateItemTotals", () => {
+    const items = [
+        section("outer"),
+        section("inner", "outer"),
+        leaf("g", "inner", 1, 10),
+        leaf("plain", null, 1, 10),
+        leaf("legacy", null, 1, 0, "Material"),
+        leaf("legacyChild", "legacy", 1, 10),
+        section("emptied", null, 250),
+    ];
+    const totals = computeEstimateItemTotals(items);
+
+    items.forEach((item, index) => {
+        assert.equal(
+            isEstimateSectionRow(item, items),
+            totals[index].isSection,
+            `predicate disagreed for ${item.id}`,
+        );
+    });
+});
+
+test("normalizeSectionTypes keeps a legacy section billable-safe within one session", () => {
+    // Reproduces the same-session sequence without a reload: load legacy rows, save, then
+    // delete the last child. Before normalization the in-memory row fell back to a leaf and
+    // billed its mirrored unitCost again.
+    const loaded = [leaf("s", null, 1, 999, "Material"), leaf("c", "s", 2, 25)];
+
+    // Save mirrors the persisted tags back into editor state.
+    const afterSave = normalizeSectionTypes(loaded);
+    assert.equal(afterSave[0].type, "Section");
+    assert.equal(afterSave[1].type, "Material");
+
+    // The user now deletes the last child; state is NOT reloaded from the server.
+    const afterDelete = afterSave.filter(row => row.id !== "c");
+    assert.equal(computeEstimateSubtotal(afterDelete), 0, "the emptied legacy section must not bill 999");
+    assert.equal(serializeEstimateItemsForSave(afterDelete)[0].unitCost, 0);
+});
+
+test("normalizeSectionTypes is idempotent and leaves non-sections alone", () => {
+    const items = [leaf("s", null, 1, 999, "Material"), leaf("c", "s", 2, 25), leaf("plain", null, 1, 5)];
+    const once = normalizeSectionTypes(items);
+    const twice = normalizeSectionTypes(once);
+
+    assert.deepEqual(twice, once);
+    assert.equal(once[2].type, "Material");
+    assert.equal(once[1], items[1], "untouched rows keep their identity");
+});
+
+test("the PDF's stored-total sum needs the same rounding pass as the subtotal", () => {
+    // 375 leaves of $0.01: the raw float sum lands just under $3.75, which drags tax and the
+    // grand total a cent below what the editor displayed.
+    const items = Array.from({ length: 375 }, (_v, i) => leaf(`c${i}`, null, 1, 0.01));
+    const stored = serializeEstimateItemsForSave(items);
+
+    const rawSum = stored.reduce((acc, item) => acc + item.total, 0);
+    assert.notEqual(rawSum, 3.75, "guard: this case is only interesting while the raw sum drifts");
+
+    assert.equal(rm(rawSum), 3.75);
+    assert.equal(computeEstimateSubtotal(items), 3.75, "editor and PDF must land on the same figure");
+});
+
+test("summing stored totals over non-section rows matches the subtotal (PDF path)", () => {
+    // The PDF sums the persisted `total` column rather than recomputing from qty * unitCost.
+    const items = [
+        section("outer"),
+        section("inner", "outer", 999),
+        leaf("g1", "inner", 2, 100),
+        leaf("g2", "inner", 1, 50),
+        leaf("direct", "outer", 1, 25),
+    ];
+    const stored = serializeEstimateItemsForSave(items);
+
+    const pdfSubtotal = stored.reduce(
+        (acc, item) => (isEstimateSectionRow(item, stored) ? acc : acc + item.total),
+        0,
+    );
+
+    assert.equal(pdfSubtotal, 275);
+    assert.equal(pdfSubtotal, computeEstimateSubtotal(items), "PDF and editor must agree");
+});
+
+test("an orphaned child (parent row deleted) is still billed as a leaf", () => {
+    const items = [leaf("orphan", "gone", 2, 15)];
+
+    assert.deepEqual(computeEstimateItemTotals(items), [{ isSection: false, total: 30 }]);
+    assert.equal(computeEstimateSubtotal(items), 30);
+});
+
+test("an empty estimate has a zero subtotal", () => {
+    assert.deepEqual(computeEstimateItemTotals([]), []);
+    assert.equal(computeEstimateSubtotal([]), 0);
+});


### PR DESCRIPTION
Fixes three money-path defects in estimate line-item serialization, flagged by a Codex peer review.

The logic was copy-pasted **four** times inside `EstimateEditor.tsx` (change-detection snapshot, save payload, the subtotal that feeds `totalAmount`/tax/milestones, and the AI-import auto-save) plus twice more in `pdf.ts`. It is now one shared module, `src/lib/estimate-item-payload.ts`.

### The three defects

1. **Only one level of nesting rolled up.** Section detection was `!parentId && hasChildren`, so a nested section was billed as a plain row using its stale mirrored `unitCost`, and the subtotal counted it *and* its children. Canonical `$275` example rendered as `$525` on the client-facing PDF.
2. **Deleting a section's last child made it billable again**, still carrying the mirrored former child total. Detection is now `type === "Section" || hasChildren`, the `unitCost` mirror writes `0`, and the tag is persisted so legacy rows self-heal.
3. **Child totals were summed without a final cent-rounding pass** — `0.10 + 0.20` produced `0.30000000000000004`.

### Also fixed (found during review)

- `pdf.ts` summed the subtotal with the old predicate and without the rounding pass, so tax, processing fee and grand total could drift from what the editor showed.
- `applyGeneratedEstimate` (AI/ChatGPT import auto-save) was a fourth copy writing straight to the money path.
- Cycle handling in the roll-up is now order-independent.
- Section tags are mirrored back into editor state after save, so a legacy section can't regress within one session.

### Verification

- `npm run test:estimate-item-payload` — 23/23 (new suite, `tsx --test`)
- `npm run typecheck`, `npm run build:next`, `eslint` (0 errors) all pass
- Two Codex review rounds; all blockers from both addressed

Budget generation in `approveEstimate` already filtered on `type !== "Section"` and needed no change.

### Deliberately out of scope (pre-existing, confirmed, filed separately)

- QuickBooks sync sends every section as its own charge line (double-counts in QBO)
- `budget-actions.ts` derives `isSection` from a Prisma field that doesn't exist, so `BudgetClient`'s existing guard is dead; `manager/variance` has no guard at all
- The app-wide `rm` half-cent rounding policy; one-level-deep nested row deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)