### PR TITLE
fix(estimates): rebalance milestones against the post-merge total on AI import

### DIFF
--- a/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
@@ -892,6 +892,22 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
     const totalMarkup = subtotal - totalBaseCost;
     const profitMargin = subtotal > 0 ? ((totalMarkup / subtotal) * 100) : 0;
 
+    /**
+     * Sell-side subtotal/tax/fee/total for an explicit items array + field set, rather than
+     * the render's `total`/`taxRate` consts, which are frozen to whatever render created a
+     * stale caller's closure. Shared so every writer of `totalAmount` — and anything that
+     * needs the new total BEFORE the state updates land, like applyGeneratedEstimate
+     * rebalancing percentage milestones — computes money exactly one way.
+     */
+    function computeSellTotals(sourceItems: any[], f: typeof fieldsRef.current) {
+        const sourceSubtotal = computeEstimateSubtotal(sourceItems);
+        const activeTax = taxOptions.find(t => t.name === f.selectedTaxName) || defaultTaxRate;
+        const sourceTaxRate = f.taxExempt ? 0 : (activeTax ? activeTax.rate / 100 : 0.088);
+        const sourceProcessingFee = f.processingFeeMarkup > 0 ? rm(sourceSubtotal * (f.processingFeeMarkup / 100)) : 0;
+        const sourceTax = rm(sourceSubtotal * sourceTaxRate);
+        return { activeTax, subtotal: sourceSubtotal, total: rm(sourceSubtotal + sourceTax + sourceProcessingFee) };
+    }
+
     async function handleSave(opts: { silent?: boolean; skipRefresh?: boolean; itemsOverride?: any[]; fieldsOverride?: Partial<typeof fieldsRef.current>; skipHistoryCapture?: boolean } = {}) {
         // Chain this save behind whatever is already in flight (see saveQueueRef comment
         // above) so saves always run one at a time, in the order they were requested. The
@@ -932,15 +948,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                     order: index
                 }));
 
-                // Recompute the sell subtotal/total (and tax) from `sourceItems`/`f` rather than
-                // the render's `total`/`taxRate` consts, which are equally frozen to the stale
-                // render for a caller with a stale closure.
-                const sourceSubtotal = computeEstimateSubtotal(sourceItems);
-                const activeTax = taxOptions.find(t => t.name === f.selectedTaxName) || defaultTaxRate;
-                const sourceTaxRate = f.taxExempt ? 0 : (activeTax ? activeTax.rate / 100 : 0.088);
-                const sourceProcessingFee = f.processingFeeMarkup > 0 ? rm(sourceSubtotal * (f.processingFeeMarkup / 100)) : 0;
-                const sourceTax = rm(sourceSubtotal * sourceTaxRate);
-                const sourceTotal = rm(sourceSubtotal + sourceTax + sourceProcessingFee);
+                const { activeTax, total: sourceTotal } = computeSellTotals(sourceItems, f);
 
                 await saveEstimate(initialEstimate.id, context.id, context.type, {
                     title: f.title, code: f.code, status: f.status, totalAmount: sourceTotal, paymentSchedules: mappedSchedules,
@@ -1465,10 +1473,27 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
             toast.error('No line items found to add');
             return;
         }
-        const newItems = [...items, ...data.items];
-        const newSchedules = data.paymentMilestones && data.paymentMilestones.length > 0
-            ? [...paymentSchedules, ...data.paymentMilestones]
-            : paymentSchedules;
+        // Base off the refs, not this function's closure: the AI/import request is async, so
+        // `items`/`paymentSchedules` here belong to whatever render kicked it off and may be
+        // several edits stale by the time the response lands.
+        const baseItems = itemsRef.current;
+        const baseSchedules = fieldsRef.current.paymentSchedules;
+        const newItems = [...baseItems, ...data.items];
+
+        // Rebalance percentage-driven milestones against the post-merge total. The [total]
+        // effect only repairs client state on the next render — it runs after the save below,
+        // so without this the DB keeps amounts split against the pre-merge total until some
+        // later save happens to correct them, and an invoice raised in between bills the
+        // stale split.
+        //
+        // Deliberately NOT applied when the payload brings its own milestones: that appends a
+        // second complete plan to the existing one, and rebalancing two 100% plans against a
+        // single total over-allocates (recalcMilestoneAmounts can only clamp the last
+        // residual). Normalizing or replacing there is a product decision, not a bug fix.
+        const incomingMilestones = data.paymentMilestones && data.paymentMilestones.length > 0;
+        const newSchedules = incomingMilestones
+            ? [...baseSchedules, ...data.paymentMilestones!]
+            : recalcMilestoneAmounts(baseSchedules, computeSellTotals(newItems, fieldsRef.current).total);
 
         // Update UI immediately — don't wait for save. itemsRef is set synchronously (not
         // just via the effect that mirrors `items`) so a save queued right behind this one
@@ -1476,7 +1501,11 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
         // records them correctly.
         itemsRef.current = newItems;
         setItems(newItems);
-        if (data.paymentMilestones && data.paymentMilestones.length > 0) {
+        // Only assigned when the payload brings milestones. On the items-only path the
+        // rebalanced schedules go to the save alone: the [total] effect updates client state
+        // itself, and it does so with a functional updater, so it can't clobber a schedule
+        // edit that has reached state but not yet the ref.
+        if (incomingMilestones) {
             setPaymentSchedules(newSchedules);
         }
         onMerged?.();


### PR DESCRIPTION
## What

One money-path defect in `applyGeneratedEstimate` — the AI-generate / ChatGPT-import auto-save path in `EstimateEditor.tsx`.

An **items-only** import passed the existing payment schedules straight into the save, so percentage-driven milestones were persisted split against the **pre-merge** total. The `[total]` effect only repairs *client* state on the next render — it runs after the save — so the database held stale amounts until some later save happened to correct them. UI and DB disagreed in the meantime, and an invoice raised off those milestones billed the stale split.

`recalcMilestoneAmounts` now runs against the post-merge total and feeds the save. The subtotal/tax/fee/total math `runSave` already does is extracted to `computeSellTotals` so the two callers cannot drift.

The merge also now sources from `itemsRef`/`fieldsRef` rather than the render closure: the AI request is async, so the closure's items and schedules can be several edits stale by the time the response lands.

## Scope — deliberately narrow

The rebalance does **not** apply when the payload brings its own milestones. That path appends a second complete plan to the existing one, and rebalancing two 100% plans against a single total over-allocates (`recalcMilestoneAmounts` can only clamp the last residual). Normalizing or replacing there is a product decision, not a bug fix. Codex caught this on the first pass — the earlier version of this PR would have made that case worse.

Client state is likewise left to the existing `[total]` effect on the items-only path. That effect uses a functional updater, so it cannot clobber a schedule edit that has reached state but not yet the ref; an unconditional value setter here could.

## History

This PR originally carried two more fixes — a narrowed save payload that silently dropped unsaved edits, and a `totalAmount` that omitted the processing fee. Both were fixed independently by #308 while this was in review, which refactored this function to delegate to `handleSave` with overrides. Rebased onto that; only the milestone defect survived.

## Verification

- `npm run typecheck` — clean
- `npm run build:next` — compiled successfully
- Three rounds of `codex-peer-review`; final pass returned no blockers

## Known, not fixed (pre-existing)

- **Field drift across the save queue.** The rebalance happens before `handleSave` queues. If `taxExempt` / tax rate / processing-fee markup changes after that but before the queued `runSave` reads `fieldsRef`, the persisted `totalAmount` uses the newer fields while the milestone split reflects the older total. Narrow (needs an items-only import, affected unpaid milestones, and a total-affecting edit inside the window) and repaired by any later save, but it does need that later save.
- **Two-plan over-allocation.** The `[total]` effect can still recalculate an appended two-plan schedule into an over-allocated state and a later save can persist it. Predates this PR; see the scope note.
- The `[total]` effect compares only `amount`, so it discards `percentage` clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)