### PR TITLE
fix(estimates): warn instead of silently storing a margin that lies (#323 mirror)

### DIFF
--- a/src/app/projects/[id]/estimates/[estimateId]/BudgetStrip.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/BudgetStrip.tsx
@@ -3,8 +3,9 @@
 import { useState } from "react";
 import { formatCurrency } from "@/lib/utils";
 import {
-    internalBudget, bufferPercent, bufferColor, bufferBgColor, costFromMargin, derivedMarginPct,
-    normalizeMarginInput, formatDerivedRate, DEFAULT_MARGIN_PCT, MAX_MARGIN_PCT,
+    internalBudget, bufferPercent, bufferColor, bufferBgColor, costFromMargin,
+    normalizeMarginInput, formatDerivedRate, marginPatchForRate, marginIsUnrepresentable,
+    marginIsStale, rawMarginPct, DEFAULT_MARGIN_PCT, MAX_MARGIN_PCT,
 } from "@/lib/budget-math";
 
 const UNIT_SUGGESTIONS = ["hrs", "sqft", "lf", "ea", "lump sum", "units", "days"];
@@ -46,8 +47,37 @@ export default function BudgetStrip({
     const isPoLocked = links.length > 0;
     const sellPrice = parseFloat(item.unitCost) || 0;
 
+    // The rate is whatever the user typed — we never rewrite it to make the margin true. When the
+    // pair can't be expressed as a storable margin, say so on the row instead of letting the
+    // clamped markupPercent quietly claim otherwise.
+    // `|| 0` would fold an unparseable stored rate into the exempt "no budget" value and hide it.
+    // Blank is genuinely no budget; anything else keeps whatever it parses to, NaN included.
+    const rateText = budgetRateVal == null ? "" : String(budgetRateVal).trim();
+    const currentRate = rateText === "" ? 0 : parseFloat(rateText);
+    const storedMargin = item.markupPercent == null ? null : parseFloat(item.markupPercent);
+    const unrepresentable = marginIsUnrepresentable(currentRate, sellPrice);
+    // A stale margin is one this editor can no longer create — it flags rows saved before the
+    // sell-price input started re-deriving. Editing either side of the row repairs it.
+    const stale = !unrepresentable && marginIsStale(storedMargin, currentRate, sellPrice);
+    const marginLies = unrepresentable || stale;
+    const marginWarning = !marginLies
+        ? null
+        : stale
+            ? `Saved margin (${storedMargin!.toFixed(2)}%) doesn't match this cost — ${formatCurrency(currentRate)} against ${formatCurrency(sellPrice)} is ${rawMarginPct(currentRate, sellPrice)!.toFixed(2)}%. Re-enter the rate or the margin to fix it.`
+            : currentRate < 0 || !Number.isFinite(currentRate)
+                ? "Budget cost isn't a valid amount — the margin can't be derived from it."
+                // Guard non-finite BEFORE the comparison branches: against an Infinity sell price
+                // both `<= 0` and `currentRate > sellPrice` read false, which used to fall through
+                // to the "under 1% of sell price" message.
+                : !Number.isFinite(sellPrice) || sellPrice <= 0
+                    ? "Budget cost is set but this line has no valid sell price — the margin below is meaningless."
+                    : currentRate > sellPrice
+                        ? `Cost exceeds sell price — this line loses ${formatCurrency(currentRate - sellPrice)}/unit. Margin can't go below 0%.`
+                        : `Cost is under 1% of the sell price — margin is capped at ${MAX_MARGIN_PCT}%.`;
+
     return (
-        <div className="flex items-center gap-3 px-4 py-2 ml-14 mr-2 mb-1 rounded-lg bg-indigo-50/60 border-l-3 border-indigo-300 text-xs">
+        <div className={`ml-14 mr-2 mb-1 rounded-lg bg-indigo-50/60 border-l-3 text-xs ${marginWarning ? "border-red-400" : "border-indigo-300"}`}>
+        <div className="flex items-center gap-3 px-4 py-2">
             {/* PO lock indicator — budget is committed, AI/Reset will skip this row */}
             {isPoLocked && (
                 <span
@@ -106,16 +136,23 @@ export default function BudgetStrip({
                         onChange={e => {
                             // Budget-side edit: update budget fields only. Customer price (unitCost)
                             // is the source of truth — we derive margin from it, never the reverse.
+                            // The rate is persisted EXACTLY as typed — clamping it here would
+                            // silently rewrite a cost the user entered. The margin always follows
+                            // the rate (marginPatchForRate), and when the pair can't be expressed
+                            // as a margin the row warns instead. Previously the `r > 0 && price > 0`
+                            // guard skipped the margin write entirely, stranding the old margin
+                            // next to a rate that no longer implied it.
                             const val = e.target.value === "" ? null : e.target.value;
                             const r = parseFloat(e.target.value) || 0;
                             const price = parseFloat(item.unitCost) || 0;
                             updateItem(item.id, {
                                 budgetRate: val,
                                 baseCost: r > 0 ? val : null,
-                                ...(r > 0 && price > 0 ? { markupPercent: derivedMarginPct(r, price).toFixed(2) } : {}),
+                                ...marginPatchForRate(r, price),
                             });
                         }}
-                        className="w-20 bg-white border border-indigo-200 rounded pl-4 pr-1.5 py-1 text-right text-xs focus:ring-1 ring-indigo-400 focus:outline-none"
+                        aria-invalid={marginLies || undefined}
+                        className={`w-20 bg-white border rounded pl-4 pr-1.5 py-1 text-right text-xs focus:ring-1 focus:outline-none ${marginLies ? "border-red-400 ring-red-400" : "border-indigo-200 ring-indigo-400"}`}
                         placeholder="Rate"
                         step="any"
                     />
@@ -230,6 +267,19 @@ export default function BudgetStrip({
                     </div>
                 )}
             </div>
+        </div>
+
+            {/* Cost/sell incoherence. Shown, never silently corrected — the rate is a number the
+                user typed, and markupPercent floors at 0, so this row's stored margin does not
+                describe its stored cost. Plain text, not a tooltip: hover is unreliable here. */}
+            {marginWarning && (
+                <div role="alert" className="flex items-start gap-1.5 px-4 pb-2 -mt-0.5 text-[11px] font-medium text-red-600">
+                    <svg className="w-3.5 h-3.5 flex-shrink-0 mt-px" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M12 9v4M12 17h.01M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
+                    </svg>
+                    <span>{marginWarning}</span>
+                </div>
+            )}
         </div>
     );
 }

--- a/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
@@ -172,7 +172,7 @@ import BudgetStrip from "./BudgetStrip";
 const POQuickCreateModal = dynamic(() => import("./POQuickCreateModal"), { ssr: false });
 const UndoPaymentModal = dynamic(() => import("@/components/UndoPaymentModal"), { ssr: false });
 
-import { internalBudget, derivedMarginPct } from "@/lib/budget-math";
+import { internalBudget, derivedMarginPct, marginPatchForRate } from "@/lib/budget-math";
 import { normalizeItemPoLinks } from "@/lib/estimate-item-po-links";
 import { formatMoneyDate, isDateOnly } from "@/lib/payment-date";
 
@@ -2743,7 +2743,20 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                                                                         <input
                                                                             type="number"
                                                                             value={item.unitCost}
-                                                                            onChange={e => updateItem(item.id, { unitCost: e.target.value })}
+                                                                            onChange={e => {
+                                                                                // Margin is derived from the cost/price pair, so moving the price
+                                                                                // has to move the margin with it. Without this, price 100 -> 200
+                                                                                // left rate 75 sitting next to a stored 25% while the line was
+                                                                                // really running 62.5%. The rate is NOT touched — the budget cost
+                                                                                // is unchanged by a price edit.
+                                                                                // No budget rate means there is no derived margin to keep in sync,
+                                                                                // and a price edit is not the place to clear one.
+                                                                                const rate = parseFloat(item.budgetRate ?? item.baseCost ?? "") || 0;
+                                                                                updateItem(item.id, {
+                                                                                    unitCost: e.target.value,
+                                                                                    ...(rate > 0 ? marginPatchForRate(rate, parseFloat(e.target.value) || 0) : {}),
+                                                                                });
+                                                                            }}
                                                                             readOnly={isLocked}
                                                                             aria-label="Unit cost"
                                                                             className={`w-20 focus:outline-none rounded px-1 py-1 text-right transition text-sm font-medium ${isLocked ? "bg-transparent text-slate-400 cursor-default" : "bg-transparent focus:bg-white focus:ring-1 ring-slate-200 hover:bg-slate-50 text-slate-700"}`}

--- a/src/lib/budget-math.ts
+++ b/src/lib/budget-math.ts
@@ -163,8 +163,15 @@ export function formatDerivedRate(rate: number, price: number): string {
   // A zero rate reads as "no budget" (internalBudget returns null, saveEstimate persists null),
   // which would contradict any non-zero margin stored beside it.
   if (!Number.isFinite(rate) || rate <= 0) return "0.00";
+  return rate.toFixed(derivedRateDecimals(price));
+}
+
+/** Decimal places formatDerivedRate stores a rate at, at this price scale. Exported shape of the
+ *  rule so marginIsStale can size its tolerance from the SAME rounding — if these two ever
+ *  disagree, healthy rows start warning. */
+export function derivedRateDecimals(price: number): number {
   const needed = Number.isFinite(price) && price > 0 ? Math.ceil(4 - Math.log10(price)) : 2;
-  return rate.toFixed(Math.min(10, Math.max(2, needed)));
+  return Math.min(10, Math.max(2, needed));
 }
 
 /**
@@ -202,6 +209,99 @@ export function costFromMargin(sell: number, marginPct: number): number {
 export function derivedMarginPct(rate: number, price: number): number {
   if (!Number.isFinite(rate) || !Number.isFinite(price) || price <= 0) return 0;
   return clampMarginPct((1 - rate / price) * 100);
+}
+
+/**
+ * The margin a rate/price pair actually implies, UNCLAMPED — or null when no margin exists
+ * (non-finite input, or a sell price of zero, which has no margin to speak of).
+ *
+ * derivedMarginPct is this value clamped. The two only disagree when the pair cannot be
+ * expressed inside [MIN_MARGIN_PCT, MAX_MARGIN_PCT], which is exactly when the stored
+ * markupPercent stops describing the stored rate — see marginIsUnrepresentable.
+ */
+export function rawMarginPct(rate: number, price: number): number | null {
+  if (!Number.isFinite(rate) || !Number.isFinite(price) || price <= 0) return null;
+  return (1 - rate / price) * 100;
+}
+
+/**
+ * True when the budget rate sitting next to a sell price cannot be described by any storable
+ * margin, so the clamped markupPercent persisted beside it is a lie.
+ *
+ * Two ways in, and BOTH matter:
+ *  - rate > price  — the line loses money. Clamps to 0, which claims cost === price.
+ *  - rate < price/100 — margin over 99. Clamps to 99, which claims a cost 100x the real one.
+ *  - price <= 0 with a rate — no sell to earn a margin on, and any stored margin is meaningless.
+ *
+ * We deliberately do NOT rewrite the rate to make the margin true: the rate is a cost the user
+ * typed, and silently moving it is worse than showing a warning (product decision, 2026-08-09 —
+ * the alternative was lowering MIN_MARGIN_PCT below 0, which would have put a sign change
+ * through all 19 consumers of markupPercent).
+ */
+export function marginIsUnrepresentable(rate: number, price: number): boolean {
+  if (rate === 0) return false; // no budget rate at all — nothing to contradict
+  // A negative or non-finite rate is not "no budget", it is a bad budget: it still persists to
+  // budgetRate (and internalBudget will happily multiply it out), while marginPatchForRate
+  // clears the margin, which then displays as the default. Warn instead of reading it as absent.
+  if (!Number.isFinite(rate) || rate < 0) return true;
+  if (!Number.isFinite(price) || price <= 0) return true; // a cost with no sell price
+  const raw = rawMarginPct(rate, price);
+  if (raw === null) return false;
+  return raw < MIN_MARGIN_PCT || raw > MAX_MARGIN_PCT;
+}
+
+/**
+ * How far apart a stored and a derived margin may sit before they count as disagreeing.
+ *
+ * A row written by either writer can legitimately be off by BOTH of these at once, so the
+ * tolerance is their sum. Sizing it at just one of them makes ordinary saves warn — rate $2.95
+ * at price $8 stores 63.13 against a true 63.125, exactly one half-step out.
+ *
+ *  - marginPatchForRate persists the margin at 2dp: half a step is 0.005 of margin.
+ *  - normalizeMarginInput persists the typed margin verbatim and derives the RATE, which
+ *    formatDerivedRate rounds to derivedRateDecimals(price) places. Half a step of rate is
+ *    (0.5 * 10^-d / price) * 100 percent of margin — the term that scales with price.
+ *
+ * Both bounds are attained exactly, and floating-point subtraction lands a hair either side of
+ * them, so the comparison must have real headroom rather than sit on the boundary.
+ */
+const MARGIN_STORAGE_HALF_STEP = 0.005;
+
+function rateRoundingMarginDrift(price: number): number {
+  if (!Number.isFinite(price) || price <= 0) return 0;
+  return ((0.5 * 10 ** -derivedRateDecimals(price)) / price) * 100;
+}
+
+/**
+ * True when a margin already stored on the item does not describe the rate/price pair stored
+ * beside it. Distinct from marginIsUnrepresentable: this catches rows where the derived margin
+ * IS representable but the persisted number is simply stale — the shape left behind by editing
+ * a sell price before that path re-derived the margin (price 100 -> 200 leaving rate 75 next to
+ * a stored 25 while the line really ran 62.5%). Edits self-heal such a row, so this only ever
+ * flags history.
+ */
+export function marginIsStale(storedPct: number | null, rate: number, price: number): boolean {
+  if (storedPct === null || !Number.isFinite(storedPct)) return false;
+  if (!Number.isFinite(rate) || rate <= 0) return false;
+  const raw = rawMarginPct(rate, price);
+  if (raw === null) return false;
+  // An unrepresentable pair is reported by marginIsUnrepresentable; don't double-flag it.
+  if (raw < MIN_MARGIN_PCT || raw > MAX_MARGIN_PCT) return false;
+  return Math.abs(raw - storedPct) > MARGIN_STORAGE_HALF_STEP + rateRoundingMarginDrift(price);
+}
+
+/**
+ * The patch that must be written whenever a budget rate and a sell price are paired up —
+ * from the rate input, and from the sell-price input that silently invalidated it before.
+ *
+ * Rate <= 0 (or blank) means "no budget", so the margin is cleared rather than left stale:
+ * saveEstimate reads a null markupPercent as the default, which is what an item with no
+ * budget looks like anyway. A margin left over from a deleted rate describes nothing.
+ */
+export function marginPatchForRate(rate: number, price: number): { markupPercent: string | null } {
+  if (!Number.isFinite(rate) || rate <= 0) return { markupPercent: null };
+  if (!Number.isFinite(price) || price <= 0) return { markupPercent: null };
+  return { markupPercent: derivedMarginPct(rate, price).toFixed(2) };
 }
 
 /**

--- a/tests/budget-math.test.ts
+++ b/tests/budget-math.test.ts
@@ -16,10 +16,15 @@ import {
     formatDerivedRate,
     costFromMargin,
     derivedMarginPct,
+    derivedRateDecimals,
     internalBudget,
     DEFAULT_MARGIN_PCT,
     MIN_MARGIN_PCT,
     MAX_MARGIN_PCT,
+    rawMarginPct,
+    marginIsUnrepresentable,
+    marginIsStale,
+    marginPatchForRate,
 } from "../src/lib/budget-math";
 
 test("clampMarginPct holds the representable range", () => {
@@ -124,4 +129,377 @@ test("formatDerivedRate never rounds a real cost down to a zero budget", () => {
     const stored = formatDerivedRate(tiny, 0.49);
     assert.ok(parseFloat(stored) > 0, `expected a non-zero rate, got ${stored}`);
     assert.notEqual(internalBudget({ quantity: 1, budgetRate: stored }), null);
+});
+
+/**
+ * INVARIANT: rawMarginPct is the UNCLAMPED margin a rate/price pair implies — it is what
+ * derivedMarginPct feeds into clampMarginPct. The two diverge exactly when the pair falls
+ * outside [MIN_MARGIN_PCT, MAX_MARGIN_PCT], and that divergence is the whole detection
+ * mechanism marginIsUnrepresentable relies on: a clamped, storable markupPercent can sit next
+ * to a rate that does not actually produce it (PR #323's original defect — rate 150 at price
+ * 100 stores a 0% margin, which implies cost === price, not a cost 50% higher than price).
+ */
+test("rawMarginPct returns the unclamped margin where derivedMarginPct clamps", () => {
+    assert.equal(rawMarginPct(150, 100), -50);
+    assert.equal(derivedMarginPct(150, 100), 0);
+
+    assert.equal(rawMarginPct(0.5, 100), 99.5);
+    assert.equal(derivedMarginPct(0.5, 100), 99);
+});
+
+/**
+ * INVARIANT: rawMarginPct is null whenever there is no real margin to report — a non-finite
+ * rate or price, or a sell price of zero/negative (no sell to earn a margin on).
+ */
+test("rawMarginPct is null for non-finite inputs and non-positive price", () => {
+    assert.equal(rawMarginPct(Infinity, 100), null);
+    assert.equal(rawMarginPct(-Infinity, 100), null);
+    assert.equal(rawMarginPct(NaN, 100), null);
+    assert.equal(rawMarginPct(100, Infinity), null);
+    assert.equal(rawMarginPct(100, NaN), null);
+    assert.equal(rawMarginPct(50, 0), null);
+    assert.equal(rawMarginPct(50, -10), null);
+});
+
+/**
+ * REGRESSION (mirror of PR #323's margin defect): entering a budget rate ABOVE the sell price
+ * used to silently store a 0% margin — clampMarginPct(-50) === 0 — which claims cost === price
+ * when the line actually loses money. marginIsUnrepresentable is the flag that catches this: the
+ * stored "0.00" is still what gets persisted (rates are never silently rewritten), but callers
+ * now have a way to know the persisted margin is a lie instead of trusting it silently.
+ */
+test("a rate above the sell price stores a lying 0% margin and is flagged unrepresentable", () => {
+    const patch = marginPatchForRate(150, 100);
+    assert.equal(patch.markupPercent, "0.00");
+    assert.equal(marginIsUnrepresentable(150, 100), true);
+});
+
+/**
+ * REGRESSION (the other direction of the same defect): a rate far below the sell price clamps to
+ * a 99% margin — clampMarginPct(99.5) === 99 — which implies a cost of $1.00 on a $100 sell price
+ * when the real rate was $0.50. Flagged the same way as the >100 case, and for the same reason:
+ * a clamped, storable value must not be trusted as a faithful description of the input rate.
+ */
+test("a rate far below the sell price stores an inflated margin and is flagged unrepresentable", () => {
+    const patch = marginPatchForRate(0.5, 100);
+    assert.equal(patch.markupPercent, "99.00");
+    assert.equal(marginIsUnrepresentable(0.5, 100), true);
+});
+
+/**
+ * INVARIANT: the honest middle of the range round-trips cleanly and is never flagged, including
+ * both boundaries — rate === price (0% margin) and rate === price / 100 (99% margin) are REAL,
+ * storable margins. These must not false-positive as unrepresentable; only values that clamp are
+ * unrepresentable.
+ */
+test("in-range rates (including both boundaries) are honest and never flagged", () => {
+    let patch = marginPatchForRate(75, 100);
+    assert.equal(patch.markupPercent, "25.00");
+    assert.equal(marginIsUnrepresentable(75, 100), false);
+
+    // Boundary: rate === price -> 0% margin, a real value, NOT unrepresentable.
+    patch = marginPatchForRate(100, 100);
+    assert.equal(patch.markupPercent, "0.00");
+    assert.equal(marginIsUnrepresentable(100, 100), false);
+
+    // Boundary: rate === price / 100 -> 99% margin, a real value, NOT unrepresentable.
+    patch = marginPatchForRate(1, 100);
+    assert.equal(patch.markupPercent, "99.00");
+    assert.equal(marginIsUnrepresentable(1, 100), false);
+});
+
+/**
+ * REGRESSION: a rate of 0 or an unparsed/blank rate (NaN) used to strand a stale margin in
+ * place, because the caller's `r > 0 && price > 0` guard skipped the write entirely and left
+ * whatever markupPercent was already stored. marginPatchForRate now returns an explicit null
+ * patch so the caller always clears the stale value instead of leaving it stranded.
+ */
+test("a zero or blank rate clears the margin instead of stranding a stale one", () => {
+    assert.deepEqual(marginPatchForRate(0, 100), { markupPercent: null });
+    assert.deepEqual(marginPatchForRate(NaN, 100), { markupPercent: null });
+});
+
+/**
+ * INVARIANT: a positive rate with no sell price to measure it against (price <= 0) has no
+ * margin to store, and is always flagged unrepresentable — there is nothing for the rate to be
+ * a percentage of.
+ */
+test("a positive rate against a non-positive price clears the margin and is unrepresentable", () => {
+    assert.deepEqual(marginPatchForRate(50, 0), { markupPercent: null });
+    assert.equal(marginIsUnrepresentable(50, 0), true);
+});
+
+/**
+ * INVARIANT: non-finite inputs must never throw, and must land on the documented result for all
+ * three functions — Infinity/NaN on either side of the pair.
+ */
+test("non-finite inputs do not throw and land on documented results", () => {
+    assert.doesNotThrow(() => {
+        rawMarginPct(Infinity, 100);
+        rawMarginPct(100, Infinity);
+        rawMarginPct(NaN, 100);
+        marginIsUnrepresentable(Infinity, 100);
+        marginIsUnrepresentable(100, Infinity);
+        marginIsUnrepresentable(NaN, 100);
+        marginPatchForRate(Infinity, 100);
+        marginPatchForRate(100, Infinity);
+        marginPatchForRate(NaN, 100);
+    });
+
+    // rate non-finite: a bad budget, not "no budget" — still persists to budgetRate while the
+    // margin next to it clears to the default, so it must be flagged rather than waved through.
+    assert.equal(marginIsUnrepresentable(Infinity, 100), true);
+    assert.equal(marginIsUnrepresentable(-Infinity, 100), true);
+    assert.equal(marginIsUnrepresentable(NaN, 100), true);
+    assert.deepEqual(marginPatchForRate(Infinity, 100), { markupPercent: null });
+    assert.deepEqual(marginPatchForRate(NaN, 100), { markupPercent: null });
+
+    // price non-finite with a real rate: "a cost with no sell price" -> true, and no patch.
+    assert.equal(marginIsUnrepresentable(50, Infinity), true);
+    assert.equal(marginIsUnrepresentable(50, NaN), true);
+    assert.deepEqual(marginPatchForRate(50, Infinity), { markupPercent: null });
+    assert.deepEqual(marginPatchForRate(50, NaN), { markupPercent: null });
+});
+
+/**
+ * PROPERTY: whenever marginIsUnrepresentable says a rate/price pair IS representable, the
+ * margin marginPatchForRate actually persists must describe that same rate — i.e.
+ * parseFloat(marginPatchForRate(rate, price).markupPercent) equals derivedMarginPct(rate, price)
+ * rounded to 2dp, at every price scale. This is the round-trip guarantee the whole detection
+ * mechanism exists to protect: a stored margin the caller did NOT flag must always be true.
+ */
+test("stored margin always describes the stored rate when not flagged unrepresentable", () => {
+    const prices = [1500, 100, 12.5, 1, 0.49];
+    const factors = [1, 0.75, 0.5, 0.25, 0.01]; // rate = price * factor -> margin = (1-factor)*100
+
+    for (const price of prices) {
+        for (const factor of factors) {
+            const rate = price * factor;
+            assert.equal(
+                marginIsUnrepresentable(rate, price),
+                false,
+                `expected rate ${rate} at price ${price} to be representable`,
+            );
+            const patch = marginPatchForRate(rate, price);
+            assert.notEqual(patch.markupPercent, null);
+            const expected = Math.round(derivedMarginPct(rate, price) * 100) / 100;
+            assert.equal(
+                parseFloat(patch.markupPercent!),
+                expected,
+                `stored margin does not describe rate ${rate} at price ${price}`,
+            );
+        }
+    }
+});
+
+/**
+ * REGRESSION: a NEGATIVE budget rate used to read as "no budget at all" (every non-positive rate
+ * short-circuited to false), but it still persists to budgetRate — and internalBudget happily
+ * multiplies it out — while marginPatchForRate clears markupPercent, which then displays the
+ * default 25%. A bad (negative) budget must not be indistinguishable from no budget. rate === 0
+ * is the one true "no budget" case and stays unflagged.
+ */
+test("a negative rate is a bad budget, not no budget, and is flagged unrepresentable", () => {
+    assert.equal(marginIsUnrepresentable(0, 100), false);
+    assert.equal(marginIsUnrepresentable(-5, 100), true);
+});
+
+/**
+ * REGRESSION: stale-margin detection. A margin persisted on an item can be left behind by an
+ * edit that changed the sell price (or rate) without re-deriving markupPercent — the reported
+ * shape was a stored 25% sitting next to rate 75 / price 200, whose real margin is 62.5%.
+ * marginIsStale is the check that surfaces this without re-flagging pairs marginIsUnrepresentable
+ * already owns.
+ */
+test("marginIsStale flags a persisted margin that no longer describes rate/price", () => {
+    // The reported regression shape: stored 25%, but rate 75 at price 200 is really 62.5%.
+    assert.equal(marginIsStale(25, 75, 200), true);
+});
+
+test("marginIsStale is false when the stored margin agrees with rate/price", () => {
+    assert.equal(marginIsStale(25, 75, 100), false);
+});
+
+test("marginIsStale is false for inputs with nothing to compare", () => {
+    assert.equal(marginIsStale(null, 75, 100), false);
+    assert.equal(marginIsStale(NaN, 75, 100), false);
+    assert.equal(marginIsStale(25, 0, 100), false);
+    assert.equal(marginIsStale(25, -5, 100), false);
+    assert.equal(marginIsStale(25, Infinity, 100), false);
+    assert.equal(marginIsStale(25, 75, 0), false);
+});
+
+/**
+ * INVARIANT: marginIsStale must never double-flag a pair marginIsUnrepresentable already reports
+ * — an out-of-range rate/price pair has no honest margin to compare a stored value against, so
+ * the unrepresentable check owns it exclusively.
+ */
+test("marginIsStale defers to marginIsUnrepresentable instead of double-flagging", () => {
+    // rate > price: clamps to 0%, marginIsUnrepresentable is the one that should catch this.
+    assert.equal(marginIsUnrepresentable(150, 100), true);
+    assert.equal(marginIsStale(0, 150, 100), false);
+
+    // rate far below price: clamps to 99%, same deferral.
+    assert.equal(marginIsUnrepresentable(0.5, 100), true);
+    assert.equal(marginIsStale(99, 0.5, 100), false);
+});
+
+/**
+ * PROPERTY (no-false-positive): a margin freshly written by marginPatchForRate must never trip
+ * marginIsStale against the same rate/price it was derived from — otherwise every newly saved
+ * row would warn on its own value. Covers a spread of prices and in-range margins, going through
+ * the same 2dp string round-trip a real save performs.
+ */
+test("a freshly derived margin never flags itself as stale", () => {
+    const prices = [1500, 100, 12.5, 1, 0.49];
+    const margins = [0, 10, 25, 50, 75, 99];
+
+    for (const price of prices) {
+        for (const marginPct of margins) {
+            const rate = costFromMargin(price, marginPct);
+            if (rate <= 0) continue; // marginIsStale requires rate > 0
+            const patch = marginPatchForRate(rate, price);
+            assert.notEqual(patch.markupPercent, null);
+            const stored = parseFloat(patch.markupPercent!);
+            assert.equal(
+                marginIsStale(stored, rate, price),
+                false,
+                `freshly stored margin ${stored} flagged stale for rate ${rate} at price ${price}`,
+            );
+        }
+    }
+});
+
+/**
+ * REGRESSION: the tolerance used to be a flat MARGIN_STORAGE_HALF_STEP (0.005), sized for only
+ * ONE writer's rounding. A row can legitimately be off by a half-step from EACH of the two
+ * writers at once — marginPatchForRate rounds the MARGIN to 2dp, formatDerivedRate rounds the
+ * RATE to derivedRateDecimals(price) places — so a row written by rounding the rate first and
+ * then re-deriving/rounding the margin can sit a combined distance from the true margin that a
+ * single half-step does not cover. Reported shape: rate 2.95 at price 8 stores margin "63.13"
+ * (marginPatchForRate(2.95, 8).markupPercent) against a true margin of 63.125 — a difference of
+ * 0.005000000000002558, which trips the old flat 0.005 boundary by float dust alone. The
+ * tolerance now adds rateRoundingMarginDrift(price) to cover the second writer's rounding, so a
+ * freshly written row must never warn.
+ */
+test("marginIsStale does not flag a freshly written row off by one half-step from each writer", () => {
+    assert.equal(marginPatchForRate(2.95, 8).markupPercent, "63.13");
+    assert.equal(marginIsStale(63.13, 2.95, 8), false);
+});
+
+/**
+ * REGRESSION: typed-margin round trip through the OTHER writer path. A margin typed by the user
+ * (25.025) derives a cost via costFromMargin, which formatDerivedRate rounds to
+ * derivedRateDecimals(price) places for storage. Reading that stored rate back must not flag the
+ * margin it was derived from as stale, even though the rate went through its own rounding step
+ * independent of the margin's.
+ */
+test("marginIsStale does not flag a typed margin against the rate rounded from it", () => {
+    const price = 100;
+    const margin = 25.025;
+    const rate = formatDerivedRate(costFromMargin(price, margin), price);
+    assert.equal(marginIsStale(margin, parseFloat(rate), price), false);
+});
+
+/**
+ * PROPERTY (no-false-positive, both writer directions): at every price scale the derived-rate
+ * decimal count actually changes at, and across a spread of in-range margins/rates, BOTH ways a
+ * row gets written must round-trip clean:
+ *  - path A (rate-first): a rate is picked, the margin stored beside it comes from
+ *    marginPatchForRate(rate, price) — mirrors a user typing a budget rate.
+ *  - path B (margin-first): a margin is stored verbatim, the rate stored beside it comes from
+ *    formatDerivedRate(costFromMargin(price, margin), price) — mirrors a user typing a margin.
+ * Neither path may ever flag its own freshly written pair as stale.
+ */
+test("both writer paths round-trip clean at every price scale (property)", () => {
+    const prices = [0.49, 1, 8, 12.5, 100, 1500, 1e6];
+    const margins = [1, 10, 25, 50, 75, 90, 99]; // keep well inside (0, 100) at every scale
+
+    for (const price of prices) {
+        for (const marginPct of margins) {
+            // Path A: rate-first. Derive a real rate from the margin so it's in range for this
+            // price, then store the MARGIN from that rate — this is what marginPatchForRate sees
+            // when a user types a rate.
+            const pickedRate = costFromMargin(price, marginPct);
+            if (pickedRate > 0) {
+                const patch = marginPatchForRate(pickedRate, price);
+                assert.notEqual(patch.markupPercent, null, `path A: no margin stored for rate ${pickedRate} at price ${price}`);
+                const storedMargin = parseFloat(patch.markupPercent!);
+                assert.equal(
+                    marginIsStale(storedMargin, pickedRate, price),
+                    false,
+                    `path A: rate ${pickedRate} at price ${price} flagged stale against its own derived margin ${storedMargin}`,
+                );
+            }
+
+            // Path B: margin-first. Store the margin verbatim, derive the RATE via
+            // formatDerivedRate(costFromMargin(...)) — this is what a user typing a margin writes.
+            const derivedRate = parseFloat(formatDerivedRate(costFromMargin(price, marginPct), price));
+            if (derivedRate > 0) {
+                assert.equal(
+                    marginIsStale(marginPct, derivedRate, price),
+                    false,
+                    `path B: margin ${marginPct} at price ${price} flagged stale against its own derived rate ${derivedRate}`,
+                );
+            }
+        }
+    }
+});
+
+/**
+ * REGRESSION: the widened tolerance must not grow large enough to swallow a REAL contradiction.
+ * Confirms detection still works at multiple price scales beyond the originally reported shape
+ * (marginIsStale(25, 75, 200) — stored 25%, but rate 75 at price 200 is really 62.5%).
+ */
+test("marginIsStale still catches genuine staleness at every price scale", () => {
+    // The originally reported shape.
+    assert.equal(marginIsStale(25, 75, 200), true);
+
+    // A large-price contradiction: stored 80%, but rate 500 at price 5000 is really 90%.
+    assert.equal(marginIsStale(80, 500, 5000), true);
+
+    // A sub-dollar contradiction: stored 50%, but rate 0.01 at price 0.05 is really 80%.
+    assert.equal(marginIsStale(50, 0.01, 0.05), true);
+});
+
+/**
+ * derivedRateDecimals is the shared rounding rule behind both formatDerivedRate and
+ * marginIsStale's tolerance — this pins the shape of that rule directly, independent of the
+ * margin math built on top of it.
+ */
+test("derivedRateDecimals: bounds, growth, and non-finite/non-positive price", () => {
+    // Large prices need no more than cents.
+    assert.equal(derivedRateDecimals(1e6), 2);
+    // Floored at 2 even for prices far larger still — never fewer than cents.
+    assert.equal(derivedRateDecimals(1e10), 2);
+
+    // Sub-dollar prices need more precision than cents to keep the implied margin accurate.
+    assert.ok(derivedRateDecimals(0.49) > 2, "expected sub-dollar price to need more than 2 decimals");
+
+    // Capped at 10 even for a price small enough that the naive formula would ask for more.
+    assert.equal(derivedRateDecimals(1e-10), 10);
+
+    // Non-positive / non-finite price has no meaningful scale — falls back to 2.
+    assert.equal(derivedRateDecimals(0), 2);
+    assert.equal(derivedRateDecimals(-5), 2);
+    assert.equal(derivedRateDecimals(NaN), 2);
+    assert.equal(derivedRateDecimals(Infinity), 2);
+});
+
+/**
+ * INVARIANT: formatDerivedRate and derivedRateDecimals must never drift apart — the doc comment
+ * on derivedRateDecimals says as much ("if these two ever disagree, healthy rows start
+ * warning"). Pins that a positive rate is always formatted at exactly derivedRateDecimals(price)
+ * decimal places, at every scale exercised above.
+ */
+test("formatDerivedRate always uses exactly derivedRateDecimals(price) decimal places", () => {
+    for (const price of [0.01, 0.49, 1, 8, 12.5, 100, 1500, 1e6]) {
+        const formatted = formatDerivedRate(1.23456789, price);
+        const decimalPlaces = formatted.includes(".") ? formatted.split(".")[1].length : 0;
+        assert.equal(
+            decimalPlaces,
+            derivedRateDecimals(price),
+            `formatDerivedRate(1.23456789, ${price}) = "${formatted}" does not match derivedRateDecimals(${price})`,
+        );
+    }
 });


### PR DESCRIPTION
## What

The budget **RATE** input clamped its derived margin into `[0, 99]` and persisted the clamp. A rate above the sell price stored `markupPercent` 0 — but a 0% margin implies cost == price, not the rate that was typed. Reverse direction too: rate `0.50` against price `100` stored 99, implying a cost of `1.00`.

This is the mirror of the MARGIN-input defect fixed in #323 (`610dde5d`), deliberately left out of it because it needed a product decision first.

## The decision

**Keep `MIN_MARGIN_PCT` at 0 and surface the contradiction, rather than clamp the rate.** Clamping would silently rewrite a cost the user typed. Allowing negative margins would put a sign change through all **19** files that read `markupPercent` (pdf, QBO sync, historical-pricing AI, change-order-core, billing-core, MCP route, budget reports) — not worth it for this.

## Changes

- The rate persists **exactly as typed**. The row warns when the rate/price pair has no representable margin: cost > sell, cost < 1% of sell, or no valid sell price.
- `marginPatchForRate` is now the single writer of a rate-derived margin. The old `r > 0 && price > 0` guard skipped the write entirely, so zeroing a rate stranded the previous margin next to no budget at all.
- **Editing the sell price re-derives the margin.** Price 100 → 200 used to leave rate 75 beside a stored 25% while the line really ran 62.5%.
- `marginIsStale` flags rows already saved in that shape. They self-heal on any edit; nothing backfills them.

### The tolerance is the subtle part

`marginIsStale` uses `0.005 + rateRoundingMarginDrift(price)`, not a flat `0.005`. Both writers round, and a healthy row can sit a half-step off **each** at once — rate `$2.95` at price `$8` stores `63.13` against a true `63.125`, landing exactly on the flat boundary. A flat epsilon would have put a red warning on ordinary saves. `derivedRateDecimals` is shared by `formatDerivedRate` and the tolerance so the two rounding rules can never drift apart.

## Verification

- `npm run test:unit` — 92 pass (20 new)
- `npm run typecheck` — clean
- `npm run build:next` — clean
- Codex peer review, 2 rounds. Round 1 caught negative rates reading as "no budget" and legacy rows staying silent. Round 2 caught the flat-epsilon false positive.
- **Browser-tested** against the Shop test estimate: rate `2000` on an `$1,800` line warns and keeps `2000`; correcting to `1350` clears the warning and stores `25.00`; doubling the price to `3600` moves the margin to `62.50` on its own. Nothing was saved — prod data verified unchanged after reload.

No schema change, so no `apply-*.mjs` to run before deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)