### PR TITLE
fix(budget): stop counting section headers in Budget and Variance totals

### DIFF
--- a/src/app/manager/variance/page.tsx
+++ b/src/app/manager/variance/page.tsx
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { formatCurrency } from "@/lib/utils";
 import { OPEN_PROJECT_STATUSES } from "@/lib/project-status";
+import { isEstimateSectionRow } from "@/lib/estimate-item-payload";
 
 export const dynamic = 'force-dynamic';
 
@@ -52,6 +53,9 @@ export default async function VarianceReportPage() {
                     
                     for (const estimate of project.estimates) {
                         for (const item of estimate.items) {
+                            // Section headers roll up their children's totals — counting them
+                            // here would double the budget for every sectioned estimate.
+                            if (isEstimateSectionRow(item, estimate.items)) continue;
                             const ccId = item.costCodeId || '__uncategorized';
                             if (!costCodeBudgets[ccId]) {
                                 costCodeBudgets[ccId] = {

--- a/src/lib/budget-actions.ts
+++ b/src/lib/budget-actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/prisma";
+import { isEstimateSectionRow } from "@/lib/estimate-item-payload";
 import { toNum } from "@/lib/prisma-helpers";
 import { canAccessProject, canUseDevAuthFallback, getCurrentUserWithPermissions, hasPermission } from "@/lib/permissions";
 
@@ -67,7 +68,9 @@ export async function getBudgetData(projectId: string) {
             balanceDue: toNum(estimate.balanceDue),
             items: estimate.items.map((item) => ({
                 ...item,
-                isSection: "isSection" in item ? Boolean((item as { isSection?: boolean }).isSection) : false,
+                // EstimateItem has no `isSection` column — derive it with the shared predicate
+                // (type === "Section" OR has children), the same rule the editor and PDF use.
+                isSection: isEstimateSectionRow(item, estimate.items),
                 quantity: toNum(item.quantity),
                 baseCost: item.baseCost === null ? null : toNum(item.baseCost),
                 markupPercent: toNum(item.markupPercent),


### PR DESCRIPTION
## Problem

`getBudgetData` derived the section-header flag as:

```ts
isSection: "isSection" in item ? Boolean((item as { isSection?: boolean }).isSection) : false
```

`model EstimateItem` has **no `isSection` column**, so the `in` check is always false and the flag was always `false`.

Two consequences:

1. `BudgetClient.tsx:272`'s `if (item.isSection) continue;` guard was dead code — every section header was summed into `originalEst` **on top of the children it already rolls up**.
2. `manager/variance/page.tsx` had no section guard at all and summed every estimate item into the cost-code budgets.

## Fix

Both call sites now use `isEstimateSectionRow(item, items)` from `src/lib/estimate-item-payload.ts` — the canonical predicate (`type === "Section"` OR has children) that the editor, subtotal, and PDF already agree on. No schema change; `include` already returns `id`/`parentId`/`type`.

## Verification

Read-only script over production data, replicating `BudgetClient`'s `originalEst` accumulation both ways:

```
Scanned 113 estimates. Sectioned (inflated before the fix): 22

Christensen Remodel — EST-413   before $450,000.00 → after $225,000.00  (subtotal $225,000.00 ✓)
Mesplay Kitchen     — EST-242   before $439,750.00 → after $219,875.00  (subtotal $219,875.00 ✓)
Mueller Remodel     — EST-237   before  $69,350.00 → after  $34,675.00  (subtotal  $34,675.00 ✓)
Berg ADU            — EST-146   before  $58,500.00 → after  $29,250.00  (subtotal  $29,250.00 ✓)
Howard/Salzer       — EST-294   before  $67,700.00 → after  $31,350.00  (subtotal  $31,350.00 ✓)

TOTAL phantom budget removed: $1,558,820.00
```

In **every** affected estimate the corrected figure matches the estimate's stored subtotal exactly. `npm run build` passes with 0 errors.

## Codex peer review

Confirmed both new call sites correct (complete sibling array, no mutation, `include` covers the needed scalars, nested/empty/legacy sections handled). It flagged four **pre-existing** section-unaware summers outside this diff, deliberately left for follow-ups to keep the blast radius small:

- `BudgetClient.tsx:281` sums change-order items with no section guard. Checked against prod: **0 of 11 change orders contain `Section`-typed rows**, so this is latent, not active. `ChangeOrderItem` has no `parentId`, so a proper fix means normalizing selections to leaves in `createChangeOrder`.
- `costing/JobCostingClient.tsx:90` re-sums `quantity * unitCost` per item.
- `lib/quickbooks.ts:779` exports every estimate row as a QB sales line (its query omits `id`/`parentId`).
- `api/ai/historical-pricing/route.ts:116` raw-sums estimate totals.

Pre-existing bug, confirmed by Codex on 2026-08-07, split out of the section roll-up fix (#315).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
