### PR TITLE
fix(quickbooks): save the estimate before syncing it to QuickBooks

### DIFF
--- a/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
@@ -828,6 +828,30 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
         setIsSyncingQB(true);
         setShowMoreMenu(false);
         try {
+            // The sync route reads the estimate from the database, so anything typed since the
+            // last save would be invisible to it and QuickBooks would receive stale prices or a
+            // stale section hierarchy. Save first, exactly as the Change Order and Purchase
+            // Order actions above do.
+            //
+            // Silent because this handler owns the messaging for the whole operation: a
+            // non-silent save toasts "Estimate saved successfully" immediately before the sync
+            // toast, and reports a save failure twice (once itself, once via the catch below).
+            // skipRefresh avoids a redundant RSC round-trip in the middle of the sync.
+            try {
+                await handleSave({ silent: true, skipRefresh: true });
+            } catch (e: any) {
+                // A CAS conflict already raised its own toast carrying the Reload action, so it
+                // must not be spoken over. Everything else has to say plainly that the push did
+                // not happen — otherwise a failed save reads as a failed sync.
+                if (!e?.isSaveConflict) {
+                    // The fixed sentence always leads: `e.message` is set for nearly every Error, so
+                    // using it as the whole message would drop the part the user actually needs.
+                    const detail = e?.message ? ` (${e.message})` : "";
+                    toast.error(`We couldn't confirm the save — QuickBooks was not updated.${detail}`);
+                }
+                return;
+            }
+
             const res = await fetch("/api/quickbooks/sync", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
@@ -2142,7 +2166,7 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
         <div
             className="flex flex-col h-full bg-slate-50"
             onBlur={(e) => {
-                if (!e.currentTarget.contains(e.relatedTarget as Node) && !showTemplateModal && !showAiModal && !showImportModal && !showSendModal && !showMoreMenu && !isSaving && !saveConflictRef.current) {
+                if (!e.currentTarget.contains(e.relatedTarget as Node) && !showTemplateModal && !showAiModal && !showImportModal && !showSendModal && !showMoreMenu && !isSaving && !isSyncingQB && !saveConflictRef.current) {
                     handleSave();
                 }
             }}
@@ -2404,9 +2428,12 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" /></svg>
                         {initialEstimate.sentAt ? "Resend" : "Send"}
                     </button>
+                    {/* isSyncingQB: the pre-sync save inside handleSyncQB runs silently, so isSaving
+                        stays false — without it this button would invite a second save that could
+                        land in the middle of the sync. */}
                     <button
                         onClick={() => handleSave()}
-                        disabled={isSaving}
+                        disabled={isSaving || isSyncingQB}
                         className="hui-btn hui-btn-primary disabled:opacity-50"
                     >
                         {isSaving ? "Saving..." : "Save"}


### PR DESCRIPTION
## The bug

`handleSyncQB` POSTs to `/api/quickbooks/sync`, which reads the estimate **from the database** by id. It didn't save first.

So: edit line items → click "Sync to QuickBooks" → the *previously saved* prices and section hierarchy go to the live accounting system, and the success toast implies your edits went with them.

`handleCreateChangeOrder` and `handleCreatePurchaseOrder` already `await handleSave()` for exactly this reason. This brings the QB path in line.

## The change

```diff
  try {
+     await handleSave({ silent: true, skipRefresh: true });
      const res = await fetch("/api/quickbooks/sync", { ... });
```

Three details that aren't obvious:

- **Silent.** A non-silent save toasts "Estimate saved successfully" immediately before the sync toast, and reports a save failure *twice* (once from `runSave`, once from this handler's catch). This handler now owns the messaging for the whole operation.
- **Save-phase errors are distinguished.** They always lead with "We couldn't confirm the save — QuickBooks was not updated", with the underlying message appended as detail rather than replacing it. Otherwise a failed *save* reads as a failed *sync*. A CAS conflict is deliberately left alone — `runSave`'s conflict toast already carries the Reload action and isn't silent-gated.
- **`isSaving` stays false during a silent save**, so the Save button and the blur autosave are now also gated on `isSyncingQB`. Without that, either could queue a second save that lands *after* the route has already read the row.

## Verification

- `tsc --noEmit` — 0 errors.
- `npm run test:estimate-item-payload` — 54/54 pass.
- Codex peer review, 2 rounds. Round 1 flagged the double-toast and misleading error wording; round 2 flagged that `silent` also suppresses the busy state (hence the two extra gates) and that `e.message ||` would swallow the fixed sentence. Both addressed. Round 2's remaining "blockers" are pre-existing route-level issues Codex itself labelled as not introduced here — being tracked separately (see below).

## Not fixed here — spun off separately

Surfaced by the same review, all pre-existing:

1. **Sync is non-idempotent.** Every call POSTs a *new* QBO estimate; `qbId` is never persisted or reused, so retries and repeat clicks create duplicates in the books.
2. **The route doesn't check the `estimates` permission** or project access — only that the caller is active staff. FIELD_CREW can call it directly.
3. **QBO total ≠ ProBuild `totalAmount`** — QBO gets leaf lines only; the processing-fee markup is omitted and tax depends on QBO's own config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)