### PR TITLE
feat(estimates): audit stale margin rows on prod (read-only, no repair needed)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "adm-zip": "^0.5.16",
+        "dotenv": "^17.4.0",
         "draco3dgltf": "^1.5.7",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "adm-zip": "^0.5.16",
+    "dotenv": "^17.4.0",
     "draco3dgltf": "^1.5.7",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",

--- a/scripts/audit-stale-margins.mjs
+++ b/scripts/audit-stale-margins.mjs
@@ -1,0 +1,220 @@
+// READ-ONLY audit of EstimateItem rows whose persisted `markupPercent` no longer
+// describes the budget rate / sell price pair stored beside it.
+//
+// Background: PR #331 added a row-level warning for that shape (editing a sell
+// price before that path re-derived the margin left price 200 next to rate 75 and
+// a stored 25% while the line really ran 62.5%). The editor can no longer CREATE
+// such a row and any edit self-heals one, but nothing repairs history — so this
+// exists to answer "how much history is there?".
+//
+// THIS SCRIPT NEVER WRITES. There is no UPDATE, INSERT or DELETE in this file and
+// no --apply flag. When it was first run against prod (2026-08-09) it found ZERO
+// stale rows out of 938 candidates — the largest discrepancy in the table was
+// 0.0046 percentage points, pure 2dp rounding — because the earlier margin
+// backfill (scripts/backfill-estimate-item-margin.mjs, PR #329) had already
+// converged markupPercent against baseCost/unitCost across the whole population.
+// A repair pass was therefore deliberately NOT shipped. If a future run reports a
+// non-zero count, the repair is to recompute markupPercent from the stored
+// rate/price via `marginPatchForRate` — markupPercent is DERIVED, baseCost and
+// unitCost are authoritative, and NO SELL PRICE OR BUDGET RATE MAY MOVE.
+//
+// WHAT "STALE" MEANS IS NOT REDEFINED HERE. The predicate is `marginIsStale()`
+// from src/lib/budget-math.ts, called with exactly the values BudgetStrip.tsx
+// derives from a row (rate = budgetRate ?? baseCost, price = unitCost,
+// stored = markupPercent), so this script and the red warning in the editor can
+// never disagree. The tolerance (0.005 + rate-rounding drift) lives inside that
+// helper and is deliberately NOT re-derived here — see budget-math.ts for why a
+// flat epsilon put a red warning on ordinary saves.
+//
+// Rows where `marginIsUnrepresentable` is true are counted separately and never
+// reported as stale: those are the intentional cost-exceeds-sell / margin-over-99
+// / no-sell-price warnings, not stale data.
+//
+// Usage (must run under tsx — this file imports the TypeScript helper directly so
+// there is no second copy of the math to drift):
+//   npx tsx scripts/audit-stale-margins.mjs             # full report
+//   npx tsx scripts/audit-stale-margins.mjs --limit 50  # cap the samples printed
+//
+// Requires (read from env or .env / .env.local):
+//   DATABASE_URL   Supabase transaction pooler URL (must include ?pgbouncer=true)
+import { PrismaClient } from "@prisma/client";
+import dotenv from "dotenv";
+import fs from "node:fs";
+import * as budgetMathModule from "../src/lib/budget-math.ts";
+
+// tsx transpiles the .ts helper to CJS while this .mjs stays native ESM, so the
+// named exports land on `default` rather than on the namespace. Take whichever
+// shape we got — the point is that there is exactly ONE copy of this math, the
+// one the UI imports.
+const { marginIsStale, marginIsUnrepresentable, rawMarginPct } =
+  budgetMathModule.default ?? budgetMathModule;
+for (const [name, fn] of Object.entries({ marginIsStale, marginIsUnrepresentable, rawMarginPct })) {
+  if (typeof fn !== "function") {
+    throw new Error(`Could not load budget-math helper \`${name}\` — run this script with \`npx tsx\`, not bare \`node\`.`);
+  }
+}
+
+const limitArg = process.argv.indexOf("--limit");
+let SAMPLE_LIMIT = 20;
+if (limitArg >= 0) {
+  // Strict: a typo must not silently become 0 samples (`parseInt` alone turns "1e3" into 1 and
+  // a missing value into NaN). An audit that prints nothing looks the same as a clean table.
+  const raw = process.argv[limitArg + 1];
+  // isSafeInteger as well as the digit test: a long enough run of digits passes /^\d+$/ but
+  // converts to Infinity, and `slice(0, Infinity)` would dump every row instead of a sample.
+  const parsed = raw === undefined ? NaN : Number(raw);
+  if (raw === undefined || !/^\d+$/.test(raw) || !Number.isSafeInteger(parsed)) {
+    throw new Error(`--limit needs a non-negative integer, got ${raw === undefined ? "nothing" : `"${raw}"`}`);
+  }
+  SAMPLE_LIMIT = parsed;
+}
+
+/**
+ * Read a key from the environment, then from the dotenv files in the order the Next.js
+ * toolchain resolves them: `.env.local` OVERRIDES `.env`. Checking `.env` first would let a
+ * committed default silently win over the local override and point a production audit at the
+ * WRONG DATABASE. (The sibling backfill script has the older, reversed order — it happens not
+ * to misfire because this repo has no bare `.env`, but do not copy it.)
+ *
+ * Parsing is delegated to `dotenv` rather than hand-rolled. A regex over the line looks fine
+ * until it meets the cases that actually occur — quoted values containing `#`, `export`
+ * prefixes, inline comments, CRLF, multiline values — and each one it gets wrong is a silent
+ * wrong-database read, which is the one failure this script must not have.
+ *
+ * `key in parsed` rather than a truthiness check on purpose: a file that assigns the key an
+ * EMPTY value has still spoken, and must win over the lower-precedence file instead of falling
+ * through to it. The missing-URL check below then fails loudly, which is the correct outcome.
+ */
+function envFromFiles(key) {
+  if (process.env[key]) return process.env[key];
+  for (const f of [".env.local", ".env"]) {
+    if (!fs.existsSync(f)) continue;
+    const parsed = dotenv.parse(fs.readFileSync(f));
+    if (key in parsed) return parsed[key];
+  }
+  return undefined;
+}
+
+const DATABASE_URL = envFromFiles("DATABASE_URL");
+if (!DATABASE_URL) throw new Error("DATABASE_URL not found in env or .env files");
+if (!DATABASE_URL.includes("pgbouncer=true")) {
+  console.warn("⚠ DATABASE_URL has no pgbouncer=true — expected the Supabase transaction pooler. Continuing.");
+}
+
+const prisma = new PrismaClient({ datasources: { db: { url: DATABASE_URL } } });
+
+// Candidate rows only. Everything is fetched as text and parsed with parseFloat so
+// the numbers fed to the helpers are bit-for-bit what BudgetStrip.tsx works with
+// (Prisma serializes Decimal to a string and the component parseFloats it).
+//
+// The WHERE clause is a cheap pre-filter, NOT the definition of stale — every row
+// it returns is still put through marginIsStale() below. COALESCE mirrors the
+// component's `budgetRate ?? baseCost`, so an explicitly-stored rate of 0 reads as
+// "no budget" here exactly as it does there.
+const CANDIDATE_SQL = `
+  SELECT
+    i."id"                                        AS "id",
+    i."estimateId"                                AS "estimateId",
+    e."code"                                      AS "estimateCode",
+    e."projectId"                                 AS "projectId",
+    e."leadId"                                    AS "leadId",
+    COALESCE(i."budgetRate", i."baseCost")::text  AS "rateText",
+    i."unitCost"::text                            AS "priceText",
+    i."markupPercent"::text                       AS "marginText"
+  FROM "EstimateItem" i
+  JOIN "Estimate" e ON e."id" = i."estimateId"
+  WHERE COALESCE(i."budgetRate", i."baseCost") IS NOT NULL
+    AND i."unitCost" IS NOT NULL
+  ORDER BY i."id" ASC
+`;
+
+/**
+ * Linear-interpolated percentile over an ascending array. Interpolation rather than a rounded
+ * index because rounding reports a real data point that can sit well off the true quantile —
+ * with deltas [1, 9] a rounded index calls the median 9 instead of 5, which would overstate a
+ * small prod population by a lot.
+ */
+function percentile(sorted, p) {
+  if (sorted.length === 0) return null;
+  if (sorted.length === 1) return sorted[0];
+  const pos = (p / 100) * (sorted.length - 1);
+  const lo = Math.floor(pos);
+  const hi = Math.ceil(pos);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (pos - lo);
+}
+
+(async () => {
+  console.log("Mode: AUDIT (read-only — this script has no write path)\n");
+
+  const candidates = await prisma.$queryRawUnsafe(CANDIDATE_SQL);
+
+  const stale = [];
+  const unrepresentable = [];
+
+  for (const row of candidates) {
+    // Same parse the component does: blank is genuinely "no budget"; anything else
+    // keeps whatever it parses to, NaN included, so a bad rate is not hidden.
+    const rateText = row.rateText == null ? "" : String(row.rateText).trim();
+    const rate = rateText === "" ? 0 : parseFloat(rateText);
+    const price = parseFloat(row.priceText) || 0;
+    const stored = row.marginText == null ? null : parseFloat(row.marginText);
+
+    if (marginIsUnrepresentable(rate, price)) {
+      unrepresentable.push({ ...row, rate, price, stored });
+      continue;
+    }
+    if (!marginIsStale(stored, rate, price)) continue;
+
+    const trueMargin = rawMarginPct(rate, price);
+    stale.push({ ...row, rate, price, stored, trueMargin, delta: Math.abs(trueMargin - stored) });
+  }
+
+  const estimates = new Set(stale.map((r) => r.estimateId));
+  const owners = new Set(stale.map((r) => r.projectId ?? `lead:${r.leadId}`));
+  const deltas = stale.map((r) => r.delta).sort((a, b) => a - b);
+
+  console.log(`${candidates.length} candidate row(s) scanned (a rate and a unit cost both present).`);
+  console.log(`${stale.length} row(s) STALE — stored margin disagrees with the rate/price beside it.`);
+  console.log(`  across ${estimates.size} estimate(s) and ${owners.size} project(s)/lead(s).`);
+  console.log(
+    `${unrepresentable.length} row(s) unrepresentable (cost exceeds sell / margin over 99 / no sell price) — intentional warnings, not stale data.\n`
+  );
+
+  if (stale.length > 0) {
+    console.log("Discrepancy spread (percentage points of margin):");
+    console.log(`  min    ${deltas[0].toFixed(4)}`);
+    console.log(`  p25    ${percentile(deltas, 25).toFixed(4)}`);
+    console.log(`  median ${percentile(deltas, 50).toFixed(4)}`);
+    console.log(`  p75    ${percentile(deltas, 75).toFixed(4)}`);
+    console.log(`  p95    ${percentile(deltas, 95).toFixed(4)}`);
+    console.log(`  max    ${deltas[deltas.length - 1].toFixed(4)}\n`);
+
+    console.log(`Sample (up to ${SAMPLE_LIMIT}):`);
+    for (const r of stale.slice(0, SAMPLE_LIMIT)) {
+      console.log(
+        `  id=${r.id} est=${r.estimateCode} rate=${r.rateText} price=${r.priceText} stored=${r.stored}% -> true=${r.trueMargin.toFixed(4)}%`
+      );
+    }
+    if (stale.length > SAMPLE_LIMIT) console.log(`  ...and ${stale.length - SAMPLE_LIMIT} more.`);
+    console.log("");
+  }
+
+  if (unrepresentable.length > 0) {
+    console.log(`Unrepresentable rows (review by hand), up to ${SAMPLE_LIMIT}:`);
+    for (const r of unrepresentable.slice(0, SAMPLE_LIMIT)) {
+      console.log(`  id=${r.id} est=${r.estimateCode} rate=${r.rateText} price=${r.priceText} stored=${r.stored}%`);
+    }
+    if (unrepresentable.length > SAMPLE_LIMIT) console.log(`  ...and ${unrepresentable.length - SAMPLE_LIMIT} more.`);
+    console.log("");
+  }
+
+  console.log("Audit complete — no writes made (none possible).");
+})()
+  .catch((e) => {
+    console.error("Audit failed:", e);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/tests/budget-math.test.ts
+++ b/tests/budget-math.test.ts
@@ -503,3 +503,144 @@ test("formatDerivedRate always uses exactly derivedRateDecimals(price) decimal p
         );
     }
 });
+
+/**
+ * The two invariants scripts/audit-stale-margins.mjs leans on when it buckets a row.
+ *
+ * The audit walks EstimateItem rows, asks marginIsUnrepresentable first and marginIsStale
+ * second, and reports the two counts as disjoint populations. Both properties below are
+ * properties of the helpers themselves, not of the script — but the script is the reason
+ * they need pinning, because a violation would silently mis-state a prod count.
+ */
+
+/**
+ * Prices spanning the scales where derivedRateDecimals changes, which is what makes the stale
+ * tolerance price-dependent. Bounded at 1e6 deliberately — see the convergence test below for
+ * why the invariant it pins is a claim about real prices, not about all of float64.
+ */
+const AUDIT_PRICE_SCALES = [0.01, 0.05, 0.49, 1, 2.5, 8, 12.5, 99.99, 100, 1500, 1e6];
+
+/** Representable pairs (0 < rate < price) across those scales. */
+const REPRESENTABLE_PAIRS = (() => {
+    const pairs: Array<[number, number]> = [];
+    for (const price of AUDIT_PRICE_SCALES) {
+        for (const frac of [0.011, 0.1, 0.25, 0.375, 0.5, 0.625, 0.8, 0.9, 0.98]) {
+            pairs.push([price * frac, price]);
+        }
+    }
+    return pairs;
+})();
+
+/**
+ * Pairs whose true margin lands EXACTLY on a 2dp rounding boundary (a .xx5), so
+ * marginPatchForRate's residual is the full half-step of 0.005 — the worst case the tolerance
+ * has to absorb. The fraction grid above never gets near this (its largest residual is ~1e-14),
+ * which would make the convergence test below vacuous on its own.
+ */
+const BOUNDARY_PAIRS = (() => {
+    const pairs: Array<[number, number]> = [];
+    for (const price of AUDIT_PRICE_SCALES) {
+        for (const marginPct of [8.375, 28.375, 55.375, 62.625, 90.125]) {
+            pairs.push([price * (1 - marginPct / 100), price]);
+        }
+    }
+    return pairs;
+})();
+
+/**
+ * INVARIANT: a pair is never both unrepresentable and stale. marginIsStale returns false for
+ * an out-of-range raw margin precisely so the two buckets stay disjoint ("don't double-flag
+ * it").
+ *
+ * Both callers happen to guard the overlap themselves — BudgetStrip.tsx tests
+ * `!unrepresentable && stale`, and the audit script `continue`s after the unrepresentable
+ * branch — so this is a contract on the helpers, not the last line of defence. It is worth
+ * pinning anyway: it is what lets a caller report the two counts as disjoint populations
+ * without re-deriving the exclusion, and a new caller that trusts the helpers would be the
+ * one to get bitten.
+ */
+test("marginIsStale and marginIsUnrepresentable never both fire on the same pair", () => {
+    const grid: Array<[number, number]> = [
+        ...REPRESENTABLE_PAIRS,
+        // Deliberately outside the representable range, plus the degenerate inputs.
+        [200, 100], [100, 100], [0.5, 100], [0.0001, 100], [-5, 100], [50, 0], [50, -1],
+        [NaN, 100], [Infinity, 100], [50, NaN], [50, Infinity], [0, 100],
+    ];
+    for (const [rate, price] of grid) {
+        for (const stored of [0, 25, 50, 62.5, 99, 100, -10]) {
+            const unrep = marginIsUnrepresentable(rate, price);
+            const stale = marginIsStale(stored, rate, price);
+            assert.ok(
+                !(unrep && stale),
+                `rate=${rate} price=${price} stored=${stored} was flagged BOTH unrepresentable and stale`,
+            );
+        }
+    }
+});
+
+/**
+ * INVARIANT: at real-world prices, the margin marginPatchForRate writes is never itself stale.
+ *
+ * This is what makes an ordinary save not warn, and it is the property any future repair pass
+ * would depend on to converge in a single run — a repair that wrote a value still outside the
+ * tolerance would re-flag the same rows forever (the failure mode the #329 backfill hit).
+ * The patch rounds to 2dp, so the residual is at most a half-step of 0.005, and the tolerance
+ * is 0.005 + a positive price-dependent term, which leaves exactly enough headroom.
+ *
+ * SCOPED TO PRICES UP TO 1e6 ON PURPOSE — this is NOT a universal claim about float64. The
+ * price-dependent term shrinks as price grows, and far above any real unit price it stops
+ * covering floating-point error in the subtraction: at price 1e16 with rate 9.1625e15 the true
+ * margin is exactly 8.375, the patch writes 8.38, and the residual computes as
+ * 0.005000000000000782 — a hair over the boundary, so it reads as stale. That is a property of
+ * the arithmetic at absurd scale, not a defect worth adding headroom for: a $10-quadrillion
+ * unit price is not a thing, and widening the tolerance would cost real sensitivity at the
+ * prices that exist. The bound is asserted below so it stays a deliberate choice.
+ */
+test("marginPatchForRate output is never stale at real-world prices — repairs converge in one pass", () => {
+    assert.ok(
+        Math.max(...AUDIT_PRICE_SCALES) <= 1e6,
+        "this invariant is only claimed up to 1e6 — see the note above before raising the grid",
+    );
+    for (const [rate, price] of [...REPRESENTABLE_PAIRS, ...BOUNDARY_PAIRS]) {
+        const written = marginPatchForRate(rate, price).markupPercent;
+        assert.notEqual(written, null, `expected a margin for rate=${rate} price=${price}`);
+        assert.equal(
+            marginIsStale(parseFloat(written!), rate, price),
+            false,
+            `rate=${rate} price=${price} wrote ${written}% which still reads as stale`,
+        );
+    }
+});
+
+/**
+ * Guards the test above from going vacuous. The convergence claim is only meaningful if the
+ * grid actually exercises the tolerance boundary — Codex found the original fraction-only grid
+ * peaked at a residual of ~1e-14, i.e. it proved nothing about the half-step case. This pins
+ * that BOUNDARY_PAIRS really does drive the residual to the full 0.005.
+ */
+test("the boundary grid actually exercises the full 0.005 rounding half-step", () => {
+    const worst = Math.max(
+        ...BOUNDARY_PAIRS.map(([rate, price]) => {
+            const written = parseFloat(marginPatchForRate(rate, price).markupPercent!);
+            return Math.abs(rawMarginPct(rate, price)! - written);
+        }),
+    );
+    assert.ok(
+        worst > 0.004_9,
+        `boundary grid only reached a residual of ${worst} — it no longer tests the half-step case`,
+    );
+});
+
+/**
+ * The canonical defect shape from PR #331, pinned end to end: a sell price edited from 100 to
+ * 200 left rate 75 next to a stored 25% while the line really ran 62.5%. This is the row the
+ * audit exists to count, and the control the prod run was checked against.
+ */
+test("the price-edit defect shape reads as stale, not unrepresentable, and repairs to the true margin", () => {
+    assert.equal(marginIsUnrepresentable(75, 200), false);
+    assert.equal(marginIsStale(25, 75, 200), true);
+    assert.equal(rawMarginPct(75, 200), 62.5);
+    assert.equal(marginPatchForRate(75, 200).markupPercent, "62.50");
+    // ...and once repaired it stops being flagged.
+    assert.equal(marginIsStale(62.5, 75, 200), false);
+});


### PR DESCRIPTION
Follow-up to #331, which added `marginIsStale()` but left the open question: **how many rows on prod are actually stale?**

## Answer: zero

```
938 candidate row(s) scanned (a rate and a unit cost both present).
0 row(s) STALE — stored margin disagrees with the rate/price beside it.
  across 0 estimate(s) and 0 project(s)/lead(s).
58 row(s) unrepresentable (cost exceeds sell / margin over 99 / no sell price)
```

The largest discrepancy anywhere in the table is **0.0046 percentage points** — pure 2-decimal rounding, comfortably inside the `0.005 + rate-rounding-drift` tolerance. Only 30 rows carry a `budgetRate` at all, and **none of them differ from `baseCost`**, so the #329 backfill (which converged `markupPercent` against `baseCost`/`unitCost`) had already swept the whole population.

Control check: `marginIsStale(25, 75, 200)` → `true`, so the predicate does fire on the real defect shape. The zero is real, not a plumbing bug.

## So no repair pass shipped

The original scope said to add the repair *only if the count justifies it*. It doesn't. This script has **no write path whatsoever** — no `UPDATE`/`INSERT`/`DELETE`, no `--apply` flag, one constant `SELECT` plus `$disconnect`. If a future run ever reports a non-zero count, the header documents the repair: recompute `markupPercent` via `marginPatchForRate`, because `markupPercent` is derived and `baseCost`/`unitCost` are authoritative. **No sell price or budget rate may move.**

The 58 `marginIsUnrepresentable` rows are reported separately and never counted as stale — those are the intentional cost-exceeds-sell warnings, not stale data.

## One source of truth for the math

The script imports `marginIsStale` / `marginIsUnrepresentable` / `rawMarginPct` from `src/lib/budget-math.ts` rather than reimplementing them, and derives rate/price/margin from a row exactly the way `BudgetStrip.tsx` does (`budgetRate ?? baseCost`, blank→0, `parseFloat(unitCost) || 0`). The tolerance stays inside the helper. Codex verified the two derivations match for every persistable value, and that the SQL pre-filter is a strict superset of the predicate — it cannot omit a stale row.

## Tests (`npm run test:unit` → 103 pass)

- **Disjointness** — the stale and unrepresentable buckets never both fire on one pair.
- **Convergence** — `marginPatchForRate` output is never itself stale, so any future repair converges in one pass (the failure mode #329 hit). Scoped to prices ≤ 1e6 with an assertion pinning the bound: Codex found the claim false at price 1e16, where the price-dependent tolerance term stops covering float error. Not worth widening the tolerance for a $10-quadrillion unit price; the limit is now a documented, asserted choice.
- **Non-vacuity guard** — the original grid's worst residual was ~1e-14, so it proved nothing about the rounding boundary. `BOUNDARY_PAIRS` drives it to the full 0.005 half-step, and a test fails if that ever stops being true.
- **Canonical defect shape** — the price 100→200 case pinned end to end.

## Codex peer review

Round 1 confirmed the derivation match, the prefilter safety, and the read-only property; it caught the overclaimed invariant and a percentile that called the median of `[1,9]` **9**. Round 2 cleared both and found only edge cases in my hand-rolled dotenv parser — replaced with `dotenv` itself, added as an explicit devDependency (it was only present transitively). Precedence is `.env.local` over `.env`, since auditing the wrong database is the one failure this script must not have.

## Verification

- `npm run test:unit` — 103 pass, 0 fail
- `npm run typecheck` — clean
- `npm run build:next` — clean
- Script run against prod read-only, three times, same numbers
- No UI change, so nothing to verify in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)
