### PR TITLE
docs: require a base-freshness check before starting and before shipping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,15 +50,32 @@ Sessions 1–2 + Gantt polish are complete. Each session lists specific files, a
 
 ## Development workflow
 ```
-1. Pick next session from ProbuildTodo.md
-2. Make changes
-3. npm run build          # must pass 0 errors
-4. git push origin main
-5. Schema changed? Run the branch's scripts/apply-*.mjs against prod FIRST (see "Deploying to Vercel")
-6. vercel --prod --token $env:VERCEL_TOKEN   # deploy only when ready
-7. Click through affected pages on prod to verify
-8. Mark items done in ProbuildTodo.md
+1. git fetch origin && git log --oneline HEAD..origin/main   # ALWAYS FIRST — see below
+2. Pick next session from ProbuildTodo.md
+3. Make changes
+4. npm run build          # must pass 0 errors
+5. git push origin main
+6. Schema changed? Run the branch's scripts/apply-*.mjs against prod FIRST (see "Deploying to Vercel")
+7. vercel --prod --token $env:VERCEL_TOKEN   # deploy only when ready
+8. Click through affected pages on prod to verify
+9. Mark items done in ProbuildTodo.md
 ```
+
+### Step 1 is not optional — check your base before you start AND before you ship
+Money-path PRs land on this repo several times a day, often from parallel worktree
+sessions working the same files. A branch cut this morning is a stale base by afternoon.
+
+Run the fetch/compare **twice**: once before writing code, and again before opening the PR.
+If `HEAD..origin/main` is non-empty, read those commits (`git show --stat <sha>`) and ask
+whether they already solved your problem or changed its shape — then rebase before continuing.
+
+Watch for parallel sessions on the same files: `gh pr list --json number,title,headRefName`.
+
+Skipping this has already cost real work. On 2026-08-07 a fix removing `purchaseOrderId`
+from `saveEstimate`'s payload was written, Codex-reviewed, and readied for deploy against a
+base five commits stale — the identical fix had already landed hours earlier in #308, whose
+multi-PO redesign also made the companion change (a hard server-side delete guard) actively
+harmful, since #308 had deliberately chosen confirm-plus-undo for PO-linked deletes.
 
 **Error diagnosis (Sentry)**
 ```bash


### PR DESCRIPTION
## Why

Money-path PRs land on this repo several times a day, frequently from parallel worktree sessions touching the same files. A branch cut in the morning is a stale base by the afternoon, and nothing in the documented workflow says to check.

## What

Adds `git fetch origin && git log --oneline HEAD..origin/main` as step 1 of the Development workflow in CLAUDE.md, with a short section explaining that it runs **twice** — before writing code, and again before opening the PR — plus a pointer to `gh pr list` for spotting parallel sessions on the same files.

Documentation only. No code changes.

## What prompted it

A fix removing `purchaseOrderId` from `saveEstimate`'s full-document save payload (a genuine cross-actor stale write) was written, Codex peer-reviewed, built, and queued for a production deploy — against a base five commits stale.

`origin/main` had meanwhile received #308, "multiple POs per line item + undo for deleted line items", which:

- had **already made the identical fix**, independently, with the same reasoning
- restructured item↔PO to many-to-many via `EstimateItemPurchaseOrder`, leaving the scalar `purchaseOrderId` as a deprecated mirror maintained by `syncLegacyPoLink`
- **deliberately chose confirm-plus-undo** for deleting PO-linked items

That last point made the companion change — a hard server-side throw when deleting a PO-linked item — actively harmful. It would have blocked an intended user action and broken #308's durable undo, which reattaches PO links after the row-recreating save. The stale base also meant the round-1 Codex review raised, as a blocker, an issue that had already been resolved upstream.

The whole branch was discarded. This doc change is all that survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
