### PR TITLE
fix(scripts): resolve .env.local over .env in every envFromFiles helper

### DIFF
--- a/scripts/audit-stale-margins.mjs
+++ b/scripts/audit-stale-margins.mjs
@@ -73,8 +73,8 @@ if (limitArg >= 0) {
  * Read a key from the environment, then from the dotenv files in the order the Next.js
  * toolchain resolves them: `.env.local` OVERRIDES `.env`. Checking `.env` first would let a
  * committed default silently win over the local override and point a production audit at the
- * WRONG DATABASE. (The sibling backfill script has the older, reversed order — it happens not
- * to misfire because this repo has no bare `.env`, but do not copy it.)
+ * WRONG DATABASE. (Every sibling script under scripts/ that resolves env this way now shares
+ * this exact order — if you add another, copy this one, not an older reversed variant.)
  *
  * Parsing is delegated to `dotenv` rather than hand-rolled. A regex over the line looks fine
  * until it meets the cases that actually occur — quoted values containing `#`, `export`

--- a/scripts/audit-stale-margins.mjs
+++ b/scripts/audit-stale-margins.mjs
@@ -73,20 +73,24 @@ if (limitArg >= 0) {
  * Read a key from the environment, then from the dotenv files in the order the Next.js
  * toolchain resolves them: `.env.local` OVERRIDES `.env`. Checking `.env` first would let a
  * committed default silently win over the local override and point a production audit at the
- * WRONG DATABASE. (Every sibling script under scripts/ that resolves env this way now shares
- * this exact order — if you add another, copy this one, not an older reversed variant.)
+ * WRONG DATABASE. (Every `envFromFiles` helper under scripts/ now shares this exact order — if
+ * you add another, copy this one, not an older reversed variant. Note that many other scripts
+ * under scripts/ still resolve env under different helper names and STILL have the reversed
+ * order; those are tracked separately.)
  *
  * Parsing is delegated to `dotenv` rather than hand-rolled. A regex over the line looks fine
  * until it meets the cases that actually occur — quoted values containing `#`, `export`
  * prefixes, inline comments, CRLF, multiline values — and each one it gets wrong is a silent
  * wrong-database read, which is the one failure this script must not have.
  *
- * `key in parsed` rather than a truthiness check on purpose: a file that assigns the key an
- * EMPTY value has still spoken, and must win over the lower-precedence file instead of falling
- * through to it. The missing-URL check below then fails loudly, which is the correct outcome.
+ * `in` rather than a truthiness check on purpose, at BOTH levels: a source that assigns the key
+ * an EMPTY value has still spoken, and must win over every lower-precedence source instead of
+ * falling through to it. The missing-URL check below then fails loudly, which is the correct
+ * outcome. An exported `DATABASE_URL=""` falling through to a file is the same wrong-database
+ * read as the reversed file order, just one level up.
  */
 function envFromFiles(key) {
-  if (process.env[key]) return process.env[key];
+  if (key in process.env) return process.env[key];
   for (const f of [".env.local", ".env"]) {
     if (!fs.existsSync(f)) continue;
     const parsed = dotenv.parse(fs.readFileSync(f));

--- a/scripts/backfill-estimate-item-margin.mjs
+++ b/scripts/backfill-estimate-item-margin.mjs
@@ -37,16 +37,33 @@
 // Requires (read from env or .env / .env.local):
 //   DATABASE_URL   Supabase transaction pooler URL (must include ?pgbouncer=true)
 import { PrismaClient } from "@prisma/client";
+import dotenv from "dotenv";
 import fs from "node:fs";
 
 const APPLY = process.argv.includes("--apply");
 
+/**
+ * Read a key from the environment, then from the dotenv files in the order the Next.js
+ * toolchain resolves them: `.env.local` OVERRIDES `.env`. Checking `.env` first would let a
+ * committed default silently win over the local override and point this script at the WRONG
+ * DATABASE — and unlike the sibling audit, this one has a real `--apply` write path that
+ * UPDATEs EstimateItem.markupPercent.
+ *
+ * Parsing is delegated to `dotenv` rather than hand-rolled. A regex over the line looks fine
+ * until it meets the cases that actually occur — quoted values containing `#`, `export`
+ * prefixes, inline comments, CRLF, multiline values — and each one it gets wrong is a silent
+ * wrong-database write, which is the one failure this script must not have.
+ *
+ * `key in parsed` rather than a truthiness check on purpose: a file that assigns the key an
+ * EMPTY value has still spoken, and must win over the lower-precedence file instead of falling
+ * through to it. The missing-URL check below then fails loudly, which is the correct outcome.
+ */
 function envFromFiles(key) {
   if (process.env[key]) return process.env[key];
-  for (const f of [".env", ".env.local"]) {
+  for (const f of [".env.local", ".env"]) {
     if (!fs.existsSync(f)) continue;
-    const m = fs.readFileSync(f, "utf8").match(new RegExp(`^${key}\\s*=\\s*"?([^"\\n]+)"?`, "m"));
-    if (m) return m[1];
+    const parsed = dotenv.parse(fs.readFileSync(f));
+    if (key in parsed) return parsed[key];
   }
   return undefined;
 }

--- a/scripts/backfill-estimate-item-margin.mjs
+++ b/scripts/backfill-estimate-item-margin.mjs
@@ -54,12 +54,14 @@ const APPLY = process.argv.includes("--apply");
  * prefixes, inline comments, CRLF, multiline values — and each one it gets wrong is a silent
  * wrong-database write, which is the one failure this script must not have.
  *
- * `key in parsed` rather than a truthiness check on purpose: a file that assigns the key an
- * EMPTY value has still spoken, and must win over the lower-precedence file instead of falling
- * through to it. The missing-URL check below then fails loudly, which is the correct outcome.
+ * `in` rather than a truthiness check on purpose, at BOTH levels: a source that assigns the key
+ * an EMPTY value has still spoken, and must win over every lower-precedence source instead of
+ * falling through to it. The missing-URL check below then fails loudly, which is the correct
+ * outcome. An exported `DATABASE_URL=""` falling through to a file is the same wrong-database
+ * write as the reversed file order, just one level up.
  */
 function envFromFiles(key) {
-  if (process.env[key]) return process.env[key];
+  if (key in process.env) return process.env[key];
   for (const f of [".env.local", ".env"]) {
     if (!fs.existsSync(f)) continue;
     const parsed = dotenv.parse(fs.readFileSync(f));

--- a/scripts/backfill-signature-storage.mjs
+++ b/scripts/backfill-signature-storage.mjs
@@ -35,12 +35,12 @@ const APPLY = process.argv.includes("--apply");
  *
  * Parsing is delegated to `dotenv` rather than hand-rolled: a regex over the line mishandles
  * quoted values containing `#`, `export` prefixes, inline comments, CRLF and multiline values,
- * and every one of those is a silent wrong-target read. `key in parsed` rather than a truthiness
- * check so a file that assigns an EMPTY value still wins over the lower-precedence file and the
- * missing-value check below fails loudly.
+ * and every one of those is a silent wrong-target read. `in` rather than a truthiness check at
+ * BOTH levels so a source that assigns an EMPTY value — an exported `DATABASE_URL=""` included —
+ * still wins over every lower-precedence source and the missing-value check below fails loudly.
  */
 function envFromFiles(key) {
-  if (process.env[key]) return process.env[key];
+  if (key in process.env) return process.env[key];
   for (const f of [".env.local", ".env"]) {
     if (!fs.existsSync(f)) continue;
     const parsed = dotenv.parse(fs.readFileSync(f));

--- a/scripts/backfill-signature-storage.mjs
+++ b/scripts/backfill-signature-storage.mjs
@@ -20,18 +20,31 @@
 //   SUPABASE_SERVICE_KEY  Supabase service role key      (only needed with --apply)
 import { PrismaClient } from "@prisma/client";
 import { createClient } from "@supabase/supabase-js";
+import dotenv from "dotenv";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 
 const STORAGE_BUCKET = "project-files";
 const APPLY = process.argv.includes("--apply");
 
+/**
+ * Read a key from the environment, then from the dotenv files in the order the Next.js
+ * toolchain resolves them: `.env.local` OVERRIDES `.env`. Checking `.env` first would let a
+ * committed default silently win over the local override and point this script's writes at the
+ * WRONG DATABASE or the WRONG STORAGE BUCKET.
+ *
+ * Parsing is delegated to `dotenv` rather than hand-rolled: a regex over the line mishandles
+ * quoted values containing `#`, `export` prefixes, inline comments, CRLF and multiline values,
+ * and every one of those is a silent wrong-target read. `key in parsed` rather than a truthiness
+ * check so a file that assigns an EMPTY value still wins over the lower-precedence file and the
+ * missing-value check below fails loudly.
+ */
 function envFromFiles(key) {
   if (process.env[key]) return process.env[key];
-  for (const f of [".env", ".env.local"]) {
+  for (const f of [".env.local", ".env"]) {
     if (!fs.existsSync(f)) continue;
-    const m = fs.readFileSync(f, "utf8").match(new RegExp(`^${key}\\s*=\\s*"?([^"\\n]+)"?`, "m"));
-    if (m) return m[1];
+    const parsed = dotenv.parse(fs.readFileSync(f));
+    if (key in parsed) return parsed[key];
   }
   return undefined;
 }

--- a/scripts/backup-migrated-public-docs.mjs
+++ b/scripts/backup-migrated-public-docs.mjs
@@ -74,17 +74,19 @@ if (!DEST) {
 /**
  * Read a key from the environment, then from the dotenv files in the order the Next.js
  * toolchain resolves them: `.env.local` OVERRIDES `.env`. Checking `.env` first would let a
- * committed default silently win over the local override and point this script's writes at the
- * WRONG DATABASE or the WRONG STORAGE BUCKET.
+ * committed default silently win over the local override and make this script read its backup
+ * source from the WRONG DATABASE or the WRONG STORAGE BUCKET — which would produce a manifest
+ * that looks complete while covering none of the rows the purge is about to delete. (This script
+ * makes no remote writes; its only writes are the local backup files.)
  *
  * Parsing is delegated to `dotenv` rather than hand-rolled: a regex over the line mishandles
  * quoted values containing `#`, `export` prefixes, inline comments, CRLF and multiline values,
- * and every one of those is a silent wrong-target read. `key in parsed` rather than a truthiness
- * check so a file that assigns an EMPTY value still wins over the lower-precedence file and the
- * missing-value check below fails loudly.
+ * and every one of those is a silent wrong-target read. `in` rather than a truthiness check at
+ * BOTH levels so a source that assigns an EMPTY value — an exported `DATABASE_URL=""` included —
+ * still wins over every lower-precedence source and the missing-value check below fails loudly.
  */
 function envFromFiles(key) {
-  if (process.env[key]) return process.env[key];
+  if (key in process.env) return process.env[key];
   for (const f of [".env.local", ".env"]) {
     if (!fs.existsSync(f)) continue;
     const parsed = dotenv.parse(fs.readFileSync(f));

--- a/scripts/backup-migrated-public-docs.mjs
+++ b/scripts/backup-migrated-public-docs.mjs
@@ -48,6 +48,7 @@
 //   SUPABASE_SERVICE_KEY  Supabase service role key
 import { PrismaClient } from "@prisma/client";
 import { createClient } from "@supabase/supabase-js";
+import dotenv from "dotenv";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
@@ -70,12 +71,24 @@ if (!DEST) {
   process.exit(1);
 }
 
+/**
+ * Read a key from the environment, then from the dotenv files in the order the Next.js
+ * toolchain resolves them: `.env.local` OVERRIDES `.env`. Checking `.env` first would let a
+ * committed default silently win over the local override and point this script's writes at the
+ * WRONG DATABASE or the WRONG STORAGE BUCKET.
+ *
+ * Parsing is delegated to `dotenv` rather than hand-rolled: a regex over the line mishandles
+ * quoted values containing `#`, `export` prefixes, inline comments, CRLF and multiline values,
+ * and every one of those is a silent wrong-target read. `key in parsed` rather than a truthiness
+ * check so a file that assigns an EMPTY value still wins over the lower-precedence file and the
+ * missing-value check below fails loudly.
+ */
 function envFromFiles(key) {
   if (process.env[key]) return process.env[key];
-  for (const f of [".env", ".env.local"]) {
+  for (const f of [".env.local", ".env"]) {
     if (!fs.existsSync(f)) continue;
-    const m = fs.readFileSync(f, "utf8").match(new RegExp(`^${key}\\s*=\\s*"?([^"\\n]+)"?`, "m"));
-    if (m) return m[1];
+    const parsed = dotenv.parse(fs.readFileSync(f));
+    if (key in parsed) return parsed[key];
   }
   return undefined;
 }

--- a/scripts/migrate-secure-docs.mjs
+++ b/scripts/migrate-secure-docs.mjs
@@ -46,6 +46,7 @@
 // This script does NOT create the `secure-docs` bucket — it must already exist.
 import { PrismaClient } from "@prisma/client";
 import { createClient } from "@supabase/supabase-js";
+import dotenv from "dotenv";
 import fs from "node:fs";
 
 const PUBLIC_BUCKET = "project-files";
@@ -54,12 +55,24 @@ const SECURE_SCHEME = "secure:";
 
 const APPLY = process.argv.includes("--apply");
 
+/**
+ * Read a key from the environment, then from the dotenv files in the order the Next.js
+ * toolchain resolves them: `.env.local` OVERRIDES `.env`. Checking `.env` first would let a
+ * committed default silently win over the local override and point this script's writes at the
+ * WRONG DATABASE or the WRONG STORAGE BUCKET.
+ *
+ * Parsing is delegated to `dotenv` rather than hand-rolled: a regex over the line mishandles
+ * quoted values containing `#`, `export` prefixes, inline comments, CRLF and multiline values,
+ * and every one of those is a silent wrong-target read. `key in parsed` rather than a truthiness
+ * check so a file that assigns an EMPTY value still wins over the lower-precedence file and the
+ * missing-value check below fails loudly.
+ */
 function envFromFiles(key) {
   if (process.env[key]) return process.env[key];
-  for (const f of [".env", ".env.local"]) {
+  for (const f of [".env.local", ".env"]) {
     if (!fs.existsSync(f)) continue;
-    const m = fs.readFileSync(f, "utf8").match(new RegExp(`^${key}\\s*=\\s*"?([^"\\n]+)"?`, "m"));
-    if (m) return m[1];
+    const parsed = dotenv.parse(fs.readFileSync(f));
+    if (key in parsed) return parsed[key];
   }
   return undefined;
 }

--- a/scripts/migrate-secure-docs.mjs
+++ b/scripts/migrate-secure-docs.mjs
@@ -63,12 +63,12 @@ const APPLY = process.argv.includes("--apply");
  *
  * Parsing is delegated to `dotenv` rather than hand-rolled: a regex over the line mishandles
  * quoted values containing `#`, `export` prefixes, inline comments, CRLF and multiline values,
- * and every one of those is a silent wrong-target read. `key in parsed` rather than a truthiness
- * check so a file that assigns an EMPTY value still wins over the lower-precedence file and the
- * missing-value check below fails loudly.
+ * and every one of those is a silent wrong-target read. `in` rather than a truthiness check at
+ * BOTH levels so a source that assigns an EMPTY value — an exported `DATABASE_URL=""` included —
+ * still wins over every lower-precedence source and the missing-value check below fails loudly.
  */
 function envFromFiles(key) {
-  if (process.env[key]) return process.env[key];
+  if (key in process.env) return process.env[key];
   for (const f of [".env.local", ".env"]) {
     if (!fs.existsSync(f)) continue;
     const parsed = dotenv.parse(fs.readFileSync(f));

--- a/scripts/purge-migrated-public-docs.mjs
+++ b/scripts/purge-migrated-public-docs.mjs
@@ -65,12 +65,14 @@ const WILL_DELETE = HAS_APPLY && HAS_CONFIRM;
  *
  * Parsing is delegated to `dotenv` rather than hand-rolled: a regex over the line mishandles
  * quoted values containing `#`, `export` prefixes, inline comments, CRLF and multiline values,
- * and every one of those is a silent wrong-target read. `key in parsed` rather than a truthiness
- * check so a file that assigns an EMPTY value still wins over the lower-precedence file and the
- * missing-value check below fails loudly.
+ * and every one of those is a silent wrong-target read. `in` rather than a truthiness check at
+ * BOTH levels so a source that assigns an EMPTY value — an exported `DATABASE_URL=""` included —
+ * still wins over every lower-precedence source and the missing-value check below fails loudly.
+ * Resolving one key from the shell and another from a file is how this script ends up enumerating
+ * paths out of one project and deleting them out of another.
  */
 function envFromFiles(key) {
-  if (process.env[key]) return process.env[key];
+  if (key in process.env) return process.env[key];
   for (const f of [".env.local", ".env"]) {
     if (!fs.existsSync(f)) continue;
     const parsed = dotenv.parse(fs.readFileSync(f));

--- a/scripts/purge-migrated-public-docs.mjs
+++ b/scripts/purge-migrated-public-docs.mjs
@@ -39,6 +39,7 @@
 //   SUPABASE_SERVICE_KEY  Supabase service role key
 import { PrismaClient } from "@prisma/client";
 import { createClient } from "@supabase/supabase-js";
+import dotenv from "dotenv";
 import fs from "node:fs";
 
 const PUBLIC_BUCKET = "project-files";
@@ -56,12 +57,24 @@ if (HAS_APPLY !== HAS_CONFIRM) {
 }
 const WILL_DELETE = HAS_APPLY && HAS_CONFIRM;
 
+/**
+ * Read a key from the environment, then from the dotenv files in the order the Next.js
+ * toolchain resolves them: `.env.local` OVERRIDES `.env`. Checking `.env` first would let a
+ * committed default silently win over the local override and point this script's DELETES at the
+ * WRONG DATABASE or the WRONG STORAGE BUCKET.
+ *
+ * Parsing is delegated to `dotenv` rather than hand-rolled: a regex over the line mishandles
+ * quoted values containing `#`, `export` prefixes, inline comments, CRLF and multiline values,
+ * and every one of those is a silent wrong-target read. `key in parsed` rather than a truthiness
+ * check so a file that assigns an EMPTY value still wins over the lower-precedence file and the
+ * missing-value check below fails loudly.
+ */
 function envFromFiles(key) {
   if (process.env[key]) return process.env[key];
-  for (const f of [".env", ".env.local"]) {
+  for (const f of [".env.local", ".env"]) {
     if (!fs.existsSync(f)) continue;
-    const m = fs.readFileSync(f, "utf8").match(new RegExp(`^${key}\\s*=\\s*"?([^"\\n]+)"?`, "m"));
-    if (m) return m[1];
+    const parsed = dotenv.parse(fs.readFileSync(f));
+    if (key in parsed) return parsed[key];
   }
   return undefined;
 }

--- a/scripts/restore-secure-docs-from-backup.mjs
+++ b/scripts/restore-secure-docs-from-backup.mjs
@@ -78,6 +78,7 @@
 //   SUPABASE_SERVICE_KEY  Supabase service role key — phase upload/both
 import { PrismaClient } from "@prisma/client";
 import { createClient } from "@supabase/supabase-js";
+import dotenv from "dotenv";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
@@ -139,12 +140,24 @@ if (!fs.existsSync(SOURCE) || !fs.statSync(SOURCE).isDirectory()) {
   process.exit(1);
 }
 
+/**
+ * Read a key from the environment, then from the dotenv files in the order the Next.js
+ * toolchain resolves them: `.env.local` OVERRIDES `.env`. Checking `.env` first would let a
+ * committed default silently win over the local override and point this script's restore writes
+ * at the WRONG DATABASE or the WRONG STORAGE BUCKET.
+ *
+ * Parsing is delegated to `dotenv` rather than hand-rolled: a regex over the line mishandles
+ * quoted values containing `#`, `export` prefixes, inline comments, CRLF and multiline values,
+ * and every one of those is a silent wrong-target read. `key in parsed` rather than a truthiness
+ * check so a file that assigns an EMPTY value still wins over the lower-precedence file and the
+ * missing-value check below fails loudly.
+ */
 function envFromFiles(key) {
   if (process.env[key]) return process.env[key];
-  for (const f of [".env", ".env.local"]) {
+  for (const f of [".env.local", ".env"]) {
     if (!fs.existsSync(f)) continue;
-    const m = fs.readFileSync(f, "utf8").match(new RegExp(`^${key}\\s*=\\s*"?([^"\\n]+)"?`, "m"));
-    if (m) return m[1];
+    const parsed = dotenv.parse(fs.readFileSync(f));
+    if (key in parsed) return parsed[key];
   }
   return undefined;
 }

--- a/scripts/restore-secure-docs-from-backup.mjs
+++ b/scripts/restore-secure-docs-from-backup.mjs
@@ -148,12 +148,14 @@ if (!fs.existsSync(SOURCE) || !fs.statSync(SOURCE).isDirectory()) {
  *
  * Parsing is delegated to `dotenv` rather than hand-rolled: a regex over the line mishandles
  * quoted values containing `#`, `export` prefixes, inline comments, CRLF and multiline values,
- * and every one of those is a silent wrong-target read. `key in parsed` rather than a truthiness
- * check so a file that assigns an EMPTY value still wins over the lower-precedence file and the
- * missing-value check below fails loudly.
+ * and every one of those is a silent wrong-target read. `in` rather than a truthiness check at
+ * BOTH levels so a source that assigns an EMPTY value — an exported `DATABASE_URL=""` included —
+ * still wins over every lower-precedence source and the missing-value check below fails loudly.
+ * Resolving one key from the shell and another from a file is how this script ends up uploading
+ * objects into one project and writing the resulting refs into another.
  */
 function envFromFiles(key) {
-  if (process.env[key]) return process.env[key];
+  if (key in process.env) return process.env[key];
   for (const f of [".env.local", ".env"]) {
     if (!fs.existsSync(f)) continue;
     const parsed = dotenv.parse(fs.readFileSync(f));


### PR DESCRIPTION
## Problem

`scripts/backfill-estimate-item-margin.mjs` and five siblings resolved `DATABASE_URL` (and `SUPABASE_URL` / `SUPABASE_SERVICE_KEY`) by reading `.env` **before** `.env.local` — backwards from how the Next.js toolchain resolves them. It only escaped misfiring because this repo has no bare `.env`; if one ever appeared, a committed default would silently win over the local override.

That matters because these are not read-only scripts:

| script | write path |
|---|---|
| `backfill-estimate-item-margin.mjs` | `--apply` UPDATEs `EstimateItem.markupPercent` |
| `backfill-signature-storage.mjs` | uploads signatures, rewrites refs |
| `migrate-secure-docs.mjs` | uploads + rewrites refs |
| `purge-migrated-public-docs.mjs` | **deletes** public originals |
| `restore-secure-docs-from-backup.mjs` | re-uploads + rewrites refs |
| `backup-migrated-public-docs.mjs` | remote-read only (local writes) |

Each copy also hand-rolled the dotenv parsing with a regex that mishandled an empty assignment (fell through to the lower-precedence file instead of winning), quoted values containing `#`, `export ` prefixes, and multiline values. Codex flagged all of these on the identical parser during PR #335.

## Fix

All six now use the parser `scripts/audit-stale-margins.mjs` got in #335 (squash 26c3c8ad):

- iterate `[".env.local", ".env"]`
- `dotenv.parse(fs.readFileSync(f))` (already an explicit devDependency)
- `key in parsed`, not truthiness — an empty assignment still wins, and the missing-value check fails loudly

Codex review (gpt-5.6-sol, xhigh) then caught the same bug one level up: `if (process.env[key])` treated an exported `DATABASE_URL=""` as absent and fell through to the files. It could do that for one key while the others stayed shell-supplied, so the purge script could enumerate paths out of one project and delete them out of another. Now `key in process.env`.

## Verification

From a temp cwd holding a wrong `.env` plus a real `.env.local`:

| case | result |
|---|---|
| both files present | reads `.env.local` ✓ |
| `DATABASE_URL=""` exported | throws, no fallback ✓ |
| empty assignment in `.env.local` | throws, does not read `.env` ✓ |
| no `.env.local` | falls back to `.env` ✓ (also proves dotenv strips the inline comment the old regex swallowed into the URL) |

Plus: `npm run typecheck` clean, eslint 0, `node --check` on all 7, CRLF preserved, and a `backfill-estimate-item-margin.mjs` dry run against prod connects and reports normally (622 scanned, 0 differing, 3 loss-making rows correctly left untouched).

Ops scripts only — nothing in the app bundle changes, so there is no UI surface to exercise.

## Out of scope

~34 other scripts under `scripts/` carry the same reversed order under different helper names (`loadEnv`, inline loops), including DDL-applying `apply-*.mjs` files. Filed separately rather than widened into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)