### PR TITLE
docs(deploy): stop documenting the vercel flag that leaked the prod token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Sessions 1–2 + Gantt polish are complete. Each session lists specific files, a
 3. npm run build          # must pass 0 errors
 4. Schema changed? Run the branch's scripts/apply-*.mjs against prod NOW, before main moves (see "Deploying to Vercel")
 5. git push origin main   # auto-deploy is ON — this ships to prod
-6. Shipping ahead of a merge? vercel --prod --token $env:VERCEL_TOKEN
+6. Shipping ahead of a merge? Use the command in "Deploying to Vercel" verbatim. NEVER pass --token.
 7. Click through affected pages on prod to verify
 8. Mark items done in ProbuildTodo.md
 ```
@@ -74,10 +74,35 @@ stripe trigger payment_intent.succeeded
 ## Deploying to Vercel (manual CLI deploy — note auto-deploy also ships `main`)
 ```powershell
 # Production deploy (from the main repo dir, not a worktree):
-vercel --prod --token $env:VERCEL_TOKEN --yes --cwd "C:\Users\jat00\workspaces\golden-touch\active\gtr-probuild-site"
+vercel --prod --yes --cwd "C:\Users\jat00\workspaces\golden-touch\active\gtr-probuild-site"
 # add --archive=tgz only as a fallback if the source upload stalls (see notes below)
 ```
 This builds a **new** production deployment. To make an existing staged deployment live instead, use `vercel promote <deployment-url>` — `--prod` does not re-promote.
+
+> **NEVER pass `--token` to any `vercel` command.** On success the CLI prints a "next steps"
+> block that replays your whole command line back, token value and all — straight into the
+> terminal and the session transcript. That has leaked the production token at least twice
+> (PR-209, and again 2026-08-09), each time forcing a rotation. The flag is unnecessary: the CLI
+> already authenticates on its own. Precedence is `--token` → a **non-empty** `VERCEL_TOKEN` in the
+> environment → the persisted login at `%APPDATA%\com.vercel.cli\Data\auth.json` (from
+> `vercel login`). The latter two are read silently and never echoed. This applies to every
+> subcommand (`deploy`, `env`, `logs`, `inspect`), not just `--prod`.
+>
+> A stale `VERCEL_TOKEN` fails every *authenticated* command with *"The token provided via
+> VERCEL_TOKEN environment variable is not valid"* — an invalid explicit credential does **not**
+> fall back to the persisted login. (Local-only commands like `vercel --version` still work, so
+> don't use those to test auth; use `vercel whoami`, which prints `jadkins-4713`.)
+>
+> **Rotating the token — never put the value on a command line.** `setx VERCEL_TOKEN "<value>"`
+> is the same leak class this rule exists to prevent: it lands the secret in argv, shell history,
+> and any agent transcript. Justin sets it himself, in his own terminal, one of these two ways:
+> - Windows GUI: Settings → *Edit environment variables for your account* → edit `VERCEL_TOKEN`.
+> - PowerShell, value read from a prompt rather than argv:
+>   `[Environment]::SetEnvironmentVariable('VERCEL_TOKEN', (Read-Host 'Paste token'), 'User')`
+>
+> Either way it only affects **new** shells, and is Windows-only — WSL needs its own copy. Confirm
+> in a fresh shell with `vercel whoami`. Claude must never be given the token value.
+
 **Pre-deploy checklist (in order):**
 1. `npm run build` passes locally with 0 errors
 2. **Schema changed?** If the branch edits `prisma/schema.prisma` and ships a `scripts/apply-*.mjs`, run it against prod BEFORE deploying (`node scripts/apply-<name>.mjs`). These scripts are additive + idempotent (`IF NOT EXISTS`, guarded FKs) and safe while the old build is live — but the new build's Prisma client selects the new columns immediately, so any page querying them throws P2022 "column does not exist" until the script runs. (2026-07-20: the company-schedule deploy went out before `apply-company-schedule-schema.mjs` ran; project pages hit the route error boundary until it was applied.)
@@ -90,6 +115,8 @@ This builds a **new** production deployment. To make an existing staged deployme
 - `--archive=tgz` is **optional, not required** — with the current `.vercelignore` the CLI source upload measures ~1,389 files (2026-08-10), far under Vercel's 15,000-file cap. That cap counts uploaded source files, not build output. Archive mode bundles everything into one tarball, which negates per-file upload caching and can make repeat deploys slower, so add it only if an upload actually stalls
 - `--cwd` points to the main repo — deploy from there, not from worktrees (worktrees lack the `.vercel` link)
 - Only deploy when changes are verified locally via `npm run build`
+- A `PreToolUse` guard (`~/.claude/hooks/block-vercel-token.mjs`, wired in `~/.claude/settings.json`) blocks `vercel` commands carrying `--token`/`-t`/an inline `VERCEL_TOKEN=`. If you hit it, drop the flag — don't work around it. It is defence-in-depth, not enforcement: it only covers Claude's Bash/PowerShell calls **on this machine**, and does nothing for a manual terminal, CI, Codex, or another machine. The rule above is still the actual control
+- Other secrets-in-argv / secrets-on-disk paths this rule does **not** cover: `--env KEY=VALUE` and `--build-env KEY=VALUE` put values in argv; `vercel env pull` and `vercel pull` write every production env var in plaintext to `.env*` / `.vercel/.env.production.local` (gitignored, but readable by any tool or backup). Treat those files as live secrets
 
 ## E2E testing — never against the live DB
 See **docs/TESTING.md**. E2E creates leads/estimates/invoices, so:


### PR DESCRIPTION
## Why

The Vercel CLI prints a "next steps" block on success that replays your whole command line back. Passing the deploy token as an argument therefore puts the secret into the terminal and the session transcript — the CLI leaks it, not the caller.

This has now happened twice: PR-209, and again on 2026-08-09. Each time it forced a token rotation. Rotating again without changing the runbook just queues up a third.

## What changed

`CLAUDE.md` — the two documented deploy commands no longer pass the flag, plus a rule explaining why, the real auth precedence, and a rotation procedure.

Verified on this machine before writing any of it:

| command | result |
|---|---|
| `vercel whoami`, no flag | exit 0, `jadkins-4713` |
| same, `VERCEL_TOKEN=""` | exit 0 — falls back to the persisted login |
| same, `VERCEL_TOKEN=garbage` | exit 1, *"The token provided via VERCEL_TOKEN environment variable is not valid"* |

So precedence is **explicit flag → non-empty `VERCEL_TOKEN` → persisted login** at `%APPDATA%\com.vercel.cli\Data\auth.json`, and an invalid env value does **not** silently fall back. That's the good failure mode: stale credentials break loudly.

The docs also now name what this rule does *not* cover — `--env`/`--build-env` put values in argv, and `vercel env pull` / `vercel pull` write every production env var in plaintext to gitignored `.env` files.

## Enforcement (outside this repo)

A doc rule that already failed twice is not a fix, so this also adds a `PreToolUse` guard at `~/.claude/hooks/block-vercel-token.mjs` (wired in `~/.claude/settings.json`), with a 26-case regression test beside it. It blocks `vercel` invocations carrying a token argument or an inline `VERCEL_TOKEN=`.

It is scoped honestly in the docs as defence-in-depth: it covers Claude's Bash/PowerShell calls on this machine and nothing else — not a manual terminal, not CI, not another machine.

## Codex review

Ran at xhigh. 8 findings; two were real defects in my own work:

1. **The rotation advice I first wrote reintroduced the leak.** I had documented `setx VERCEL_TOKEN "<value>"`, which lands the secret in argv and shell history — the exact class being prevented. Replaced with the Windows GUI path or a `Read-Host` prompt, and an explicit note that Claude is never given the value.
2. **The guard had a bypass.** `& "vercel" --token x` (PowerShell call operator) slipped through the original word-boundary regex. Rewritten to parse command position instead of matching the word anywhere — which also fixed a false positive that blocked this very commit message.

Also corrected two overstatements it caught: `VERCEL_TOKEN` must be *non-empty* to win, and a stale value breaks *authenticated* commands (`vercel --version` still works, so it's useless as an auth check).

Three findings are pre-existing inaccuracies unrelated to the leak, left alone as out of scope and filed separately: the `vercel.json` auto-deploy claim points at a key that isn't in the file, `--archive=tgz` is justified by a 15,000-file limit the repo is nowhere near (~1,389 files), and a plaintext `.vercel/.env.production.local` is sitting in the main checkout.

## Not deployed

Docs only — no application code changed, so a prod deploy would ship an identical build. Given auto-deploy is off specifically to control build spend, that seemed like the wrong call to make unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)