### PR TITLE
fix(payments): render payment calendar dates in the day they were picked

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:qbo-expense-sync": "tsx --test tests/qbo-expense-sync.test.ts tests/qbo-expense-sync-route.test.ts tests/qbo-expense-sync-ui.test.tsx tests/qbo-purchase-changes.test.ts tests/qbo-expense-guard.test.ts",
     "test:qbo-receipt-push": "tsx --test tests/qbo-receipt-push.test.ts",
     "test:estimate-item-payload": "tsx --test tests/estimate-item-payload.test.ts",
+    "test:payment-date": "tsx --test tests/payment-date-display.test.ts",
     "test:e2e": "playwright test",
     "test:mobile-e2e": "node e2e/mobile-app/run-mobile-e2e.mjs",
     "test:qa": "npx playwright test e2e/quality-gate.spec.ts",

--- a/src/app/portal/estimates/[id]/PortalEstimateClient.tsx
+++ b/src/app/portal/estimates/[id]/PortalEstimateClient.tsx
@@ -12,6 +12,7 @@ import DocumentLetterhead from "@/components/DocumentLetterhead";
 import { buildLetterheadConfig } from "@/lib/letterhead";
 import { buildPdf } from "@/lib/build-pdf";
 import { getTaxCertStatus } from "@/lib/tax-cert";
+import { formatMoneyDate } from "@/lib/payment-date";
 
 class PaymentSectionErrorBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean }> {
     constructor(props: { children: React.ReactNode }) {
@@ -593,7 +594,7 @@ export default function PortalEstimateClient({ initialEstimate, companySettings 
                                                     )}
                                                 </div>
                                                 {isPaid && p.paymentDate && (
-                                                    <p className="text-xs text-slate-400 mt-0.5">Paid {new Date(p.paymentDate).toLocaleDateString()}</p>
+                                                    <p className="text-xs text-slate-400 mt-0.5">Paid {formatMoneyDate(p.paymentDate, {})}</p>
                                                 )}
                                                 {!isPaid && p.dueDate && (
                                                     <p className="text-xs text-slate-400 mt-0.5">Due {new Date(p.dueDate).toLocaleDateString()}</p>

--- a/src/app/portal/invoices/[id]/PortalInvoiceClient.tsx
+++ b/src/app/portal/invoices/[id]/PortalInvoiceClient.tsx
@@ -6,6 +6,7 @@ import PortalPayButton from "@/components/PortalPayButton";
 import { formatCurrency } from "@/lib/utils";
 import DocumentLetterhead from "@/components/DocumentLetterhead";
 import { buildLetterheadConfig } from "@/lib/letterhead";
+import { formatMoneyDate } from "@/lib/payment-date";
 
 class PaymentSectionErrorBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean }> {
     constructor(props: { children: React.ReactNode }) {
@@ -288,7 +289,7 @@ export default function PortalInvoiceClient({ initialInvoice, companySettings, p
                                                         ? `Due: ${new Date(payment.dueDate).toLocaleDateString()}`
                                                         : 'Due upon receipt'}
                                                     {isPaidItem && payment.paymentDate && (
-                                                        <span className="ml-2">• Paid {new Date(payment.paymentDate).toLocaleDateString()}</span>
+                                                        <span className="ml-2">• Paid {formatMoneyDate(payment.paymentDate, {})}</span>
                                                     )}
                                                 </p>
                                                 {payment.coBilling && (

--- a/src/app/portal/projects/[id]/page.tsx
+++ b/src/app/portal/projects/[id]/page.tsx
@@ -13,6 +13,7 @@ import { resolveSessionClientId } from "@/lib/portal-auth";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 import PortalProjectTracker from "./PortalProjectTracker";
+import { formatMoneyDate } from "@/lib/payment-date";
 import PortalStagePin from "./PortalStagePin";
 import PortalUpdatesFeed from "./PortalUpdatesFeed";
 import {
@@ -425,7 +426,7 @@ export default async function PortalProjectDetail(props: {
                                                         {payment.status === 'Paid' && (
                                                             <span className="inline-flex items-center text-xs text-green-600 bg-green-50 px-1.5 py-0.5 rounded-full border border-green-200">
                                                                 <svg className="w-3 h-3 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
-                                                                Paid{payment.paymentMethod ? ` via ${payment.paymentMethod === 'quickbooks' ? 'QuickBooks' : payment.paymentMethod.toUpperCase()}` : ''}{(payment.paidAt || payment.paymentDate) ? ` · ${new Date(payment.paidAt || payment.paymentDate).toLocaleDateString()}` : ''}
+                                                                Paid{payment.paymentMethod ? ` via ${payment.paymentMethod === 'quickbooks' ? 'QuickBooks' : payment.paymentMethod.toUpperCase()}` : ''}{(payment.paidAt || payment.paymentDate) ? ` · ${formatMoneyDate(payment.paidAt || payment.paymentDate, {})}` : ''}
                                                             </span>
                                                         )}
                                                         {payment.status === 'Processing' && (

--- a/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
@@ -173,6 +173,7 @@ const UndoPaymentModal = dynamic(() => import("@/components/UndoPaymentModal"), 
 
 import { internalBudget, derivedMarginPct } from "@/lib/budget-math";
 import { normalizeItemPoLinks } from "@/lib/estimate-item-po-links";
+import { formatMoneyDate, isDateOnly } from "@/lib/payment-date";
 
 // Prompt the user copies into ChatGPT so its output imports cleanly via "Import from ChatGPT".
 // Mirrors the JSON shape that /api/ai-estimate/import + transformPhasesToItems expect.
@@ -3004,7 +3005,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                                                             Paid
                                                         </span>
                                                         {paidOn && (
-                                                            <span className="text-[10px] text-slate-400">{new Date(paidOn).toLocaleDateString()}</span>
+                                                            <span className="text-[10px] text-slate-400">{formatMoneyDate(paidOn, {})}</span>
                                                         )}
                                                         <button
                                                             onClick={async () => {
@@ -3710,7 +3711,17 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                                                     <div className="min-w-0">
                                                         <p className="text-sm font-medium text-slate-800">{ev.title}</p>
                                                         {ev.detail && <p className="text-xs text-slate-500 truncate" title={ev.detail}>{ev.detail}</p>}
-                                                        <p className="text-xs text-slate-400">{new Date(ev.ts).toLocaleString(undefined, { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' })}</p>
+                                                        <p className="text-xs text-slate-400">
+                                                            {(() => {
+                                                                const evDate = new Date(ev.ts);
+                                                                const dateStr = formatMoneyDate(evDate, { month: 'short', day: 'numeric', year: 'numeric' });
+                                                                // Calendar-day values (e.g. paidAt-less settled payments) carry no real
+                                                                // time-of-day — showing "12:00 AM" would be misleading, so only append
+                                                                // a time for values that are genuine instants.
+                                                                if (isDateOnly(evDate)) return dateStr;
+                                                                return `${dateStr}, ${evDate.toLocaleString(undefined, { hour: 'numeric', minute: '2-digit' })}`;
+                                                            })()}
+                                                        </p>
                                                     </div>
                                                 </div>
                                             );

--- a/src/app/projects/[id]/invoices/[invoiceId]/InvoiceEditor.tsx
+++ b/src/app/projects/[id]/invoices/[invoiceId]/InvoiceEditor.tsx
@@ -12,6 +12,7 @@ import UndoPaymentModal from "@/components/UndoPaymentModal";
 import DocumentComments from "@/components/DocumentComments";
 import { toast } from "sonner";
 import { formatCurrency } from "@/lib/utils";
+import { formatMoneyDate } from "@/lib/payment-date";
 
 const METHOD_LABELS: Record<string, string> = {
     card: "Card",
@@ -892,7 +893,7 @@ export default function InvoiceEditor({ project, initialInvoice }: { project: an
                                             </td>
                                             <td className="px-6 py-4 text-right text-hui-textMuted">
                                                 {payment.paymentDate
-                                                    ? new Date(payment.paymentDate).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+                                                    ? formatMoneyDate(payment.paymentDate, { year: 'numeric', month: 'short', day: 'numeric' })
                                                     : '—'}
                                             </td>
                                             <td className="px-6 py-4 text-right">

--- a/src/app/reports/payments/page.tsx
+++ b/src/app/reports/payments/page.tsx
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { parsePaymentsFilters, queryPaymentsData } from "@/lib/payments-report";
 import { formatLocalDateString } from "@/lib/report-utils";
+import { formatMoneyDate, formatMoneyMonth } from "@/lib/payment-date";
 import PaymentsFiltersForm from "./PaymentsFiltersForm";
 
 export default async function PaymentsReportPage({
@@ -26,7 +27,7 @@ export default async function PaymentsReportPage({
 
     const byMonth: Record<string, typeof rows> = {};
     for (const r of rows) {
-        const key = new Date(r.date).toLocaleString("en-US", { month: "long", year: "numeric" });
+        const key = formatMoneyMonth(new Date(r.date));
         if (!byMonth[key]) byMonth[key] = [];
         byMonth[key].push(r);
     }
@@ -101,7 +102,7 @@ export default async function PaymentsReportPage({
                                         </td>
                                         <td className="px-4 py-3 text-hui-textMuted">{r.clientName}</td>
                                         <td className="px-4 py-3 text-hui-textMuted">
-                                            {new Date(r.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
+                                            {formatMoneyDate(r.date, { month: "short", day: "numeric", year: "numeric" }, "en-US")}
                                         </td>
                                         <td className="px-4 py-3 text-hui-textMuted capitalize">{r.paymentMethod ?? "—"}</td>
                                         <td className="px-4 py-3 text-right font-semibold text-hui-textMain">{fmt(r.amount)}</td>

--- a/src/app/reports/profitability/page.tsx
+++ b/src/app/reports/profitability/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { toNum } from "@/lib/prisma-helpers";
 import { formatCurrency } from "@/lib/utils";
 import OverheadEditor from "./OverheadEditor";
+import { formatMoneyDate } from "@/lib/payment-date";
 
 export const dynamic = "force-dynamic";
 
@@ -111,7 +112,8 @@ export default async function ProfitabilityPage({ searchParams }: { searchParams
                 if (!inPeriod(date, from)) continue;
                 payments.push({
                     name: pay.name, invoiceCode: inv.code, amount: toNum(pay.amount),
-                    date: date ? new Date(date) : null, method: pay.paymentMethod, reference: pay.referenceNumber,
+                    date: date ? new Date(date) : null,
+                    method: pay.paymentMethod, reference: pay.referenceNumber,
                 });
             }
         }
@@ -254,7 +256,7 @@ export default async function ProfitabilityPage({ searchParams }: { searchParams
                                             {r.payments.map((p, i) => (
                                                 <div key={`p${i}`} className="flex justify-between gap-3 bg-green-50/60 border border-green-100 rounded-md px-3 py-1.5">
                                                     <span className="text-slate-600 truncate">
-                                                        <span className="text-green-700 font-semibold">IN</span> · {p.date ? p.date.toLocaleDateString() : "—"} · {p.invoiceCode} · {p.name}
+                                                        <span className="text-green-700 font-semibold">IN</span> · {p.date ? formatMoneyDate(p.date) : "—"} · {p.invoiceCode} · {p.name}
                                                         {p.method ? ` · ${p.method === "quickbooks" ? "QuickBooks" : p.method}` : ""}{p.reference ? ` #${p.reference}` : ""}
                                                     </span>
                                                     <span className="font-semibold text-green-700 shrink-0">+{formatCurrency(p.amount)}</span>

--- a/src/app/reports/sales-tax/page.tsx
+++ b/src/app/reports/sales-tax/page.tsx
@@ -4,6 +4,7 @@ import { getSessionOrDev } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { formatCurrency } from "@/lib/utils";
+import { formatMoneyDate } from "@/lib/payment-date";
 import {
     groupRowsByMonth,
     parseSalesTaxFilters,
@@ -141,7 +142,7 @@ export default async function SalesTaxReportPage({
                                 {rows.map(r => (
                                     <tr key={r.id} className="border-b border-hui-border last:border-0 hover:bg-hui-surface/50">
                                         <td className="px-4 py-3 text-hui-textMuted whitespace-nowrap">
-                                            {r.date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
+                                            {formatMoneyDate(r.date, { month: "short", day: "numeric", year: "numeric" }, "en-US")}
                                         </td>
                                         <td className="px-4 py-3 font-mono text-xs">
                                             <Link href={r.href} className="text-hui-primary hover:underline">

--- a/src/app/reports/stripe-backfill/page.tsx
+++ b/src/app/reports/stripe-backfill/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { formatMoneyDate } from "@/lib/payment-date";
 
 interface BackfillDetail {
     sessionId: string;
@@ -52,7 +53,9 @@ function formatCurrency(n?: number) {
 
 function formatDate(iso?: string) {
     if (!iso) return "—";
-    return new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    // session.created from Stripe is a real instant — formatMoneyDate renders it in the
+    // viewer's local zone (it only forces UTC for stored calendar-day values).
+    return formatMoneyDate(iso, { month: "short", day: "numeric", year: "numeric" }, "en-US");
 }
 
 function formatMethod(m?: string) {

--- a/src/app/reports/transactions/TransactionTabs.tsx
+++ b/src/app/reports/transactions/TransactionTabs.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import Link from "next/link";
+import { formatMoneyDate } from "@/lib/payment-date";
 
 type SerializedRow = {
     id: string;
@@ -98,11 +99,7 @@ export default function TransactionTabs({
                                             className="border-b border-hui-border last:border-0 hover:bg-hui-surface/50"
                                         >
                                             <td className="px-4 py-3 text-hui-textMuted">
-                                                {new Date(row.date).toLocaleDateString("en-US", {
-                                                    month: "short",
-                                                    day: "numeric",
-                                                    year: "numeric",
-                                                })}
+                                                {formatMoneyDate(row.date, { month: "short", day: "numeric", year: "numeric" }, "en-US")}
                                             </td>
                                             <td className="px-4 py-3 text-hui-textMain">
                                                 {row.description}
@@ -212,11 +209,7 @@ export default function TransactionTabs({
                                                 className="border-b border-hui-border last:border-0 hover:bg-hui-surface/50"
                                             >
                                                 <td className="px-4 py-3 text-hui-textMuted">
-                                                    {new Date(row.date).toLocaleDateString("en-US", {
-                                                        month: "short",
-                                                        day: "numeric",
-                                                        year: "numeric",
-                                                    })}
+                                                    {formatMoneyDate(row.date, { month: "short", day: "numeric", year: "numeric" }, "en-US")}
                                                 </td>
                                                 <td className="px-4 py-3 text-hui-textMain">
                                                     {row.description}

--- a/src/app/reports/transactions/TransactionsFiltersForm.tsx
+++ b/src/app/reports/transactions/TransactionsFiltersForm.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import Link from "next/link";
 import type { TransactionsFilters, TransactionType } from "@/lib/transactions-report";
 import { formatLocalDateString } from "@/lib/report-utils";
+import { formatMoneyDate } from "@/lib/payment-date";
 
 type Option = { id: string; name: string };
 
@@ -177,7 +178,7 @@ export default function TransactionsFiltersForm({
                                 {rows.map(row => (
                                     <tr key={row.id} className="border-b border-hui-border last:border-0 hover:bg-hui-surface/50">
                                         <td className="px-4 py-3 text-hui-textMuted">
-                                            {new Date(row.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
+                                            {formatMoneyDate(row.date, { month: "short", day: "numeric", year: "numeric" }, "en-US")}
                                         </td>
                                         <td className="px-4 py-3 text-hui-textMain">{row.description}</td>
                                         <td className="px-4 py-3">
@@ -239,7 +240,7 @@ export default function TransactionsFiltersForm({
                                     {group.rows.map(row => (
                                         <tr key={row.id} className="border-b border-hui-border last:border-0 hover:bg-hui-surface/50">
                                             <td className="px-4 py-3 text-hui-textMuted">
-                                                {new Date(row.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
+                                                {formatMoneyDate(row.date, { month: "short", day: "numeric", year: "numeric" }, "en-US")}
                                             </td>
                                             <td className="px-4 py-3 text-hui-textMain">{row.description}</td>
                                             <td className="px-4 py-3">

--- a/src/components/UndoPaymentModal.tsx
+++ b/src/components/UndoPaymentModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { formatCurrency } from "@/lib/utils";
+import { formatMoneyDate } from "@/lib/payment-date";
 
 interface UndoPaymentModalProps {
     milestoneName: string;
@@ -99,7 +100,7 @@ export default function UndoPaymentModal({
                         {paidDate && (
                             <>
                                 <span className="text-slate-300">|</span>
-                                <span>Paid {new Date(paidDate).toLocaleDateString()}</span>
+                                <span>Paid {formatMoneyDate(paidDate, {})}</span>
                             </>
                         )}
                     </div>

--- a/src/lib/payment-date.ts
+++ b/src/lib/payment-date.ts
@@ -58,3 +58,53 @@ export function isBackdatedPayment(
     }
     return todayDayNumber(now) - paymentDay > BACKDATED_RECEIPT_CUTOFF_DAYS;
 }
+
+const DEFAULT_DAY_OPTS: Intl.DateTimeFormatOptions = { year: "numeric", month: "short", day: "numeric" };
+
+/**
+ * True when the value carries no time-of-day (exactly 00:00:00.000 UTC) — i.e. it is a
+ * stored calendar day, not an instant. Manual payments (parsePaymentDateInput → local
+ * midnight, UTC on Vercel) land here; Stripe/QuickBooks writes, which store real
+ * instants in the same column, do not.
+ */
+export function isDateOnly(d: Date): boolean {
+    return d.getUTCHours() === 0 && d.getUTCMinutes() === 0
+        && d.getUTCSeconds() === 0 && d.getUTCMilliseconds() === 0;
+}
+
+/**
+ * Render a money-record date for display. Calendar-day values (no time-of-day) render
+ * via UTC fields so the picked day survives in any viewer timezone; real instants render
+ * in the viewer's local zone. Display-only — never use for math, filtering, or sorting.
+ */
+export function formatMoneyDate(
+    value: Date | string | null | undefined,
+    opts: Intl.DateTimeFormatOptions = DEFAULT_DAY_OPTS,
+    locale?: string,
+): string {
+    if (!value) return "";
+    const d = typeof value === "string" ? new Date(value) : value;
+    if (isNaN(d.getTime())) return "";
+    return d.toLocaleDateString(locale, isDateOnly(d) ? { ...opts, timeZone: "UTC" } : opts);
+}
+
+/** Same rule, for a month/year grouping label. */
+export function formatMoneyMonth(value: Date, locale = "en-US"): string {
+    const opts: Intl.DateTimeFormatOptions = { month: "long", year: "numeric" };
+    return value.toLocaleString(locale, isDateOnly(value) ? { ...opts, timeZone: "UTC" } : opts);
+}
+
+/** Month bucket key "YYYY-MM" under the same rule — must agree with formatMoneyMonth. */
+export function formatMoneyMonthKey(value: Date): string {
+    const y = isDateOnly(value) ? value.getUTCFullYear() : value.getFullYear();
+    const m = isDateOnly(value) ? value.getUTCMonth() : value.getMonth();
+    return `${y}-${String(m + 1).padStart(2, "0")}`;
+}
+
+/** "YYYY-MM-DD" for CSV export, same rule. */
+export function formatMoneyDateISO(value: Date): string {
+    const y = isDateOnly(value) ? value.getUTCFullYear() : value.getFullYear();
+    const m = isDateOnly(value) ? value.getUTCMonth() : value.getMonth();
+    const d = isDateOnly(value) ? value.getUTCDate() : value.getDate();
+    return `${y}-${String(m + 1).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+}

--- a/src/lib/payment-notifications.ts
+++ b/src/lib/payment-notifications.ts
@@ -1,7 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { sendNotification } from "@/lib/email";
 import { formatCurrency } from "@/lib/utils";
-import { isBackdatedPayment } from "@/lib/payment-date";
+import { isBackdatedPayment, formatMoneyDate } from "@/lib/payment-date";
 
 function isToggleOn(settings: { notificationToggles?: string | null } | null, key: string): boolean {
     if (!settings?.notificationToggles) return true;
@@ -104,7 +104,8 @@ export async function notifyMilestonePaid(paymentScheduleId: string, opts?: { de
         const amount = formatCurrency(s.amount);
         const remaining = formatCurrency(s.invoice.balanceDue);
         const newBalanceNum = Number(s.invoice.balanceDue.toString());
-        const when = (s.paymentDate || s.paidAt || new Date()).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+        const whenOpts: Intl.DateTimeFormatOptions = { year: "numeric", month: "long", day: "numeric" };
+        const when = formatMoneyDate(s.paymentDate || s.paidAt || new Date(), whenOpts, "en-US");
         const link = s.invoice.project
             ? `https://probuild.goldentouchremodeling.com/projects/${s.invoice.project.id}/invoices/${s.invoice.id}`
             : "https://probuild.goldentouchremodeling.com/invoices";

--- a/src/lib/sales-tax-report.ts
+++ b/src/lib/sales-tax-report.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { toNum } from "@/lib/prisma-helpers";
 import { parseLocalDateString, formatLocalDateString } from "./report-utils";
+import { formatMoneyMonth, formatMoneyMonthKey, formatMoneyDateISO } from "./payment-date";
 export { parseLocalDateString, formatLocalDateString } from "./report-utils";
 
 export type SalesTaxBasis = "cash" | "accrual";
@@ -333,8 +334,8 @@ export async function querySalesTaxData(filters: SalesTaxFilters): Promise<{ row
 export function groupRowsByMonth(rows: SalesTaxRow[]) {
     const byMonth = new Map<string, { month: string; key: string; count: number; gross: number; subtotal: number; tax: number }>();
     for (const r of rows) {
-        const key = `${r.date.getFullYear()}-${String(r.date.getMonth() + 1).padStart(2, "0")}`;
-        const label = r.date.toLocaleString("en-US", { month: "long", year: "numeric" });
+        const key = formatMoneyMonthKey(r.date);
+        const label = formatMoneyMonth(r.date);
         const curr = byMonth.get(key) || { month: label, key, count: 0, gross: 0, subtotal: 0, tax: 0 };
         curr.count += 1;
         curr.gross += r.gross;
@@ -367,7 +368,7 @@ export function rowsToCsv(rows: SalesTaxRow[], basis: SalesTaxBasis): string {
 
     const lines = [headers.join(",")];
     for (const r of rows) {
-        const dateStr = formatLocalDateString(r.date);
+        const dateStr = formatMoneyDateISO(r.date);
         if (basis === "cash") {
             lines.push([
                 dateStr,

--- a/tests/payment-date-display.test.ts
+++ b/tests/payment-date-display.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    isDateOnly,
+    formatMoneyDate,
+    formatMoneyMonth,
+    formatMoneyMonthKey,
+    formatMoneyDateISO,
+} from "../src/lib/payment-date";
+
+// These tests only mean something in a west-of-UTC zone — that is where a stored
+// calendar day (UTC midnight) rendered as the PREVIOUS day. Run under TZ=America/Los_Angeles.
+const PT = process.env.TZ === "America/Los_Angeles";
+
+// Real shapes observed in prod:
+//   manual entry (parsePaymentDateInput -> local midnight, UTC on Vercel)
+const MANUAL_JUL_28 = "2026-07-28T00:00:00.000Z";
+//   QuickBooks import (paidAt copied into paymentDate) — noon UTC, a real instant
+const QBO_JUL_20 = "2026-07-20T12:00:00.000Z";
+//   Stripe webhook (new Date()) — 5:30pm PT on Jul 28 is Jul 29 in UTC
+const STRIPE_JUL_28_PT = "2026-07-29T00:30:00.000Z";
+
+test("isDateOnly distinguishes stored calendar days from real instants", () => {
+    assert.equal(isDateOnly(new Date(MANUAL_JUL_28)), true);
+    assert.equal(isDateOnly(new Date(QBO_JUL_20)), false);
+    assert.equal(isDateOnly(new Date(STRIPE_JUL_28_PT)), false);
+});
+
+test("a manually recorded calendar day keeps its picked day (the reported bug)", () => {
+    // Regression: this rendered "Jul 27, 2026" for Pacific viewers.
+    assert.equal(formatMoneyDate(MANUAL_JUL_28), "Jul 28, 2026");
+    assert.equal(formatMoneyDate("2026-07-22T00:00:00.000Z"), "Jul 22, 2026");
+    // Accepts a Date as well as an ISO string.
+    assert.equal(formatMoneyDate(new Date(MANUAL_JUL_28)), "Jul 28, 2026");
+});
+
+test("real instants still render in the viewer's local zone", () => {
+    // QBO noon-UTC lands on the same calendar day either way.
+    assert.equal(formatMoneyDate(QBO_JUL_20), "Jul 20, 2026");
+    if (PT) {
+        // A Stripe payment taken at 5:30pm PT on Jul 28 must NOT show as Jul 29.
+        assert.equal(formatMoneyDate(STRIPE_JUL_28_PT), "Jul 28, 2026");
+    }
+});
+
+test("null, undefined and malformed input render as empty, never 'Invalid Date'", () => {
+    for (const bad of [null, undefined, "", "not-a-date"]) {
+        assert.equal(formatMoneyDate(bad as never), "");
+    }
+    assert.equal(formatMoneyDate(new Date("nope")), "");
+});
+
+test("month bucket key and label always agree", () => {
+    for (const v of [MANUAL_JUL_28, QBO_JUL_20, STRIPE_JUL_28_PT, "2026-08-01T00:00:00.000Z"]) {
+        const d = new Date(v);
+        const [year, month] = formatMoneyMonthKey(d).split("-");
+        const label = formatMoneyMonth(d);
+        assert.ok(
+            label.includes(year),
+            `key ${formatMoneyMonthKey(d)} and label "${label}" disagree on year for ${v}`,
+        );
+        const monthName = new Date(Date.UTC(2026, Number(month) - 1, 15))
+            .toLocaleString("en-US", { month: "long", timeZone: "UTC" });
+        assert.ok(
+            label.startsWith(monthName),
+            `key ${formatMoneyMonthKey(d)} and label "${label}" disagree on month for ${v}`,
+        );
+    }
+});
+
+test("a first-of-month calendar day does not fall into the previous month", () => {
+    // Sales-tax remittance is monthly — an Aug 1 payment must not group into July.
+    const augFirst = new Date("2026-08-01T00:00:00.000Z");
+    assert.equal(formatMoneyMonthKey(augFirst), "2026-08");
+    assert.equal(formatMoneyMonth(augFirst), "August 2026");
+    assert.equal(formatMoneyDateISO(augFirst), "2026-08-01");
+});
+
+test("CSV export writes the picked calendar day", () => {
+    assert.equal(formatMoneyDateISO(new Date(MANUAL_JUL_28)), "2026-07-28");
+    assert.equal(formatMoneyDateISO(new Date("2026-07-22T00:00:00.000Z")), "2026-07-22");
+});


### PR DESCRIPTION
## The bug

`PaymentSchedule.paymentDate` is stored as midnight of the picked day in the **writer's** timezone (UTC on Vercel). Client components rendered it with `toLocaleDateString()`, so Pacific viewers saw the **previous** day. Observed on prod: a payment recorded `07/28/2026` displayed "Jul 27, 2026"; `07/22` showed "Jul 21".

## Why the obvious fix is wrong

The column has two incompatible meanings depending on the writer:

| Writer | Value | Meaning |
|---|---|---|
| Manual entry (`parsePaymentDateInput`) | `new Date(y, mo-1, d)` → exactly `00:00:00.000Z` on Vercel | **calendar day** |
| Stripe webhook (`route.ts:80`) | `new Date()` | **instant** |
| QuickBooks (`quickbooks-payments.ts:320/369`) | `paidAt` (noon UTC) | **instant** |

`paidAt` is always an instant, so field provenance can't discriminate either. A blanket "render `paymentDate` as UTC" would have newly broken evening-Pacific Stripe payments — Codex review caught exactly this in round 1 against an earlier field-flag approach.

## The fix

Decide the render zone from the **value**: a timestamp with no UTC time-of-day carries no time information and is a calendar day (render UTC); anything else is a real instant (render local). Centralised in `src/lib/payment-date.ts` as `isDateOnly`, `formatMoneyDate`, `formatMoneyMonth`, `formatMoneyMonthKey`, `formatMoneyDateISO`, then routed through every payment-date display site.

Covers the invoice + estimate editors, all three client-portal views, the paid-milestone receipt email, and the payments / transactions / sales-tax / profitability / stripe-backfill reports — including sales-tax **month bucketing and CSV export**, where a 1st-of-month payment could land in the wrong remittance period.

**Display-only.** No change to parsing, storage, `paidAt`-first precedence, sort comparators, or Prisma filters.

## Verification

Prod data shows zero ambiguity for the discriminator: 11 manual rows at exact UTC midnight, 11 QBO rows at noon UTC, no instant on the boundary.

In a confirmed `America/Los_Angeles` browser (old code → "Jul 27", new → "Jul 28"):

- **INV-00173** — the reported payment now reads Jul 28, 2026
- **INV-00171** — a calendar-day check (Jul 22) and a QBO instant (Jul 20) render correctly side by side, proving no regression on instants
- **Client portal**, via the Shop test project (INV-00169, `paymentDate` 6/15 vs `paidAt` 6/16) — all three views render 6/15/2026
- **Reports** — sales tax July bucket correct incl. CSV (`2026-07-22`, `2026-07-28`); transactions 201 rows clean; payments report July correct

New: `tests/payment-date-display.test.ts` (`npm run test:payment-date`), 7 tests, green under UTC / PT / ET / Tokyo / Sydney.

Two Codex review rounds. Round 1 found the original field-flag premise wrong and drove this rework.

## Known-open, deliberately not in scope

1. `payments-report.ts` and `transactions-report.ts` use `paidAt ?? paymentDate`, so **back-dated payments are reported on the record date**. Verified live: the Mesplay 7/22 check and Hoppe 7/28 check both show "Aug 7, 2026" and land in the August bucket. `sales-tax-report.ts` uses the opposite precedence and is correct. Flipping this changes what those reports report, so it needs a product call.
2. `isDateOnly` is a heuristic. The durable fix is normalising calendar days at every writer (or a real `DATE` column), which would remove it. Schema change, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)