### PR TITLE
fix(estimates): margin input clamped inconsistently from the cost it derived

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
         run: npx prettier --check . --ignore-unknown
         continue-on-error: true
 
+      # Hermetic pure-logic suites — no DB, no network, so they belong in this job rather
+      # than the Postgres one. CI ran neither of these before: tests/ was never wired up at
+      # all, so the estimate money-math coverage added with PR #315 was gating nothing.
+      - name: Unit tests
+        run: npm run test:unit
+
       - name: Build
         run: npm run build 2>&1 | tee /tmp/build-output.txt
         env:

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "test:qbo-receipt-push": "tsx --test tests/qbo-receipt-push.test.ts",
     "test:estimate-item-payload": "tsx --test tests/estimate-item-payload.test.ts",
     "test:payment-date": "tsx --test tests/payment-date-display.test.ts",
+    "test:budget-math": "tsx --test tests/budget-math.test.ts",
+    "test:unit": "tsx --test tests/estimate-item-payload.test.ts tests/budget-math.test.ts tests/payment-date-display.test.ts",
     "test:e2e": "playwright test",
     "test:mobile-e2e": "node e2e/mobile-app/run-mobile-e2e.mjs",
     "test:qa": "npx playwright test e2e/quality-gate.spec.ts",

--- a/src/app/projects/[id]/estimates/[estimateId]/BudgetStrip.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/BudgetStrip.tsx
@@ -147,8 +147,8 @@ export default function BudgetStrip({
                             const { stored, derivedFrom } = normalizeMarginInput(e.target.value);
                             const price = parseFloat(item.unitCost) || 0;
                             updateItem(index, "markupPercent", stored);
-                            if (derivedFrom !== null && price > 0) {
-                                const rateStr = formatDerivedRate(costFromMargin(price, derivedFrom));
+                            if (price > 0) {
+                                const rateStr = formatDerivedRate(costFromMargin(price, derivedFrom), price);
                                 updateItem(index, "budgetRate", rateStr);
                                 updateItem(index, "baseCost", rateStr);
                             }

--- a/src/app/projects/[id]/estimates/[estimateId]/BudgetStrip.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/BudgetStrip.tsx
@@ -2,15 +2,12 @@
 
 import { useState } from "react";
 import { formatCurrency } from "@/lib/utils";
-import { internalBudget, bufferPercent, bufferColor, bufferBgColor, costFromMargin, derivedMarginPct } from "@/lib/budget-math";
+import {
+    internalBudget, bufferPercent, bufferColor, bufferBgColor, costFromMargin, derivedMarginPct,
+    normalizeMarginInput, formatDerivedRate, DEFAULT_MARGIN_PCT, MAX_MARGIN_PCT,
+} from "@/lib/budget-math";
 
 const UNIT_SUGGESTIONS = ["hrs", "sqft", "lf", "ea", "lump sum", "units", "days"];
-
-/** Returns a numeric margin %, defaulting to 25 when the value is empty/NaN. Capped at 99 to prevent costFromMargin returning 0. */
-function effectiveMargin(raw: string | number | null | undefined): number {
-    const n = parseFloat(String(raw ?? ""));
-    return Number.isFinite(n) ? Math.min(n, 99) : 25;
-}
 
 interface BudgetStripProps {
     item: any;
@@ -139,16 +136,19 @@ export default function BudgetStrip({
                 <div className="relative">
                     <input
                         type="number"
-                        value={item.markupPercent ?? 25}
+                        value={item.markupPercent ?? DEFAULT_MARGIN_PCT}
+                        min={0}
+                        max={MAX_MARGIN_PCT}
                         onChange={e => {
                             // Margin edit: recompute budgetRate from the preserved sell price.
                             // unitCost is never written — customer pricing stays locked.
-                            const m = effectiveMargin(e.target.value);
+                            // `stored` and `derivedFrom` come out of one normalization so the margin
+                            // we persist is always the margin the rate was derived from.
+                            const { stored, derivedFrom } = normalizeMarginInput(e.target.value);
                             const price = parseFloat(item.unitCost) || 0;
-                            updateItem(index, "markupPercent", e.target.value === "" ? null : e.target.value);
-                            if (price > 0) {
-                                const newRate = costFromMargin(price, m);
-                                const rateStr = newRate.toFixed(2);
+                            updateItem(index, "markupPercent", stored);
+                            if (derivedFrom !== null && price > 0) {
+                                const rateStr = formatDerivedRate(costFromMargin(price, derivedFrom));
                                 updateItem(index, "budgetRate", rateStr);
                                 updateItem(index, "baseCost", rateStr);
                             }

--- a/src/lib/budget-math.ts
+++ b/src/lib/budget-math.ts
@@ -44,6 +44,72 @@ export function bufferPercent(item: {
 }
 
 /**
+ * The margin range the cost/sell conversions can actually represent.
+ * At 100 both costFromMargin and sellFromMargin collapse to 0, and below 0 the reverse
+ * derivation (derivedMarginPct) floors at 0 — so a stored value outside this range can
+ * never round-trip, and the stored margin stops describing the stored cost.
+ */
+export const MIN_MARGIN_PCT = 0;
+export const MAX_MARGIN_PCT = 99;
+
+/** Clamp a margin % into the representable range. The single clamp every margin input shares. */
+export function clampMarginPct(pct: number): number {
+  // NaN first — it compares false against everything, so it must not fall through to `return pct`.
+  // ±Infinity deliberately clamps by comparison (an overflowing entry lands on the nearer bound).
+  if (Number.isNaN(pct)) return MIN_MARGIN_PCT;
+  if (pct < MIN_MARGIN_PCT) return MIN_MARGIN_PCT;
+  if (pct > MAX_MARGIN_PCT) return MAX_MARGIN_PCT;
+  return pct;
+}
+
+/** What a margin input shows when markupPercent is unset. Any rate derived while the field is
+ *  empty must use this same number, or the visible margin stops matching the stored cost. */
+export const DEFAULT_MARGIN_PCT = 25;
+
+export type NormalizedMarginInput = {
+  /** Value to persist to `markupPercent`; null clears the field. */
+  stored: string | null;
+  /** Margin the budget rate must be derived from, or null when no rate should be derived. */
+  derivedFrom: number | null;
+};
+
+/**
+ * Normalize a raw margin-input keystroke into the pair that must be written together.
+ *
+ * The invariant: `stored` and `derivedFrom` always describe the SAME margin. Clamping the
+ * value that feeds the rate while persisting the raw input is what let `markupPercent = 100`
+ * sit next to a cost derived from 99% — and since costFromMargin/sellFromMargin both return 0
+ * at >= 100, a stored 100 also collapsed downstream sell/cost math to zero.
+ */
+export function normalizeMarginInput(raw: string): NormalizedMarginInput {
+  // Empty clears the stored value, but the input then displays the default — so a rate derived
+  // now must come from that default for the two to keep agreeing.
+  if (raw === "") return { stored: null, derivedFrom: DEFAULT_MARGIN_PCT };
+
+  const parsed = parseFloat(raw);
+  // A fragment mid-typing ("-", ".") is not a margin yet: keep the keystroke, derive nothing.
+  // Substituting a default here would pin the cost to a margin the user never entered.
+  // Only NaN qualifies — an entry that overflows to Infinity ("1e309") is a real number and
+  // must clamp like any other out-of-range value rather than being stored as typed.
+  if (Number.isNaN(parsed)) return { stored: raw, derivedFrom: null };
+
+  const clamped = clampMarginPct(parsed);
+  // Preserve the raw text when it is already in range, so "25." and "25.0" survive typing.
+  // Safe because it re-parses to `clamped`, which is what keeps stored and derived in agreement.
+  return { stored: clamped === parsed ? raw : String(clamped), derivedFrom: clamped };
+}
+
+/**
+ * Format a derived per-unit rate for storage. Two decimals for money, except where that would
+ * round a real cost down to "0.00" — a zero rate reads as "no budget" (internalBudget returns
+ * null, saveEstimate persists null), which would contradict the margin stored beside it.
+ */
+export function formatDerivedRate(rate: number): string {
+  if (!Number.isFinite(rate) || rate <= 0) return "0.00";
+  return rate >= 0.005 ? rate.toFixed(2) : rate.toPrecision(2);
+}
+
+/**
  * Calculate sell price from cost and target margin percentage.
  * Formula: sell = cost / (1 - margin/100).
  * Returns 0 if margin >= 100 (would be infinite).
@@ -77,10 +143,7 @@ export function costFromMargin(sell: number, marginPct: number): number {
  */
 export function derivedMarginPct(rate: number, price: number): number {
   if (!Number.isFinite(rate) || !Number.isFinite(price) || price <= 0) return 0;
-  const m = (1 - rate / price) * 100;
-  if (m < 0) return 0;
-  if (m > 99) return 99;
-  return m;
+  return clampMarginPct((1 - rate / price) * 100);
 }
 
 /**

--- a/src/lib/budget-math.ts
+++ b/src/lib/budget-math.ts
@@ -69,8 +69,8 @@ export const DEFAULT_MARGIN_PCT = 25;
 export type NormalizedMarginInput = {
   /** Value to persist to `markupPercent`; null clears the field. */
   stored: string | null;
-  /** Margin the budget rate must be derived from, or null when no rate should be derived. */
-  derivedFrom: number | null;
+  /** The margin the budget rate must be derived from. */
+  derivedFrom: number;
 };
 
 /**
@@ -82,16 +82,16 @@ export type NormalizedMarginInput = {
  * at >= 100, a stored 100 also collapsed downstream sell/cost math to zero.
  */
 export function normalizeMarginInput(raw: string): NormalizedMarginInput {
-  // Empty clears the stored value, but the input then displays the default — so a rate derived
-  // now must come from that default for the two to keep agreeing.
-  if (raw === "") return { stored: null, derivedFrom: DEFAULT_MARGIN_PCT };
-
   const parsed = parseFloat(raw);
-  // A fragment mid-typing ("-", ".") is not a margin yet: keep the keystroke, derive nothing.
-  // Substituting a default here would pin the cost to a margin the user never entered.
-  // Only NaN qualifies — an entry that overflows to Infinity ("1e309") is a real number and
-  // must clamp like any other out-of-range value rather than being stored as typed.
-  if (Number.isNaN(parsed)) return { stored: raw, derivedFrom: null };
+
+  // Empty, or a fragment that is not a number yet ("-", "."), clears the stored value. The
+  // input then displays the default, so the rate has to be derived from that same default to
+  // keep the two agreeing. Storing the fragment instead would be worse than useless:
+  // saveEstimate turns an unparseable markupPercent into the default anyway, so it would
+  // persist a margin that contradicts the cost sitting next to it.
+  // Only NaN counts as a fragment — an entry that overflows to Infinity ("1e309") is a real
+  // number and clamps like any other out-of-range value.
+  if (raw === "" || Number.isNaN(parsed)) return { stored: null, derivedFrom: DEFAULT_MARGIN_PCT };
 
   const clamped = clampMarginPct(parsed);
   // Preserve the raw text when it is already in range, so "25." and "25.0" survive typing.
@@ -100,13 +100,21 @@ export function normalizeMarginInput(raw: string): NormalizedMarginInput {
 }
 
 /**
- * Format a derived per-unit rate for storage. Two decimals for money, except where that would
- * round a real cost down to "0.00" — a zero rate reads as "no budget" (internalBudget returns
- * null, saveEstimate persists null), which would contradict the margin stored beside it.
+ * Format a derived per-unit rate for storage, at enough precision that the margin implied by
+ * the stored rate still matches the margin stored beside it.
+ *
+ * Cents are plenty for ordinary unit prices, but rounding to cents is not scale-free: a half
+ * cent is a rounding error of `0.5 / price` percent of margin. At a $1,500 sell that is
+ * invisible; at a $0.49 sell it moves the implied margin by a full point, and at $0.01 it can
+ * round a 50% margin to a rate implying 0%. `budgetRate`/`baseCost` are unconstrained Decimals,
+ * so the extra places persist. Kept to whatever keeps the implied margin accurate to 2dp.
  */
-export function formatDerivedRate(rate: number): string {
+export function formatDerivedRate(rate: number, price: number): string {
+  // A zero rate reads as "no budget" (internalBudget returns null, saveEstimate persists null),
+  // which would contradict any non-zero margin stored beside it.
   if (!Number.isFinite(rate) || rate <= 0) return "0.00";
-  return rate >= 0.005 ? rate.toFixed(2) : rate.toPrecision(2);
+  const needed = Number.isFinite(price) && price > 0 ? Math.ceil(4 - Math.log10(price)) : 2;
+  return rate.toFixed(Math.min(10, Math.max(2, needed)));
 }
 
 /**

--- a/tests/budget-math.test.ts
+++ b/tests/budget-math.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Margin/cost coherence for the estimate budget strip.
+ *
+ * The invariant under test: the margin persisted to `markupPercent` and the budget rate stored
+ * beside it always describe the SAME margin. The original defect clamped the value that fed
+ * `costFromMargin` at 99 but persisted the raw input, so entering 100 stored a 100% margin next
+ * to a cost derived from 99% — and since costFromMargin/sellFromMargin both return 0 at >= 100,
+ * a stored 100 additionally collapsed downstream sell/cost math to zero.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+    clampMarginPct,
+    normalizeMarginInput,
+    formatDerivedRate,
+    costFromMargin,
+    derivedMarginPct,
+    internalBudget,
+    DEFAULT_MARGIN_PCT,
+    MIN_MARGIN_PCT,
+    MAX_MARGIN_PCT,
+} from "../src/lib/budget-math";
+
+test("clampMarginPct holds the representable range", () => {
+    assert.equal(clampMarginPct(25), 25);
+    assert.equal(clampMarginPct(0), 0);
+    assert.equal(clampMarginPct(MAX_MARGIN_PCT), MAX_MARGIN_PCT);
+    assert.equal(clampMarginPct(100), MAX_MARGIN_PCT);
+    assert.equal(clampMarginPct(1e9), MAX_MARGIN_PCT);
+    assert.equal(clampMarginPct(-10), MIN_MARGIN_PCT);
+    // Infinity is out of range at the TOP — it must not fall through to the floor.
+    assert.equal(clampMarginPct(Infinity), MAX_MARGIN_PCT);
+    assert.equal(clampMarginPct(-Infinity), MIN_MARGIN_PCT);
+    assert.equal(clampMarginPct(NaN), MIN_MARGIN_PCT);
+});
+
+test("normalizeMarginInput persists exactly the margin the rate is derived from", () => {
+    // The regression: 100 must not store 100 while the cost comes from 99.
+    const hundred = normalizeMarginInput("100");
+    assert.equal(hundred.stored, String(MAX_MARGIN_PCT));
+    assert.equal(hundred.derivedFrom, MAX_MARGIN_PCT);
+
+    const negative = normalizeMarginInput("-10");
+    assert.equal(negative.stored, String(MIN_MARGIN_PCT));
+    assert.equal(negative.derivedFrom, MIN_MARGIN_PCT);
+
+    // An entry that overflows to Infinity is still a real number: it must clamp to the ceiling,
+    // not get stored as typed and not fall through to the floor.
+    const huge = normalizeMarginInput("1e309");
+    assert.equal(huge.stored, String(MAX_MARGIN_PCT));
+    assert.equal(huge.derivedFrom, MAX_MARGIN_PCT);
+});
+
+test("normalizeMarginInput keeps in-range text verbatim so typing survives", () => {
+    for (const raw of ["0", "25", "25.", "25.0", "99", "7.5"]) {
+        const { stored, derivedFrom } = normalizeMarginInput(raw);
+        assert.equal(stored, raw, `expected ${raw} to be stored verbatim`);
+        assert.equal(derivedFrom, parseFloat(raw));
+    }
+});
+
+test("whatever is stored always re-parses to the margin the rate came from", () => {
+    // The core invariant, independent of how the text is spelled.
+    for (const raw of ["0", "25", "25.", "99", "100", "-10", "1e309", "1e", ""]) {
+        const { stored, derivedFrom } = normalizeMarginInput(raw);
+        if (derivedFrom === null) continue;
+        if (stored === null) continue;
+        assert.equal(parseFloat(stored), derivedFrom, `stored/derived disagree for ${raw}`);
+    }
+});
+
+test("normalizeMarginInput clears on empty but still derives from the displayed default", () => {
+    const { stored, derivedFrom } = normalizeMarginInput("");
+    assert.equal(stored, null);
+    // The input renders `markupPercent ?? DEFAULT_MARGIN_PCT`, so a rate derived while the field
+    // is empty has to come from that same default or the visible margin would be a lie.
+    assert.equal(derivedFrom, DEFAULT_MARGIN_PCT);
+});
+
+test("normalizeMarginInput derives nothing from an unfinished keystroke", () => {
+    // Note "1e" is NOT here: parseFloat("1e") is 1, so it is a usable margin, not a fragment.
+    for (const raw of ["-", ".", "e5", "abc"]) {
+        const { stored, derivedFrom } = normalizeMarginInput(raw);
+        assert.equal(stored, raw, `expected ${raw} to be kept as typed`);
+        assert.equal(derivedFrom, null, `expected no rate to be derived from ${raw}`);
+    }
+});
+
+test("stored margin round-trips back from the stored cost", () => {
+    const price = 100;
+    for (const raw of ["0", "10", "25", "60", "99", "100", "-10"]) {
+        const { stored, derivedFrom } = normalizeMarginInput(raw);
+        assert.notEqual(derivedFrom, null);
+        const rate = parseFloat(formatDerivedRate(costFromMargin(price, derivedFrom!)));
+        // What the sibling budget-rate input would show for that cost must be what we stored.
+        assert.equal(
+            Math.round(derivedMarginPct(rate, price) * 100) / 100,
+            Math.round(parseFloat(stored!) * 100) / 100,
+            `margin/cost disagree for input ${raw}`,
+        );
+    }
+});
+
+test("a 100% entry no longer collapses the derived cost to zero", () => {
+    const price = 250;
+    const { derivedFrom } = normalizeMarginInput("100");
+    const cost = costFromMargin(price, derivedFrom!);
+    assert.ok(cost > 0, "cost must stay positive — costFromMargin returns 0 at margin >= 100");
+    assert.equal(formatDerivedRate(cost), "2.50");
+});
+
+test("formatDerivedRate never rounds a real cost down to a zero budget", () => {
+    assert.equal(formatDerivedRate(75), "75.00");
+    assert.equal(formatDerivedRate(0.5), "0.50");
+    assert.equal(formatDerivedRate(0), "0.00");
+
+    // Price 0.49 at 99% margin is $0.0049/unit. Two decimals would store "0.00", which
+    // internalBudget reads as "no budget at all" while markupPercent still claims 99.
+    const tiny = costFromMargin(0.49, MAX_MARGIN_PCT);
+    const stored = formatDerivedRate(tiny);
+    assert.ok(parseFloat(stored) > 0, `expected a non-zero rate, got ${stored}`);
+    assert.notEqual(internalBudget({ quantity: 1, budgetRate: stored }), null);
+});

--- a/tests/budget-math.test.ts
+++ b/tests/budget-math.test.ts
@@ -64,7 +64,6 @@ test("whatever is stored always re-parses to the margin the rate came from", () 
     // The core invariant, independent of how the text is spelled.
     for (const raw of ["0", "25", "25.", "99", "100", "-10", "1e309", "1e", ""]) {
         const { stored, derivedFrom } = normalizeMarginInput(raw);
-        if (derivedFrom === null) continue;
         if (stored === null) continue;
         assert.equal(parseFloat(stored), derivedFrom, `stored/derived disagree for ${raw}`);
     }
@@ -78,47 +77,51 @@ test("normalizeMarginInput clears on empty but still derives from the displayed 
     assert.equal(derivedFrom, DEFAULT_MARGIN_PCT);
 });
 
-test("normalizeMarginInput derives nothing from an unfinished keystroke", () => {
+test("normalizeMarginInput treats an unfinished keystroke as cleared, not as a margin", () => {
+    // Storing the fragment would be worse than dropping it: saveEstimate turns an unparseable
+    // markupPercent into the default, leaving a stored margin that contradicts the stored cost.
     // Note "1e" is NOT here: parseFloat("1e") is 1, so it is a usable margin, not a fragment.
     for (const raw of ["-", ".", "e5", "abc"]) {
         const { stored, derivedFrom } = normalizeMarginInput(raw);
-        assert.equal(stored, raw, `expected ${raw} to be kept as typed`);
-        assert.equal(derivedFrom, null, `expected no rate to be derived from ${raw}`);
+        assert.equal(stored, null, `expected ${raw} to clear the stored margin`);
+        assert.equal(derivedFrom, DEFAULT_MARGIN_PCT, `expected ${raw} to fall back to the default`);
     }
 });
 
-test("stored margin round-trips back from the stored cost", () => {
-    const price = 100;
-    for (const raw of ["0", "10", "25", "60", "99", "100", "-10"]) {
-        const { stored, derivedFrom } = normalizeMarginInput(raw);
-        assert.notEqual(derivedFrom, null);
-        const rate = parseFloat(formatDerivedRate(costFromMargin(price, derivedFrom!)));
-        // What the sibling budget-rate input would show for that cost must be what we stored.
-        assert.equal(
-            Math.round(derivedMarginPct(rate, price) * 100) / 100,
-            Math.round(parseFloat(stored!) * 100) / 100,
-            `margin/cost disagree for input ${raw}`,
-        );
+test("stored margin round-trips back from the stored cost at every price scale", () => {
+    // Rounding to cents is not scale-free: a half cent is 0.5/price percent of margin, so a
+    // cent-rounded rate silently misstates the margin at small unit prices.
+    for (const price of [1500, 100, 12.5, 1, 0.49, 0.01]) {
+        for (const raw of ["0", "10", "25", "60", "99", "100", "-10"]) {
+            const { stored, derivedFrom } = normalizeMarginInput(raw);
+            const rate = parseFloat(formatDerivedRate(costFromMargin(price, derivedFrom), price));
+            // What the sibling budget-rate input would show for that cost must be what we stored.
+            assert.equal(
+                Math.round(derivedMarginPct(rate, price) * 100) / 100,
+                Math.round(parseFloat(stored!) * 100) / 100,
+                `margin/cost disagree for input ${raw} at price ${price}`,
+            );
+        }
     }
 });
 
 test("a 100% entry no longer collapses the derived cost to zero", () => {
     const price = 250;
     const { derivedFrom } = normalizeMarginInput("100");
-    const cost = costFromMargin(price, derivedFrom!);
+    const cost = costFromMargin(price, derivedFrom);
     assert.ok(cost > 0, "cost must stay positive — costFromMargin returns 0 at margin >= 100");
-    assert.equal(formatDerivedRate(cost), "2.50");
+    assert.equal(formatDerivedRate(cost, price), "2.50");
 });
 
 test("formatDerivedRate never rounds a real cost down to a zero budget", () => {
-    assert.equal(formatDerivedRate(75), "75.00");
-    assert.equal(formatDerivedRate(0.5), "0.50");
-    assert.equal(formatDerivedRate(0), "0.00");
+    assert.equal(formatDerivedRate(75, 100), "75.00");
+    assert.equal(formatDerivedRate(0.5, 1), "0.5000");
+    assert.equal(formatDerivedRate(0, 100), "0.00");
 
     // Price 0.49 at 99% margin is $0.0049/unit. Two decimals would store "0.00", which
     // internalBudget reads as "no budget at all" while markupPercent still claims 99.
     const tiny = costFromMargin(0.49, MAX_MARGIN_PCT);
-    const stored = formatDerivedRate(tiny);
+    const stored = formatDerivedRate(tiny, 0.49);
     assert.ok(parseFloat(stored) > 0, `expected a non-zero rate, got ${stored}`);
     assert.notEqual(internalBudget({ quantity: 1, budgetRate: stored }), null);
 });


### PR DESCRIPTION
## What

The Margin input in `BudgetStrip` capped the value at 99 to compute `budgetRate`/`baseCost` via `costFromMargin`, but persisted the **raw** input to `markupPercent`. Entering `100` stored a 100% margin next to a cost derived from 99% — the stored margin and the stored cost described different things. And since `costFromMargin`/`sellFromMargin` both return 0 for margin >= 100, a stored 100 also collapsed downstream sell/cost math to zero.

Found by a Codex peer review on 2026-08-07; pre-existing.

## Changes

- **`normalizeMarginInput`** (`budget-math.ts`) returns `{stored, derivedFrom}` from **one** clamp, so the persisted margin is always the margin the rate came from. Out-of-range entries snap visibly to 0/99.
- **`clampMarginPct`** checks `NaN` first, so an entry overflowing to `Infinity` (`1e309`) clamps to the ceiling instead of falling through to the floor.
- An unfinished keystroke (`-`, `.`) **clears** the field and derives from the default, exactly like empty. Keeping the fragment would persist a margin that contradicts the cost beside it, because `normalizeEstimateItemForSave` turns an unparseable margin into the default anyway.
- **`formatDerivedRate`** scales its precision to the sell price. Rounding a derived rate to cents is not scale-free — a half cent is `0.5 / price` percent of margin. Invisible at a $1,500 sell; at $0.49 it moved the implied margin a full point, and at $0.01 a 50% margin stored a rate implying 0%. `budgetRate`/`baseCost` are unconstrained `Decimal`s, so the extra places persist.

## Tests

`tests/budget-math.test.ts` asserts the invariant directly: whatever is stored always re-parses to the margin the cost was derived from, and round-trips back through `derivedMarginPct` — across six price scales down to $0.01, which is what catches the rounding case.

CI ran no `tests/` suite at all, so the estimate money-math coverage from #315 and the payment-date coverage from #317 were gating nothing. All three hermetic suites now run in the build job via `npm run test:unit` (50 tests, no DB/network).

## Verification

- `npm run typecheck` — clean
- `npm run build:next` — succeeds
- `npm run test:unit` — 50/50 pass
- Browser, against the Shop test estimate: entering `100` snapped the field to `99` with rate `$15.00` on a `$1,500` sell (before: the margin field stuck at 100 and the rate was never written at all); `-10` snapped to `0`. Reloaded without saving — no writes persisted.

## Rebase note

Two fixes this branch originally carried turned out to have landed independently on main while it was in review, so they were dropped during the rebase:

- `updateItem` rebuilding from the render snapshot (which made the three-field budget writes clobber each other) — fixed by #312, which also added `updateItemById` for the async-callsite index problem.
- `toItemData` doing `parseFloat(markupPercent) || 25`, rewriting an explicit 0 margin — `normalizeEstimateItemForSave`'s `numberOr` already preserves an explicit 0.

## Deferred (pre-existing, not in this diff)

- The sibling budget-rate input clamps one way: rate `150` on price `100` stores margin `0` but keeps rate `150`. Clamping the rate would silently rewrite a cost the user typed, so whether the margin field should be able to express a loss is a product decision.
- `price <= 0` leaves a stale rate, and sell-price (`unitCost`) edits don't rederive the margin. That input lives in `EstimateEditor`, not `BudgetStrip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)