### PR TITLE
fix(takeoffs): carry AI internal costing into the estimate

### DIFF
--- a/src/app/api/takeoffs/ai-estimate/route.ts
+++ b/src/app/api/takeoffs/ai-estimate/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import Anthropic from "@anthropic-ai/sdk";
+import { isTaxCostCode, numOr, numOrNull } from "@/lib/takeoff-costing";
 
 export async function POST(req: NextRequest) {
     if (!process.env.ANTHROPIC_API_KEY) {
@@ -321,24 +322,42 @@ Sort items by phase code, then by cost type within each phase. Be thorough and p
         const typeMap: Record<string, string> = {};
         for (const ct of costTypes) typeMap[ct.name] = ct.id;
 
-        const estimateItems = aiItems.map((item: any, idx: number) => ({
-            id: `ai_${Date.now()}_${idx}`,
-            name: item.name || "Unnamed Item",
-            description: item.description || "",
-            type: item.costType || "Material",
-            quantity: item.quantity || 1,
-            unit: item.unit || "each",
-            unitCost: item.unitCost || 0,
-            total: item.total || (item.quantity || 1) * (item.unitCost || 0),
-            parentId: null,
-            costCodeId: codeMap[item.costCode] || null,
-            costTypeId: typeMap[item.costType] || null,
-            costCode: item.costCode || "",
-            order: idx,
-            isAllowance: item.isAllowance || false,
-        }));
+        // The prompt asks for baseCost/markupPercent per item — that is the internal costing the
+        // BudgetStrip and margin reporting read, and it used to be dropped here entirely. Carry it
+        // through, but normalize first: the model returns JSON, and a stringy or garbage number
+        // silently poisons the totals below (0 + "250" is the string "0250").
+        //
+        // These rows stay in the AI's own vocabulary — `markupPercent` here is TRUE MARKUP
+        // (sell = cost x (1 + m/100)), which is what the prompt asks for and what the takeoff
+        // preview screen renders. The estimate side stores gross margin under the same field name;
+        // convert-to-estimate does that translation when it writes EstimateItem rows.
+        const estimateItems = aiItems.map((item: any, idx: number) => {
+            const costCode = String(item.costCode || "").trim();
+            // Sales tax is a pass-through: no markup, whatever the model returned.
+            const isTaxItem = isTaxCostCode(costCode);
+            const quantity = numOr(item.quantity, 1);
+            const unitCost = numOr(item.unitCost, 0);
+            return {
+                id: `ai_${Date.now()}_${idx}`,
+                name: item.name || "Unnamed Item",
+                description: item.description || "",
+                type: item.costType || "Material",
+                quantity,
+                unit: item.unit || "each",
+                baseCost: numOrNull(item.baseCost),
+                markupPercent: isTaxItem ? 0 : numOrNull(item.markupPercent),
+                unitCost,
+                total: numOr(item.total, quantity * unitCost),
+                parentId: null,
+                costCodeId: codeMap[costCode] || null,
+                costTypeId: typeMap[item.costType] || null,
+                costCode,
+                order: idx,
+                isAllowance: item.isAllowance || false,
+            };
+        });
 
-        const totalEstimate = estimateItems.reduce((sum: number, i: any) => sum + (i.total || 0), 0);
+        const totalEstimate = estimateItems.reduce((sum: number, i: any) => sum + i.total, 0);
 
         const paymentMilestones = aiMilestones.map((m: any, idx: number) => ({
             id: `pm_${Date.now()}_${idx}`,

--- a/src/app/api/takeoffs/convert-to-estimate/route.ts
+++ b/src/app/api/takeoffs/convert-to-estimate/route.ts
@@ -1,5 +1,36 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { derivedMarginPct } from "@/lib/budget-math";
+import { isTaxCostCode, numOr, numOrNull } from "@/lib/takeoff-costing";
+
+/** The margin stored when a takeoff row carries no usable costing at all. */
+const DEFAULT_MARGIN_PCT = 25;
+
+/**
+ * Translate a takeoff row's costing into the value `EstimateItem.markupPercent` actually holds.
+ *
+ * Despite the column name, the estimate side stores GROSS MARGIN — `sellFromMargin` inverts it as
+ * `sell = cost / (1 - m/100)` (see the note in `lib/budget-math.ts`). The AI takeoff prompt speaks
+ * true MARKUP instead (`sell = cost x (1 + m/100)`), so the model's "25" describes a 20% margin.
+ * Writing it through unconverted would put a number on the line that disagrees with the line's own
+ * cost and price, and every downstream margin read would inherit that.
+ *
+ * Preference order:
+ *  1. Derive from the row's own cost and price — the pair is what the client was quoted, so the
+ *     margin derived from it keeps the row internally consistent no matter what the model claimed.
+ *  2. Convert the stated markup: margin = markup / (100 + markup) x 100.
+ *  3. Fall back to the default margin (also covers legacy rows saved before costing was carried).
+ */
+function marginPercentFor(item: any, baseCost: number | null, unitCost: number): number {
+    if (baseCost != null && baseCost > 0 && unitCost > 0) {
+        return derivedMarginPct(baseCost, unitCost);
+    }
+    const markup = numOrNull(item.markupPercent);
+    if (markup != null && markup > -100) {
+        return (markup / (100 + markup)) * 100;
+    }
+    return DEFAULT_MARGIN_PCT;
+}
 
 // POST /api/takeoffs/convert-to-estimate
 // Converts AI-generated takeoff data into a real Estimate with line items
@@ -56,17 +87,26 @@ export async function POST(req: NextRequest) {
         // Create all estimate line items
         for (let idx = 0; idx < items.length; idx++) {
             const item = items[idx];
+            // Tax is a pass-through: never let the default margin land on a tax line. Takeoffs
+            // generated before the AI mapping carried markupPercent have no value stored at all,
+            // so this guard also repairs those.
+            const isTaxItem = isTaxCostCode(item.costCode);
+
+            const baseCost = numOrNull(item.baseCost);
+            const unitCost = numOr(item.unitCost, 0);
+            const quantity = numOr(item.quantity, 1);
+
             await prisma.estimateItem.create({
                 data: {
                     estimateId: estimate.id,
                     name: item.name || "Unnamed Item",
                     description: item.description || "",
                     type: item.type || item.costType || "Material",
-                    quantity: parseFloat(item.quantity) || 1,
-                    baseCost: item.baseCost != null ? parseFloat(item.baseCost) : null,
-                    markupPercent: item.markupPercent != null ? parseFloat(item.markupPercent) : 25,
-                    unitCost: parseFloat(item.unitCost) || 0,
-                    total: parseFloat(item.total) || 0,
+                    quantity,
+                    baseCost,
+                    markupPercent: isTaxItem ? 0 : marginPercentFor(item, baseCost, unitCost),
+                    unitCost,
+                    total: numOr(item.total, 0),
                     order: idx,
                     parentId: null,
                     costCodeId: item.costCodeId || null,

--- a/src/app/projects/[id]/takeoffs/TakeoffsClient.tsx
+++ b/src/app/projects/[id]/takeoffs/TakeoffsClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useCallback, useEffect } from "react";
 import { formatCurrency } from "@/lib/utils";
+import { isTaxRow, numOr, rmc } from "@/lib/takeoff-costing";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
@@ -32,6 +33,35 @@ interface TakeoffsClientProps {
     contextName: string;
 }
 
+const preTaxTotal = (items: any[]) =>
+    items.filter(i => !isTaxRow(i)).reduce((sum, i) => sum + numOr(i.total, 0), 0);
+
+/**
+ * Re-scale the sales-tax row after a markup change.
+ *
+ * Markup edits deliberately skip the tax row (tax carries no margin), but tax is a percentage of
+ * everything else — so raising the markup raises the tax owed too. Leaving the row alone quietly
+ * under-bills: a $1,000 subtotal marked up to $1,200 still carried the $84 tax computed on $1,000.
+ *
+ * The rate is taken from the row's own share of the pre-tax subtotal it was computed against,
+ * which keeps this correct for any rate without re-parsing it out of the line's name.
+ */
+function withTaxFollowingSubtotal(sourceItems: any[], nextItems: any[]): any[] {
+    const oldPreTax = preTaxTotal(sourceItems);
+    const newPreTax = preTaxTotal(nextItems);
+    if (oldPreTax <= 0 || newPreTax === oldPreTax) return nextItems;
+
+    const factor = newPreTax / oldPreTax;
+    return nextItems.map(item => {
+        if (!isTaxRow(item)) return item;
+        const total = rmc(numOr(item.total, 0) * factor);
+        const quantity = numOr(item.quantity, 1) || 1;
+        const unitCost = rmc(total / quantity);
+        // Tax is a pure pass-through, so its internal cost is the tax itself.
+        return { ...item, total, unitCost, ...(item.baseCost != null ? { baseCost: unitCost } : {}) };
+    });
+}
+
 export default function TakeoffsClient({ contextType, contextId, contextName }: TakeoffsClientProps) {
     const router = useRouter();
     const [takeoffs, setTakeoffs] = useState<Takeoff[]>([]);
@@ -43,6 +73,14 @@ export default function TakeoffsClient({ contextType, contextId, contextName }: 
     const [viewMode, setViewMode] = useState<"internal" | "client">("internal");
     const [globalMarkup, setGlobalMarkup] = useState(25);
     const [adjustedItems, setAdjustedItems] = useState<any[] | null>(null);
+
+    // Markup adjustments belong to the takeoff they were made on. They are persisted on convert,
+    // so carrying them across a takeoff switch would write one takeoff's line items onto another.
+    const selectedTakeoffId = selectedTakeoff?.id ?? null;
+    useEffect(() => {
+        setAdjustedItems(null);
+        setGlobalMarkup(25);
+    }, [selectedTakeoffId]);
 
     // Create modal state
     const [createName, setCreateName] = useState("");
@@ -238,6 +276,10 @@ export default function TakeoffsClient({ contextType, contextId, contextName }: 
                 throw new Error(err.error || "AI estimate failed");
             }
             const result = await res.json();
+            // A regeneration replaces the line items, so adjustments made against the old ones
+            // no longer refer to anything real.
+            setAdjustedItems(null);
+            setGlobalMarkup(25);
             setAiResult(result);
             toast.success(`AI analyzed plans and generated ${result.count} line items!`);
             openTakeoff(selectedTakeoff.id);
@@ -252,6 +294,35 @@ export default function TakeoffsClient({ contextType, contextId, contextName }: 
         if (!selectedTakeoff) return;
         setConverting(true);
         try {
+            // Markup edits (global or per-line) only live in `adjustedItems`, but the convert
+            // endpoint reads the takeoff's stored JSON — so without this the user's adjusted
+            // margins are silently discarded and the original AI pricing is what gets billed.
+            // Persist them first, re-deriving the total and the percentage-based milestones.
+            if (adjustedItems) {
+                const stored = selectedTakeoff.aiEstimateData ? JSON.parse(selectedTakeoff.aiEstimateData) : {};
+                const totalEstimate = rmc(adjustedItems.reduce((sum: number, i: any) => sum + numOr(i.total, 0), 0));
+                // Independently rounded percentages need not add up to the total, so the last
+                // milestone absorbs the remainder — the schedule must bill the whole estimate.
+                const storedMilestones: any[] = stored.paymentMilestones || [];
+                let allocated = 0;
+                const paymentMilestones = storedMilestones.map((m: any, idx: number) => {
+                    const isLast = idx === storedMilestones.length - 1;
+                    const amount = isLast
+                        ? rmc(totalEstimate - allocated)
+                        : rmc((numOr(m.percentage, 0) / 100) * totalEstimate);
+                    allocated = rmc(allocated + amount);
+                    return { ...m, amount: amount.toFixed(2) };
+                });
+                const aiEstimateData = JSON.stringify({ ...stored, items: adjustedItems, paymentMilestones, totalEstimate });
+                const saveRes = await fetch(`/api/takeoffs/${selectedTakeoff.id}`, {
+                    method: "PATCH",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ aiEstimateData }),
+                });
+                if (!saveRes.ok) throw new Error("Could not save your markup adjustments — nothing was converted");
+                setSelectedTakeoff({ ...selectedTakeoff, aiEstimateData });
+            }
+
             const res = await fetch("/api/takeoffs/convert-to-estimate", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
@@ -660,13 +731,13 @@ export default function TakeoffsClient({ contextType, contextId, contextName }: 
                                                                 const newMarkup = parseFloat(e.target.value) || 0;
                                                                 setGlobalMarkup(newMarkup);
                                                                 const items = adjustedItems || parsedAiData.items || [];
-                                                                setAdjustedItems(items.map((item: any) => {
-                                                                    const itemIsTax = /tax/i.test(item.costCode || '') || /tax/i.test(item.name || '');
-                                                                    if (itemIsTax) return item;
+                                                                const repriced = items.map((item: any) => {
+                                                                    if (isTaxRow(item)) return item;
                                                                     const base = item.baseCost || item.unitCost / (1 + (item.markupPercent || 25) / 100);
                                                                     const sell = base * (1 + newMarkup / 100);
-                                                                    return { ...item, markupPercent: newMarkup, unitCost: Math.round(sell * 100) / 100, total: Math.round(sell * item.quantity * 100) / 100 };
-                                                                }));
+                                                                    return { ...item, markupPercent: newMarkup, unitCost: rmc(sell), total: rmc(sell * item.quantity) };
+                                                                });
+                                                                setAdjustedItems(withTaxFollowingSubtotal(items, repriced));
                                                             }}
                                                             className="w-16 text-center text-sm font-bold border border-slate-300 rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-400"
                                                             min={0} max={100} step={1}
@@ -689,8 +760,8 @@ export default function TakeoffsClient({ contextType, contextId, contextName }: 
 
                                         {viewMode === "internal" && (() => {
                                             const items = adjustedItems || parsedAiData.items || [];
-                                            const totalCost = items.filter((i: any) => !/tax/i.test(i.costCode || '') && !/tax/i.test(i.name || '')).reduce((s: number, i: any) => s + ((i.baseCost || i.unitCost / (1 + (i.markupPercent || 25) / 100)) * (i.quantity || 1)), 0);
-                                            const totalSellExTax = items.filter((i: any) => !/tax/i.test(i.costCode || '') && !/tax/i.test(i.name || '')).reduce((s: number, i: any) => s + (i.total || 0), 0);
+                                            const totalCost = items.filter((i: any) => !isTaxRow(i)).reduce((s: number, i: any) => s + ((i.baseCost || i.unitCost / (1 + (i.markupPercent || 25) / 100)) * (i.quantity || 1)), 0);
+                                            const totalSellExTax = items.filter((i: any) => !isTaxRow(i)).reduce((s: number, i: any) => s + (i.total || 0), 0);
                                             const totalSell = items.reduce((s: number, i: any) => s + (i.total || 0), 0);
                                             const totalMarkup = totalSellExTax - totalCost;
                                             const marginPct = totalSellExTax > 0 ? (totalMarkup / totalSellExTax * 100) : 0;
@@ -739,14 +810,14 @@ export default function TakeoffsClient({ contextType, contextId, contextName }: 
                                                     {((adjustedItems || parsedAiData.items || []) as any[])
                                                         .slice()
                                                         .sort((a: any, b: any) => {
-                                                            const aIsTax = /tax/i.test(a.costCode || '') || /tax/i.test(a.name || '');
-                                                            const bIsTax = /tax/i.test(b.costCode || '') || /tax/i.test(b.name || '');
+                                                            const aIsTax = isTaxRow(a);
+                                                            const bIsTax = isTaxRow(b);
                                                             if (aIsTax && !bIsTax) return 1;
                                                             if (!aIsTax && bIsTax) return -1;
                                                             return 0;
                                                         })
                                                         .map((item: any, idx: number) => {
-                                                        const isTax = /tax/i.test(item.costCode || '') || /tax/i.test(item.name || '');
+                                                        const isTax = isTaxRow(item);
                                                         const baseCost = isTax ? item.unitCost : (item.baseCost || item.unitCost / (1 + (item.markupPercent || 25) / 100));
                                                         const mkp = isTax ? 0 : (item.markupPercent ?? 25);
                                                         return (
@@ -784,8 +855,8 @@ export default function TakeoffsClient({ contextType, contextId, contextName }: 
                                                                                     const newItems = [...sourceItems];
                                                                                     const base = newItems[origIdx].baseCost || newItems[origIdx].unitCost / (1 + (newItems[origIdx].markupPercent || 25) / 100);
                                                                                     const sell = base * (1 + newMkp / 100);
-                                                                                    newItems[origIdx] = { ...newItems[origIdx], markupPercent: newMkp, unitCost: Math.round(sell * 100) / 100, total: Math.round(sell * newItems[origIdx].quantity * 100) / 100 };
-                                                                                    setAdjustedItems(newItems);
+                                                                                    newItems[origIdx] = { ...newItems[origIdx], markupPercent: newMkp, unitCost: rmc(sell), total: rmc(sell * newItems[origIdx].quantity) };
+                                                                                    setAdjustedItems(withTaxFollowingSubtotal(sourceItems, newItems));
                                                                                 }}
                                                                                 className="w-14 text-center text-sm font-bold text-blue-700 border border-blue-300 rounded-md px-1 py-1 bg-white focus:outline-none focus:ring-2 focus:ring-blue-400"
                                                                                 min={0} max={100} step={1}

--- a/src/lib/takeoff-costing.ts
+++ b/src/lib/takeoff-costing.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared rules for the AI takeoff → estimate costing pipeline.
+ *
+ * The takeoff screen, the AI mapping route, and the convert-to-estimate route all have to agree
+ * on which rows are sales tax: tax is a pass-through, so it carries no margin and must not move
+ * when someone adjusts markup. They previously each decided this on their own — the UI matched
+ * `/tax/i` against the code *or* the name while the server matched the cost code — so a line
+ * merely named "…tax…" was excluded from markup in the UI and then marked up by the server.
+ */
+
+/** The reserved phase code the AI prompt assigns to the WA sales tax line. */
+const TAX_COST_CODE = "99-TAX";
+
+/**
+ * Whether a cost code marks a sales-tax pass-through row.
+ *
+ * Matches the reserved code exactly, plus any `99-TAX-…` sub-code, so an unrelated code that
+ * merely begins with those characters (`99-TAXABLE`) is not swept in.
+ */
+export function isTaxCostCode(costCode: unknown): boolean {
+    const code = String(costCode ?? "").trim().toUpperCase();
+    return code === TAX_COST_CODE || code.startsWith(`${TAX_COST_CODE}-`);
+}
+
+/** Whether a takeoff/estimate row is the sales-tax pass-through line. */
+export function isTaxRow(row: { costCode?: unknown }): boolean {
+    return isTaxCostCode(row?.costCode);
+}
+
+/**
+ * Parse a value that arrived as JSON (or as a form string) into a finite number, or null.
+ * Guards the money path against `parseFloat("12junk") === 12` and against stringy numbers
+ * silently turning a `+` sum into string concatenation.
+ */
+export function numOrNull(value: unknown): number | null {
+    if (value === null || value === undefined || value === "") return null;
+    const parsed = typeof value === "number" ? value : Number(String(value).trim());
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+/** `numOrNull` with a fallback for values that must end up numeric. */
+export function numOr(value: unknown, fallback: number): number {
+    return numOrNull(value) ?? fallback;
+}
+
+/** Round to cents. */
+export const rmc = (n: number) => Math.round(n * 100) / 100;


### PR DESCRIPTION
## The bug

The AI takeoff prompt explicitly asks the model for `baseCost` and `markupPercent` per line item, and states that TAX lines must have `markupPercent` 0 (tax is a pass-through). The mapping in `ai-estimate/route.ts` never carried either field into the object it persisted to `takeoff.aiEstimateData`, so `convert-to-estimate` fell through to its default.

Every AI-generated estimate line landed with `baseCost` null and a flat 25% margin, tax lines included. The internal budget the AI computed was thrown away: the BudgetStrip showed "—" and margin reporting was wrong from the first save.

## The fix

**Carry the costing through the mapping**, and translate it at the estimate boundary.

`EstimateItem.markupPercent` semantically holds **gross margin** — `sellFromMargin` inverts it as `cost / (1 - m/100)`, documented in `lib/budget-math.ts`. The AI prompt speaks **true markup** (`cost x (1 + m/100)`), so the model's "25" describes a 20% margin. Writing it through unconverted would put a number on the line that disagrees with the line's own cost and price. `marginPercentFor` derives the margin from the row's own cost/price pair, so each line stays internally consistent; tax rows are pinned to 0 in both routes, which also repairs takeoffs stored before this change.

## Two adjacent losses on the same path (found in review)

- **Markup edits never reached conversion.** Global and per-line markup edits lived only in `adjustedItems`; Convert posts just the `takeoffId` and the server re-reads stored JSON, so the user's adjusted margins were silently discarded and the original AI pricing was billed. They are now persisted before conversion, with the total and percentage-based milestones re-derived (last milestone absorbs the rounding remainder so the schedule bills the whole estimate). Adjustments are cleared when the selected takeoff changes or the estimate is regenerated, so one takeoff's line items can never be written onto another.
- **Markup edits under-billed sales tax.** Edits correctly skip the tax row, but tax is a percentage of everything else — a $1,000 subtotal marked up to $1,200 kept the $84 tax computed on $1,000. The row now tracks the pre-tax subtotal at its own effective rate.

Tax detection was `/tax/i` against code-or-name in the UI but a cost-code match on the server, so a line merely *named* "…tax…" was excluded from markup in the UI and then marked up by the server. Both now use one shared rule (`src/lib/takeoff-costing.ts`: exact `99-TAX` plus `99-TAX-*`), along with shared numeric parsing that keeps stringy JSON out of the totals.

## Verification

`npm run build` clean. Verified end to end against three live AI generations on the sanctioned "Shop" test project (all test data removed afterward), reading the persisted `EstimateItem` rows directly:

- Non-tax lines store their AI `baseCost` at margin 20.00 (AI markup 25), and `sellFromMargin(baseCost, margin)` reproduces the stored `unitCost` exactly on every row.
- The tax line stores margin 0.00.
- Driving the real UI: Global Markup 40 persists as a **28.57% margin** (40/140) and rescales the tax line 789.00 → 883.68, holding its original 8.35% rate; milestone amounts sum to the estimate total to the cent.
- The Costing & Expenses view now shows a real per-line internal budget and buffer instead of "—".

## Review

Two rounds of Codex peer review. Round 1 caught the markup-vs-margin semantic mismatch (fixed), NaN hardening and numeric normalization (fixed), and the dropped markup edits (fixed). Round 2 caught the stale-adjustments-across-takeoffs write, the un-scaled tax row, the tax-detection inconsistency, and milestone rounding (all fixed).

**Deliberately not done:** wrapping the estimate + item creation in a transaction. It is pre-existing (a failed item write can leave a partial estimate) and a larger refactor than this fix warrants — the numeric hardening removes the realistic trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)