### PR TITLE
fix(estimates): reject line items whose parent lives in another estimate

### DIFF
--- a/scripts/audit-estimate-item-parents.mjs
+++ b/scripts/audit-estimate-item-parents.mjs
@@ -1,0 +1,146 @@
+// READ-ONLY audit of EstimateItem.parentId integrity: cross-estimate parent links,
+// dangling parents, and parentId cycles.
+//
+// Background: `EstimateItem.parentId` is a self-referencing FK with NO estimate-scope
+// constraint, so the database will happily accept a child whose parent lives in a
+// different estimate. `saveEstimate` passed submitted parentIds straight through, so a
+// crafted save could create exactly that. It matters because the section roll-up
+// (`computeEstimateItemTotals`) walks parent/child to price section headers, and that
+// subtotal drives totalAmount -> tax -> payment milestones: a cross-estimate link lets
+// one estimate's money be computed over another estimate's tree.
+//
+// The guard now lives in `assertEstimateItemParentsInScope`
+// (src/lib/estimate-item-upsert.ts). It fails CLOSED: once it ships, any estimate that
+// ALREADY contains one of these rows can no longer be saved at all. That is why this
+// script exists — to find out, before deploying, whether such history is present.
+//
+// THIS SCRIPT NEVER WRITES. There is no UPDATE, INSERT or DELETE in this file and no
+// --apply flag. If it reports a non-zero count, do NOT auto-repair: reparenting a line
+// item moves money between estimates. Bring the rows to the owner first.
+//
+// Usage:
+//   node scripts/audit-estimate-item-parents.mjs
+//   node scripts/audit-estimate-item-parents.mjs --limit 50   # cap the samples printed
+//
+// Requires (read from env or .env / .env.local):
+//   DATABASE_URL   Supabase transaction pooler URL (must include ?pgbouncer=true)
+import { PrismaClient } from "@prisma/client";
+import dotenv from "dotenv";
+import fs from "node:fs";
+
+const limitArg = process.argv.indexOf("--limit");
+let SAMPLE_LIMIT = 20;
+if (limitArg >= 0) {
+  const raw = process.argv[limitArg + 1];
+  const parsed = raw === undefined ? NaN : Number(raw);
+  if (raw === undefined || !/^\d+$/.test(raw) || !Number.isSafeInteger(parsed)) {
+    throw new Error(`--limit needs a non-negative integer, got ${raw === undefined ? "nothing" : `"${raw}"`}`);
+  }
+  SAMPLE_LIMIT = parsed;
+}
+
+/**
+ * Read a key from env, then from the dotenv files in the order the Next.js toolchain
+ * resolves them: `.env.local` OVERRIDES `.env`. Checking `.env` first would let a
+ * committed default win over the local override and point a production audit at the
+ * WRONG DATABASE. Same helper as the sibling ops scripts standardized in #338.
+ *
+ * `key in` rather than a truthiness check, in both the env and the file lookup: a source that
+ * assigns the key an EMPTY value has still spoken, and must win over the lower-precedence one
+ * instead of falling through to it. The missing-URL check below then fails loudly, which is the
+ * correct outcome.
+ */
+function envFromFiles(key) {
+  if (key in process.env) return process.env[key];
+  for (const f of [".env.local", ".env"]) {
+    if (!fs.existsSync(f)) continue;
+    const parsed = dotenv.parse(fs.readFileSync(f));
+    if (key in parsed) return parsed[key];
+  }
+  return undefined;
+}
+
+const DATABASE_URL = envFromFiles("DATABASE_URL");
+if (!DATABASE_URL) throw new Error("DATABASE_URL not found in env or .env files");
+if (!DATABASE_URL.includes("pgbouncer=true")) {
+  console.warn("⚠ DATABASE_URL has no pgbouncer=true — expected the Supabase transaction pooler. Continuing.");
+}
+
+const prisma = new PrismaClient({ datasources: { db: { url: DATABASE_URL } } });
+
+// A LEFT JOIN, not an inner one: a parentId pointing at a row that no longer exists is
+// its own defect and must not be silently dropped from the report by an inner join.
+const LINK_SQL = `
+  SELECT
+    c."id"          AS "childId",
+    c."name"        AS "childName",
+    c."estimateId"  AS "childEstimateId",
+    ce."code"       AS "childEstimateCode",
+    c."parentId"    AS "parentId",
+    p."estimateId"  AS "parentEstimateId",
+    pe."code"       AS "parentEstimateCode"
+  FROM "EstimateItem" c
+  LEFT JOIN "EstimateItem" p ON p."id" = c."parentId"
+  LEFT JOIN "Estimate" ce ON ce."id" = c."estimateId"
+  LEFT JOIN "Estimate" pe ON pe."id" = p."estimateId"
+  WHERE c."parentId" IS NOT NULL
+    AND (p."id" IS NULL OR p."estimateId" <> c."estimateId")
+`;
+
+// Postgres' CYCLE clause does the detection; the recursion is seeded from every row that
+// has a parent, so a cycle is found whichever member we happen to start from.
+const CYCLE_SQL = `
+  WITH RECURSIVE walk("startId", "id", "parentId") AS (
+    SELECT i."id", i."id", i."parentId"
+    FROM "EstimateItem" i
+    WHERE i."parentId" IS NOT NULL
+    UNION ALL
+    SELECT w."startId", p."id", p."parentId"
+    FROM walk w
+    JOIN "EstimateItem" p ON p."id" = w."parentId"
+  ) CYCLE "id" SET "isCycle" USING "path"
+  SELECT DISTINCT w."startId" AS "itemId", i."estimateId" AS "estimateId", e."code" AS "estimateCode"
+  FROM walk w
+  JOIN "EstimateItem" i ON i."id" = w."startId"
+  LEFT JOIN "Estimate" e ON e."id" = i."estimateId"
+  WHERE w."isCycle"
+`;
+
+const TOTAL_SQL = `SELECT COUNT(*)::int AS "n" FROM "EstimateItem" WHERE "parentId" IS NOT NULL`;
+
+try {
+  const [totals, badLinks, cycles] = await Promise.all([
+    prisma.$queryRawUnsafe(TOTAL_SQL),
+    prisma.$queryRawUnsafe(LINK_SQL),
+    prisma.$queryRawUnsafe(CYCLE_SQL),
+  ]);
+
+  const parented = totals[0]?.n ?? 0;
+  const dangling = badLinks.filter(r => r.parentEstimateId === null);
+  const crossEstimate = badLinks.filter(r => r.parentEstimateId !== null);
+
+  console.log(`\nEstimateItem rows with a parentId: ${parented}`);
+  console.log(`  cross-estimate parent links: ${crossEstimate.length}`);
+  console.log(`  dangling parentId (parent row missing): ${dangling.length}`);
+  console.log(`  rows in a parentId cycle: ${cycles.length}`);
+
+  const sample = (label, rows, fmt) => {
+    if (rows.length === 0) return;
+    console.log(`\n${label} (showing ${Math.min(rows.length, SAMPLE_LIMIT)} of ${rows.length}):`);
+    for (const row of rows.slice(0, SAMPLE_LIMIT)) console.log(`  ${fmt(row)}`);
+  };
+
+  sample("CROSS-ESTIMATE", crossEstimate, r =>
+    `item ${r.childId} "${r.childName}" in ${r.childEstimateCode ?? r.childEstimateId} -> parent ${r.parentId} in ${r.parentEstimateCode ?? r.parentEstimateId}`);
+  sample("DANGLING", dangling, r =>
+    `item ${r.childId} "${r.childName}" in ${r.childEstimateCode ?? r.childEstimateId} -> missing parent ${r.parentId}`);
+  sample("CYCLIC", cycles, r =>
+    `item ${r.itemId} in ${r.estimateCode ?? r.estimateId}`);
+
+  const clean = crossEstimate.length === 0 && dangling.length === 0 && cycles.length === 0;
+  console.log(clean
+    ? "\n✓ Clean — no estimate is made unsavable by the new parentId guard.\n"
+    : "\n✗ Rows above would be REJECTED by assertEstimateItemParentsInScope. Those estimates cannot be saved until the data is corrected. Do not auto-repair: reparenting moves money between estimates.\n");
+} finally {
+  await prisma.$disconnect();
+}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -23,7 +23,7 @@ import { LEGACY_MARKUP_MARGIN_PCT, roundMoney, sellFromMargin } from "./budget-m
 import { canUseDevAuthFallback, getCurrentUserWithPermissions, getUserWithPermissionsByEmail, hasPermission, canAccessProject, PortalAuthError } from "./permissions";
 import { logActivity } from "./activity-log";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
-import { upsertEstimateItems, EstimateStaleSaveError } from "./estimate-item-upsert";
+import { upsertEstimateItems, assertEstimateItemParentsInScope, EstimateStaleSaveError } from "./estimate-item-upsert";
 import { appendPunchItemsInTransaction } from "./punch-items";
 import { runDailyLogTaskMatch } from "./daily-log-task-match";
 import { postDailyLogSummary } from "./chat-webhook";
@@ -3127,6 +3127,15 @@ export async function saveEstimate(estimateId: string, contextId: string, contex
         // 1. Differential Item Upsert
         const existingItems = await tx.estimateItem.findMany({ where: { estimateId } });
         const existingItemsMap = new Map(existingItems.map(item => [item.id, item]));
+
+        // Payload check, ahead of every item write (and ahead of the destructive delete pass
+        // below). Item ids are already scoped by existingItemsMap, but parentId used to be passed
+        // straight through, and EstimateItem's self-referencing FK does not require parent and
+        // child to share an estimateId — so a save could hang this estimate's rows off another
+        // estimate's tree, and the section roll-up would then compute this estimate's subtotal
+        // (and therefore its tax and payment milestones) over that other tree. Throwing here
+        // aborts the whole transaction, so the estimate-level update above never survives either.
+        assertEstimateItemParentsInScope(items, existingItemsMap.keys());
 
         const incomingItemIds = new Set(items.map(item => item.id).filter(Boolean));
         const deletedItems = existingItems.filter(item => !incomingItemIds.has(item.id));

--- a/src/lib/estimate-item-upsert.ts
+++ b/src/lib/estimate-item-upsert.ts
@@ -46,14 +46,113 @@ export type ExistingEstimateItem = {
 };
 
 /**
- * Upserts every incoming line item, parents before children (so a child's `parentId` FK always
- * resolves to an already-written row). Assumes the caller has already taken the
+ * Depth of every submitted row within the submitted tree: 0 for a row with no parent (or whose
+ * parent is not in this payload, i.e. an already-persisted row), parent depth + 1 otherwise.
+ *
+ * Throws on any `parentId` cycle, of any length. The payload is the complete tree — `saveEstimate`
+ * deletes every persisted row the payload omits — so a cycle anywhere in the saved estimate is
+ * visible here.
+ *
+ * Two things ride on this one walk:
+ *  - Cycle rejection. `computeEstimateItemTotals` survives cyclic data by valuing every row in the
+ *    cycle at 0, so a cycle does not hang the app — it silently prices work at nothing, which then
+ *    flows into totalAmount -> tax -> payment milestones. Cheaper to refuse the write.
+ *  - Write order (see `upsertEstimateItems`). Grouping by depth writes every parent before its
+ *    children at any nesting level.
+ */
+function resolveItemDepths(items: readonly { id?: string | null; parentId?: string | null }[]): number[] {
+    const indexById = new Map<string, number>();
+    items.forEach((item, index) => {
+        const id = item.id ? String(item.id) : null;
+        // Later duplicates lose, matching buildItemGraph in estimate-item-payload.
+        if (id && !indexById.has(id)) indexById.set(id, index);
+    });
+
+    const depths = new Array<number>(items.length).fill(-1);
+    for (let start = 0; start < items.length; start++) {
+        if (depths[start] >= 0) continue;
+        const path: number[] = [];
+        const onPath = new Set<number>();
+        let cursor: number | undefined = start;
+        while (cursor !== undefined) {
+            if (onPath.has(cursor)) {
+                throw new Error("Estimate item parent chain is cyclic");
+            }
+            if (depths[cursor] >= 0) break;
+            path.push(cursor);
+            onPath.add(cursor);
+            const parentId: string | null = items[cursor].parentId ? String(items[cursor].parentId) : null;
+            cursor = parentId ? indexById.get(parentId) : undefined;
+        }
+        // path runs deepest-first (start ... topmost). Assign from the topmost down.
+        let depth = cursor === undefined ? 0 : depths[cursor] + 1;
+        for (let k = path.length - 1; k >= 0; k--) {
+            depths[path[k]] = depth;
+            depth++;
+        }
+    }
+    return depths;
+}
+
+/**
+ * Reject any submitted `parentId` that does not name a row of THIS estimate.
+ *
+ * `EstimateItem.parentId` is a self-referencing FK with no estimate-scope constraint, so the
+ * database happily accepts a child whose parent lives in a different estimate. That is not a
+ * cosmetic problem: `computeEstimateItemTotals` walks parent/child to roll section headers up,
+ * the subtotal drives `totalAmount` -> tax -> payment milestones, and `selectedBillableRows`
+ * resolves a selected header to its descendant leaves. A cross-estimate link therefore lets one
+ * estimate's money be computed over another estimate's tree.
+ *
+ * In scope = the ids already persisted under this estimate, plus the ids submitted in this same
+ * payload (a brand-new section and its brand-new children arrive together, and neither is
+ * persisted yet). A submitted id that is really some other estimate's row cannot smuggle itself
+ * in that way: it is absent from `existingItemsMap`, so it routes to `create`, and the create
+ * fails on the primary-key unique constraint.
+ *
+ * Cycles are rejected too, by `resolveItemDepths` — a row that is its own parent gets its own
+ * message because it is the one cycle a caller can produce by mis-wiring a single field.
+ */
+export function assertEstimateItemParentsInScope(
+    items: readonly { id?: string | null; parentId?: string | null }[],
+    existingItemIds: Iterable<string>,
+): void {
+    const inScope = new Set<string>(existingItemIds);
+    for (const item of items) {
+        if (item.id) inScope.add(String(item.id));
+    }
+
+    for (const item of items) {
+        const parentId = item.parentId ? String(item.parentId) : null;
+        if (!parentId) continue;
+        if (item.id && String(item.id) === parentId) {
+            throw new Error("Estimate item cannot be its own parent");
+        }
+        if (!inScope.has(parentId)) {
+            throw new Error("Estimate item parent does not belong to this estimate");
+        }
+    }
+
+    resolveItemDepths(items);
+}
+
+/**
+ * Upserts every incoming line item, ancestors before descendants (so a child's `parentId` FK
+ * always resolves to an already-written row). Assumes the caller has already taken the
  * `Estimate.itemsRevision` compare-and-set — this function does not throw on conflicts because
  * there is nothing left to conflict with by the time it runs.
  *
  * - Existing row (`item.id && existingItemsMap.has(item.id)`): plain `update`.
  * - New row: `create`, id-specifying so undo-of-delete can re-create rows under their original
  *   ids.
+ *
+ * Ordering is by tree depth, not by a flat roots-then-everything-else split. That split only ever
+ * guaranteed ONE level: a brand-new three-level section (grandparent/parent/child all new) whose
+ * rows happened to arrive deepest-first put the grandchild's `create` before its parent's, and
+ * the FK rejected it. Depth grouping holds at any nesting level, whatever order the payload is in.
+ *
+ * The `order` fallback stays per-group, so it now restarts per depth level. It only applies when a
+ * row carries no explicit `order`; the editor always sends one (`serializeEstimateItemsForSave`).
  */
 export async function upsertEstimateItems(
     tx: EstimateItemTxClient,
@@ -63,10 +162,14 @@ export async function upsertEstimateItems(
         existingItemsMap: Map<string, ExistingEstimateItem>;
     },
 ): Promise<void> {
-    const parentItems = items.filter((i: any) => !i.parentId);
-    const childItems = items.filter((i: any) => i.parentId);
+    const depths = resolveItemDepths(items);
+    const groups: any[][] = [];
+    items.forEach((item: any, index: number) => {
+        (groups[depths[index]] ??= []).push(item);
+    });
 
-    for (const group of [parentItems, childItems]) {
+    for (const group of groups) {
+        if (!group) continue;
         for (let idx = 0; idx < group.length; idx++) {
             const item = group[idx];
             const { id, ...itemData } = {

--- a/tests/estimate-item-upsert.test.ts
+++ b/tests/estimate-item-upsert.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
     EstimateStaleSaveError,
+    assertEstimateItemParentsInScope,
     upsertEstimateItems,
     type EstimateItemTxClient,
     type ExistingEstimateItem,
@@ -111,6 +112,56 @@ test("parents are upserted before children (order matters for the parentId FK)",
     assert.deepEqual(updateOrder, ["parent", "child"]);
 });
 
+test("three new levels are written ancestors-first even when the payload is deepest-first", async () => {
+    // The old roots-then-everything-else split only guaranteed ONE level: with this payload it
+    // created the grandparent, then tried to create the grandchild before its parent existed and
+    // the parentId FK rejected it. Depth grouping holds at any nesting level.
+    const { tx, calls } = makeFakeTx();
+
+    await upsertEstimateItems(tx, {
+        estimateId: "est1",
+        items: [
+            { id: "grandchild", parentId: "child", name: "Leaf", quantity: 1, unitCost: 1 },
+            { id: "child", parentId: "root", name: "Sub-section", quantity: 1, unitCost: 1, type: "Section" },
+            { id: "root", name: "Section", quantity: 1, unitCost: 1, type: "Section" },
+        ],
+        existingItemsMap: new Map<string, ExistingEstimateItem>(),
+    });
+
+    assert.deepEqual(calls.map(c => c.args.data.id), ["root", "child", "grandchild"]);
+});
+
+test("upsertEstimateItems refuses a cyclic payload rather than writing part of it", async () => {
+    const { tx, calls } = makeFakeTx();
+
+    await assert.rejects(
+        () => upsertEstimateItems(tx, {
+            estimateId: "est1",
+            items: [
+                { id: "a", parentId: "b", name: "A", quantity: 1, unitCost: 1 },
+                { id: "b", parentId: "a", name: "B", quantity: 1, unitCost: 1 },
+            ],
+            existingItemsMap: new Map<string, ExistingEstimateItem>(),
+        }),
+        /cyclic/,
+    );
+    assert.equal(calls.length, 0, "nothing is written before the graph is known to be sound");
+});
+
+test("a row whose parent is persisted but absent from the payload writes in the first group", async () => {
+    const { tx, calls } = makeFakeTx();
+    // The parent already exists in the database, so its FK resolves without being rewritten here.
+    const existingItemsMap = new Map([["kid", existing({ id: "kid", name: "Sub-item" })]]);
+
+    await upsertEstimateItems(tx, {
+        estimateId: "est1",
+        items: [{ id: "kid", parentId: "already-persisted-section", name: "Sub-item", quantity: 1, unitCost: 1 }],
+        existingItemsMap,
+    });
+
+    assert.deepEqual(calls.map(c => c.method), ["update"]);
+});
+
 test("the `order` fallback is per-group (parents and children each restart from 0)", async () => {
     const { tx, calls } = makeFakeTx();
     const existingItemsMap = new Map<string, ExistingEstimateItem>();
@@ -209,6 +260,115 @@ test("persisted field set matches ESTIMATE_ITEM_SAVE_FIELDS (the shared normaliz
     assert.equal("approvalStatus" in data, false, "approval columns are owned solely by updateItemApproval");
     assert.equal("approvalNote" in data, false);
     assert.equal("id" in data, false, "create keeps id at the top level, not inside data twice");
+});
+
+/**
+ * parentId scope. EstimateItem's self-referencing FK does not require parent and child to share
+ * an estimateId, so without this guard a save can hang one estimate's rows off another
+ * estimate's tree — and the section roll-up that drives totalAmount -> tax -> milestones would
+ * then be computed across both.
+ */
+test("a parentId naming a row of THIS estimate is accepted (persisted parent)", () => {
+    assertEstimateItemParentsInScope(
+        [{ id: "child", parentId: "parent" }],
+        ["parent", "child"],
+    );
+});
+
+test("a parentId naming a brand-new section in the same payload is accepted", () => {
+    // Add Category then drag items under it, all before the first save: neither row is
+    // persisted yet, so the persisted-id set is empty and only the payload vouches for them.
+    assertEstimateItemParentsInScope(
+        [{ id: "new-section", parentId: null }, { id: "new-child", parentId: "new-section" }],
+        [],
+    );
+});
+
+test("a parentId belonging to a DIFFERENT estimate is rejected", () => {
+    assert.throws(
+        () => assertEstimateItemParentsInScope(
+            [{ id: "child", parentId: "other-estimates-section" }],
+            ["child"],
+        ),
+        /parent does not belong to this estimate/,
+    );
+});
+
+test("the foreign parentId is rejected even when the rest of the payload is in scope", () => {
+    assert.throws(
+        () => assertEstimateItemParentsInScope(
+            [
+                { id: "a", parentId: null },
+                { id: "b", parentId: "a" },
+                { id: "c", parentId: "foreign" },
+            ],
+            ["a", "b", "c"],
+        ),
+        /parent does not belong to this estimate/,
+    );
+});
+
+test("a row that is its own parent is rejected", () => {
+    assert.throws(
+        () => assertEstimateItemParentsInScope([{ id: "a", parentId: "a" }], ["a"]),
+        /cannot be its own parent/,
+    );
+});
+
+test("a multi-row parentId cycle is rejected, even though every id is in scope", () => {
+    // A -> B -> C -> A. Every parent names a real row of this estimate, so the scope check alone
+    // passes it. computeEstimateItemTotals then values every row in the cycle at 0, which would
+    // quietly zero the subtotal that drives totalAmount -> tax -> milestones.
+    assert.throws(
+        () => assertEstimateItemParentsInScope(
+            [
+                { id: "a", parentId: "c" },
+                { id: "b", parentId: "a" },
+                { id: "c", parentId: "b" },
+            ],
+            ["a", "b", "c"],
+        ),
+        /cyclic/,
+    );
+});
+
+test("a deep, acyclic chain is accepted", () => {
+    assertEstimateItemParentsInScope(
+        [
+            { id: "d", parentId: "c" },
+            { id: "c", parentId: "b" },
+            { id: "b", parentId: "a" },
+            { id: "a", parentId: null },
+        ],
+        [],
+    );
+});
+
+test("absent, null and empty-string parentId are all treated as root rows", () => {
+    assertEstimateItemParentsInScope(
+        [{ id: "a" }, { id: "b", parentId: null }, { id: "c", parentId: "" }],
+        [],
+    );
+});
+
+test("a payload id vouches for a parent only for parentId — it still routes to create", async () => {
+    // The in-scope set includes payload ids so a same-payload parent works. That cannot be used
+    // to smuggle another estimate's row in: an id absent from existingItemsMap routes to create,
+    // and a create under an id that already exists elsewhere fails the primary-key constraint.
+    const { tx, calls } = makeFakeTx();
+    assertEstimateItemParentsInScope(
+        [{ id: "sect", parentId: null }, { id: "kid", parentId: "sect" }],
+        [],
+    );
+    await upsertEstimateItems(tx, {
+        estimateId: "est1",
+        items: [
+            { id: "sect", name: "Section", quantity: 1, unitCost: 1, type: "Section" },
+            { id: "kid", parentId: "sect", name: "Sub-item", quantity: 1, unitCost: 1 },
+        ],
+        existingItemsMap: new Map<string, ExistingEstimateItem>(),
+    });
+    assert.deepEqual(calls.map(c => c.method), ["create", "create"]);
 });
 
 test("EstimateStaleSaveError is a plain, message-only sentinel", () => {


### PR DESCRIPTION
Follow-up to #333. Codex flagged this during that review and it was left out as a data-integrity issue rather than an auth one.

## The bug

`saveEstimate` validated submitted item ids against the current estimate's item map, but passed `parentId` straight through. `EstimateItem.parentId` is a self-referencing FK with no estimate-scope constraint, so a save could create an item whose parent belongs to a **different estimate**.

That matters because `computeEstimateItemTotals` walks parent/child to roll section headers up, and the subtotal drives `totalAmount` -> tax -> payment milestones. A cross-estimate link lets one estimate's totals be computed over another estimate's tree — the same roll-up path as #315 and the #320/#321/#325/#326 double-count sweep.

## The fix

`assertEstimateItemParentsInScope` requires every non-null `parentId` to name a row of **this** estimate: an id already persisted here, or one submitted in the same payload (a brand-new section and its children arrive together, neither persisted yet). It sits with the other payload guards, before the item writes and before the destructive delete pass, and uses the same error style as the `"Estimate does not belong to the supplied context"` guard from #333.

A submitted id that is really another estimate's row cannot smuggle itself in: it is absent from `existingItemsMap`, so it routes to `create`, and a `create` under an id that exists elsewhere fails the primary-key constraint. There is no `upsert`/`createMany`/`skipDuplicates` on this path.

## Two pre-existing defects in the same graph (both raised in review)

- **Cycles longer than one row passed everything.** `A -> B -> C -> A` is entirely in scope. The totals walk survives it — by valuing every member at 0, which silently prices work at nothing. Rejected now, at any length.
- **The write order only ever guaranteed one level.** `upsertEstimateItems` split rows into roots vs everything-else, so a brand-new three-level section whose rows arrived deepest-first put a grandchild's `create` before its parent's and the FK rejected a legitimate save. Ordering is by tree depth now.

Both fall out of one walk (`resolveItemDepths`), so there is no second copy of the traversal to drift.

## Verification

- `npm run test:unit` — 123 pass. New cases: cross-estimate parent rejected, same-payload parent accepted, multi-row cycle rejected, deep acyclic chain accepted, three-level payload written ancestors-first, cyclic payload writes nothing.
- `npm run build` — 0 errors.
- **Prod audit** (`scripts/audit-estimate-item-parents.mjs`, read-only, no `--apply`): 0 cross-estimate, 0 dangling, 0 cyclic out of 282 parented rows. The guard fails closed, so pre-existing bad history would make an estimate unsavable — there is none. Controls run before trusting the zero: the inverted predicate matched all 282 healthy links, the recursive walk executed (max depth 2), and a synthetic 3-row cycle was caught by the `CYCLE` clause.

## Not in this PR

A DB-level composite FK `(parentId, estimateId) -> (id, estimateId)` is the real structural fix and Codex rated it high-priority. It needs a schema migration plus the `scripts/apply-*.mjs` run-before-deploy dance and owner sign-off, so it is filed separately rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)