### PR TITLE
fix(estimates): stop the margin input storing a margin with no sell price

### DIFF
--- a/src/app/projects/[id]/estimates/[estimateId]/BudgetStrip.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/BudgetStrip.tsx
@@ -3,9 +3,9 @@
 import { useState } from "react";
 import { formatCurrency } from "@/lib/utils";
 import {
-    internalBudget, bufferPercent, bufferColor, bufferBgColor, costFromMargin,
-    normalizeMarginInput, formatDerivedRate, marginPatchForRate, marginIsUnrepresentable,
-    marginIsStale, rawMarginPct, DEFAULT_MARGIN_PCT, MAX_MARGIN_PCT,
+    internalBudget, bufferPercent, bufferColor, bufferBgColor,
+    marginPatchForInput, marginPatchForRate, marginIsUnrepresentable,
+    marginIsStale, marginIsSettable, rawMarginPct, DEFAULT_MARGIN_PCT, MAX_MARGIN_PCT,
 } from "@/lib/budget-math";
 
 const UNIT_SUGGESTIONS = ["hrs", "sqft", "lf", "ea", "lump sum", "units", "days"];
@@ -46,6 +46,9 @@ export default function BudgetStrip({
     const isLead = contextType === "lead";
     const isPoLocked = links.length > 0;
     const sellPrice = parseFloat(item.unitCost) || 0;
+    // A margin with no sell price to be a share of can't be stored honestly — the rate write is
+    // skipped and markupPercent ends up describing nothing (the gap #331 surfaced but left open).
+    const marginInputDisabled = isPoLocked || !marginIsSettable(sellPrice);
 
     // The rate is whatever the user typed — we never rewrite it to make the margin true. When the
     // pair can't be expressed as a storable margin, say so on the row instead of letting the
@@ -180,15 +183,21 @@ export default function BudgetStrip({
                             // unitCost is never written — customer pricing stays locked.
                             // `stored` and `derivedFrom` come out of one normalization so the margin
                             // we persist is always the margin the rate was derived from.
-                            const { stored, derivedFrom } = normalizeMarginInput(e.target.value);
-                            const price = parseFloat(item.unitCost) || 0;
-                            const rateStr = price > 0 ? formatDerivedRate(costFromMargin(price, derivedFrom), price) : null;
-                            updateItem(item.id, {
-                                markupPercent: stored,
-                                ...(rateStr !== null ? { budgetRate: rateStr, baseCost: rateStr } : {}),
-                            });
+                            // One patch or none: the margin and the rate derived from it are never
+                            // written apart. Persisting the margin while the rate write was skipped
+                            // for want of a sell price is the defect this closes — null here means
+                            // the margin can't describe anything, and the input is disabled to match.
+                            const patch = marginPatchForInput(e.target.value, parseFloat(item.unitCost) || 0);
+                            if (patch) updateItem(item.id, patch);
                         }}
-                        disabled={isPoLocked}
+                        disabled={marginInputDisabled}
+                        title={
+                            isPoLocked
+                                ? undefined
+                                : marginInputDisabled
+                                    ? "Enter a sell price before setting a margin — a margin is a share of the sell price."
+                                    : undefined
+                        }
                         className="w-14 bg-white border border-indigo-200 rounded px-1.5 pr-4 py-1 text-right text-xs focus:ring-1 ring-indigo-400 focus:outline-none disabled:opacity-60 disabled:cursor-not-allowed"
                         step="any"
                     />

--- a/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
+++ b/src/app/projects/[id]/estimates/[estimateId]/EstimateEditor.tsx
@@ -172,7 +172,7 @@ import BudgetStrip from "./BudgetStrip";
 const POQuickCreateModal = dynamic(() => import("./POQuickCreateModal"), { ssr: false });
 const UndoPaymentModal = dynamic(() => import("@/components/UndoPaymentModal"), { ssr: false });
 
-import { internalBudget, derivedMarginPct, marginPatchForRate } from "@/lib/budget-math";
+import { internalBudget, derivedMarginPct, marginPatchForRate, marginIsSettable } from "@/lib/budget-math";
 import { normalizeItemPoLinks } from "@/lib/estimate-item-po-links";
 import { formatMoneyDate, isDateOnly } from "@/lib/payment-date";
 
@@ -232,6 +232,12 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
     const [isImporting, setIsImporting] = useState(false);
     const [showMoreMenu, setShowMoreMenu] = useState(false);
     const [viewMode, setViewMode] = useState<"internal" | "client">("client");
+    // The row whose sell price is being repaired. In internal view the price normally locks once a
+    // budget rate exists, but a row with NO valid sell price has to be repairable or its disabled
+    // margin input tells the user to do something they can't. Unlocking on the price alone isn't
+    // enough: typing "100" emits "1" first, which is already valid and would relock the field
+    // mid-keystroke at $1. Repair mode is held for the whole focus and released on blur.
+    const [repairingSellPriceItemId, setRepairingSellPriceItemId] = useState<string | null>(null);
     const [showTemplateModal, setShowTemplateModal] = useState(false);
     const [templateName, setTemplateName] = useState("");
     const [isSavingTemplate, setIsSavingTemplate] = useState(false);
@@ -2764,7 +2770,13 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                                                                             className="w-full bg-transparent focus:outline-none focus:bg-white focus:ring-1 ring-slate-200 rounded px-2 py-1 text-right hover:bg-slate-50 transition text-sm font-medium text-slate-700"
                                                                         />
                                                                     </div>
-                                                                    {(() => { const isLocked = viewMode === "internal" && !!(item.budgetRate ?? item.baseCost); return (
+                                                                    {/* In internal view the price follows from cost + margin, so a row with a
+                                                                        budget rate locks it. But a row with no valid sell price has a disabled
+                                                                        margin input telling the user to enter one — locking the price too would
+                                                                        make that instruction unfollowable and trap the row. Unlock exactly
+                                                                        those rows, and keep them unlocked for the whole repair (see
+                                                                        repairingSellPriceItemId) so a half-typed value can't relock the field. */}
+                                                                    {(() => { const isLocked = viewMode === "internal" && !!(item.budgetRate ?? item.baseCost) && marginIsSettable(parseFloat(item.unitCost) || 0) && repairingSellPriceItemId !== item.id; return (
                                                                     <div className="w-28 px-2 flex items-center justify-end flex-shrink-0">
                                                                         <span className={`text-sm flex-shrink-0 ${isLocked ? "text-slate-300" : "text-slate-400"}`}>$</span>
                                                                         <input
@@ -2784,6 +2796,13 @@ export default function EstimateEditor({ context, initialEstimate, salesTaxes = 
                                                                                     ...(rate > 0 ? marginPatchForRate(rate, parseFloat(e.target.value) || 0) : {}),
                                                                                 });
                                                                             }}
+                                                                            onFocus={() => {
+                                                                                // Entering repair mode only matters for a row that is currently
+                                                                                // unlocked BECAUSE its sell price is invalid — a normally locked
+                                                                                // row is readOnly and never receives focus this way anyway.
+                                                                                if (!marginIsSettable(parseFloat(item.unitCost) || 0)) setRepairingSellPriceItemId(item.id);
+                                                                            }}
+                                                                            onBlur={() => setRepairingSellPriceItemId(prev => (prev === item.id ? null : prev))}
                                                                             readOnly={isLocked}
                                                                             aria-label="Unit cost"
                                                                             className={`w-20 focus:outline-none rounded px-1 py-1 text-right transition text-sm font-medium ${isLocked ? "bg-transparent text-slate-400 cursor-default" : "bg-transparent focus:bg-white focus:ring-1 ring-slate-200 hover:bg-slate-50 text-slate-700"}`}

--- a/src/lib/budget-math.ts
+++ b/src/lib/budget-math.ts
@@ -163,7 +163,44 @@ export function formatDerivedRate(rate: number, price: number): string {
   // A zero rate reads as "no budget" (internalBudget returns null, saveEstimate persists null),
   // which would contradict any non-zero margin stored beside it.
   if (!Number.isFinite(rate) || rate <= 0) return "0.00";
-  return rate.toFixed(derivedRateDecimals(price));
+  const formatted = rate.toFixed(derivedRateDecimals(price));
+  if (roundedRateIsFaithful(parseFloat(formatted), rate, price)) return formatted;
+  // derivedRateDecimals caps at 10 places, which is not enough at extreme scales. Below roughly a
+  // 1e-9 sell price the rounding step stops being small next to the price itself: the cost rounds
+  // to zero (read as "no budget" beside a 99% margin — and marginIsStale exempts rate 0, so
+  // nothing warns), or it rounds UP past the sell price, or it simply lands on a rate implying a
+  // wildly different margin than the one stored next to it.
+  //
+  // Fall back to the exact value rather than to more decimal places: every fixed width has a
+  // scale where it fails (toFixed caps at 100 places, which dies around 5e-101). String()
+  // round-trips exactly through parseFloat and Prisma's Decimal, so the pair stays honest at any
+  // representable scale. Exponent notation ("9.49e-11") is expected here and is valid numeric
+  // input on both sides.
+  return String(rate);
+}
+
+/**
+ * Whether rounding a rate to the price's decimal scale kept it describing the same margin.
+ *
+ * The tolerance is the absolute MARGIN_STORAGE_HALF_STEP, deliberately NOT the price-scaled
+ * rateRoundingMarginDrift. That drift is what marginIsStale must ALLOW (it is the error the
+ * rounding legitimately introduces), so reusing it here would be circular — and at a 1e-11 price
+ * it permits 500 margin points, which is how a rounded rate implying 20% sat next to a persisted
+ * 25% with nothing noticing. derivedRateDecimals is built to keep the implied margin good to 2dp,
+ * so this bound is met with room to spare at every ordinary price; it only bites where the cap at
+ * 10 places stops that from being true.
+ */
+function roundedRateIsFaithful(rounded: number, exact: number, price: number): boolean {
+  if (!(rounded > 0)) return false; // a zero rate is "no budget", not a cost
+  if (!Number.isFinite(price) || price <= 0) return true; // no margin to be faithful to
+  // Rounding must not turn a real margin into a loss. A rate that ALREADY exceeded the price is a
+  // genuine loss-making row — #331's territory, warned about rather than reformatted — so it is
+  // judged on margin drift like any other rather than being pushed onto the exact path.
+  if (rounded > price && exact <= price) return false;
+  const roundedMargin = rawMarginPct(rounded, price);
+  const exactMargin = rawMarginPct(exact, price);
+  if (roundedMargin === null || exactMargin === null) return false;
+  return Math.abs(roundedMargin - exactMargin) <= MARGIN_STORAGE_HALF_STEP;
 }
 
 /** Decimal places formatDerivedRate stores a rate at, at this price scale. Exported shape of the
@@ -248,6 +285,48 @@ export function marginIsUnrepresentable(rate: number, price: number): boolean {
   const raw = rawMarginPct(rate, price);
   if (raw === null) return false;
   return raw < MIN_MARGIN_PCT || raw > MAX_MARGIN_PCT;
+}
+
+/**
+ * True when a margin can mean anything on this line — i.e. there is a sell price to earn it on.
+ *
+ * A margin is a share OF the sell price (cost = sell * (1 - m/100)), so with no sell price there
+ * is nothing for it to be a share of: costFromMargin returns 0 at every margin, the rate input's
+ * `price > 0` guard skips the rate write entirely, and whatever the user typed persists to
+ * markupPercent describing nothing. #331 made that state visible; this stops it being created.
+ *
+ * The margin input is disabled when this is false rather than the typed value being rewritten —
+ * same product call as #331 (2026-08-09): never silently move a number the user typed, and never
+ * store one that lies. Rows that already carry the contradiction keep warning; the fix for those
+ * is entering a sell price, which re-derives the pair.
+ */
+export function marginIsSettable(price: number): boolean {
+  return Number.isFinite(price) && price > 0;
+}
+
+/**
+ * The complete write a margin-input keystroke produces, or null when the margin cannot be set.
+ *
+ * The margin and the rate derived from it are ONE write — returning them together is what makes
+ * them impossible to half-apply. The defect this closes was exactly a half-apply: the margin was
+ * persisted unconditionally while the rate write sat behind its own `price > 0` check.
+ *
+ * Null means "no write at all" — the input is disabled in that state, so this is the belt to that
+ * suspenders, not a silent no-op the user can hit.
+ */
+export function marginPatchForInput(
+  raw: string,
+  price: number,
+): { markupPercent: string | null; budgetRate: string; baseCost: string } | null {
+  if (!marginIsSettable(price)) return null;
+  const { stored, derivedFrom } = normalizeMarginInput(raw);
+  const cost = costFromMargin(price, derivedFrom);
+  // A subnormal price can underflow to a zero cost before formatting ever sees it. A zero rate is
+  // "no budget", so writing it beside a margin would be the same lie from the other direction —
+  // refuse the write instead of storing a pair that contradicts itself.
+  if (!Number.isFinite(cost) || cost <= 0) return null;
+  const rate = formatDerivedRate(cost, price);
+  return { markupPercent: stored, budgetRate: rate, baseCost: rate };
 }
 
 /**

--- a/tests/budget-math.test.ts
+++ b/tests/budget-math.test.ts
@@ -25,6 +25,8 @@ import {
     marginIsUnrepresentable,
     marginIsStale,
     marginPatchForRate,
+    marginIsSettable,
+    marginPatchForInput,
 } from "../src/lib/budget-math";
 
 test("clampMarginPct holds the representable range", () => {
@@ -643,4 +645,175 @@ test("the price-edit defect shape reads as stale, not unrepresentable, and repai
     assert.equal(marginPatchForRate(75, 200).markupPercent, "62.50");
     // ...and once repaired it stops being flagged.
     assert.equal(marginIsStale(62.5, 75, 200), false);
+});
+
+/**
+ * The gap #331 surfaced but deliberately left open: with no sell price the margin input wrote
+ * `markupPercent` while the rate write was skipped by its own `price > 0` guard, so the row
+ * persisted a margin describing nothing. Product call 2026-08-09 (same precedent as #331 — never
+ * rewrite a number the user typed): disable the input instead. marginIsSettable is that gate.
+ */
+test("marginIsSettable is true exactly when a sell price exists to earn a margin on", () => {
+    assert.equal(marginIsSettable(100), true);
+    assert.equal(marginIsSettable(0.01), true);
+
+    // No sell price — every margin yields the same cost (0), so none of them mean anything.
+    assert.equal(marginIsSettable(0), false);
+    // A negative sell price is not a scale a share can be taken of either.
+    assert.equal(marginIsSettable(-100), false);
+    // Non-finite prices must gate the same way, or `1e999` in the price field re-opens the hole:
+    // Infinity passes a bare `price > 0` check while costFromMargin returns NaN/Infinity.
+    assert.equal(marginIsSettable(NaN), false);
+    assert.equal(marginIsSettable(Infinity), false);
+    assert.equal(marginIsSettable(-Infinity), false);
+});
+
+/**
+ * One-directional on purpose: every price the gate rejects is a price the #331 row warning
+ * already flags, so a disabled margin input is never a silently-broken row. The converse is NOT
+ * claimed — marginIsUnrepresentable also fires on rate-side reasons (rate > price, rate under
+ * price/100) for rows whose margin is perfectly settable, which is why an earlier equivalence
+ * assertion here was wrong.
+ */
+test("every price marginIsSettable rejects is a price the row already warns about", () => {
+    for (const price of [0, -100, NaN, Infinity, -Infinity]) {
+        assert.equal(marginIsSettable(price), false);
+        // Any real budget rate on such a row must warn — that is what makes the disable honest.
+        for (const rate of [0.01, 1, 100, 1e6]) {
+            assert.equal(
+                marginIsUnrepresentable(rate, price),
+                true,
+                `price ${price} with rate ${rate} is gated but not warned`,
+            );
+        }
+    }
+});
+
+/**
+ * marginPatchForInput IS the margin input's write — the component does nothing but apply what it
+ * returns. Null means no write at all, which is what makes the margin and its rate inseparable:
+ * the defect was persisting markupPercent while the rate write was skipped for want of a price.
+ */
+test("marginPatchForInput refuses to write anything without a sell price", () => {
+    for (const price of [0, -100, NaN, Infinity, -Infinity]) {
+        for (const typed of ["", "0", "25", "99", "100", "-10"]) {
+            assert.equal(
+                marginPatchForInput(typed, price),
+                null,
+                `price ${price}, typed ${typed}: expected no write`,
+            );
+        }
+    }
+});
+
+/**
+ * The other half: once a sell price exists the patch always carries ALL THREE fields, and the
+ * margin it persists is the one the rate it persists actually implies. A patch that set the
+ * margin without the rate (or vice versa) is the bug.
+ *
+ * The 1e-9 price is the case Codex round 1 caught: derivedRateDecimals caps at 10 places, so the
+ * derived cost used to format as "0.0000000000" — a zero rate reads as "no budget" while a 99%
+ * margin sits beside it, and marginIsStale exempts rate 0 so nothing warned.
+ */
+test("marginPatchForInput writes margin and rate together, and they agree", () => {
+    for (const price of [1e-9, 0.01, 0.49, 8, 100, 1500, 1e6]) {
+        for (const typed of ["", "0", "25", "63.125", "99", "100", "-10"]) {
+            const patch = marginPatchForInput(typed, price);
+            assert.ok(patch, `price ${price}, typed ${typed}: expected a write`);
+            // Rate and baseCost are one value written to two mirrored columns.
+            assert.equal(patch.budgetRate, patch.baseCost);
+
+            const rate = parseFloat(patch.budgetRate);
+            // A zero rate is "no budget", which would contradict any margin stored next to it.
+            assert.ok(rate > 0, `price ${price}, typed ${typed}: rate stored as ${patch.budgetRate}`);
+            assert.notEqual(internalBudget({ quantity: 1, budgetRate: patch.budgetRate }), null);
+
+            // The persisted margin (null renders as the default) must describe the persisted rate.
+            // marginIsStale is the project's own "do these disagree" predicate, tolerance included:
+            // a freshly written pair must never trip the warning the row renders.
+            const shown = patch.markupPercent === null ? DEFAULT_MARGIN_PCT : parseFloat(patch.markupPercent);
+            assert.equal(
+                marginIsStale(shown, rate, price),
+                false,
+                `price ${price}, typed ${typed}: rate ${patch.budgetRate} does not describe ${shown}%`,
+            );
+            assert.equal(
+                marginIsUnrepresentable(rate, price),
+                false,
+                `price ${price}, typed ${typed}: the write itself produced an unrepresentable pair`,
+            );
+        }
+    }
+});
+
+/**
+ * INVARIANT behind the blocker above, held directly on formatDerivedRate: a positive cost must
+ * never be stored as zero, at ANY price scale. The doc comment promises exactly this; the
+ * 10-decimal cap used to break it below about 1e-8.
+ */
+test("formatDerivedRate never stores a positive cost as zero, at any scale", () => {
+    for (const price of [1e-12, 1e-9, 1e-6, 0.01, 1, 1500]) {
+        for (const margin of [0, 25, 99]) {
+            const cost = costFromMargin(price, margin);
+            if (cost <= 0) continue;
+            const stored = formatDerivedRate(cost, price);
+            assert.ok(
+                parseFloat(stored) > 0,
+                `cost ${cost} at price ${price} (margin ${margin}%) stored as "${stored}"`,
+            );
+        }
+    }
+});
+
+/**
+ * The scales Codex round 2 named. Any FIXED number of decimal places has a price below which the
+ * derived cost rounds to zero (toFixed caps at 100 places, so even the padded fallback died around
+ * 5e-101), and a padded-but-inexact rate re-derives a margin hundreds of points off the one stored
+ * beside it — which marginIsStale's tolerance, sized from derivedRateDecimals, is far too generous
+ * to catch. The fix is exact serialization, so the assertion is exactness, not "enough digits".
+ */
+test("formatDerivedRate round-trips a positive rate exactly at any representable scale", () => {
+    for (const rate of [Number.MIN_VALUE, 4.9e-101, 5e-101, 1e-11, 9.49e-11, 1e-9, 0.0049, 75, 1e6]) {
+        for (const price of [Number.MIN_VALUE, 1e-11, 1e-9, 0.49, 100, 1500]) {
+            const stored = formatDerivedRate(rate, price);
+            assert.ok(parseFloat(stored) > 0, `rate ${rate} at price ${price} stored as "${stored}"`);
+            // Exact, not merely non-zero: an inexact rate is a margin that lies.
+            assert.equal(parseFloat(stored), rate, `rate ${rate} at price ${price} stored as "${stored}"`);
+        }
+    }
+});
+
+/**
+ * The patch-level consequence: at these scales the stored rate used to exceed the sell price
+ * outright (price 9.49e-11 at a 25% margin stored 1e-10) or imply 20% where 25% was persisted.
+ * Asserts the margin the stored rate implies EQUALS the margin stored beside it, rather than
+ * leaning on marginIsStale — whose tolerance is too loose to be a real check down here.
+ */
+test("marginPatchForInput stays exact at extreme sell-price scales", () => {
+    for (const price of [1e-11, 1.44e-11, 1.49e-11, 9.49e-11, 1e-9, 1e-6]) {
+        for (const typed of ["0", "25", "99", "100"]) {
+            const patch = marginPatchForInput(typed, price);
+            assert.ok(patch, `price ${price}, typed ${typed}: expected a write`);
+            const rate = parseFloat(patch.budgetRate);
+            assert.ok(rate > 0 && rate <= price, `price ${price}, typed ${typed}: rate ${rate} out of range`);
+            const shown = patch.markupPercent === null ? DEFAULT_MARGIN_PCT : parseFloat(patch.markupPercent);
+            assert.ok(
+                Math.abs(rawMarginPct(rate, price)! - shown) < 1e-9,
+                `price ${price}, typed ${typed}: rate implies ${rawMarginPct(rate, price)}%, stored ${shown}%`,
+            );
+            assert.equal(marginIsUnrepresentable(rate, price), false);
+        }
+    }
+});
+
+/**
+ * A subnormal price underflows costFromMargin to zero before formatting ever runs. A zero rate is
+ * "no budget", so pairing it with a margin is the same contradiction from the other side — the
+ * patch refuses rather than storing it.
+ */
+test("marginPatchForInput refuses to write when the derived cost underflows to zero", () => {
+    assert.equal(costFromMargin(Number.MIN_VALUE, 99), 0, "precondition: this price underflows");
+    assert.equal(marginPatchForInput("99", Number.MIN_VALUE), null);
+    // A margin of 0 leaves the cost equal to the price, which does not underflow — still writable.
+    assert.notEqual(marginPatchForInput("0", Number.MIN_VALUE), null);
 });


### PR DESCRIPTION
Closes the gap PR #331 surfaced but deliberately left open.

## The bug
The Margin input in `BudgetStrip.tsx` wrote `markupPercent` unconditionally, while the paired budget-rate write sat behind its own `price > 0` check. Set a line's sell price to 0 with a budget rate already on it, change the margin, and the row persisted a margin that described nothing. #331 made that **visible** (`marginIsUnrepresentable` renders a row warning) but the inconsistency still reached the database.

## The product call
Justin, 2026-08-09, same precedent as #331: **never silently rewrite a number the user typed, and never store one that lies.** So the input is disabled when there is no valid sell price, rather than storing the margin as intent — that would have meant `markupPercent` temporarily describing nothing across all 19 of its consumers.

## The change
- **`marginIsSettable(price)`** (finite && > 0) gates the input's `disabled` state, alongside the existing `isPoLocked`. Non-finite prices gate too — `1e999` passes a bare `price > 0` while `costFromMargin` returns NaN.
- **`marginPatchForInput(raw, price)`** is now the entire write. Margin and the rate derived from it come back as one patch or not at all, so they can no longer be half-applied; the component just applies what it returns.
- **`formatDerivedRate` no longer stores a dishonest rate at tiny sell prices.** `derivedRateDecimals` caps at 10 places, so below roughly a 1e-9 price the cost rounded to zero (read as "no budget" beside a 99% margin — and `marginIsStale` exempts rate 0, so nothing warned), rounded up past the sell price, or implied 20% next to a persisted 25%. It now falls back to exact serialization when rounding would move the implied margin past `MARGIN_STORAGE_HALF_STEP`.
- **The internal-view sell price no longer traps the row.** It locked whenever a budget rate existed, which on exactly the broken rows made the new tooltip's instruction ("enter a sell price") impossible to follow. Repair mode is held for the whole focus, because typing `100` emits `1` first and a per-render unlock relocked the field at $1.

## Verification
- `tests/budget-math.test.ts`: **107 pass** (`npm run test:unit`, wired into CI)
- `npm run typecheck` and `npm run build:next` both clean
- Browser-verified against Shop estimate EST-00309: disabled + tooltip with no price; red warning row with a rate and no price; sell price editable; typing 1 → 10 → 100 never relocks; blur relocks; the row lands at rate 75 / price 100 / margin 25.00% with the warning cleared. **Nothing was saved** — network log shows page loads only.

## Review
Two Codex rounds. Round 1 caught the tiny-price zero-rate hole and that the first cut of the tests didn't pin the component invariant. Round 2 caught the mid-keystroke relock and that the padded-decimals fix was still lossy rather than merely zeroing. Both rounds are addressed above.

Left out of scope (pre-existing, flagged by Codex, spun off separately): a non-finite budget rate is silently discarded on save, and the budget-rate input is not disabled for PO-locked rows despite the lock icon's claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)