### PR TITLE
fix(change-orders): stop estimate section headers double-counting a CO

### DIFF
--- a/src/app/api/integrations/co-audit/route.ts
+++ b/src/app/api/integrations/co-audit/route.ts
@@ -1,7 +1,7 @@
 import { createHash, timingSafeEqual } from "crypto";
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { coTaxRate, coTaxLabel, coItemsSubtotal } from "@/lib/co-tax";
+import { coTaxRate, coTaxLabel, coItemsSubtotal, coSectionRowNames, coSectionRowError } from "@/lib/co-tax";
 
 // One-off data-repair surface for the pre-2026-07-09 change-order editor bug:
 // the editor saved totalAmount tax-INCLUSIVE (item subtotal × (1 + rate)) while
@@ -46,8 +46,12 @@ const rc = (n: number) => Math.round(n * 100) / 100;
 // row the audit reports as ok can never be mutated by a follow-up POST.
 const OK_TOLERANCE = 0.01;
 
-type Verdict = "ok" | "tax-inflated" | "drift" | "no-items";
-function classify(stored: number, subtotal: number, expectedBilled: number, itemCount: number): Verdict {
+type Verdict = "ok" | "tax-inflated" | "drift" | "no-items" | "has-sections";
+function classify(stored: number, subtotal: number, expectedBilled: number, itemCount: number, sectionCount: number): Verdict {
+    // A section header mirrors the total of the lines beneath it, so no subtotal derived from
+    // these rows is trustworthy — including the one POST would write back. Reported ahead of
+    // every other verdict so the row can never be recomputed to a number nobody can justify.
+    if (sectionCount > 0) return "has-sections";
     if (itemCount === 0) return "no-items";
     if (Math.abs(stored - subtotal) <= OK_TOLERANCE) return "ok";
     if (Math.abs(stored - expectedBilled) <= 0.02) return "tax-inflated";
@@ -65,7 +69,7 @@ export async function GET(req: Request) {
             approvedAt: true, sentAt: true,
             project: { select: { id: true, name: true } },
             estimate: { select: { code: true, taxExempt: true, taxRatePercent: true, taxRateName: true } },
-            items: { select: { type: true, quantity: true, unitCost: true, total: true } },
+            items: { select: { name: true, type: true, quantity: true, unitCost: true, total: true } },
         },
     });
 
@@ -87,7 +91,8 @@ export async function GET(req: Request) {
         const tax = rc(subtotal * rate);
         const expectedBilled = rc(subtotal + tax); // what billing charges once fixed
         const inflated = rc(stored - subtotal);
-        const verdict = classify(stored, subtotal, expectedBilled, co.items.length);
+        const sectionNames = coSectionRowNames(co.items);
+        const verdict = classify(stored, subtotal, expectedBilled, co.items.length, sectionNames.length);
 
         const milestones = coMilestones
             .filter(m => m.invoice.projectId === co.project.id && m.name.startsWith(`${co.code} — `))
@@ -107,6 +112,7 @@ export async function GET(req: Request) {
             storedTotalAmount: stored,
             storedBalanceDue: rc(Number(co.balanceDue)),
             itemCount: co.items.length,
+            sectionRowNames: sectionNames,
             itemSubtotal: subtotal,
             storedLineTotalsSum: rc(co.items.reduce((s, i) => s + Number(i.total), 0)),
             taxTreatment: coTaxLabel(co.estimate),
@@ -127,6 +133,7 @@ export async function GET(req: Request) {
             taxInflated: rows.filter(r => r.verdict === "tax-inflated").length,
             drift: rows.filter(r => r.verdict === "drift").length,
             noItems: rows.filter(r => r.verdict === "no-items").length,
+            hasSections: rows.filter(r => r.verdict === "has-sections").length,
         },
         changeOrders: rows,
     });
@@ -166,7 +173,7 @@ export async function POST(req: Request) {
         }
         const items = await tx.changeOrderItem.findMany({
             where: { changeOrderId },
-            select: { type: true, quantity: true, unitCost: true },
+            select: { name: true, type: true, quantity: true, unitCost: true },
         });
         // Re-derive the verdict under the lock — the repair only applies to the
         // tax-inclusive-total bug. A drift row (total matches neither subtotal
@@ -178,7 +185,14 @@ export async function POST(req: Request) {
             select: { taxExempt: true, taxRatePercent: true, taxRateName: true },
         });
         const expectedBilled = rc(subtotal + rc(subtotal * coTaxRate(estimateTax)));
-        const verdict = classify(stored, subtotal, expectedBilled, items.length);
+        const sectionNames = coSectionRowNames(items);
+        const verdict = classify(stored, subtotal, expectedBilled, items.length, sectionNames.length);
+        // Not repairable here: writing back a subtotal that excludes the headers would leave
+        // the rows in place and a total nobody can justify, and a later GET would call it
+        // "ok" while send and approve stay correctly blocked. Fix the items, not the total.
+        if (verdict === "has-sections") {
+            return { ok: false as const, error: coSectionRowError(co.code, sectionNames) };
+        }
         if (verdict === "no-items") {
             return { ok: false as const, error: `${co.code} has no line items — nothing to recompute from; review by hand.` };
         }

--- a/src/app/api/integrations/co-audit/route.ts
+++ b/src/app/api/integrations/co-audit/route.ts
@@ -65,7 +65,7 @@ export async function GET(req: Request) {
             approvedAt: true, sentAt: true,
             project: { select: { id: true, name: true } },
             estimate: { select: { code: true, taxExempt: true, taxRatePercent: true, taxRateName: true } },
-            items: { select: { quantity: true, unitCost: true, total: true } },
+            items: { select: { type: true, quantity: true, unitCost: true, total: true } },
         },
     });
 
@@ -82,7 +82,7 @@ export async function GET(req: Request) {
 
     const rows = cos.map(co => {
         const stored = rc(Number(co.totalAmount));
-        const subtotal = coItemsSubtotal(co.items.map(i => ({ quantity: i.quantity, unitCost: Number(i.unitCost) })));
+        const subtotal = coItemsSubtotal(co.items.map(i => ({ type: i.type, quantity: i.quantity, unitCost: Number(i.unitCost) })));
         const rate = coTaxRate(co.estimate);
         const tax = rc(subtotal * rate);
         const expectedBilled = rc(subtotal + tax); // what billing charges once fixed
@@ -166,13 +166,13 @@ export async function POST(req: Request) {
         }
         const items = await tx.changeOrderItem.findMany({
             where: { changeOrderId },
-            select: { quantity: true, unitCost: true },
+            select: { type: true, quantity: true, unitCost: true },
         });
         // Re-derive the verdict under the lock — the repair only applies to the
         // tax-inclusive-total bug. A drift row (total matches neither subtotal
         // nor subtotal+tax) may carry an intentional edit, so it needs an
         // explicit force from a human.
-        const subtotal = coItemsSubtotal(items.map(i => ({ quantity: i.quantity, unitCost: Number(i.unitCost) })));
+        const subtotal = coItemsSubtotal(items.map(i => ({ type: i.type, quantity: i.quantity, unitCost: Number(i.unitCost) })));
         const estimateTax = await tx.estimate.findUnique({
             where: { id: co.estimateId },
             select: { taxExempt: true, taxRatePercent: true, taxRateName: true },

--- a/src/app/portal/change-orders/[id]/PortalChangeOrderClient.tsx
+++ b/src/app/portal/change-orders/[id]/PortalChangeOrderClient.tsx
@@ -6,7 +6,7 @@ import SignaturePad from "@/components/SignaturePad";
 import Link from "next/link";
 import { toast } from "sonner";
 import { formatCurrency } from "@/lib/utils";
-import { coTaxRate, coTaxLabel, coLineCents, coItemsSubtotal } from "@/lib/co-tax";
+import { coTaxRate, coTaxLabel, coLineCents, coItemsSubtotal, billableCoItems } from "@/lib/co-tax";
 
 export default function PortalChangeOrderClient({ initialData, companySettings }: { initialData: any, companySettings?: any }) {
     const [isApproving, setIsApproving] = useState(false);
@@ -214,7 +214,9 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
                                 </tr>
                             </thead>
                             <tbody className="divide-y divide-slate-100">
-                                {items.map((item: any) => {
+                                {/* Line amounts must sum to the subtotal below, which excludes
+                                    section headers — a header mirrors the lines beneath it. */}
+                                {billableCoItems(items).map((item: any) => {
                                     const itemTotal = coLineCents(Number(item.quantity || 0), Number(item.unitCost || 0)) / 100;
                                     return (
                                         <tr key={item.id}>

--- a/src/app/projects/[id]/budget/BudgetClient.tsx
+++ b/src/app/projects/[id]/budget/BudgetClient.tsx
@@ -280,8 +280,9 @@ export default function BudgetClient({ project, data }: { project: { id: string;
         // Change orders add to revised
         for (const co of changeOrders) {
             // Section headers mirror their children's rolled-up total, so counting both
-            // inflates revisedEst. billableCoItems passes an all-headers CO through
-            // untouched — dropping every row there would total that CO to zero.
+            // inflates revisedEst. Nothing can create such a row anymore and the money paths
+            // reject any that predate the guard; dropping it here just keeps the budget
+            // honest while a human sorts that change order out.
             for (const item of billableCoItems(co.items)) {
                 const gk = getGroupKey(item);
                 const row = getOrCreate(gk);

--- a/src/app/projects/[id]/budget/BudgetClient.tsx
+++ b/src/app/projects/[id]/budget/BudgetClient.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
+import { billableCoItems } from "@/lib/co-tax";
 
 // ─── Types ──────────────────────────────────────────────────────
 interface BudgetData {
@@ -278,7 +279,10 @@ export default function BudgetClient({ project, data }: { project: { id: string;
 
         // Change orders add to revised
         for (const co of changeOrders) {
-            for (const item of co.items) {
+            // Section headers mirror their children's rolled-up total, so counting both
+            // inflates revisedEst. billableCoItems passes an all-headers CO through
+            // untouched — dropping every row there would total that CO to zero.
+            for (const item of billableCoItems(co.items)) {
                 const gk = getGroupKey(item);
                 const row = getOrCreate(gk);
                 row.revisedEst += num(item.total);

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -16,7 +16,7 @@ import { resolveSessionClientId } from "./portal-auth";
 import { persistOwnedSignature } from "./signature-storage";
 import { parseProductUrl, MAX_PRICE as PRODUCT_PARSE_MAX_PRICE } from "./product-parse";
 import { isHttpUrl } from "./url-safety";
-import { normalizeEstimateItemForSave } from "./estimate-item-payload";
+import { normalizeEstimateItemForSave, selectedBillableRows } from "./estimate-item-payload";
 import { LEGACY_MARKUP_MARGIN_PCT, roundMoney, sellFromMargin } from "./budget-math";
 import { canUseDevAuthFallback, getCurrentUserWithPermissions, getUserWithPermissionsByEmail, hasPermission, canAccessProject, PortalAuthError } from "./permissions";
 import { logActivity } from "./activity-log";
@@ -8706,7 +8706,10 @@ export async function createChangeOrder(projectId: string, estimateId: string, i
     await prisma.changeOrder.update({ where: { id: changeOrder.id }, data: { code: coCode } });
 
     if (itemIds && itemIds.length > 0) {
-        const selectedItems = estimate.items.filter(i => itemIds.includes(i.id));
+        // Section headers carry their children's rolled-up total, and ChangeOrderItem is flat,
+        // so copying a header alongside its children would bill the section twice. Selecting a
+        // header means "bill this whole phase" — it resolves to the leaves underneath it.
+        const selectedItems = selectedBillableRows(estimate.items, itemIds);
         for (const item of selectedItems) {
             await prisma.changeOrderItem.create({
                 data: {

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -16,7 +16,7 @@ import { prisma } from "@/lib/prisma";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { sendNotification } from "./email";
 import { formatCurrency } from "./utils";
-import { coTaxRate, coTaxLabel, coLineCents } from "./co-tax";
+import { coTaxRate, coTaxLabel, coLineCents, billableCoItems } from "./co-tax";
 import { deriveInvoiceTaxFields, toNum } from "./prisma-helpers";
 import { dateInputInTimeZone, endOfDateInTimeZone, resolveCompanyTimeZone } from "./company-timezone";
 
@@ -1874,10 +1874,10 @@ export async function sendChangeOrderToClientCore(
         // bills and locks, and a $0 approved CO can't be repaired.
         const items = await tx.changeOrderItem.findMany({
             where: { changeOrderId },
-            select: { quantity: true, unitCost: true },
+            select: { type: true, quantity: true, unitCost: true },
         });
         const storedSubtotalCents = Math.round(Number(co.totalAmount) * 100);
-        const renderedSubtotalCents = items.reduce(
+        const renderedSubtotalCents = billableCoItems(items).reduce(
             (sum, item) => sum + coLineCents(item.quantity, Number(item.unitCost)),
             0,
         );

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -2067,6 +2067,20 @@ export async function createChangeOrderDraft(input: ChangeOrderDraftInput) {
     const validTypes = ["Labor", "Material", "Allowance", "Subcontractor", "Equipment", "Other"];
     const warnings: string[] = [];
 
+    // "Section" is refused outright rather than coerced like other unknown types below. A
+    // typo is worth absorbing; a section header is not — it is the rolled-up total of other
+    // lines, so quietly filing it as Material would smuggle a double-count past every guard
+    // that looks for `type === "Section"`, with nothing downstream able to tell afterwards.
+    const sectionTyped = items.filter(item => item.costType?.trim().toLowerCase() === "section");
+    if (sectionTyped.length > 0) {
+        return {
+            ok: false as const,
+            error: `Cost type "Section" is not a change-order line (${sectionTyped.map(i => `"${i.name}"`).join(", ")}). `
+                + `A section header mirrors the total of the lines beneath it, so list those lines instead. `
+                + `Use one of: ${validTypes.join(", ")}.`,
+        };
+    }
+
     // Integer-cents math end to end so float artifacts (e.g. 1.005) can't
     // mis-round a line: unit costs become integer cents, line totals stay in
     // cents, and dollars only reappear at persistence.

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -16,7 +16,7 @@ import { prisma } from "@/lib/prisma";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { sendNotification } from "./email";
 import { formatCurrency } from "./utils";
-import { coTaxRate, coTaxLabel, coLineCents, billableCoItems } from "./co-tax";
+import { coTaxRate, coTaxLabel, coLineCents, billableCoItems, coSectionRowError, coSectionRowNames } from "./co-tax";
 import { deriveInvoiceTaxFields, toNum } from "./prisma-helpers";
 import { dateInputInTimeZone, endOfDateInTimeZone, resolveCompanyTimeZone } from "./company-timezone";
 
@@ -1550,6 +1550,18 @@ export async function billChangeOrderCore(
         if (co.pricingType === "COST_PLUS") {
             return { ok: false as const, error: `${co.code} is cost plus — use bill_cost_plus_change_order with a through date.` };
         }
+        // Billing invoices the stored totalAmount and never re-derives it from items, so the
+        // send and approval guards do not protect a CO that reached Approved before those
+        // guards existed. Re-check the one condition that makes the stored total untrustworthy
+        // rather than revalidating the whole subtotal — an Approved CO is a signed number, and
+        // failing it on ordinary drift would block legitimate billing.
+        const billItems = await tx.changeOrderItem.findMany({
+            where: { changeOrderId },
+            select: { name: true, type: true },
+        });
+        const sectionRows = coSectionRowNames(billItems);
+        if (sectionRows.length > 0) return { ok: false as const, error: coSectionRowError(co.code, sectionRows) };
+
         const subtotalCents = Math.round(Number(co.totalAmount) * 100);
         if (subtotalCents <= 0) return { ok: false as const, error: `Change order ${co.code} has a $0 total — nothing to bill.` };
         const estimateTax = await tx.estimate.findUnique({
@@ -1874,8 +1886,14 @@ export async function sendChangeOrderToClientCore(
         // bills and locks, and a $0 approved CO can't be repaired.
         const items = await tx.changeOrderItem.findMany({
             where: { changeOrderId },
-            select: { type: true, quantity: true, unitCost: true },
+            select: { name: true, type: true, quantity: true, unitCost: true },
         });
+        // Legacy rows written before section headers were rejected at the write path. A header
+        // mirrors the total of the lines beneath it, so it must never reach a client signature.
+        const sectionRows = coSectionRowNames(items);
+        if (sectionRows.length > 0) {
+            return { kind: "error", error: coSectionRowError(co.code, sectionRows) };
+        }
         const storedSubtotalCents = Math.round(Number(co.totalAmount) * 100);
         const renderedSubtotalCents = billableCoItems(items).reduce(
             (sum, item) => sum + coLineCents(item.quantity, Number(item.unitCost)),

--- a/src/lib/change-order-core.ts
+++ b/src/lib/change-order-core.ts
@@ -1,6 +1,6 @@
 import { prisma } from "./prisma";
 import { dateInputInTimeZone, resolveCompanyTimeZone } from "./company-timezone";
-import { coLineCents } from "./co-tax";
+import { billableCoItems, coLineCents } from "./co-tax";
 
 type ChangeOrderItemInput = {
     id?: string;
@@ -74,8 +74,8 @@ function normalizeSchedules(
     });
 }
 
-function itemSubtotalCents(items: Array<{ quantity: number; unitCost: unknown }>): number {
-    return items.reduce((sum, item) => sum + coLineCents(item.quantity, Number(item.unitCost)), 0);
+function itemSubtotalCents(items: Array<{ type?: string | null; quantity: number; unitCost: unknown }>): number {
+    return billableCoItems(items).reduce((sum, item) => sum + coLineCents(item.quantity, Number(item.unitCost)), 0);
 }
 
 /**
@@ -192,13 +192,11 @@ export async function updateChangeOrderCore(id: string, data: ChangeOrderUpdateI
             const existingIds = new Set(existing.map(i => i.id));
             const existingById = new Map(existing.map((item) => [item.id, item]));
 
-            let totalCents = 0;
             const rows = items.map((item, idx) => {
                 const quantity = parseFloat(String(item.quantity ?? "")) || 0;
                 const unitCost = parseFloat(String(item.unitCost ?? "")) || 0;
                 const unitCents = Math.round(unitCost * 100);
                 const lineCents = coLineCents(quantity, unitCost);
-                totalCents += lineCents;
                 // On a row that matches an existing item, an omitted (undefined)
                 // description/costCodeId/costTypeId keeps the stored value —
                 // resolved here, under the same row lock as the write, so a
@@ -219,6 +217,10 @@ export async function updateChangeOrderCore(id: string, data: ChangeOrderUpdateI
                     costTypeId: item.costTypeId === undefined ? (prior?.costTypeId ?? null) : (item.costTypeId || null),
                 };
             });
+            // Persisted total must use the same billable-row rule the approval and send
+            // guards recompute with, or a payload carrying a section header would store a
+            // subtotal those guards then reject as "out of sync with its items".
+            const totalCents = itemSubtotalCents(rows);
             const incomingIds = new Set(rows.map(r => r.id).filter(Boolean));
             const toDelete = existing.filter(i => !incomingIds.has(i.id)).map(i => i.id);
             const itemRowsChanged = rows.length !== existing.length || rows.some((row) => {
@@ -369,7 +371,7 @@ export async function approveChangeOrderCore(
 
         const items = await tx.changeOrderItem.findMany({
             where: { changeOrderId: id },
-            select: { quantity: true, unitCost: true },
+            select: { type: true, quantity: true, unitCost: true },
         });
         if (current.pricingType !== "COST_PLUS" && items.length === 0) {
             throw new Error(`Change order ${current.code} must contain at least one priced item before it can be approved.`);

--- a/src/lib/change-order-core.ts
+++ b/src/lib/change-order-core.ts
@@ -1,6 +1,6 @@
 import { prisma } from "./prisma";
 import { dateInputInTimeZone, resolveCompanyTimeZone } from "./company-timezone";
-import { billableCoItems, coLineCents } from "./co-tax";
+import { billableCoItems, coLineCents, coSectionRowError, coSectionRowNames } from "./co-tax";
 
 type ChangeOrderItemInput = {
     id?: string;
@@ -92,6 +92,7 @@ export async function updateChangeOrderCore(id: string, data: ChangeOrderUpdateI
     return prisma.$transaction(async (tx) => {
         // Serialize editors with send, approval, billing, and co-audit repair.
         const locked = await tx.$queryRaw<Array<{
+            code: string;
             status: string;
             title: string;
             description: string | null;
@@ -105,7 +106,7 @@ export async function updateChangeOrderCore(id: string, data: ChangeOrderUpdateI
             companySignedAt: Date | null;
             companySignatureUrl: string | null;
         }>>`
-            SELECT "status", "title", "description", "totalAmount", "pricingType", "markupPercent",
+            SELECT "code", "status", "title", "description", "totalAmount", "pricingType", "markupPercent",
                    "approvedBy", "approvedAt", "clientSignatureUrl",
                    "companySignedBy", "companySignedAt", "companySignatureUrl"
             FROM "ChangeOrder" WHERE "id" = ${id} FOR UPDATE`;
@@ -204,11 +205,17 @@ export async function updateChangeOrderCore(id: string, data: ChangeOrderUpdateI
                 // editor always sends explicit values (x || null), so this only
                 // affects connector callers. Empty string / null still clears.
                 const prior = item.id ? existingById.get(item.id) : undefined;
+                // `type` is keep-prior too (the MCP omits it whenever costType is omitted),
+                // and the *effective* type is what decides whether this row is billable. Read
+                // the stored value here or the subtotal computed below would disagree with the
+                // one the send and approval guards recompute after reload — a mismatch those
+                // guards treat as "out of sync with its items", permanently.
+                const effectiveType = item.type ?? prior?.type ?? undefined;
                 return {
                     id: item.id || undefined,
                     name: item.name || "",
                     description: item.description === undefined ? (prior?.description ?? null) : (item.description || null),
-                    ...(item.type ? { type: item.type } : {}),
+                    ...(effectiveType ? { type: effectiveType } : {}),
                     quantity,
                     unitCost: unitCents / 100,
                     total: lineCents / 100,
@@ -217,9 +224,11 @@ export async function updateChangeOrderCore(id: string, data: ChangeOrderUpdateI
                     costTypeId: item.costTypeId === undefined ? (prior?.costTypeId ?? null) : (item.costTypeId || null),
                 };
             });
-            // Persisted total must use the same billable-row rule the approval and send
-            // guards recompute with, or a payload carrying a section header would store a
-            // subtotal those guards then reject as "out of sync with its items".
+            // Refuse a section header at the point it would enter the change order, rather
+            // than storing a row every downstream reader then has to second-guess.
+            const sectionRows = coSectionRowNames(rows);
+            if (sectionRows.length > 0) throw new Error(coSectionRowError(current.code, sectionRows));
+
             const totalCents = itemSubtotalCents(rows);
             const incomingIds = new Set(rows.map(r => r.id).filter(Boolean));
             const toDelete = existing.filter(i => !incomingIds.has(i.id)).map(i => i.id);
@@ -371,8 +380,11 @@ export async function approveChangeOrderCore(
 
         const items = await tx.changeOrderItem.findMany({
             where: { changeOrderId: id },
-            select: { type: true, quantity: true, unitCost: true },
+            select: { name: true, type: true, quantity: true, unitCost: true },
         });
+        // Legacy rows written before section headers were rejected at the write path.
+        const sectionRows = coSectionRowNames(items);
+        if (sectionRows.length > 0) throw new Error(coSectionRowError(current.code, sectionRows));
         if (current.pricingType !== "COST_PLUS" && items.length === 0) {
             throw new Error(`Change order ${current.code} must contain at least one priced item before it can be approved.`);
         }

--- a/src/lib/change-order-core.ts
+++ b/src/lib/change-order-core.ts
@@ -210,7 +210,14 @@ export async function updateChangeOrderCore(id: string, data: ChangeOrderUpdateI
                 // the stored value here or the subtotal computed below would disagree with the
                 // one the send and approval guards recompute after reload — a mismatch those
                 // guards treat as "out of sync with its items", permanently.
-                const effectiveType = item.type ?? prior?.type ?? undefined;
+                //
+                // Blank counts as "not specified", not as "clear it": the column is NOT NULL
+                // with a default, so there is nothing to clear it to. Were a blank allowed to
+                // win, an incoming `type: ""` against a stored Section would drop `type` from
+                // both this row (hiding the header from the guard below) and the Prisma write
+                // (leaving Section in the database) — reintroducing the exact mismatch above.
+                const requestedType = typeof item.type === "string" ? item.type.trim() : undefined;
+                const effectiveType = requestedType || prior?.type || undefined;
                 return {
                     id: item.id || undefined,
                     name: item.name || "",

--- a/src/lib/co-tax.ts
+++ b/src/lib/co-tax.ts
@@ -38,20 +38,38 @@ export function coLineCents(quantity: number, unitCost: number): number {
 }
 
 /**
- * The change-order rows that actually carry money.
+ * A section header has no place in a change order.
  *
- * `ChangeOrderItem` is flat — no `parentId` — so a row copied from a sectioned estimate keeps
- * `type: "Section"` and the section's *rolled-up* unitCost, which is the sum of the leaf rows
- * sitting right beside it. Billing both double-counts the section. `createChangeOrder` now
- * expands a section selection to its leaves so new COs never contain a header at all; this
- * guard covers rows written before that fix and any connector payload that sends one.
+ * `ChangeOrderItem` is flat — no `parentId` — so a row copied out of a sectioned estimate
+ * keeps `type: "Section"` and the section's *rolled-up* unitCost, which is the sum of the leaf
+ * rows copied beside it. Billing both double-counts the section.
  *
- * A CO whose rows are *all* headers passes through untouched: it carries no leaves to
- * double-count, and filtering it would silently total the change order to zero.
+ * Nothing can legitimately produce such a row: the CO editor and the MCP both restrict `type`
+ * to Labor / Material / Allowance / Subcontractor / Equipment / Other, and `createChangeOrder`
+ * now resolves a section selection to its leaves. A header is therefore corrupt data, never a
+ * standalone "bill this whole phase" line — which is why the money paths (write, send,
+ * approve) reject it outright instead of guessing at what it was meant to charge. Flat rows
+ * cannot tell a duplicate header apart from a standalone one, and a wrong guess is a wrong
+ * invoice in either direction.
+ */
+export function coSectionRowNames<T extends { type?: string | null; name?: string | null }>(items: readonly T[]): string[] {
+    return items.filter(item => item.type === "Section").map(item => item.name?.trim() || "(unnamed)");
+}
+
+/** Error text shared by every money path that refuses a change order carrying section headers. */
+export function coSectionRowError(code: string, sectionNames: readonly string[]): string {
+    return `Change order ${code} contains estimate section headers (${sectionNames.join(", ")}). `
+        + `A header mirrors the total of the lines beneath it, so billing it would charge that work twice. `
+        + `Delete those rows, or rebuild the change order from the estimate, before continuing.`;
+}
+
+/**
+ * The change-order rows that carry money. Read paths (subtotals shown on screen, the budget
+ * roll-up) use this so a corrupt legacy row inflates nothing while a human sorts it out; the
+ * money paths refuse the change order entirely rather than render a number from it.
  */
 export function billableCoItems<T extends { type?: string | null }>(items: readonly T[]): readonly T[] {
-    const billable = items.filter(item => item.type !== "Section");
-    return billable.length === 0 ? items : billable;
+    return items.filter(item => item.type !== "Section");
 }
 
 export function coItemsSubtotal(items: Array<{ type?: string | null; quantity?: number | string | null; unitCost?: number | string | null }>): number {

--- a/src/lib/co-tax.ts
+++ b/src/lib/co-tax.ts
@@ -37,8 +37,25 @@ export function coLineCents(quantity: number, unitCost: number): number {
     return Math.round(Number(((quantity || 0) * unitCents).toPrecision(12)));
 }
 
-export function coItemsSubtotal(items: Array<{ quantity?: number | string | null; unitCost?: number | string | null }>): number {
-    return items.reduce((cents, item) => cents + coLineCents(
+/**
+ * The change-order rows that actually carry money.
+ *
+ * `ChangeOrderItem` is flat — no `parentId` — so a row copied from a sectioned estimate keeps
+ * `type: "Section"` and the section's *rolled-up* unitCost, which is the sum of the leaf rows
+ * sitting right beside it. Billing both double-counts the section. `createChangeOrder` now
+ * expands a section selection to its leaves so new COs never contain a header at all; this
+ * guard covers rows written before that fix and any connector payload that sends one.
+ *
+ * A CO whose rows are *all* headers passes through untouched: it carries no leaves to
+ * double-count, and filtering it would silently total the change order to zero.
+ */
+export function billableCoItems<T extends { type?: string | null }>(items: readonly T[]): readonly T[] {
+    const billable = items.filter(item => item.type !== "Section");
+    return billable.length === 0 ? items : billable;
+}
+
+export function coItemsSubtotal(items: Array<{ type?: string | null; quantity?: number | string | null; unitCost?: number | string | null }>): number {
+    return billableCoItems(items).reduce((cents, item) => cents + coLineCents(
         parseFloat(String(item.quantity)) || 0,
         parseFloat(String(item.unitCost)) || 0,
     ), 0) / 100;

--- a/src/lib/estimate-item-payload.ts
+++ b/src/lib/estimate-item-payload.ts
@@ -56,7 +56,15 @@ function num(value: unknown): number {
  * be impossible, but is not enforced at the DB level) is treated as contributing 0 rather
  * than recursing forever.
  */
-export function computeEstimateItemTotals<T extends EstimateItemLike>(items: readonly T[]): EstimateItemTotal[] {
+const ROOTED = 1;
+const UNROOTED = 2;
+
+/**
+ * Parent/child indexes, section detection, and rootedness — the shared reading of the item
+ * tree. `computeEstimateItemTotals` and `selectedBillableRows` both walk it, and they must
+ * agree: a row the totals call values at 0 must not be a row the selection call bills.
+ */
+function buildItemGraph<T extends EstimateItemLike>(items: readonly T[]) {
     const childIndexesByParent = new Map<string, number[]>();
     const indexById = new Map<string, number>();
 
@@ -81,8 +89,6 @@ export function computeEstimateItemTotals<T extends EstimateItemLike>(items: rea
     // Rows whose parent chain loops instead of terminating at a root. Resolved up front so
     // the outcome does not depend on the order rows happen to appear in: every row in (or
     // hanging off) a cycle totals 0 and contributes 0, whichever end we start walking from.
-    const ROOTED = 1;
-    const UNROOTED = 2;
     const rootedness = new Array<number>(items.length).fill(0);
     for (let start = 0; start < items.length; start++) {
         if (rootedness[start] !== 0) continue;
@@ -100,6 +106,12 @@ export function computeEstimateItemTotals<T extends EstimateItemLike>(items: rea
         }
         for (const index of path) rootedness[index] = verdict;
     }
+
+    return { childIndexesByParent, indexById, isSectionAt, rootedness };
+}
+
+export function computeEstimateItemTotals<T extends EstimateItemLike>(items: readonly T[]): EstimateItemTotal[] {
+    const { childIndexesByParent, isSectionAt, rootedness } = buildItemGraph(items);
 
     const resolved = new Array<number | undefined>(items.length);
 
@@ -149,44 +161,36 @@ export function isEstimateSectionRow<T extends EstimateItemLike>(item: T, items:
  * and its descendant leaves come along, including ones the user did not tick individually.
  *
  * Document order is preserved and each leaf appears once no matter how many of its ancestors
- * were selected. Cyclic `parentId` data is walked at most once per row, matching
- * `computeEstimateItemTotals`' refusal to recurse forever.
+ * were selected. Rows in a cyclic `parentId` component are skipped entirely: the estimate
+ * values them at 0 (see `computeEstimateItemTotals`), so billing one would charge for work the
+ * estimate it came from prices at nothing.
  */
 export function selectedBillableRows<T extends EstimateItemLike>(
     items: readonly T[],
     selectedIds: readonly string[],
 ): T[] {
-    const childrenByParent = new Map<string, T[]>();
-    const byId = new Map<string, T>();
-    for (const item of items) {
-        const id = item.id ? String(item.id) : null;
-        if (id && !byId.has(id)) byId.set(id, item);
-        const parentId = item.parentId ? String(item.parentId) : null;
-        if (!parentId) continue;
-        const siblings = childrenByParent.get(parentId);
-        if (siblings) siblings.push(item);
-        else childrenByParent.set(parentId, [item]);
-    }
+    const { childIndexesByParent, indexById, isSectionAt, rootedness } = buildItemGraph(items);
 
-    const visited = new Set<string>();
-    const leafIds = new Set<string>();
-    const visit = (item: T) => {
-        const id = item.id ? String(item.id) : null;
-        if (!id || visited.has(id)) return;
-        visited.add(id);
-        if (isEstimateSectionRow(item, items)) {
-            for (const child of childrenByParent.get(id) ?? []) visit(child);
+    const visited = new Array<boolean>(items.length).fill(false);
+    const billable = new Array<boolean>(items.length).fill(false);
+    const visit = (index: number) => {
+        if (visited[index]) return;
+        visited[index] = true;
+        if (rootedness[index] === UNROOTED) return;
+        if (isSectionAt(index)) {
+            const id = items[index].id ? String(items[index].id) : null;
+            for (const childIndex of (id && childIndexesByParent.get(id)) || []) visit(childIndex);
             return;
         }
-        leafIds.add(id);
+        billable[index] = true;
     };
 
     for (const selectedId of selectedIds) {
-        const item = byId.get(String(selectedId));
-        if (item) visit(item);
+        const index = indexById.get(String(selectedId));
+        if (index !== undefined) visit(index);
     }
 
-    return items.filter(item => !!item.id && leafIds.has(String(item.id)));
+    return items.filter((_item, index) => billable[index]);
 }
 
 /**

--- a/src/lib/estimate-item-payload.ts
+++ b/src/lib/estimate-item-payload.ts
@@ -140,6 +140,56 @@ export function isEstimateSectionRow<T extends EstimateItemLike>(item: T, items:
 }
 
 /**
+ * Resolve a set of selected estimate rows to the billable leaves they stand for.
+ *
+ * A section header mirrors its children's rolled-up total, so copying a header *and* its
+ * children into a flat model — `ChangeOrderItem` has no `parentId`, so the hierarchy that
+ * `isEstimateSectionRow` needs cannot be reconstructed there — bills the section twice.
+ * Selecting a header is read as "everything under this phase": the header itself drops out
+ * and its descendant leaves come along, including ones the user did not tick individually.
+ *
+ * Document order is preserved and each leaf appears once no matter how many of its ancestors
+ * were selected. Cyclic `parentId` data is walked at most once per row, matching
+ * `computeEstimateItemTotals`' refusal to recurse forever.
+ */
+export function selectedBillableRows<T extends EstimateItemLike>(
+    items: readonly T[],
+    selectedIds: readonly string[],
+): T[] {
+    const childrenByParent = new Map<string, T[]>();
+    const byId = new Map<string, T>();
+    for (const item of items) {
+        const id = item.id ? String(item.id) : null;
+        if (id && !byId.has(id)) byId.set(id, item);
+        const parentId = item.parentId ? String(item.parentId) : null;
+        if (!parentId) continue;
+        const siblings = childrenByParent.get(parentId);
+        if (siblings) siblings.push(item);
+        else childrenByParent.set(parentId, [item]);
+    }
+
+    const visited = new Set<string>();
+    const leafIds = new Set<string>();
+    const visit = (item: T) => {
+        const id = item.id ? String(item.id) : null;
+        if (!id || visited.has(id)) return;
+        visited.add(id);
+        if (isEstimateSectionRow(item, items)) {
+            for (const child of childrenByParent.get(id) ?? []) visit(child);
+            return;
+        }
+        leafIds.add(id);
+    };
+
+    for (const selectedId of selectedIds) {
+        const item = byId.get(String(selectedId));
+        if (item) visit(item);
+    }
+
+    return items.filter(item => !!item.id && leafIds.has(String(item.id)));
+}
+
+/**
  * Tag every detected section with `type: "Section"`, leaving all other rows untouched.
  *
  * `serializeEstimateItemsForSave` normalizes the rows it *persists*, but it is deliberately

--- a/src/lib/pdf.ts
+++ b/src/lib/pdf.ts
@@ -4,7 +4,7 @@ import { toNum } from './prisma-helpers';
 import { buildLetterheadConfig, type LetterheadConfig } from './letterhead';
 import { isOwnSignatureStorageUrl } from './signature-storage';
 import { isSecureRef, downloadDocBytes } from './secure-storage';
-import { coTaxRate, coTaxLabel } from './co-tax';
+import { coTaxRate, coTaxLabel, billableCoItems } from './co-tax';
 import { drawRichHtml, drawWrappedText, measureWrappedLines, type RichTextCtx } from './pdf-richtext';
 import { isEstimateSectionRow, rm } from './estimate-item-payload';
 
@@ -1163,7 +1163,11 @@ export async function generateChangeOrderPdf(coId: string): Promise<Buffer> {
     };
     // Fully empty placeholder rows (no name, no description, $0) would render
     // as orphan "$0.00" lines — drop them. Anything with text or money stays.
-    const coVisibleItems = co.items.filter(it =>
+    // Section headers are excluded before the empty-row filter: a header mirrors the total
+    // of the lines beneath it, so printing it would make the visible lines out-sum the
+    // subtotal the customer signs. (The send guard refuses such a CO outright; this keeps an
+    // unsent draft's preview honest.)
+    const coVisibleItems = billableCoItems(co.items).filter(it =>
         (it.name || '').trim() || (it.description || '').trim() || Number(it.total) || Number(it.unitCost));
     // Reserve through the first item so neither the cost-plus terms block nor
     // the table header is left orphaned when the first row's preflight breaks.

--- a/tests/estimate-item-payload.test.ts
+++ b/tests/estimate-item-payload.test.ts
@@ -13,7 +13,7 @@ import {
     selectedBillableRows,
 } from "../src/lib/estimate-item-payload";
 import { buildQBEstimateLines } from "../src/lib/quickbooks";
-import { billableCoItems, coItemsSubtotal } from "../src/lib/co-tax";
+import { billableCoItems, coItemsSubtotal, coSectionRowNames } from "../src/lib/co-tax";
 
 type Row = {
     id: string;
@@ -527,17 +527,20 @@ test("selectedBillableRows drops an emptied section and preserves document order
     assert.deepEqual(selectedBillableRows(rows, ["last", "empty", "first"]).map(r => r.id), ["first", "last"]);
 });
 
-test("selectedBillableRows terminates on cyclic parentId data", () => {
+test("selectedBillableRows skips a cyclic component instead of billing it", () => {
     const rows: Row[] = [
-        { id: "x", parentId: "y", quantity: 1, unitCost: 5 },
-        { id: "y", parentId: "x", quantity: 1, unitCost: 5 },
+        { id: "x", parentId: "y", type: "Section", quantity: 1, unitCost: 10 },
+        { id: "y", parentId: "x", type: "Section", quantity: 1, unitCost: 10 },
+        { id: "leaf", parentId: "x", quantity: 1, unitCost: 25 },
     ];
-    // Both are "sections" (each has a child), so the cycle resolves to no billable rows
-    // rather than recursing forever.
+    // computeEstimateItemTotals values every row in an unrooted component at 0, so billing
+    // the leaf would charge $25 for work the estimate it came from prices at nothing.
+    assert.deepEqual(computeEstimateItemTotals(rows).map(t => t.total), [0, 0, 0]);
     assert.deepEqual(selectedBillableRows(rows, ["x"]).map(r => r.id), []);
+    assert.deepEqual(selectedBillableRows(rows, ["leaf"]).map(r => r.id), []);
 });
 
-test("billableCoItems excludes section rows but never zeroes an all-header CO", () => {
+test("billableCoItems drops section rows without guessing at their meaning", () => {
     const mixed = [
         { type: "Section", quantity: 1, unitCost: 1000 },
         { type: "Material", quantity: 1, unitCost: 300 },
@@ -545,14 +548,43 @@ test("billableCoItems excludes section rows but never zeroes an all-header CO", 
     ];
     assert.equal(coItemsSubtotal(mixed), 1000);
 
-    // A legitimate "bill this whole phase" CO whose every row is a header must still
-    // total its rows — filtering them all would silently bill $0.
+    // No fallback for an all-headers CO. Flat rows cannot tell a header that duplicates the
+    // lines beside it from a standalone charge, and neither reading can be assumed: two
+    // nested headers would double-count, a standalone one would vanish. Nothing can create
+    // such a row (editor and MCP both reject type "Section"), so the money paths refuse the
+    // change order outright rather than render a number from it.
     const headersOnly = [
-        { type: "Section", quantity: 1, unitCost: 1000 },
-        { type: "Section", quantity: 1, unitCost: 2000 },
+        { type: "Section", name: "Phase 1", quantity: 1, unitCost: 1000 },
+        { type: "Section", name: "Phase 2", quantity: 1, unitCost: 2000 },
     ];
-    assert.equal(coItemsSubtotal(headersOnly), 3000);
-    assert.equal(billableCoItems(headersOnly).length, 2);
+    assert.equal(billableCoItems(headersOnly).length, 0);
+    assert.deepEqual(coSectionRowNames(headersOnly), ["Phase 1", "Phase 2"]);
+    assert.deepEqual(coSectionRowNames(mixed), ["(unnamed)"]);
+    assert.deepEqual(coSectionRowNames([{ type: "Material", name: "Tile" }]), []);
+});
+
+test("every money path refuses a change order carrying section headers", () => {
+    const root = path.join(__dirname, "..");
+    const guarded = {
+        "src/lib/change-order-core.ts": 2,   // write + approve
+        "src/lib/billing-core.ts": 2,        // send + bill
+    };
+    for (const [file, expected] of Object.entries(guarded)) {
+        const source = readFileSync(path.join(root, file), "utf8");
+        assert.equal(
+            source.split("coSectionRowNames(").length - 1, expected,
+            `${file} should guard ${expected} money paths against section rows`,
+        );
+    }
+});
+
+test("an omitted type keeps the stored one, so the persisted total stays reproducible", () => {
+    // The MCP omits `type` whenever costType is omitted. updateChangeOrderCore must read the
+    // prior type before totalling, or the stored subtotal disagrees forever with the one the
+    // send and approval guards recompute after reload.
+    const core = readFileSync(path.join(__dirname, "..", "src/lib/change-order-core.ts"), "utf8");
+    assert.match(core, /const effectiveType = item\.type \?\? prior\?\.type \?\? undefined;/);
+    assert.match(core, /\.\.\.\(effectiveType \? \{ type: effectiveType \} : \{\}\)/);
 });
 
 test("createChangeOrder normalizes its selection through the shared helper", () => {

--- a/tests/estimate-item-payload.test.ts
+++ b/tests/estimate-item-payload.test.ts
@@ -578,12 +578,39 @@ test("every money path refuses a change order carrying section headers", () => {
     }
 });
 
+test("a blank type falls back to the stored one rather than erasing it", () => {
+    // `type: ""` against a stored Section must not resolve to "no type": that would hide the
+    // header from the write guard AND leave Section in the database, so the stored total
+    // would count a row the send/approve guards then exclude — permanently out of sync.
+    const core = readFileSync(path.join(__dirname, "..", "src/lib/change-order-core.ts"), "utf8");
+    assert.match(core, /const requestedType = typeof item\.type === "string" \? item\.type\.trim\(\) : undefined;/);
+    assert.match(core, /const effectiveType = requestedType \|\| prior\?\.type \|\| undefined;/);
+});
+
+test("the connector refuses a Section cost type instead of coercing it to Material", () => {
+    // Coercion would smuggle a rolled-up header past every `type === "Section"` guard,
+    // disguised as a billable line nothing downstream could identify.
+    const billing = readFileSync(path.join(__dirname, "..", "src/lib/billing-core.ts"), "utf8");
+    assert.match(billing, /costType\?\.trim\(\)\.toLowerCase\(\) === "section"/);
+    assert.match(billing, /Cost type "Section" is not a change-order line/);
+});
+
+test("the audit reports section rows and refuses to recompute past them", () => {
+    // Recomputing would write back a subtotal excluding the headers while leaving the rows
+    // in place, so a later GET reads "ok" while send and approve stay correctly blocked.
+    const audit = readFileSync(path.join(__dirname, "..", "src/app/api/integrations/co-audit/route.ts"), "utf8");
+    assert.match(audit, /if \(sectionCount > 0\) return "has-sections";/);
+    assert.match(audit, /if \(verdict === "has-sections"\)[\s\S]{0,120}?coSectionRowError\(co\.code, sectionNames\)/);
+    // The section verdict must be decided before the empty and tolerance branches.
+    assert.ok(audit.indexOf('return "has-sections"') < audit.indexOf('return "no-items"'));
+});
+
 test("an omitted type keeps the stored one, so the persisted total stays reproducible", () => {
     // The MCP omits `type` whenever costType is omitted. updateChangeOrderCore must read the
     // prior type before totalling, or the stored subtotal disagrees forever with the one the
     // send and approval guards recompute after reload.
     const core = readFileSync(path.join(__dirname, "..", "src/lib/change-order-core.ts"), "utf8");
-    assert.match(core, /const effectiveType = item\.type \?\? prior\?\.type \?\? undefined;/);
+    assert.match(core, /const effectiveType = requestedType \|\| prior\?\.type \|\| undefined;/);
     assert.match(core, /\.\.\.\(effectiveType \? \{ type: effectiveType \} : \{\}\)/);
 });
 

--- a/tests/estimate-item-payload.test.ts
+++ b/tests/estimate-item-payload.test.ts
@@ -10,8 +10,10 @@ import {
     serializeEstimateItemsForSave,
     ESTIMATE_ITEM_SAVE_FIELDS,
     normalizeEstimateItemForSave,
+    selectedBillableRows,
 } from "../src/lib/estimate-item-payload";
 import { buildQBEstimateLines } from "../src/lib/quickbooks";
+import { billableCoItems, coItemsSubtotal } from "../src/lib/co-tax";
 
 type Row = {
     id: string;
@@ -471,4 +473,90 @@ test("saveEstimate and the editor both go through the shared projection", () => 
     const fn = body.slice(0, body.indexOf("\n    }") + 6);
     assert.match(fn, /setItems\(prev =>/);
     assert.doesNotMatch(fn, /\[\.\.\.items\]/);
+});
+
+// ─── Change-order section double-count (Codex review, 2026-08-07) ─────────────
+// ChangeOrderItem is flat — no parentId — so a section header copied into a CO keeps
+// type "Section" and its children's rolled-up unitCost. Billing both double-counts it.
+
+test("selectedBillableRows expands a selected section to its leaves", () => {
+    const rows: Row[] = [
+        { id: "sec", type: "Section", quantity: 1, unitCost: 1000 },
+        { id: "a", parentId: "sec", quantity: 1, unitCost: 300 },
+        { id: "b", parentId: "sec", quantity: 1, unitCost: 700 },
+    ];
+    const picked = selectedBillableRows(rows, ["sec", "a", "b"]);
+    assert.deepEqual(picked.map(r => r.id), ["a", "b"]);
+    // The header's mirrored 1000 is gone; the CO bills 300 + 700 once.
+    assert.equal(picked.reduce((s, r) => s + Number(r.unitCost), 0), 1000);
+});
+
+test("selectedBillableRows takes the whole phase when only the header is ticked", () => {
+    const rows: Row[] = [
+        { id: "sec", type: "Section", quantity: 1, unitCost: 1000 },
+        { id: "a", parentId: "sec", quantity: 1, unitCost: 300 },
+        { id: "b", parentId: "sec", quantity: 1, unitCost: 700 },
+        { id: "loose", quantity: 1, unitCost: 50 },
+    ];
+    assert.deepEqual(selectedBillableRows(rows, ["sec"]).map(r => r.id), ["a", "b"]);
+});
+
+test("selectedBillableRows recurses through nested sections and dedupes", () => {
+    const rows: Row[] = [
+        { id: "outer", type: "Section", quantity: 1, unitCost: 900 },
+        { id: "inner", parentId: "outer", type: "Section", quantity: 1, unitCost: 900 },
+        { id: "leaf", parentId: "inner", quantity: 3, unitCost: 300 },
+    ];
+    assert.deepEqual(selectedBillableRows(rows, ["outer", "inner", "leaf"]).map(r => r.id), ["leaf"]);
+});
+
+test("selectedBillableRows drops a legacy section detected only by its children", () => {
+    const rows: Row[] = [
+        { id: "sec", quantity: 1, unitCost: 400 },
+        { id: "a", parentId: "sec", quantity: 1, unitCost: 400 },
+    ];
+    assert.deepEqual(selectedBillableRows(rows, ["sec", "a"]).map(r => r.id), ["a"]);
+});
+
+test("selectedBillableRows drops an emptied section and preserves document order", () => {
+    const rows: Row[] = [
+        { id: "first", quantity: 1, unitCost: 10 },
+        { id: "empty", type: "Section", quantity: 1, unitCost: 999 },
+        { id: "last", quantity: 1, unitCost: 20 },
+    ];
+    assert.deepEqual(selectedBillableRows(rows, ["last", "empty", "first"]).map(r => r.id), ["first", "last"]);
+});
+
+test("selectedBillableRows terminates on cyclic parentId data", () => {
+    const rows: Row[] = [
+        { id: "x", parentId: "y", quantity: 1, unitCost: 5 },
+        { id: "y", parentId: "x", quantity: 1, unitCost: 5 },
+    ];
+    // Both are "sections" (each has a child), so the cycle resolves to no billable rows
+    // rather than recursing forever.
+    assert.deepEqual(selectedBillableRows(rows, ["x"]).map(r => r.id), []);
+});
+
+test("billableCoItems excludes section rows but never zeroes an all-header CO", () => {
+    const mixed = [
+        { type: "Section", quantity: 1, unitCost: 1000 },
+        { type: "Material", quantity: 1, unitCost: 300 },
+        { type: "Labor", quantity: 1, unitCost: 700 },
+    ];
+    assert.equal(coItemsSubtotal(mixed), 1000);
+
+    // A legitimate "bill this whole phase" CO whose every row is a header must still
+    // total its rows — filtering them all would silently bill $0.
+    const headersOnly = [
+        { type: "Section", quantity: 1, unitCost: 1000 },
+        { type: "Section", quantity: 1, unitCost: 2000 },
+    ];
+    assert.equal(coItemsSubtotal(headersOnly), 3000);
+    assert.equal(billableCoItems(headersOnly).length, 2);
+});
+
+test("createChangeOrder normalizes its selection through the shared helper", () => {
+    const actions = readFileSync(path.join(__dirname, "..", "src/lib/actions.ts"), "utf8");
+    const body = actions.slice(actions.indexOf("export async function createChangeOrder("));
+    assert.match(body.slice(0, body.indexOf("\n}")), /selectedBillableRows\(estimate\.items, itemIds\)/);
 });


### PR DESCRIPTION
Deferred finding from the Codex peer review that shipped alongside #320 (which fixed this same class of bug in the Budget and Variance views).

## The bug

`ChangeOrderItem` is a flat model — no `parentId`. So when "Select all" in the estimate editor ticked a section header *and* its children, `createChangeOrder` copied the header across too, keeping `type: "Section"` and the section's **mirrored rolled-up** `unitCost`/`total`. That total is the sum of the leaf rows copied right beside it, so the CO subtotal billed the section twice, and `BudgetClient`'s `revisedEst` inherited the inflation.

**Blast radius today: zero.** A read-only scan of all 11 production change orders found 0 Section-typed rows. This is latent, fixed before someone builds a CO from a sectioned selection.

## The fix

Fixed **upstream**, not at the subtotal. `createChangeOrder` now resolves the selection to its billable descendant leaves via `selectedBillableRows`, so a CO never contains a header at all. Ticking a header reads as "bill this whole phase" and pulls its leaves in. The rejected alternative was adding `parentId` to `ChangeOrderItem` and preserving hierarchy end to end — a much larger change to a model every CO reader assumes is flat.

The review flagged that filtering `type === "Section"` in `BudgetClient` is **not** safe alone, because an all-headers CO would then total zero. Rather than guess, this PR removes the ambiguity: **nothing can legitimately create a Section row in a CO** — the CO editor has no Section option and the MCP validates `type` against Labor/Material/Allowance/Subcontractor/Equipment/Other. A header is therefore corrupt data, never a standalone phase charge. Flat rows can't tell the two apart, and both guesses are wrong in some case (two nested headers double-count; a standalone one vanishes).

So the four **money paths reject** the change order by name and tell the user to rebuild it — write, approve, send, and bill — while **read paths** (budget roll-up, on-screen subtotals, portal, PDF) drop the row so nothing inflates in the meantime.

## Also fixed (round 2 of review)

- **Connector partial updates.** `updateChangeOrderCore` computed the persisted total from the payload's `type`, but `type` is keep-prior — the MCP omits it whenever `costType` is omitted. A partial update stored a subtotal including a header the guards then excluded on reload, leaving the CO permanently unsendable. Effective type is now `item.type ?? prior.type` for both the total and the write.
- **Legacy Approved COs.** `billChangeOrderCore` invoices the stored `totalAmount` and never re-derives it, so the send/approve guards don't protect a CO approved before they existed. It now re-checks for headers under its own lock. Deliberately *only* that check, not a full stored-vs-rendered revalidation — an Approved CO is a signed number, and failing it on ordinary drift would block legitimate billing.
- **Cycle handling.** `selectedBillableRows` now shares `computeEstimateItemTotals`' rootedness walk, so a cyclic component the estimate values at $0 is skipped rather than billed. Also drops section lookup from O(n²) to O(n).
- **Customer-facing renders.** The portal item table and the CO PDF filter headers, so visible line amounts cannot out-sum the signed subtotal.

## Verification

- `npm run build` — 0 errors
- 39/39 in `tests/estimate-item-payload.test.ts` (12 new, covering leaf expansion, header-only selection, nested sections, dedup, document order, emptied sections, cycles, and the four rejection points)
- Read-only production scan, re-run after the fix: **11 change orders, 0 with Section rows, every stored total already exactly equal to the guarded total** — no existing CO changes behavior
- Two rounds of `codex-peer-review` (money path)

## Known, deliberately out of scope

The co-audit verdict tolerates a delta ≤ $0.01 while send and approval compare integer cents exactly, so a 1-cent drift reports "ok" but stays hard-blocked. Pre-existing and unrelated to sections; flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)