### PR TITLE
fix(scripts): make the margin backfill actually converge

### DIFF
--- a/scripts/backfill-estimate-item-margin.mjs
+++ b/scripts/backfill-estimate-item-margin.mjs
@@ -24,7 +24,11 @@
 // the true margin is exactly 0 and IS corrected — that is not a loss.
 //
 // SAFE TO RE-RUN: idempotent — once a row's stored markupPercent matches the
-// derived value it drops out of the target set.
+// derived value it drops out of the target set. The predicate compares against
+// the CLAMPED, ROUNDED value, which is what actually gets written; comparing
+// against the raw margin instead meant a row whose true margin exceeds 99 was
+// written as 99, still differed from its raw value, and was rewritten on every
+// run — reported as "differing" forever despite already being correct.
 //
 // Usage:
 //   node scripts/backfill-estimate-item-margin.mjs            # dry run — report only, no writes
@@ -69,7 +73,7 @@ const TARGET_SQL = `
     AND "baseCost" > 0
     AND "unitCost" > 0
     AND "baseCost" <= "unitCost"
-    AND ABS("markupPercent" - (1 - "baseCost"::float8 / "unitCost"::float8) * 100) > 0.01
+    AND ABS("markupPercent" - LEAST(99, GREATEST(0, ROUND(((1 - "baseCost"::float8 / "unitCost"::float8) * 100)::numeric, 2)))::float8) > 0.01
   ORDER BY "id" ASC
 `;
 
@@ -86,6 +90,9 @@ const LOSS_SQL = `
     AND "baseCost" > 0
     AND "unitCost" > 0
     AND "baseCost" > "unitCost"
+    -- Compared against the UNCLAMPED true margin on purpose. These rows are never
+    -- written, so this is a report, not a convergence check: a loss row already
+    -- storing 0 still misrepresents a negative margin and must stay visible.
     AND ABS("markupPercent" - (1 - "baseCost"::float8 / "unitCost"::float8) * 100) > 0.01
   ORDER BY "id" ASC
 `;
@@ -147,7 +154,7 @@ const LOSS_SQL = `
       AND "baseCost" > 0
       AND "unitCost" > 0
       AND "baseCost" <= "unitCost"
-      AND ABS("markupPercent" - (1 - "baseCost"::float8 / "unitCost"::float8) * 100) > 0.01
+      AND ABS("markupPercent" - LEAST(99, GREATEST(0, ROUND(((1 - "baseCost"::float8 / "unitCost"::float8) * 100)::numeric, 2)))::float8) > 0.01
   `);
   console.log(`Updated ${updated} row(s).`);
 })()


### PR DESCRIPTION
Follow-up to #324, found by re-running the backfill after applying it to production.

## The bug

The script writes the **clamped, rounded** margin (`LEAST(99, GREATEST(0, ROUND(…, 2)))`) but selected rows by comparing the stored value against the **raw** margin.

A row whose true margin exceeds 99 — tiny `baseCost` against a normal `unitCost` — is written as `99`, still differs from its raw `99.9`, and gets rewritten on every run. It reports as "differing" forever despite already being correct.

After the production run this left **33 rows** permanently restating themselves:

```
baseCost=0.078125 unitCost=12.5 stored=99% -> derived=99%   <- "differs"
```

The stored data was already right. The predicate was wrong. Comparing against the value actually written makes it converge — a re-run now reports **0 differing**.

## Loss rows keep the unclamped comparison, on purpose

Those rows are never written, so that query is a *report*, not a convergence check. A loss-making row already storing `0` still misrepresents a negative margin and must stay visible. Verified: all 3 still surface after the fix.

## Verification

Dry run against production, post-fix:

```
621 row(s) scanned
0 row(s) differ from the derived margin by more than 0.01
⚠ 3 row(s) are strictly loss-making — NOT written, reported for review
```

Script-only change; no application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)