### PR TITLE
fix(estimates): resolve DEFAULT_MARGIN_PCT collision that broke main

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -17,7 +17,7 @@ import { persistOwnedSignature } from "./signature-storage";
 import { parseProductUrl, MAX_PRICE as PRODUCT_PARSE_MAX_PRICE } from "./product-parse";
 import { isHttpUrl } from "./url-safety";
 import { normalizeEstimateItemForSave } from "./estimate-item-payload";
-import { DEFAULT_MARGIN_PCT, roundMoney, sellFromMargin } from "./budget-math";
+import { LEGACY_MARKUP_MARGIN_PCT, roundMoney, sellFromMargin } from "./budget-math";
 import { canUseDevAuthFallback, getCurrentUserWithPermissions, getUserWithPermissionsByEmail, hasPermission, canAccessProject, PortalAuthError } from "./permissions";
 import { logActivity } from "./activity-log";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
@@ -13859,7 +13859,7 @@ export async function createEstimateFromRoomDesign(roomId: string) {
             ? productById.get(asset.assetId.slice(5))
             : undefined;
         const def = getItemDef(asset.assetId);
-        const marginPercent = DEFAULT_MARGIN_PCT;
+        const marginPercent = LEGACY_MARKUP_MARGIN_PCT;
         const name = product?.name ?? def?.name ?? `${asset.assetType.charAt(0).toUpperCase()}${asset.assetType.slice(1)}`;
 
         const metadata = (asset.metadata ?? {}) as Record<string, any>;

--- a/src/lib/budget-math.ts
+++ b/src/lib/budget-math.ts
@@ -34,17 +34,17 @@ export function roundMoney(value: number, decimals = 0): number {
 }
 
 /**
- * Default gross margin for items produced by paths that USED to apply a 25%
- * markup-on-cost (Room Studio furnish, AI takeoff). Equals that legacy markup
- * exactly (base * 1.25 === base / 0.8), which is what makes the conversion
- * price-neutral.
+ * The gross margin equal to the legacy 25% markup-on-cost, for the paths that
+ * used to apply one (Room Studio furnish). base * 1.25 === base / 0.8, which
+ * is what makes converting those writers to margin price-neutral.
  *
- * Deliberately NOT the same as the plain `25` default used by the schema and
- * by hand-added estimate items (EstimateItem.markupPercent @default(25),
- * saveEstimate's fallback). Those 25s were always a 25% MARGIN and are already
- * canonical, so they must stay 25 — do not "unify" them to this constant.
+ * Deliberately NOT `DEFAULT_MARGIN_PCT` (25) below. That one is what an empty
+ * margin input shows, and it matches EstimateItem.markupPercent @default(25) —
+ * those 25s always meant a 25% MARGIN and are already canonical. This constant
+ * exists only to reproduce old markup-on-cost prices exactly. Different
+ * numbers, different jobs — do not merge them.
  */
-export const DEFAULT_MARGIN_PCT = 20;
+export const LEGACY_MARKUP_MARGIN_PCT = 20;
 
 /**
  * Convert a legacy markup-on-cost percentage to the canonical gross-margin


### PR DESCRIPTION
## main is currently red

`tsc --noEmit` fails on `main`, so `npm run build` exits 2 and **every production deploy is blocked**:

```
src/lib/budget-math.ts(47,14): error TS2451: Cannot redeclare block-scoped variable 'DEFAULT_MARGIN_PCT'.
src/lib/budget-math.ts(117,14): error TS2451: Cannot redeclare block-scoped variable 'DEFAULT_MARGIN_PCT'.
```

#323 and #324 each added a `DEFAULT_MARGIN_PCT` to `budget-math.ts`, in **different regions of the file**. Git saw no conflict, and each PR was green against its own merge commit — the duplicate only exists once both are squashed onto main. Classic semantic conflict that textual merging can't see.

## Fix: rename, don't collapse

The two constants are different numbers doing different jobs. Merging them would move prices in whichever path lost:

| Constant | Value | Job |
|---|---|---|
| `DEFAULT_MARGIN_PCT` (#323) | 25 | What an empty margin input shows; matches `EstimateItem.markupPercent @default(25)`. These 25s always meant a 25% **margin** and are already canonical. |
| `LEGACY_MARKUP_MARGIN_PCT` (#324) | 20 | The margin equal to the legacy 25% **markup-on-cost** (`base * 1.25 === base / 0.8`). Exists only so the Room Studio writer reproduces its old prices exactly. |

#323 keeps the `DEFAULT_MARGIN_PCT` name; #324's constant is renamed and its doc comment now states explicitly why the two must not be unified.

Only consumer of the renamed constant is the Room Studio path in `actions.ts`. No behavior change, no price change — this is a rename plus a comment.

## Verification

`npx tsc --noEmit` → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)