### PR TITLE
fix(estimates): unify markupPercent on one gross-margin semantic

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -477,9 +477,9 @@ model EstimateItem {
   description   String?
   type          String         @default("Material") // Legacy fallback
   quantity      Float          @default(1)
-  baseCost      Decimal? // Raw cost before markup (internal only)
-  markupPercent Float          @default(25) // Markup percentage (internal only)
-  unitCost      Decimal          @default(0) // Sell price = baseCost * (1 + markupPercent/100)
+  baseCost      Decimal? // Raw cost before margin (internal only)
+  markupPercent Float          @default(25) // Gross margin % on sell price (internal only; field name is legacy/misleading — see src/lib/budget-math.ts)
+  unitCost      Decimal          @default(0) // Sell price = baseCost / (1 - markupPercent/100)
   total         Decimal          @default(0)
   order         Int            @default(0)
   parentId      String?

--- a/scripts/backfill-estimate-item-margin.mjs
+++ b/scripts/backfill-estimate-item-margin.mjs
@@ -1,0 +1,160 @@
+// One-time backfill: correct EstimateItem.markupPercent for rows written by the
+// old markup-on-cost writers, so the column agrees with the canonical semantic
+// (gross margin % on sell price — see src/lib/budget-math.ts).
+//
+// Only markupPercent is ever written by this script. It NEVER touches unitCost,
+// total, baseCost, or any estimate/invoice total — those are the customer-facing
+// prices and must not move. (Assertion: the only UPDATE statement in this file
+// sets exactly one column, "markupPercent".)
+//
+// Target rows: baseCost and unitCost are both known and positive, and the stored
+// markupPercent disagrees (by more than a rounding tolerance) with the margin
+// implied by baseCost/unitCost — i.e. rows priced under the old
+// markup-on-cost formula (unitCost = baseCost * (1 + markupPercent/100)) instead
+// of the canonical margin formula (unitCost = baseCost / (1 - markupPercent/100)).
+//
+// Derived value: markupPercent = (1 - baseCost/unitCost) * 100, rounded to 2
+// decimals, clamped to [0, 99] to match derivedMarginPct() in budget-math.ts.
+//
+// STRICTLY LOSS-MAKING ROWS ARE NOT WRITTEN. Where baseCost > unitCost (cost
+// exceeds sell) the true margin is negative, and the [0, 99] clamp would stamp
+// "0%" over the stored value — making a line item that loses money look like it
+// merely breaks even. Those rows are reported for human review instead, and left
+// exactly as they are. Where baseCost == unitCost (break-even / pass-through),
+// the true margin is exactly 0 and IS corrected — that is not a loss.
+//
+// SAFE TO RE-RUN: idempotent — once a row's stored markupPercent matches the
+// derived value it drops out of the target set.
+//
+// Usage:
+//   node scripts/backfill-estimate-item-margin.mjs            # dry run — report only, no writes
+//   node scripts/backfill-estimate-item-margin.mjs --apply    # write corrected markupPercent
+//
+// Requires (read from env or .env / .env.local):
+//   DATABASE_URL   Supabase transaction pooler URL (must include ?pgbouncer=true)
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+const APPLY = process.argv.includes("--apply");
+
+function envFromFiles(key) {
+  if (process.env[key]) return process.env[key];
+  for (const f of [".env", ".env.local"]) {
+    if (!fs.existsSync(f)) continue;
+    const m = fs.readFileSync(f, "utf8").match(new RegExp(`^${key}\\s*=\\s*"?([^"\\n]+)"?`, "m"));
+    if (m) return m[1];
+  }
+  return undefined;
+}
+
+const DATABASE_URL = envFromFiles("DATABASE_URL");
+if (!DATABASE_URL) throw new Error("DATABASE_URL not found in env or .env files");
+if (!DATABASE_URL.includes("pgbouncer=true")) {
+  console.warn("⚠ DATABASE_URL has no pgbouncer=true — expected the Supabase transaction pooler. Continuing.");
+}
+
+const prisma = new PrismaClient({ datasources: { db: { url: DATABASE_URL } } });
+
+// Rows where the stored markupPercent disagrees with the margin implied by
+// baseCost/unitCost by more than 0.01 percentage points.
+const TARGET_SQL = `
+  SELECT
+    "id",
+    "baseCost"::float8 AS "baseCost",
+    "unitCost"::float8 AS "unitCost",
+    "markupPercent" AS "storedMarkupPercent",
+    LEAST(99, GREATEST(0, ROUND(((1 - "baseCost"::float8 / "unitCost"::float8) * 100)::numeric, 2)))::float8 AS "derivedMarginPct"
+  FROM "EstimateItem"
+  WHERE "baseCost" IS NOT NULL
+    AND "baseCost" > 0
+    AND "unitCost" > 0
+    AND "baseCost" <= "unitCost"
+    AND ABS("markupPercent" - (1 - "baseCost"::float8 / "unitCost"::float8) * 100) > 0.01
+  ORDER BY "id" ASC
+`;
+
+// Cost strictly exceeds sell price: true margin is negative. Reported, never written.
+const LOSS_SQL = `
+  SELECT
+    "id",
+    "baseCost"::float8 AS "baseCost",
+    "unitCost"::float8 AS "unitCost",
+    "markupPercent" AS "storedMarkupPercent",
+    ROUND(((1 - "baseCost"::float8 / "unitCost"::float8) * 100)::numeric, 2)::float8 AS "trueMarginPct"
+  FROM "EstimateItem"
+  WHERE "baseCost" IS NOT NULL
+    AND "baseCost" > 0
+    AND "unitCost" > 0
+    AND "baseCost" > "unitCost"
+    AND ABS("markupPercent" - (1 - "baseCost"::float8 / "unitCost"::float8) * 100) > 0.01
+  ORDER BY "id" ASC
+`;
+
+(async () => {
+  console.log(APPLY ? "Backfill mode: APPLY (writing corrected markupPercent)\n" : "Backfill mode: DRY RUN (pass --apply to write)\n");
+
+  const [{ count: scanned }] = await prisma.$queryRawUnsafe(
+    `SELECT count(*)::int AS count FROM "EstimateItem" WHERE "baseCost" IS NOT NULL AND "baseCost" > 0 AND "unitCost" > 0`
+  );
+  const [{ count: zeroBaseCost }] = await prisma.$queryRawUnsafe(
+    `SELECT count(*)::int AS count FROM "EstimateItem" WHERE "baseCost" = 0 AND "unitCost" > 0`
+  );
+  const rows = await prisma.$queryRawUnsafe(TARGET_SQL);
+  const lossRows = await prisma.$queryRawUnsafe(LOSS_SQL);
+
+  console.log(`${scanned} row(s) scanned (baseCost and unitCost both known and positive).`);
+  console.log(`${rows.length} row(s) differ from the derived margin by more than 0.01.`);
+  console.log(`${zeroBaseCost} row(s) have baseCost = 0 with a positive unitCost — not touched by this script (not in scanned set).\n`);
+
+  const sample = rows.slice(0, 20);
+  if (sample.length > 0) {
+    console.log("Sample (up to 20):");
+    for (const r of sample) {
+      console.log(
+        `  id=${r.id} baseCost=${r.baseCost} unitCost=${r.unitCost} stored=${r.storedMarkupPercent}% -> derived=${r.derivedMarginPct}%`
+      );
+    }
+    console.log("");
+  }
+
+  if (lossRows.length > 0) {
+    console.log(
+      `⚠ ${lossRows.length} row(s) are strictly loss-making (cost exceeds sell): baseCost > unitCost.`
+    );
+    console.log("  NOT written — a clamp to 0% would disguise a loss. Review these by hand:");
+    for (const r of lossRows.slice(0, 20)) {
+      console.log(
+        `  id=${r.id} baseCost=${r.baseCost} unitCost=${r.unitCost} stored=${r.storedMarkupPercent}% -> true margin=${r.trueMarginPct}%`
+      );
+    }
+    if (lossRows.length > 20) console.log(`  ...and ${lossRows.length - 20} more.`);
+    console.log("");
+  }
+
+  if (!APPLY) {
+    console.log("Dry run complete — no writes made. Pass --apply to update markupPercent.");
+    return;
+  }
+
+  // Single set-based UPDATE, same WHERE predicate as TARGET_SQL, deriving the
+  // value in SQL rather than SELECTing rows and writing back a preloaded value —
+  // avoids N round-trips and avoids clobbering a concurrent edit with stale data.
+  // markupPercent is the only column this statement may write.
+  const updated = await prisma.$executeRawUnsafe(`
+    UPDATE "EstimateItem"
+    SET "markupPercent" = LEAST(99, GREATEST(0, ROUND(((1 - "baseCost"::float8 / "unitCost"::float8) * 100)::numeric, 2)))::float8
+    WHERE "baseCost" IS NOT NULL
+      AND "baseCost" > 0
+      AND "unitCost" > 0
+      AND "baseCost" <= "unitCost"
+      AND ABS("markupPercent" - (1 - "baseCost"::float8 / "unitCost"::float8) * 100) > 0.01
+  `);
+  console.log(`Updated ${updated} row(s).`);
+})()
+  .catch((e) => {
+    console.error("Backfill failed:", e);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/import-houzz.mjs
+++ b/scripts/import-houzz.mjs
@@ -894,6 +894,8 @@ async function importDocumentItems(section) {
             total: totalPayment,
             order: order++,
             baseCost: materialCost > 0 ? (quantity > 0 ? materialCost / quantity : materialCost) : null,
+            // Houzz PROFIT_PERCENTAGE is already a gross-margin-on-sell value, matching
+            // the canonical markupPercent semantic (see src/lib/budget-math.ts) — no conversion needed.
             markupPercent: parseMoney(row.PROFIT_PERCENTAGE) || 0,
           },
         });

--- a/src/app/api/ai/historical-pricing/route.ts
+++ b/src/app/api/ai/historical-pricing/route.ts
@@ -30,7 +30,7 @@ export async function POST(req: NextRequest) {
             return NextResponse.json({
                 success: true,
                 analysis:
-                    "No historical pricing data found yet. As you create more estimates across projects, this tool will analyze your pricing patterns, average costs by category, markup trends, and give you recommendations for competitive yet profitable pricing.",
+                    "No historical pricing data found yet. As you create more estimates across projects, this tool will analyze your pricing patterns, average costs by category, margin trends, and give you recommendations for competitive yet profitable pricing.",
             });
         }
 
@@ -41,7 +41,7 @@ export async function POST(req: NextRequest) {
                 count: number;
                 totalCost: number;
                 totalUnitCost: number;
-                markups: number[];
+                margins: number[];
                 names: string[];
                 projectTypes: string[];
             }
@@ -54,7 +54,7 @@ export async function POST(req: NextRequest) {
                     count: 0,
                     totalCost: 0,
                     totalUnitCost: 0,
-                    markups: [],
+                    margins: [],
                     names: [],
                     projectTypes: [],
                 };
@@ -63,7 +63,7 @@ export async function POST(req: NextRequest) {
             entry.count++;
             entry.totalCost += Number(item.total) || 0;
             entry.totalUnitCost += Number(item.unitCost) || 0;
-            entry.markups.push(item.markupPercent || 0);
+            entry.margins.push(item.markupPercent || 0);
             if (!entry.names.includes(item.name)) {
                 entry.names.push(item.name);
             }
@@ -80,10 +80,10 @@ export async function POST(req: NextRequest) {
                 itemCount: data.count,
                 averageCost: data.totalCost / data.count,
                 averageUnitCost: data.totalUnitCost / data.count,
-                averageMarkup:
-                    data.markups.reduce((a, b) => a + b, 0) / data.markups.length,
-                minMarkup: Math.min(...data.markups),
-                maxMarkup: Math.max(...data.markups),
+                averageMargin:
+                    data.margins.reduce((a, b) => a + b, 0) / data.margins.length,
+                minMargin: Math.min(...data.margins),
+                maxMargin: Math.max(...data.margins),
                 sampleItems: data.names.slice(0, 10),
                 projectTypes: data.projectTypes.slice(0, 5),
             })
@@ -110,7 +110,7 @@ Location: ${currentEstimate.project?.location || "Not specified"}
 Current items: ${currentEstimate.items
                     .map(
                         (i) =>
-                            `${i.name} (${i.type}) - qty: ${i.quantity}, unit: $${Number(i.unitCost).toFixed(2)}, total: $${Number(i.total).toFixed(2)}, markup: ${i.markupPercent}%`
+                            `${i.name} (${i.type}) - qty: ${i.quantity}, unit: $${Number(i.unitCost).toFixed(2)}, total: $${Number(i.total).toFixed(2)}, margin: ${i.markupPercent}%`
                     )
                     .join("; ")}
 Total estimate: $${currentEstimate.items.reduce((sum, i) => sum + (Number(i.total) || 0), 0).toFixed(2)}
@@ -118,9 +118,9 @@ Total estimate: $${currentEstimate.items.reduce((sum, i) => sum + (Number(i.tota
             }
         }
 
-        const prompt = `Analyze historical pricing data from this contractor's past projects. Provide: average costs by category, markup patterns, price trends, and recommendations for competitive yet profitable pricing.
+        const prompt = `Analyze historical pricing data from this contractor's past projects. Provide: average costs by category, margin patterns, price trends, and recommendations for competitive yet profitable pricing.
 
-Historical Data Summary (${allItems.length} total line items across all projects):
+Historical Data Summary (${allItems.length} total line items across all projects). averageMargin/minMargin/maxMargin are gross margin percentages of sell price (margin% = (1 - baseCost/unitCost) * 100), not markup-on-cost:
 ${JSON.stringify(categorySummaries, null, 2)}
 
 ${currentEstimateContext}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -17,6 +17,7 @@ import { persistOwnedSignature } from "./signature-storage";
 import { parseProductUrl, MAX_PRICE as PRODUCT_PARSE_MAX_PRICE } from "./product-parse";
 import { isHttpUrl } from "./url-safety";
 import { normalizeEstimateItemForSave } from "./estimate-item-payload";
+import { DEFAULT_MARGIN_PCT, roundMoney, sellFromMargin } from "./budget-math";
 import { canUseDevAuthFallback, getCurrentUserWithPermissions, getUserWithPermissionsByEmail, hasPermission, canAccessProject, PortalAuthError } from "./permissions";
 import { logActivity } from "./activity-log";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
@@ -13858,7 +13859,7 @@ export async function createEstimateFromRoomDesign(roomId: string) {
             ? productById.get(asset.assetId.slice(5))
             : undefined;
         const def = getItemDef(asset.assetId);
-        const markupPercent = 25;
+        const marginPercent = DEFAULT_MARGIN_PCT;
         const name = product?.name ?? def?.name ?? `${asset.assetType.charAt(0).toUpperCase()}${asset.assetType.slice(1)}`;
 
         const metadata = (asset.metadata ?? {}) as Record<string, any>;
@@ -13894,7 +13895,7 @@ export async function createEstimateFromRoomDesign(roomId: string) {
             ?? `GTR-${(def?.category ?? "item").slice(0, 3).toUpperCase()}-${(def?.id ?? asset.assetId).toUpperCase().replace(/[^A-Z0-9]+/g, "").slice(0, 10)}-${wIn}`;
         detailsArray.unshift(`SKU: ${sku}`);
 
-        const unitCost = Math.round(baseCost * (1 + markupPercent / 100));
+        const unitCost = roundMoney(sellFromMargin(baseCost, marginPercent));
         const total = unitCost * 1;
         totalEstimate += total;
 
@@ -13906,7 +13907,7 @@ export async function createEstimateFromRoomDesign(roomId: string) {
             type: "Material",
             quantity: 1,
             baseCost,
-            markupPercent,
+            markupPercent: marginPercent,
             unitCost,
             total,
             costCodeId,

--- a/src/lib/budget-math.ts
+++ b/src/lib/budget-math.ts
@@ -2,7 +2,57 @@
  * Budget math utilities for estimate internal costing.
  * Uses plain JS arithmetic (sufficient for display-only calculations).
  * Precision-critical storage uses Prisma Decimal on the server side.
+ *
+ * CANONICAL SEMANTIC: `EstimateItem.markupPercent` stores GROSS MARGIN ON
+ * SELL PRICE despite its name (cost = sell * (1 - m/100), sell = cost / (1 - m/100)).
+ * baseCost + unitCost are the authoritative pair; markupPercent is derived
+ * from them (see derivedMarginPct). Do not treat it as markup-on-cost.
  */
+
+/**
+ * Round a number to `decimals` places, collapsing IEEE-754 floating-point
+ * drift before rounding. Plain `Math.round(x * f) / f` can disagree with an
+ * algebraically equivalent computation when a value lands exactly on a
+ * rounding boundary (e.g. 20.40 / 0.8 === 25.499999999999996, which rounds
+ * down, while the algebraically identical 20.40 * 1.25 === 25.5, which
+ * rounds up). Snapping to 12 significant digits first removes that drift so
+ * sellFromMargin(cost, margin) rounds the same way the legacy
+ * markup-on-cost formula did — this is what keeps price conversion neutral
+ * (NO SELL PRICE MAY MOVE).
+ *
+ * Uses toPrecision (relative) rather than toFixed (absolute): a fixed number
+ * of decimal places leaves too little headroom at decimals=2 and would round
+ * genuinely-below-the-boundary values UP (1.004999996 -> 1.01). Binary drift
+ * from these operations shows up around the 15th significant digit, so 12 is
+ * comfortably clear of real precision while still absorbing the noise.
+ */
+export function roundMoney(value: number, decimals = 0): number {
+  const f = 10 ** decimals;
+  const scaled = value * f;
+  if (!Number.isFinite(scaled)) return value;
+  return Math.round(Number(scaled.toPrecision(12))) / f;
+}
+
+/**
+ * Default gross margin for items produced by paths that USED to apply a 25%
+ * markup-on-cost (Room Studio furnish, AI takeoff). Equals that legacy markup
+ * exactly (base * 1.25 === base / 0.8), which is what makes the conversion
+ * price-neutral.
+ *
+ * Deliberately NOT the same as the plain `25` default used by the schema and
+ * by hand-added estimate items (EstimateItem.markupPercent @default(25),
+ * saveEstimate's fallback). Those 25s were always a 25% MARGIN and are already
+ * canonical, so they must stay 25 — do not "unify" them to this constant.
+ */
+export const DEFAULT_MARGIN_PCT = 20;
+
+/**
+ * Convert a legacy markup-on-cost percentage to the canonical gross-margin
+ * percentage. Formula: margin% = markup% / (100 + markup%) * 100.
+ */
+export function marginFromMarkup(markupPct: number): number {
+  return (markupPct / (100 + markupPct)) * 100;
+}
 
 /**
  * Calculate internal budget for an estimate item.


### PR DESCRIPTION
## The bug

`EstimateItem.markupPercent` had **two conflicting interpretations** (found by Codex peer review, pre-existing, not from #312):

- `actions.ts` (Room Studio furnish → estimate) and the AI-takeoff path computed `unitCost = baseCost * (1 + markupPercent/100)` — a **true markup on cost**.
- `budget-math.ts` / `BudgetStrip.tsx` treat the same field as a **gross margin on sell price**: `cost = sell * (1 - m/100)`. `budget-math.ts` even carried a NOTE admitting the field is misnamed.

So a stored `25` meant a **20% margin** from one writer and a **25% margin** from the other. Anything aggregating the column mixed the two — including `/api/ai/historical-pricing`, which averages it to feed AI pricing advice.

## The decision

**Gross margin on sell is canonical for `EstimateItem`.** It's the dominant reading and the one the BudgetStrip UI actually exposes. Every writer now agrees.

The column is **deliberately not renamed** — the trap was the disagreement (and the mislabeled UI), not the identifier. A rename is a mechanical no-logic-change follow-up.

Cost-plus change orders keep markup-on-cost **on purpose**: "Cost + X% + tax" is a contractual term shown to clients. `ChangeOrder*` / `billing-core.ts` untouched.

## No price moves

A 25% markup-on-cost *is* a 20% margin: `base * 1.25 === base / 0.8`. Converted writers use `DEFAULT_MARGIN_PCT` (20) and emit identical prices.

This needed a real fix, not just algebra — `20.40 / 0.8 = 25.499999999999996` rounds to **$25**, where the algebraically identical `20.40 * 1.25 = 25.5` rounds to **$26**. New `roundMoney()` snaps that drift to 12 significant digits. Verified by brute force over **20,000,000 values: zero mismatches**.

## Also fixed along the way

- **Tax items were losing their `0`.** `|| 25` fallbacks coerced a legitimate `0` into 25, and the ai-estimate item mapping dropped `baseCost`/`markupPercent` entirely so convert-to-estimate stamped a default on every item — tax included. Tax is pass-through and must carry no margin.
- **`max={100}` on the margin input** would have zeroed every sell price (`sellFromMargin(x, 100)` divides by zero). Capped at 99.
- `schema.prisma`'s `unitCost` comment stated the wrong formula.

## Backfill

`scripts/backfill-estimate-item-margin.mjs` recomputes `markupPercent` from the authoritative `baseCost`/`unitCost` pair — self-correcting, so it's a no-op for rows the budget path already wrote correctly.

Dry run on prod: **621 scanned, 160 to correct.** `markupPercent` is the only column it can write; no price, total, or invoice amount is touched. Dry-run by default, idempotent, single set-based UPDATE.

**3 strictly loss-making rows are reported and deliberately NOT written** — the `[0,99]` clamp would stamp "0%" over them and disguise a real loss as break-even:

| id | baseCost | unitCost | stored | true margin |
|---|---|---|---|---|
| `96z3i9vsc` | 14000 | 13000 | 25% | **-7.69%** |
| `mdig29q68` | 9900 | 6000 | 27% | **-65%** |
| `pzr6xdjhm` | 8500 | 3250 | 26% | **-161.54%** |

Those are a business data-quality question, not a code one.

## Verification

- `npm run build` — 0 errors
- Two rounds of Codex peer review; all blockers addressed
- Brute-force price-neutrality proof (20M values)
- Backfill dry-run against prod, read-only
- `e2e/money-pipeline.spec.ts` — via CI on this PR

## Known pre-existing bug, NOT fixed here

`handleConvertToEstimate` in `TakeoffsClient.tsx` sends only `takeoffId`, so the user's on-screen margin edits are **discarded** at conversion. That makes the takeoff margin editor effectively a preview. Out of scope for this change; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)