### PR TITLE
fix(quickbooks): stop double-counting estimate section headers in QBO sync

### DIFF
--- a/src/app/api/quickbooks/sync/route.ts
+++ b/src/app/api/quickbooks/sync/route.ts
@@ -43,7 +43,13 @@ export async function POST(req: NextRequest) {
                 select: {
                     id: true, code: true, title: true, status: true,
                     totalAmount: true, balanceDue: true, createdAt: true, projectId: true,
-                    items: { select: { name: true, quantity: true, unitCost: true, total: true, type: true } },
+                    // id/parentId feed the section-header detection in `buildQBEstimateLines`.
+                    // orderBy keeps QB LineNum in the estimate's own row order rather than
+                    // whatever order Postgres happens to return.
+                    items: {
+                        orderBy: [{ order: "asc" }, { id: "asc" }],
+                        select: { id: true, parentId: true, name: true, quantity: true, unitCost: true, total: true, type: true },
+                    },
                     project: { include: { client: true } },
                 },
             });
@@ -61,7 +67,11 @@ export async function POST(req: NextRequest) {
                 code: estimate.code,
                 title: estimate.title,
                 totalAmount: toNum(estimate.totalAmount),
+                // Passed through whole — `syncEstimateToQB` drops section headers itself, so the
+                // hierarchy fields have to survive this mapping.
                 items: estimate.items.map(i => ({
+                    id: i.id,
+                    parentId: i.parentId,
                     name: i.name,
                     quantity: i.quantity,
                     unitCost: toNum(i.unitCost),

--- a/src/lib/quickbooks.ts
+++ b/src/lib/quickbooks.ts
@@ -9,6 +9,7 @@ import {
     getMockQboInvoice,
     mockSendQBPaymentCreate,
 } from "./quickbooks-mock";
+import { isEstimateSectionRow } from "./estimate-item-payload";
 
 export const QB_API_BASE = process.env.QB_SANDBOX === "true"
     ? "https://sandbox-quickbooks.api.intuit.com/v3/company"
@@ -760,6 +761,54 @@ export async function getRecentQBPaymentsList(tokens: QBTokens, sinceDaysAgo: nu
     }));
 }
 
+/** The estimate-item shape `buildQBEstimateLines` needs: billing figures plus enough
+ *  hierarchy (`id`/`parentId`/`type`) to tell section headers from billable leaves. */
+export type QBEstimateItem = {
+    // Required, not optional: a caller that omits the hierarchy silently loses legacy
+    // section detection (a section is only recognizable by its type tag OR its children),
+    // which is exactly the bug this function exists to prevent.
+    id: string;
+    parentId: string | null;
+    name: string;
+    quantity: number;
+    unitCost: number;
+    total: number;
+    type: string;
+};
+
+/**
+ * Billable QB estimate lines, one per LEAF row.
+ *
+ * Section headers are dropped. A section's stored total is a roll-up of its children, so
+ * emitting it as a line bills that amount a second time on top of the child rows it
+ * summarizes — a nested section double-counts twice over (an outer section holding a $250
+ * inner section plus a $25 leaf shipped $800 of lines against a $275 subtotal).
+ *
+ * The filter lives here rather than in the caller so any future caller inherits it; it uses
+ * the same `isEstimateSectionRow` predicate as the editor subtotal and the PDF, so all three
+ * readers agree on which rows are headers.
+ *
+ * The returned amounts sum to the estimate's pre-tax SUBTOTAL, which is not the same as its
+ * stored `totalAmount` (that column also carries tax and any processing-fee markup). QBO
+ * computes its own sales tax on the lines it receives, so pushing a tax line here would
+ * double-charge; the processing-fee gap is a separate open question — see the callers.
+ */
+export function buildQBEstimateLines(items: readonly QBEstimateItem[], itemId: string) {
+    return items
+        .filter(item => !isEstimateSectionRow(item, items))
+        .map((item, i) => ({
+            LineNum: i + 1,
+            Description: item.name,
+            Amount: item.total,
+            DetailType: "SalesItemLineDetail",
+            SalesItemLineDetail: {
+                ItemRef: { value: itemId },
+                Qty: item.quantity,
+                UnitPrice: item.unitCost,
+            },
+        }));
+}
+
 /** Push an estimate to QB. Returns the QB estimate ID. */
 export async function syncEstimateToQB(
     tokens: QBTokens,
@@ -768,25 +817,21 @@ export async function syncEstimateToQB(
         code: string;
         title: string;
         totalAmount: number;
-        items: Array<{ name: string; quantity: number; unitCost: number; total: number; type: string }>;
+        items: QBEstimateItem[];
         customerId: string;
         itemId: string;
         project: { name: string } | null;
     },
     glMappings: Record<string, string> = {}
 ): Promise<{ qbId: string; qbUrl: string }> {
-    // Build QB Estimate payload
-    const lines = estimate.items.map((item, i) => ({
-        LineNum: i + 1,
-        Description: item.name,
-        Amount: item.total,
-        DetailType: "SalesItemLineDetail",
-        SalesItemLineDetail: {
-            ItemRef: { value: estimate.itemId },
-            Qty: item.quantity,
-            UnitPrice: item.unitCost,
-        },
-    }));
+    const lines = buildQBEstimateLines(estimate.items, estimate.itemId);
+
+    // QBO rejects a transaction with no lines (error 2020, "Required param missing"). An
+    // estimate that is empty, or that is nothing but section headers, reaches this point with
+    // everything filtered out — fail with something legible instead of a raw QB API error.
+    if (!lines.length) {
+        throw new Error("QB estimate sync failed: estimate has no billable line items");
+    }
 
     const payload = {
         TxnDate: new Date().toISOString().split("T")[0],

--- a/tests/estimate-item-payload.test.ts
+++ b/tests/estimate-item-payload.test.ts
@@ -9,6 +9,7 @@ import {
     rm,
     serializeEstimateItemsForSave,
 } from "../src/lib/estimate-item-payload";
+import { buildQBEstimateLines } from "../src/lib/quickbooks";
 
 type Row = {
     id: string;
@@ -303,6 +304,81 @@ test("summing stored totals over non-section rows matches the subtotal (PDF path
 
     assert.equal(pdfSubtotal, 275);
     assert.equal(pdfSubtotal, computeEstimateSubtotal(items), "PDF and editor must agree");
+});
+
+// --- QuickBooks estimate sync ----------------------------------------------------
+// These exercise the real `buildQBEstimateLines` used by syncEstimateToQB, not a
+// re-implementation of it — deleting the filter must turn these red.
+
+const qbRows = (items: readonly Row[]) =>
+    serializeEstimateItemsForSave(items).map(item => ({
+        ...item,
+        name: String(item.id),
+        parentId: item.parentId ?? null,
+        quantity: Number(item.quantity ?? 0),
+        unitCost: Number(item.unitCost ?? 0),
+        type: String(item.type ?? ""),
+    }));
+
+test("QB estimate lines exclude section rows and sum to the pre-tax subtotal", () => {
+    const items = [
+        section("outer"),
+        section("inner", "outer", 999),
+        leaf("g1", "inner", 2, 100),
+        leaf("g2", "inner", 1, 50),
+        leaf("direct", "outer", 1, 25),
+    ];
+    const stored = qbRows(items);
+
+    // What the pre-fix payload shipped: every row, including both section levels.
+    assert.equal(stored.reduce((acc, item) => acc + item.total, 0), 800);
+
+    const lines = buildQBEstimateLines(stored, "svc-1");
+
+    assert.deepEqual(lines.map(l => l.Description), ["g1", "g2", "direct"]);
+    assert.equal(
+        rm(lines.reduce((acc, l) => acc + l.Amount, 0)),
+        computeEstimateSubtotal(items),
+        "QB line amounts must sum to the estimate subtotal",
+    );
+    assert.equal(rm(lines.reduce((acc, l) => acc + l.Amount, 0)), 275);
+});
+
+test("QB line numbers stay contiguous after sections are filtered out", () => {
+    const stored = qbRows([
+        section("s"),
+        leaf("a", "s", 1, 10),
+        leaf("b", "s", 1, 20),
+        leaf("c", null, 1, 30),
+    ]);
+
+    assert.deepEqual(buildQBEstimateLines(stored, "svc-1").map(l => l.LineNum), [1, 2, 3]);
+});
+
+test("QB lines keep Qty/UnitPrice from the leaf row", () => {
+    const stored = qbRows([leaf("a", null, 3, 19.999)]);
+    const [line] = buildQBEstimateLines(stored, "svc-1");
+
+    assert.equal(line.Amount, 60);
+    assert.equal(line.SalesItemLineDetail.Qty, 3);
+    assert.equal(line.SalesItemLineDetail.ItemRef.value, "svc-1");
+});
+
+test("an estimate of nothing but sections produces zero QB lines", () => {
+    // syncEstimateToQB turns this into a legible error rather than a QBO 2020.
+    const stored = qbRows([section("outer"), section("inner", "outer")]);
+
+    assert.equal(buildQBEstimateLines(stored, "svc-1").length, 0);
+    assert.equal(buildQBEstimateLines([], "svc-1").length, 0);
+});
+
+test("orphaned and legacy rows still bill as QB lines", () => {
+    // An orphan (parent deleted) is a leaf; an untyped row WITH children is a section.
+    const stored = qbRows([leaf("orphan", "gone", 2, 15), leaf("legacy", null, 1, 999, "Material"), leaf("kid", "legacy", 2, 25)]);
+    const lines = buildQBEstimateLines(stored, "svc-1");
+
+    assert.deepEqual(lines.map(l => l.Description), ["orphan", "kid"]);
+    assert.equal(rm(lines.reduce((acc, l) => acc + l.Amount, 0)), 80);
 });
 
 test("an orphaned child (parent row deleted) is still billed as a leaf", () => {


### PR DESCRIPTION
## The bug

Estimate section headers store a **rolled-up** total (the sum of their children), but the QuickBooks estimate sync mapped *every* item row into the payload, and `syncEstimateToQB` turned each one into a `SalesItemLineDetail` with `Amount: item.total`. Every section was therefore billed to QuickBooks **on top of** the child rows it already summarizes.

A nested section double-counts twice over:

| rows | canonical subtotal | QB lines shipped |
|---|---|---|
| outer section → inner section ($250 of children) + one $25 direct leaf | **$275** | **$800** |

## The fix

Section rows are dropped using the shared `isEstimateSectionRow` predicate from `lib/estimate-item-payload.ts`, so QB lines now agree with the editor subtotal and the PDF on which rows are headers and which are billable.

The filter lives in a new exported `buildQBEstimateLines()` in `lib/quickbooks.ts` rather than in the API route, so the one existing caller and any future one inherit it — and so it is directly testable.

Also in this change:

- **Empty line array now fails legibly.** An estimate that is empty, or that is nothing but section headers, previously would have hit QBO with a zero-line POST and come back as error 2020 (`Required param missing`). `syncEstimateToQB` now throws `"estimate has no billable line items"` before the API call.
- **Deterministic line order.** The route's items query gained `orderBy: [{ order: "asc" }, { id: "asc" }]` so QB `LineNum` follows the estimate's own row order rather than whatever order Postgres returns.

## Known divergence (pre-existing, not made worse)

The resulting line amounts sum to the estimate's **pre-tax subtotal**, not to its stored `totalAmount` — that column is `subtotal + tax + processingFee` (`EstimateEditor.tsx` ~L938).

This is pre-existing and is strictly improved by this PR: QB previously received an inflated double-counted figure, and now receives the true subtotal. Closing the remaining gap is a separate product decision — QBO computes its own sales tax on the lines it receives, so pushing a tax line risks double-charging, and the processing-fee markup needs a call on whether it belongs in the books as a line.

## Verification

- `tsc --noEmit` — **0 errors**, byte-identical to the pre-change baseline.
- `npm run test:estimate-item-payload` — **28/28 pass** (5 new QB cases: section exclusion + subtotal reconciliation, contiguous `LineNum`, Qty/UnitPrice passthrough, all-sections → zero lines, orphan/legacy row handling).
- **Mutation-tested:** neutering the filter to `.filter(() => true)` turns 4 of the new tests red, so they exercise the real `buildQBEstimateLines` rather than re-implementing it.
- **Codex peer review, 2 rounds.** Round 1 returned a blocker (the `totalAmount` reconciliation claim — confirmed and documented above) plus 3 real issues, all addressed. Round 2: no blockers, no real issues.

## Not addressed here

`handleSyncQB` does not `await handleSave()` before reading the database (`EstimateEditor.tsx` ~L820), so clicking Sync immediately after an edit can ship stale prices or hierarchy. Pre-existing and unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)