### PR TITLE
fix(co-audit): make the CO audit verdict agree with the money guards

### DIFF
--- a/src/app/api/integrations/co-audit/route.ts
+++ b/src/app/api/integrations/co-audit/route.ts
@@ -86,7 +86,8 @@ export async function GET(req: Request) {
         // billChangeOrderCore refuses a signed CO whose schedule rows do not sum to the
         // subtotal, so a repair that moves totalAmount without them trades one stuck state
         // for a later one. Surfaced here, refused by POST.
-        const scheduleCents = co.paymentSchedules.reduce((s, r) => s + Math.round(Number(r.amount) * 100), 0);
+        const scheduleRowCents = co.paymentSchedules.map(r => Math.round(Number(r.amount) * 100));
+        const scheduleCents = scheduleRowCents.reduce((s, c) => s + c, 0);
 
         const milestones = coMilestones
             .filter(m => m.invoice.projectId === co.project.id && m.name.startsWith(`${co.code} — `))
@@ -106,7 +107,8 @@ export async function GET(req: Request) {
             verdict,
             scheduleRowCount: co.paymentSchedules.length,
             scheduleTotal: scheduleCents / 100,
-            scheduleMatchesSubtotal: co.paymentSchedules.length === 0 || scheduleCents === Math.round(subtotal * 100),
+            scheduleMatchesSubtotal: co.paymentSchedules.length === 0
+                || (scheduleCents === Math.round(subtotal * 100) && scheduleRowCents.every(c => c > 0)),
             storedTotalAmount: stored,
             storedBalanceDue: rc(Number(co.balanceDue)),
             itemCount: co.items.length,
@@ -229,9 +231,16 @@ export async function POST(req: Request) {
             select: { amount: true },
         });
         if (schedules.length) {
-            const scheduleCents = schedules.reduce((s, r) => s + Math.round(Number(r.amount) * 100), 0);
+            const rowCents = schedules.map(r => Math.round(Number(r.amount) * 100));
+            const scheduleCents = rowCents.reduce((s, c) => s + c, 0);
             if (scheduleCents !== Math.round(subtotal * 100)) {
                 return { ok: false as const, error: `${co.code} has ${schedules.length} payment schedule row(s) summing to $${(scheduleCents / 100).toFixed(2)}, which is not the item subtotal $${subtotal.toFixed(2)}. Billing rejects that mismatch after signature, so rebalance the schedule in the editor instead of resetting the total here.` };
+            }
+            // Billing also refuses any nonpositive row ("schedule rows reach or exceed the
+            // subtotal before the final remainder"), so a sum check alone would still let a
+            // 0.00 or negative row through to fail after signature.
+            if (rowCents.some(c => c <= 0)) {
+                return { ok: false as const, error: `${co.code} has a payment schedule row of $0.00 or less. Billing refuses those after signature, so fix the schedule in the editor before resetting the total here.` };
             }
         }
         await tx.changeOrder.update({

--- a/src/app/api/integrations/co-audit/route.ts
+++ b/src/app/api/integrations/co-audit/route.ts
@@ -1,7 +1,7 @@
 import { createHash, timingSafeEqual } from "crypto";
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { coTaxRate, coTaxLabel, coItemsSubtotal, coSectionRowNames, coSectionRowError } from "@/lib/co-tax";
+import { coTaxRate, coTaxLabel, coItemsSubtotal, coSectionRowNames, coSectionRowError, classifyCoTotal } from "@/lib/co-tax";
 
 // One-off data-repair surface for the pre-2026-07-09 change-order editor bug:
 // the editor saved totalAmount tax-INCLUSIVE (item subtotal × (1 + rate)) while
@@ -42,21 +42,10 @@ function authorized(req: Request): boolean {
 // exactly like billing does, not merely close to it.
 const rc = (n: number) => Math.round(n * 100) / 100;
 
-// GET's "ok" tolerance and POST's no-op tolerance are the SAME constant so a
-// row the audit reports as ok can never be mutated by a follow-up POST.
-const OK_TOLERANCE = 0.01;
-
-type Verdict = "ok" | "tax-inflated" | "drift" | "no-items" | "has-sections";
-function classify(stored: number, subtotal: number, expectedBilled: number, itemCount: number, sectionCount: number): Verdict {
-    // A section header mirrors the total of the lines beneath it, so no subtotal derived from
-    // these rows is trustworthy — including the one POST would write back. Reported ahead of
-    // every other verdict so the row can never be recomputed to a number nobody can justify.
-    if (sectionCount > 0) return "has-sections";
-    if (itemCount === 0) return "no-items";
-    if (Math.abs(stored - subtotal) <= OK_TOLERANCE) return "ok";
-    if (Math.abs(stored - expectedBilled) <= 0.02) return "tax-inflated";
-    return "drift";
-}
+// GET and POST share one verdict function (classifyCoTotal, beside the money math it must
+// agree with) so a row the audit reports as ok can never be mutated by a follow-up POST —
+// and, just as importantly, a row the send/approve guards block can never be reported ok.
+const classify = classifyCoTotal;
 
 export async function GET(req: Request) {
     if (!authorized(req)) return NextResponse.json({ ok: false, reason: "unauthorized" }, { status: 401 });
@@ -197,10 +186,17 @@ export async function POST(req: Request) {
             return { ok: false as const, error: `${co.code} has no line items — nothing to recompute from; review by hand.` };
         }
         if (verdict === "ok") {
+            // Cents-exact, so this really is a no-op: send and approve compare the same
+            // two integers and will let the row through.
             return { ok: true as const, changed: false, code: co.code, totalAmount: stored, note: "Already equals the item subtotal." };
         }
         if (verdict === "drift" && force !== true) {
-            return { ok: false as const, error: `${co.code} is a drift row (stored $${stored.toFixed(2)} matches neither the item subtotal $${subtotal.toFixed(2)} nor subtotal+tax $${expectedBilled.toFixed(2)}) — pass force:true only after a human confirms the items are canonical.` };
+            // Sub-cent drift is a rounding artifact, not an edit anyone made on purpose —
+            // say so, because that row is hard-blocked from send and approve until it is fixed.
+            const rounding = Math.abs(Math.round(stored * 100) - Math.round(subtotal * 100)) <= 1
+                ? ` It is off by a single cent, which send and approve reject outright, so force:true is the intended fix here.`
+                : "";
+            return { ok: false as const, error: `${co.code} is a drift row (stored $${stored.toFixed(2)} matches neither the item subtotal $${subtotal.toFixed(2)} nor subtotal+tax $${expectedBilled.toFixed(2)}) — pass force:true only after a human confirms the items are canonical.${rounding}` };
         }
         await tx.changeOrder.update({
             where: { id: changeOrderId },

--- a/src/app/api/integrations/co-audit/route.ts
+++ b/src/app/api/integrations/co-audit/route.ts
@@ -53,9 +53,10 @@ export async function GET(req: Request) {
     const cos = await prisma.changeOrder.findMany({
         orderBy: { number: "asc" },
         select: {
-            id: true, code: true, title: true, status: true,
+            id: true, code: true, title: true, status: true, pricingType: true,
             totalAmount: true, balanceDue: true, createdAt: true, updatedAt: true,
             approvedAt: true, sentAt: true,
+            paymentSchedules: { select: { amount: true } },
             project: { select: { id: true, name: true } },
             estimate: { select: { code: true, taxExempt: true, taxRatePercent: true, taxRateName: true } },
             items: { select: { name: true, type: true, quantity: true, unitCost: true, total: true } },
@@ -81,7 +82,11 @@ export async function GET(req: Request) {
         const expectedBilled = rc(subtotal + tax); // what billing charges once fixed
         const inflated = rc(stored - subtotal);
         const sectionNames = coSectionRowNames(co.items);
-        const verdict = classify(stored, subtotal, expectedBilled, co.items.length, sectionNames.length);
+        const verdict = classify(stored, subtotal, expectedBilled, co.items.length, sectionNames.length, co.pricingType);
+        // billChangeOrderCore refuses a signed CO whose schedule rows do not sum to the
+        // subtotal, so a repair that moves totalAmount without them trades one stuck state
+        // for a later one. Surfaced here, refused by POST.
+        const scheduleCents = co.paymentSchedules.reduce((s, r) => s + Math.round(Number(r.amount) * 100), 0);
 
         const milestones = coMilestones
             .filter(m => m.invoice.projectId === co.project.id && m.name.startsWith(`${co.code} — `))
@@ -97,7 +102,11 @@ export async function GET(req: Request) {
             title: co.title,
             project: co.project.name,
             status: co.status,
+            pricingType: co.pricingType,
             verdict,
+            scheduleRowCount: co.paymentSchedules.length,
+            scheduleTotal: scheduleCents / 100,
+            scheduleMatchesSubtotal: co.paymentSchedules.length === 0 || scheduleCents === Math.round(subtotal * 100),
             storedTotalAmount: stored,
             storedBalanceDue: rc(Number(co.balanceDue)),
             itemCount: co.items.length,
@@ -123,6 +132,9 @@ export async function GET(req: Request) {
             drift: rows.filter(r => r.verdict === "drift").length,
             noItems: rows.filter(r => r.verdict === "no-items").length,
             hasSections: rows.filter(r => r.verdict === "has-sections").length,
+            costPlus: rows.filter(r => r.verdict === "cost-plus").length,
+            unpriced: rows.filter(r => r.verdict === "unpriced").length,
+            scheduleOutOfSync: rows.filter(r => !r.scheduleMatchesSubtotal).length,
         },
         changeOrders: rows,
     });
@@ -144,8 +156,8 @@ export async function POST(req: Request) {
 
     const result = await prisma.$transaction(async tx => {
         // Row lock so a concurrent approve/send/bill serializes against the fix.
-        const locked = await tx.$queryRaw<Array<{ id: string; code: string; title: string; status: string; totalAmount: unknown; balanceDue: unknown; projectId: string; estimateId: string }>>`
-            SELECT "id", "code", "title", "status", "totalAmount", "balanceDue", "projectId", "estimateId"
+        const locked = await tx.$queryRaw<Array<{ id: string; code: string; title: string; status: string; pricingType: string; totalAmount: unknown; balanceDue: unknown; projectId: string; estimateId: string }>>`
+            SELECT "id", "code", "title", "status", "pricingType", "totalAmount", "balanceDue", "projectId", "estimateId"
             FROM "ChangeOrder" WHERE "id" = ${changeOrderId} FOR UPDATE`;
         const co = locked[0];
         if (!co) return { ok: false as const, error: "Change order not found" };
@@ -175,15 +187,24 @@ export async function POST(req: Request) {
         });
         const expectedBilled = rc(subtotal + rc(subtotal * coTaxRate(estimateTax)));
         const sectionNames = coSectionRowNames(items);
-        const verdict = classify(stored, subtotal, expectedBilled, items.length, sectionNames.length);
+        const verdict = classify(stored, subtotal, expectedBilled, items.length, sectionNames.length, co.pricingType);
         // Not repairable here: writing back a subtotal that excludes the headers would leave
         // the rows in place and a total nobody can justify, and a later GET would call it
         // "ok" while send and approve stay correctly blocked. Fix the items, not the total.
         if (verdict === "has-sections") {
             return { ok: false as const, error: coSectionRowError(co.code, sectionNames) };
         }
+        if (verdict === "cost-plus") {
+            // Its total comes from actuals, not these items, and the send/approve guards skip
+            // the subtotal comparison for it — so there is nothing here to be out of sync, and
+            // overwriting it with the item subtotal would destroy a legitimate number.
+            return { ok: false as const, error: `${co.code} is COST_PLUS — its total bills from actuals, not from the item subtotal, so there is nothing for this repair to reconcile.` };
+        }
         if (verdict === "no-items") {
             return { ok: false as const, error: `${co.code} has no line items — nothing to recompute from; review by hand.` };
+        }
+        if (verdict === "unpriced") {
+            return { ok: false as const, error: `${co.code} has a nonpositive total ($${stored.toFixed(2)}) or item subtotal ($${subtotal.toFixed(2)}) — send and approve reject it as unpriced, and writing the subtotal back would not change that. Price the items first.` };
         }
         if (verdict === "ok") {
             // Cents-exact, so this really is a no-op: send and approve compare the same
@@ -197,6 +218,21 @@ export async function POST(req: Request) {
                 ? ` It is off by a single cent, which send and approve reject outright, so force:true is the intended fix here.`
                 : "";
             return { ok: false as const, error: `${co.code} is a drift row (stored $${stored.toFixed(2)} matches neither the item subtotal $${subtotal.toFixed(2)} nor subtotal+tax $${expectedBilled.toFixed(2)}) — pass force:true only after a human confirms the items are canonical.${rounding}` };
+        }
+        // billChangeOrderCore refuses a signed CO whose schedule rows do not sum to the
+        // subtotal ("schedule amounts are out of sync with the signed subtotal"). Moving
+        // totalAmount out from under them would unstick send and approve only to wedge
+        // billing later, so refuse rather than guess how to redistribute the difference —
+        // which row absorbs it is a human's call, not this route's.
+        const schedules = await tx.changeOrderPaymentSchedule.findMany({
+            where: { changeOrderId },
+            select: { amount: true },
+        });
+        if (schedules.length) {
+            const scheduleCents = schedules.reduce((s, r) => s + Math.round(Number(r.amount) * 100), 0);
+            if (scheduleCents !== Math.round(subtotal * 100)) {
+                return { ok: false as const, error: `${co.code} has ${schedules.length} payment schedule row(s) summing to $${(scheduleCents / 100).toFixed(2)}, which is not the item subtotal $${subtotal.toFixed(2)}. Billing rejects that mismatch after signature, so rebalance the schedule in the editor instead of resetting the total here.` };
+            }
         }
         await tx.changeOrder.update({
             where: { id: changeOrderId },

--- a/src/lib/co-tax.ts
+++ b/src/lib/co-tax.ts
@@ -79,6 +79,50 @@ export function coItemsSubtotal(items: Array<{ type?: string | null; quantity?: 
     ), 0) / 100;
 }
 
+export type CoTotalVerdict = "ok" | "tax-inflated" | "drift" | "no-items" | "has-sections";
+
+/** Cents, rounded exactly the way the send and approve guards round before comparing. */
+const toCents = (n: number) => Math.round((Number(n) || 0) * 100);
+
+// The legacy editor wrote `subtotal * (1 + rate)` in one multiply, which can land a cent away
+// from the guards' `round(subtotal) + round(subtotal * rate)`. That slack belongs to the
+// tax-inflated *diagnosis* only — never to "ok".
+const TAX_INFLATED_SLACK_CENTS = 2;
+
+/**
+ * Classify a stored change-order totalAmount against the subtotal its items produce.
+ *
+ * "ok" is cents-exact on purpose. approveChangeOrderCore and the send guard both compare
+ * `storedSubtotalCents !== renderedSubtotalCents` with no tolerance, so a row one cent off
+ * is hard-blocked from send and approve. Reporting it "ok" made the audit POST decline to
+ * repair it too ("already correct"), leaving the change order stuck with no way out. A
+ * one-cent difference must therefore fall through to a repairable verdict.
+ */
+export function classifyCoTotal(
+    stored: number,
+    subtotal: number,
+    expectedBilled: number,
+    itemCount: number,
+    sectionCount: number,
+): CoTotalVerdict {
+    // A section header mirrors the total of the lines beneath it, so no subtotal derived from
+    // these rows is trustworthy — including the one a repair would write back. Reported ahead of
+    // every other verdict so the row can never be recomputed to a number nobody can justify.
+    if (sectionCount > 0) return "has-sections";
+    if (itemCount === 0) return "no-items";
+    const storedCents = toCents(stored);
+    const subtotalCents = toCents(subtotal);
+    if (storedCents === subtotalCents) return "ok";
+    const billedCents = toCents(expectedBilled);
+    // Only meaningful when tax actually moves the number. On a tax-exempt change order
+    // expectedBilled *is* the subtotal, and calling a stray cent "tax-inflated" would both
+    // misreport the cause and skip the human confirmation a drift row requires.
+    if (billedCents !== subtotalCents && Math.abs(storedCents - billedCents) <= TAX_INFLATED_SLACK_CENTS) {
+        return "tax-inflated";
+    }
+    return "drift";
+}
+
 export function coTaxLabel(estimate: EstimateTaxInfo): string {
     if (estimate?.taxExempt) return "Tax Exempt";
     const pctDisplay = (coTaxRate(estimate) * 100).toFixed(1).replace(/\.0$/, "");

--- a/src/lib/co-tax.ts
+++ b/src/lib/co-tax.ts
@@ -79,24 +79,32 @@ export function coItemsSubtotal(items: Array<{ type?: string | null; quantity?: 
     ), 0) / 100;
 }
 
-export type CoTotalVerdict = "ok" | "tax-inflated" | "drift" | "no-items" | "has-sections";
+export type CoTotalVerdict =
+    | "ok" | "tax-inflated" | "drift" | "no-items" | "has-sections" | "cost-plus" | "unpriced";
 
 /** Cents, rounded exactly the way the send and approve guards round before comparing. */
 const toCents = (n: number) => Math.round((Number(n) || 0) * 100);
 
 // The legacy editor wrote `subtotal * (1 + rate)` in one multiply, which can land a cent away
-// from the guards' `round(subtotal) + round(subtotal * rate)`. That slack belongs to the
-// tax-inflated *diagnosis* only — never to "ok".
-const TAX_INFLATED_SLACK_CENTS = 2;
+// from the guards' `round(subtotal) + round(subtotal * rate)`. Brute-forcing both formulas
+// across every cent value at the rates this app uses puts the maximum divergence at exactly
+// one cent, and the single multiply is always the LARGER of the two — so the slack is one
+// cent and one-sided. It belongs to the tax-inflated *diagnosis* only, never to "ok".
+const TAX_INFLATED_SLACK_CENTS = 1;
 
 /**
  * Classify a stored change-order totalAmount against the subtotal its items produce.
  *
- * "ok" is cents-exact on purpose. approveChangeOrderCore and the send guard both compare
- * `storedSubtotalCents !== renderedSubtotalCents` with no tolerance, so a row one cent off
- * is hard-blocked from send and approve. Reporting it "ok" made the audit POST decline to
- * repair it too ("already correct"), leaving the change order stuck with no way out. A
- * one-cent difference must therefore fall through to a repairable verdict.
+ * Every branch here answers one question: would the send and approve guards let this row
+ * through? "ok" must mean yes and nothing weaker, so it is cents-exact —
+ * `approveChangeOrderCore` and the send guard compare `storedSubtotalCents !==
+ * renderedSubtotalCents` with no tolerance. While this tolerated a cent, a one-cent row was
+ * reported healthy, refused by the repair POST as already-correct, and hard-blocked from
+ * send and approve with no remediation path at all.
+ *
+ * The guards also skip the subtotal comparison entirely for COST_PLUS and reject nonpositive
+ * cents outright, so those get their own verdicts rather than being scored against a
+ * subtotal that means nothing for them.
  */
 export function classifyCoTotal(
     stored: number,
@@ -104,20 +112,33 @@ export function classifyCoTotal(
     expectedBilled: number,
     itemCount: number,
     sectionCount: number,
+    pricingType: string = "FIXED",
 ): CoTotalVerdict {
     // A section header mirrors the total of the lines beneath it, so no subtotal derived from
     // these rows is trustworthy — including the one a repair would write back. Reported ahead of
-    // every other verdict so the row can never be recomputed to a number nobody can justify.
+    // every other verdict (as the money paths refuse it ahead of every other check) so the row
+    // can never be recomputed to a number nobody can justify.
     if (sectionCount > 0) return "has-sections";
+    // A cost-plus change order bills from actuals; its totalAmount is not derived from these
+    // items and the guards exempt it. Resetting it to the item subtotal would destroy a
+    // legitimate number, so it is reported and never repaired.
+    if (pricingType === "COST_PLUS") return "cost-plus";
     if (itemCount === 0) return "no-items";
     const storedCents = toCents(stored);
     const subtotalCents = toCents(subtotal);
+    // The guards reject nonpositive cents on their own ("no priced items yet"), so equality
+    // here would be an "ok" that still cannot send. Repair cannot help either — writing a
+    // zero subtotal back leaves the row just as unsendable.
+    if (storedCents <= 0 || subtotalCents <= 0) return "unpriced";
     if (storedCents === subtotalCents) return "ok";
     const billedCents = toCents(expectedBilled);
-    // Only meaningful when tax actually moves the number. On a tax-exempt change order
-    // expectedBilled *is* the subtotal, and calling a stray cent "tax-inflated" would both
-    // misreport the cause and skip the human confirmation a drift row requires.
-    if (billedCents !== subtotalCents && Math.abs(storedCents - billedCents) <= TAX_INFLATED_SLACK_CENTS) {
+    // Only meaningful when tax actually moves the number, and only above the subtotal. On a
+    // tax-exempt CO expectedBilled *is* the subtotal, and a symmetric window would let a
+    // stored value BELOW the subtotal — which the legacy tax-inclusive formula can never
+    // produce — claim the tax-inflated verdict and skip the confirmation a drift row needs.
+    if (billedCents > subtotalCents
+        && storedCents > subtotalCents
+        && Math.abs(storedCents - billedCents) <= TAX_INFLATED_SLACK_CENTS) {
         return "tax-inflated";
     }
     return "drift";

--- a/src/lib/co-tax.ts
+++ b/src/lib/co-tax.ts
@@ -136,9 +136,13 @@ export function classifyCoTotal(
     // tax-exempt CO expectedBilled *is* the subtotal, and a symmetric window would let a
     // stored value BELOW the subtotal — which the legacy tax-inclusive formula can never
     // produce — claim the tax-inflated verdict and skip the confirmation a drift row needs.
+    // The window is [billed, billed + 1], not ±1: the single multiply is never SMALLER than
+    // the staged one, so a value below expectedBilled is something else and must earn its
+    // repair through force.
+    const overBilled = storedCents - billedCents;
     if (billedCents > subtotalCents
         && storedCents > subtotalCents
-        && Math.abs(storedCents - billedCents) <= TAX_INFLATED_SLACK_CENTS) {
+        && overBilled >= 0 && overBilled <= TAX_INFLATED_SLACK_CENTS) {
         return "tax-inflated";
     }
     return "drift";

--- a/tests/estimate-item-payload.test.ts
+++ b/tests/estimate-item-payload.test.ts
@@ -619,11 +619,20 @@ test("the audit's ok verdict is cents-exact, matching the send and approve guard
 });
 
 test("the audit still diagnoses the tax-inclusive totals it exists to repair", () => {
-    // The legacy editor wrote subtotal * (1 + rate) in one multiply, which can land a cent
-    // off the guards' round(subtotal) + round(subtotal * rate). That slack stays.
+    // The legacy editor wrote subtotal * (1 + rate) in one multiply, which lands at most one
+    // cent above the guards' round(subtotal) + round(subtotal * rate). One cent of slack, and
+    // only upward — the single multiply is never the smaller of the two.
     assert.equal(classifyCoTotal(1088, 1000, 1088, 4, 0), "tax-inflated");
-    assert.equal(classifyCoTotal(1088.02, 1000, 1088, 4, 0), "tax-inflated");
-    assert.equal(classifyCoTotal(1088.03, 1000, 1088, 4, 0), "drift");
+    assert.equal(classifyCoTotal(1088.01, 1000, 1088, 4, 0), "tax-inflated");
+    assert.equal(classifyCoTotal(1088.02, 1000, 1088, 4, 0), "drift");
+});
+
+test("the tax-inflated slack cannot swallow a value below the subtotal", () => {
+    // A near-zero rate puts expectedBilled a cent above the subtotal, so a symmetric window
+    // would have let $999.99 — which no tax-inclusive formula can produce — auto-repair
+    // without the confirmation a drift row requires.
+    assert.equal(classifyCoTotal(999.99, 1000, 1000.01, 4, 0), "drift");
+    assert.equal(classifyCoTotal(1000.01, 1000, 1000.01, 4, 0), "tax-inflated");
 });
 
 test("a stray cent on a tax-exempt CO is drift, not a mislabelled tax inflation", () => {
@@ -635,6 +644,24 @@ test("a stray cent on a tax-exempt CO is drift, not a mislabelled tax inflation"
 
 test("an item-less CO is never classified from an empty subtotal", () => {
     assert.equal(classifyCoTotal(1000, 0, 0, 0, 0), "no-items");
+});
+
+test("a cost-plus CO is reported, never scored against its item subtotal", () => {
+    // Both guards skip the subtotal comparison for COST_PLUS, so its total legitimately
+    // differs from the items. Resetting it to the subtotal would destroy a real number.
+    assert.equal(classifyCoTotal(5000, 1000, 1088, 4, 0, "COST_PLUS"), "cost-plus");
+    assert.equal(classifyCoTotal(5000, 0, 0, 0, 0, "COST_PLUS"), "cost-plus");
+    assert.equal(classifyCoTotal(5000, 1000, 1088, 4, 0, "FIXED"), "drift");
+    // Corrupt section rows still outrank it — every money path refuses those first.
+    assert.equal(classifyCoTotal(5000, 1000, 1088, 4, 1, "COST_PLUS"), "has-sections");
+});
+
+test("a nonpositive total is unpriced, not ok — the guards reject it either way", () => {
+    // storedCents <= 0 || renderedCents <= 0 is its own rejection in both guards, so equality
+    // at zero is an "ok" that still cannot send, and writing the subtotal back fixes nothing.
+    assert.equal(classifyCoTotal(0, 0, 0, 3, 0), "unpriced");
+    assert.equal(classifyCoTotal(-50, -50, -50, 3, 0), "unpriced");
+    assert.equal(classifyCoTotal(1000, 0, 0, 3, 0), "unpriced");
 });
 
 test("an omitted type keeps the stored one, so the persisted total stays reproducible", () => {

--- a/tests/estimate-item-payload.test.ts
+++ b/tests/estimate-item-payload.test.ts
@@ -633,6 +633,9 @@ test("the tax-inflated slack cannot swallow a value below the subtotal", () => {
     // without the confirmation a drift row requires.
     assert.equal(classifyCoTotal(999.99, 1000, 1000.01, 4, 0), "drift");
     assert.equal(classifyCoTotal(1000.01, 1000, 1000.01, 4, 0), "tax-inflated");
+    // Nor a cent BELOW expectedBilled: the single multiply is never the smaller of the two,
+    // so $1087.99 against a $1088.00 expectation is not the legacy bug and needs force.
+    assert.equal(classifyCoTotal(1087.99, 1000, 1088, 4, 0), "drift");
 });
 
 test("a stray cent on a tax-exempt CO is drift, not a mislabelled tax inflation", () => {

--- a/tests/estimate-item-payload.test.ts
+++ b/tests/estimate-item-payload.test.ts
@@ -13,7 +13,7 @@ import {
     selectedBillableRows,
 } from "../src/lib/estimate-item-payload";
 import { buildQBEstimateLines } from "../src/lib/quickbooks";
-import { billableCoItems, coItemsSubtotal, coSectionRowNames } from "../src/lib/co-tax";
+import { billableCoItems, classifyCoTotal, coItemsSubtotal, coSectionRowNames } from "../src/lib/co-tax";
 
 type Row = {
     id: string;
@@ -601,10 +601,40 @@ test("the audit reports section rows and refuses to recompute past them", () => 
     // Recomputing would write back a subtotal excluding the headers while leaving the rows
     // in place, so a later GET reads "ok" while send and approve stay correctly blocked.
     const audit = readFileSync(path.join(__dirname, "..", "src/app/api/integrations/co-audit/route.ts"), "utf8");
-    assert.match(audit, /if \(sectionCount > 0\) return "has-sections";/);
     assert.match(audit, /if \(verdict === "has-sections"\)[\s\S]{0,120}?coSectionRowError\(co\.code, sectionNames\)/);
-    // The section verdict must be decided before the empty and tolerance branches.
-    assert.ok(audit.indexOf('return "has-sections"') < audit.indexOf('return "no-items"'));
+    // The section verdict must be decided before the empty and equality branches.
+    assert.equal(classifyCoTotal(100, 100, 108.8, 3, 1), "has-sections");
+    assert.equal(classifyCoTotal(100, 100, 108.8, 0, 1), "has-sections");
+});
+
+test("the audit's ok verdict is cents-exact, matching the send and approve guards", () => {
+    // Both guards compare `storedSubtotalCents !== renderedSubtotalCents` with no tolerance.
+    // While the audit tolerated a cent, a one-cent row was reported "ok", refused by the
+    // repair POST as already-correct, and hard-blocked from send and approve forever.
+    assert.equal(classifyCoTotal(1000, 1000, 1088, 4, 0), "ok");
+    assert.equal(classifyCoTotal(1000.01, 1000, 1088, 4, 0), "drift");
+    assert.equal(classifyCoTotal(999.99, 1000, 1088, 4, 0), "drift");
+    // Float dust must not decide the verdict: 0.1 + 0.2 stored against a 0.30 subtotal.
+    assert.equal(classifyCoTotal(0.1 + 0.2, 0.3, 0.33, 2, 0), "ok");
+});
+
+test("the audit still diagnoses the tax-inclusive totals it exists to repair", () => {
+    // The legacy editor wrote subtotal * (1 + rate) in one multiply, which can land a cent
+    // off the guards' round(subtotal) + round(subtotal * rate). That slack stays.
+    assert.equal(classifyCoTotal(1088, 1000, 1088, 4, 0), "tax-inflated");
+    assert.equal(classifyCoTotal(1088.02, 1000, 1088, 4, 0), "tax-inflated");
+    assert.equal(classifyCoTotal(1088.03, 1000, 1088, 4, 0), "drift");
+});
+
+test("a stray cent on a tax-exempt CO is drift, not a mislabelled tax inflation", () => {
+    // With no tax, expectedBilled *is* the subtotal, so the tax-inflated slack would otherwise
+    // swallow every rounding drift and auto-repair it without the human confirmation drift needs.
+    assert.equal(classifyCoTotal(1000.01, 1000, 1000, 4, 0), "drift");
+    assert.equal(classifyCoTotal(1000, 1000, 1000, 4, 0), "ok");
+});
+
+test("an item-less CO is never classified from an empty subtotal", () => {
+    assert.equal(classifyCoTotal(1000, 0, 0, 0, 0), "no-items");
 });
 
 test("an omitted type keeps the stored one, so the persisted total stays reproducible", () => {


### PR DESCRIPTION
## The bug

`classify()` in the change-order audit accepted a $0.01 delta between a CO's stored `totalAmount` and its recomputed item subtotal and called it **"ok"**. Both money guards compare **integer cents exactly**:

- `approveChangeOrderCore` — `storedSubtotalCents !== renderedSubtotalCents` throws "pricing is out of sync with its items"
- the send guard in `billing-core.ts` — same comparison, returns an error

So a CO one cent off was reported healthy by the audit GET, refused by the audit POST as already-correct, and **hard-blocked from send and approve forever with no remediation path**.

Found by Codex during #325, deferred there as pre-existing.

## The fix

The verdict moves to `src/lib/co-tax.ts` as `classifyCoTotal`, beside the money math it has to agree with. Every branch now answers one question: *would the send and approve guards let this row through?*

- **"ok" is cents-exact.** A one-cent row falls to `drift`, repairable via `force: true`, and the error text says so.
- **`cost-plus` (new).** Both guards skip the subtotal comparison for `COST_PLUS` — it bills from actuals, so its total legitimately differs from the items. The old code would have overwritten a real number, and on a matching tax-inflated verdict it wouldn't even have needed `force`. Reported, never repaired.
- **`unpriced` (new).** The guards reject nonpositive cents on their own, so a fixed CO pricing to $0 was an "ok" that still couldn't send. Repair can't help either.
- **Payment schedules.** `billChangeOrderCore` refuses a signed CO whose schedule rows don't sum to the subtotal, or that has any nonpositive row. Repairing `totalAmount` out from under them traded a stuck send for a wedged bill. POST now refuses; which row absorbs a difference is a human's call, not this route's.
- **Tax slack: 2 cents symmetric → 1 cent, one-sided.** Brute-forcing the legacy `subtotal * (1 + rate)` against the guards' `round(subtotal) + round(subtotal * rate)` across every cent value at the rates in use puts max divergence at exactly one cent, always upward. The old window admitted values the legacy formula cannot produce and auto-repaired them without `force`.

## Review

Codex peer review, two rounds. Round 1 found the cost-plus clobber, the stale schedules, the oversized slack, and the nonpositive "ok"; round 2 found the slack was still symmetric around `billedCents` and that the schedule check needed per-row positivity, not just the sum. All fixed.

**Left open (Codex, low):** `ChangeOrderPaymentSchedule.changeOrderId` has no `@@index`, so the new child lookup can scan while holding the money lock. Needs a schema migration — separate PR.

## Verification

- `npm run typecheck` — clean
- `npm run build:next` — clean
- `npm run test:unit` — 78/78, including 7 new behavioural tests for the verdicts

No schema change, so no `apply-*.mjs` to run before deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)