### PR TITLE
fix(estimates): scope estimate LISTS to the caller, not just the detail page

### DIFF
--- a/e2e/estimate-scope-rules.spec.ts
+++ b/e2e/estimate-scope-rules.spec.ts
@@ -1,0 +1,140 @@
+import { expect, test } from "@playwright/test";
+import {
+    canAccessEstimate,
+    estimateScopeWhere,
+    canAccessProject,
+    accessibleProjectIds,
+    type EstimateOwner,
+    type ProjectScopedUser,
+} from "../src/lib/access-rules";
+
+/**
+ * The list filter and the detail-page assertion have to answer identically for
+ * every input, or the estimate list shows rows whose detail page throws
+ * Forbidden — the exact bug this pair of PRs closed.
+ *
+ * The companion spec (financial-action-auth.spec.ts) proves the WIRING: that
+ * each action calls the right helper. This one proves the RULE: that the two
+ * forms of the rule actually agree. Source-grep assertions cannot catch a
+ * predicate that still mentions every expected token but returns the wrong
+ * answer, so these tests run the real functions over a truth table.
+ */
+
+/** Minimal evaluator for the where-fragment shapes estimateScopeWhere emits. */
+function whereAdmits(where: any, row: EstimateOwner & { id: string }): boolean {
+    if (where.id?.in) return where.id.in.includes(row.id);
+    if (where.OR) return where.OR.some((branch: any) => whereAdmits(branch, row));
+
+    // Leaf branch: every stated key must hold.
+    for (const [key, cond] of Object.entries(where) as [keyof EstimateOwner, any][]) {
+        const value = row[key] ?? null;
+        if (cond === null) {
+            if (value !== null) return false;
+        } else if (cond?.in) {
+            if (value === null || !cond.in.includes(value)) return false;
+        } else if (cond && "not" in cond) {
+            if (cond.not === null ? value === null : value === cond.not) return false;
+        } else if (value !== cond) {
+            return false;
+        }
+    }
+    return true;
+}
+
+const ADMIN: ProjectScopedUser = { role: "ADMIN" };
+const MANAGER: ProjectScopedUser = { role: "MANAGER" };
+// FINANCE is deliberately NOT exempt from project scoping for estimates.
+const FINANCE_NO_ACCESS: ProjectScopedUser = { role: "FINANCE", permissions: { estimates: true } };
+const FINANCE_ON_P1: ProjectScopedUser = {
+    role: "FINANCE", permissions: { estimates: true }, projectAccess: [{ projectId: "p1" }],
+};
+const ESTIMATOR_LEADS: ProjectScopedUser = {
+    role: "EMPLOYEE", permissions: { estimates: true, leadAccess: true }, projectAccess: [{ projectId: "p1" }],
+};
+const LEADS_ONLY: ProjectScopedUser = { role: "EMPLOYEE", permissions: { estimates: true, leadAccess: true } };
+const CREW_ON_P2: ProjectScopedUser = {
+    role: "FIELD_CREW", permissions: { estimates: true }, assignedProjects: [{ id: "p2" }],
+};
+const NOBODY: ProjectScopedUser = { role: "EMPLOYEE", permissions: {} };
+
+const USERS: [string, ProjectScopedUser][] = [
+    ["ADMIN", ADMIN], ["MANAGER", MANAGER],
+    ["FINANCE (no project access)", FINANCE_NO_ACCESS], ["FINANCE (access to p1)", FINANCE_ON_P1],
+    ["estimator with p1 + leadAccess", ESTIMATOR_LEADS], ["leadAccess only", LEADS_ONLY],
+    ["crew assigned to p2", CREW_ON_P2], ["no access at all", NOBODY],
+];
+
+const ROWS: [string, EstimateOwner & { id: string }][] = [
+    ["project-owned p1", { id: "e1", projectId: "p1", leadId: null }],
+    ["project-owned p2", { id: "e2", projectId: "p2", leadId: null }],
+    ["project-owned p9 (nobody has it)", { id: "e3", projectId: "p9", leadId: null }],
+    ["lead-owned", { id: "e4", projectId: null, leadId: "l1" }],
+    ["converted: lead l1 AND project p1", { id: "e5", projectId: "p1", leadId: "l1" }],
+    ["converted: lead l1 AND project p9", { id: "e6", projectId: "p9", leadId: "l1" }],
+    ["ownerless", { id: "e7", projectId: null, leadId: null }],
+];
+
+test("the estimate list filter and the detail assertion agree on every row", () => {
+    for (const [userLabel, user] of USERS) {
+        const where = estimateScopeWhere(user);
+        for (const [rowLabel, row] of ROWS) {
+            expect(
+                whereAdmits(where, row),
+                `${userLabel} / ${rowLabel}: the list filter and canAccessEstimate must agree`,
+            ).toBe(canAccessEstimate(user, row));
+        }
+    }
+});
+
+test("an ownerless estimate is invisible and untouchable for everyone, including admins", () => {
+    const ownerless = { id: "e7", projectId: null, leadId: null };
+    for (const [label, user] of USERS) {
+        expect(canAccessEstimate(user, ownerless), `${label} must not be granted an ownerless estimate`).toBe(false);
+        expect(whereAdmits(estimateScopeWhere(user), ownerless), `${label} must not see an ownerless estimate`).toBe(false);
+    }
+});
+
+test("leadAccess never rescues an estimate on a project the user cannot reach", () => {
+    // Converted estimates carry BOTH ids. Project ownership takes precedence,
+    // so holding leadAccess must not open another job's numbers.
+    const convertedOnUnreachableProject = { id: "e6", projectId: "p9", leadId: "l1" };
+    expect(canAccessEstimate(LEADS_ONLY, convertedOnUnreachableProject)).toBe(false);
+    expect(whereAdmits(estimateScopeWhere(LEADS_ONLY), convertedOnUnreachableProject)).toBe(false);
+    // ...while a purely lead-owned estimate still is reachable.
+    expect(canAccessEstimate(LEADS_ONLY, { id: "e4", projectId: null, leadId: "l1" })).toBe(true);
+});
+
+test("FINANCE is scoped to its projects for estimates, unlike company-wide reports", () => {
+    const onP1 = { id: "e1", projectId: "p1", leadId: null };
+    expect(canAccessEstimate(FINANCE_ON_P1, onP1)).toBe(true);
+    expect(canAccessEstimate(FINANCE_NO_ACCESS, onP1)).toBe(false);
+    expect(whereAdmits(estimateScopeWhere(FINANCE_NO_ACCESS), onP1)).toBe(false);
+});
+
+test("ADMIN and MANAGER see every attached estimate", () => {
+    for (const admin of [ADMIN, MANAGER]) {
+        for (const [label, row] of ROWS) {
+            const expected = !!(row.projectId || row.leadId);
+            expect(whereAdmits(estimateScopeWhere(admin), row), `${admin.role} / ${label}`).toBe(expected);
+        }
+    }
+});
+
+test("a missing user is treated as no access, never as full access", () => {
+    for (const noUser of [null, undefined, {} as any]) {
+        const where = estimateScopeWhere(noUser);
+        for (const [label, row] of ROWS) {
+            expect(whereAdmits(where, row), `absent user must not see ${label}`).toBe(false);
+        }
+    }
+});
+
+test("accessibleProjectIds stays the set form of canAccessProject", () => {
+    for (const [label, user] of USERS) {
+        const ids = accessibleProjectIds(user);
+        for (const projectId of ["p1", "p2", "p9"]) {
+            const fromSet = ids === "ALL" || ids.includes(projectId);
+            expect(fromSet, `${label} / ${projectId}`).toBe(canAccessProject(user, projectId));
+        }
+    }
+});

--- a/e2e/financial-action-auth.spec.ts
+++ b/e2e/financial-action-auth.spec.ts
@@ -112,8 +112,10 @@ test("all staff financial actions authorize inside the exported action", () => {
   expect(exportSource(source, "createInvoiceFromEstimate")).toContain("assertEstimateScope(");
 
   // Company-wide by design: the template/assembly library is not per-job.
+  // getAllEstimates is NOT in this list — it lists per-job documents, and is
+  // covered by the list-scoping test below.
   const companyWideEstimateActions = [
-    "getAllEstimates", "getEstimateTemplates", "saveItemsAsAssembly", "deleteAssembly",
+    "getEstimateTemplates", "saveItemsAsAssembly", "deleteAssembly",
   ];
   for (const name of companyWideEstimateActions) {
     expectGuardBeforeDatabase(source, name, "await assertEstimatePermission(");
@@ -172,6 +174,74 @@ test("all staff financial actions authorize inside the exported action", () => {
   for (const name of ["saveCompanySettings", "updateCompanyProjectStatuses", "saveCompanySubcontractorTrades"]) {
     expectGuardBeforeDatabase(source, name, "await assertCompanySettingsPermission(");
   }
+});
+
+test("estimate readers filter by the same scope the detail page asserts", () => {
+  const source = readFileSync(join(process.cwd(), "src/lib/actions.ts"), "utf8");
+  const permissions = readFileSync(join(process.cwd(), "src/lib/permissions.ts"), "utf8");
+
+  // A list that returns rows whose detail page throws Forbidden is its own bug.
+  // Every reader that returns estimates must apply the filter form of the same
+  // rule assertEstimateScope applies to a single row.
+  {
+    const action = exportSource(source, "getAllEstimates");
+    const guardIndex = action.indexOf("await assertEstimatePermission(");
+    const filterIndex = action.indexOf("where: estimateScopeWhere(user)");
+    const databaseIndex = action.indexOf("prisma.");
+    expect(guardIndex, "getAllEstimates must assert the estimates permission").toBeGreaterThanOrEqual(0);
+    expect(filterIndex, "getAllEstimates must scope the list, not just gate the permission").toBeGreaterThanOrEqual(0);
+    expect(guardIndex, "getAllEstimates must authorize before database access").toBeLessThan(databaseIndex);
+  }
+
+  // The staff branch of the portal preview used to fetch any id by id alone.
+  {
+    const action = exportSource(source, "getEstimateForPortal");
+    expect(action, "the staff preview branch must be scoped")
+      .toContain("const staffFilter = { AND: [{ id }, estimateScopeWhere(staffUser)] }");
+    expect(action, "the staff preview must not fall back to an unscoped fetch by id")
+      .not.toMatch(/where: \{ id \},/);
+    // Both the primary query and its degraded fallback must use it — the
+    // fallback runs on exactly the error paths nobody exercises by hand.
+    expect(action.match(/where: staffFilter/g) ?? [], "both staff queries must use the scoped filter").toHaveLength(2);
+  }
+
+  // Nested embeds are the same exposure by another route: a lead or project
+  // getter that includes estimates hands back rows the caller may not open.
+  for (const name of ["getLeads", "getLead", "getProjects", "getProject", "getClients"]) {
+    expect(exportSource(source, name), `${name} must scope the estimates it embeds`)
+      .toContain("scopedEstimateRelation(");
+  }
+  expect(source, "no estimates relation may be embedded without the scope filter")
+    .not.toMatch(/estimates: safeEstimateInclude/);
+
+  // The predicate itself must keep doing the work — without this every
+  // assertion above still passes while estimateScopeWhere is gutted to `{}`.
+  const predicateStart = source.indexOf("function estimateScopeWhere(");
+  expect(predicateStart, "estimateScopeWhere must exist").toBeGreaterThanOrEqual(0);
+  const predicateEnd = /\nasync function |\nfunction |\nexport /.exec(source.slice(predicateStart + 30));
+  const predicate = source.slice(
+    predicateStart,
+    predicateEnd ? predicateStart + 30 + predicateEnd.index : undefined,
+  );
+  for (const needle of [
+    "accessibleProjectIds(user)",           // project branch, shared with canAccessProject
+    'hasPermission(user, "leadAccess")',    // lead branch, same gate as assertEstimateScope
+    "projectId: null",                      // leadAccess must NOT rescue a project-owned row
+    "MATCHES_NO_ESTIMATE",                  // no accessible scope => no rows, not all rows
+  ]) {
+    expect(predicate, `estimateScopeWhere must still contain ${needle}`).toContain(needle);
+  }
+
+  // Agreement is structural, not coincidental: assertEstimateScope's project
+  // branch is canAccessProject, estimateScopeWhere's is accessibleProjectIds,
+  // and canAccessProject is defined in terms of accessibleProjectIds. Break
+  // that chain and the assertion and the filter can disagree again.
+  expect(permissions, "canAccessProject must derive from accessibleProjectIds")
+    .toMatch(/export function canAccessProject\([\s\S]{0,400}accessibleProjectIds\(user\)/);
+  expect(
+    source.slice(source.indexOf("function assertEstimateScope(")),
+    "assertEstimateScope must still route project-owned estimates through canAccessProject",
+  ).toContain("canAccessProject(user, scope.projectId)");
 });
 
 test("dual-auth financial actions keep explicit portal or machine authorization", () => {

--- a/e2e/financial-action-auth.spec.ts
+++ b/e2e/financial-action-auth.spec.ts
@@ -75,7 +75,10 @@ test("all staff financial actions authorize inside the exported action", () => {
   // The helpers themselves must keep doing the work. Without this, any caller
   // assertion above still passes while the helper it names is gutted to a no-op.
   const helperBodies: Record<string, string[]> = {
-    assertEstimateScope: ["canAccessProject(", 'hasPermission(user, "leadAccess")', "throw new Error"],
+    // The decision itself lives in access-rules.ts and is behaviourally tested
+    // by estimate-scope-rules.spec.ts; what must hold HERE is that the
+    // assertion still delegates to it rather than re-deciding locally.
+    assertEstimateScope: ["canAccessEstimate(", "throw new Error"],
     assertEstimateAccess: ["assertEstimatePermission(", "assertEstimateScope("],
     assertEstimateProjectAccess: ["assertEstimatePermission(", "assertEstimateScope("],
     assertEstimateLeadAccess: ["assertEstimatePermission(", "assertEstimateScope("],
@@ -214,34 +217,35 @@ test("estimate readers filter by the same scope the detail page asserts", () => 
   expect(source, "no estimates relation may be embedded without the scope filter")
     .not.toMatch(/estimates: safeEstimateInclude/);
 
-  // The predicate itself must keep doing the work — without this every
-  // assertion above still passes while estimateScopeWhere is gutted to `{}`.
-  const predicateStart = source.indexOf("function estimateScopeWhere(");
-  expect(predicateStart, "estimateScopeWhere must exist").toBeGreaterThanOrEqual(0);
-  const predicateEnd = /\nasync function |\nfunction |\nexport /.exec(source.slice(predicateStart + 30));
-  const predicate = source.slice(
-    predicateStart,
-    predicateEnd ? predicateStart + 30 + predicateEnd.index : undefined,
-  );
-  for (const needle of [
-    "accessibleProjectIds(user)",           // project branch, shared with canAccessProject
-    'hasPermission(user, "leadAccess")',    // lead branch, same gate as assertEstimateScope
-    "projectId: null",                      // leadAccess must NOT rescue a project-owned row
-    "MATCHES_NO_ESTIMATE",                  // no accessible scope => no rows, not all rows
-  ]) {
-    expect(predicate, `estimateScopeWhere must still contain ${needle}`).toContain(needle);
-  }
+  // The relation wrapper must apply the predicate, not an empty where — every
+  // nested-embed assertion above would still pass if it returned `where: {}`.
+  const relationStart = source.indexOf("function scopedEstimateRelation");
+  expect(relationStart, "scopedEstimateRelation must exist").toBeGreaterThanOrEqual(0);
+  expect(
+    source.slice(relationStart, relationStart + 400),
+    "scopedEstimateRelation must apply estimateScopeWhere to the relation",
+  ).toContain("where: estimateScopeWhere(user)");
 
-  // Agreement is structural, not coincidental: assertEstimateScope's project
-  // branch is canAccessProject, estimateScopeWhere's is accessibleProjectIds,
-  // and canAccessProject is defined in terms of accessibleProjectIds. Break
-  // that chain and the assertion and the filter can disagree again.
-  expect(permissions, "canAccessProject must derive from accessibleProjectIds")
-    .toMatch(/export function canAccessProject\([\s\S]{0,400}accessibleProjectIds\(user\)/);
+  // Agreement is structural, not coincidental. Both forms of the rule are
+  // defined in access-rules.ts and are behaviourally verified against each
+  // other over a truth table in estimate-scope-rules.spec.ts; what must hold
+  // here is that actions.ts keeps delegating to them instead of re-deciding.
   expect(
     source.slice(source.indexOf("function assertEstimateScope(")),
-    "assertEstimateScope must still route project-owned estimates through canAccessProject",
-  ).toContain("canAccessProject(user, scope.projectId)");
+    "assertEstimateScope must delegate to the shared rule",
+  ).toContain("canAccessEstimate(user, scope)");
+  expect(permissions, "permissions.ts must re-export the shared rules, not redefine them")
+    .toMatch(/export \{[\s\S]{0,400}canAccessEstimate,[\s\S]{0,200}estimateScopeWhere,[\s\S]{0,200}\} from "\.\/access-rules"/);
+  expect(source, "actions.ts must not keep a private copy of the scope predicate")
+    .not.toMatch(/\nfunction estimateScopeWhere\(/);
+
+  // The reader that has no throwing assertion of its own must not swallow
+  // infrastructure failures — an outage rendered as "no estimates" is a page
+  // of plausible zeroes, not an error.
+  const resolverStart = source.indexOf("async function currentStaffUserOrNull(");
+  expect(resolverStart, "currentStaffUserOrNull must exist").toBeGreaterThanOrEqual(0);
+  const resolver = source.slice(resolverStart, source.indexOf("async function assertActiveStaff("));
+  expect(resolver, "currentStaffUserOrNull must not catch and flatten errors").not.toContain("catch");
 });
 
 test("dual-auth financial actions keep explicit portal or machine authorization", () => {

--- a/scripts/verify-selection-templates.ts
+++ b/scripts/verify-selection-templates.ts
@@ -38,6 +38,7 @@ const linkDeps = read("src/lib/decision-schedule-link-dependencies.ts");
 const linkActionsCore = read("src/lib/decision-link-actions-core.ts");
 const aiSortCore = read("src/lib/selection-ai-sort-core.ts");
 const permissions = read("src/lib/permissions.ts");
+const accessRules = read("src/lib/access-rules.ts");
 const actions = read("src/lib/actions.ts");
 const proxy = read("src/proxy.ts");
 const teamDecisionsSection = read("src/app/projects/[id]/selections/TeamDecisionsSection.tsx");
@@ -65,7 +66,17 @@ assert.ok(!/CREATE POLICY[\s\S]*"DecisionTemplate/i.test(applyScript), "Decision
 
 // ── Authorization split: CRUD is ADMIN/MANAGER, apply is any project staff ──
 
-assert.match(permissions, /export function isAdminOrManager/, "permissions.ts must export isAdminOrManager");
+// The pure rules moved to access-rules.ts (no Prisma/next-auth imports, so they
+// can be unit-tested); permissions.ts re-exports them. What matters to this
+// contract is that `import { isAdminOrManager } from "@/lib/permissions"` still
+// resolves and that the role list behind it is the shared one, not a local copy.
+assert.match(accessRules, /export function isAdminOrManager/, "access-rules.ts must define isAdminOrManager");
+assert.match(accessRules, /ADMIN_ROLES\.includes\(user\.role\)/, "isAdminOrManager must use the shared ADMIN_ROLES list");
+assert.match(
+    permissions,
+    /export \{[\s\S]*?\bisAdminOrManager\b[\s\S]*?\} from "\.\/access-rules"/,
+    "permissions.ts must re-export isAdminOrManager so existing imports keep resolving",
+);
 assert.match(templateCrudCore, /isAdminOrManager/, "template CRUD must gate on isAdminOrManager");
 assert.match(templateCrudCore, /requireAdminOrManager/, "template CRUD must have an admin/manager requirement helper");
 assert.match(templateApplyCore, /canAccessProject/, "applyDecisionTemplate must gate on canAccessProject");

--- a/src/lib/access-rules.ts
+++ b/src/lib/access-rules.ts
@@ -1,0 +1,135 @@
+/**
+ * Pure access rules — no imports, no database, no session.
+ *
+ * These used to live in permissions.ts, which pulls in Prisma, next-auth and
+ * next/headers. That made the rules impossible to test behaviourally: a spec
+ * could only grep their source for tokens, which passes just as happily against
+ * a gutted implementation. Everything here is a plain function of its arguments,
+ * so e2e/estimate-scope-rules.spec.ts can import it and check the actual
+ * decisions against a truth table.
+ *
+ * permissions.ts re-exports all of these, so existing callers are unchanged.
+ */
+
+export type PermissionKey =
+    // Administrative
+    | "manageTeamMembers" | "manageSubs" | "manageVendors"
+    | "companySettings" | "costCodesCategories"
+    // Project screens
+    | "schedules" | "estimates" | "invoices" | "contracts"
+    | "roomDesigner" | "changeOrders" | "financialReports"
+    | "timeClock" | "dailyLogs" | "files" | "takeoffs"
+    // Leads
+    | "createLead" | "clientCommunication" | "leadAccess";
+
+export const ADMIN_ROLES = ["ADMIN", "MANAGER"];
+
+export function isAdminOrManager(user: { role: string }): boolean {
+    return ADMIN_ROLES.includes(user.role);
+}
+
+// Default permissions by role (used when no UserPermission record exists)
+function getDefaultPermission(role: string, key: PermissionKey): boolean {
+    const defaults: Record<string, PermissionKey[]> = {
+        FIELD_CREW: ["schedules", "roomDesigner", "timeClock", "dailyLogs", "files", "costCodesCategories"],
+        FINANCE: ["estimates", "invoices", "financialReports", "timeClock", "changeOrders", "costCodesCategories"],
+        EMPLOYEE: ["schedules", "roomDesigner", "timeClock", "dailyLogs", "files", "costCodesCategories"],
+    };
+
+    return (defaults[role] || defaults.EMPLOYEE)?.includes(key) ?? false;
+}
+
+// Check if user has a specific permission
+export function hasPermission(
+    user: { role: string; permissions?: any | null },
+    key: PermissionKey
+): boolean {
+    // Admins and Managers always have full access
+    if (ADMIN_ROLES.includes(user.role)) return true;
+
+    // If no permissions record, use defaults based on role
+    if (!user.permissions) {
+        return getDefaultPermission(user.role, key);
+    }
+
+    return !!user.permissions[key];
+}
+
+export type ProjectScopedUser = {
+    role: string;
+    permissions?: any | null;
+    projectAccess?: { projectId: string }[];
+    assignedProjects?: { id: string }[];
+};
+
+/**
+ * The set form of canAccessProject: every project id this user may reach, or
+ * "ALL" for the roles that pass unconditionally. Exists so a list query can be
+ * filtered by exactly the same rule that canAccessProject() applies to a single
+ * id — a second hand-rolled predicate is how a list and its detail page drift
+ * apart. Invariant: canAccessProject(u, p) === (ids === "ALL" || ids.includes(p)).
+ */
+export function accessibleProjectIds(user: ProjectScopedUser): string[] | "ALL" {
+    if (ADMIN_ROLES.includes(user.role)) return "ALL";
+    return Array.from(new Set([
+        ...(user.projectAccess ?? []).map(pa => pa.projectId),
+        ...(user.assignedProjects ?? []).map(p => p.id),
+    ]));
+}
+
+// Check if user can access a specific project
+export function canAccessProject(user: ProjectScopedUser, projectId: string): boolean {
+    const ids = accessibleProjectIds(user);
+    return ids === "ALL" || ids.includes(projectId);
+}
+
+/** What an estimate hangs off. Both columns are optional in the schema. */
+export type EstimateOwner = { projectId?: string | null; leadId?: string | null };
+
+/**
+ * THE estimate scope rule. Both the assertion (assertEstimateScope in
+ * actions.ts) and the list filter (estimateScopeWhere below) are defined in
+ * terms of this one function, so they cannot answer differently.
+ *
+ * FINANCE is deliberately NOT exempt the way assertFinancialProjectScope
+ * exempts it for company-wide reports — an estimate is a per-job document.
+ */
+export function canAccessEstimate(user: ProjectScopedUser, scope: EstimateOwner): boolean {
+    // Fail CLOSED on an ownerless estimate. "No project and no lead" means there
+    // is nothing to check access against, so nobody passes — not even an admin.
+    if (!scope.projectId && !scope.leadId) return false;
+    // Project ownership wins: a converted estimate carries BOTH ids, and
+    // `leadAccess` must not rescue an estimate on a job the user can't reach.
+    if (scope.projectId) return canAccessProject(user, scope.projectId);
+    return hasPermission(user, "leadAccess");
+}
+
+/** Matches no estimate at all. Used where the caller has no accessible scope. */
+const MATCHES_NO_ESTIMATE = { id: { in: [] as string[] } };
+
+/** Any estimate attached to something — the filter form of the ownerless check. */
+const ATTACHED_TO_AN_OWNER = { OR: [{ projectId: { not: null } }, { leadId: { not: null } }] };
+
+/**
+ * The Prisma where-fragment form of canAccessEstimate: the same decision asked
+ * of a whole table at once. Every branch mirrors a branch of canAccessEstimate,
+ * including the ownerless one — an unattached estimate is filtered out for
+ * every role, because canAccessEstimate rejects it for every role.
+ *
+ * Safe to drop into a top-level `where`, a nested relation `where`, or an
+ * `AND: [...]` alongside an id.
+ */
+export function estimateScopeWhere(user: ProjectScopedUser | null | undefined): any {
+    if (!user?.role) return MATCHES_NO_ESTIMATE;
+
+    const projectIds = accessibleProjectIds(user);
+    if (projectIds === "ALL") return ATTACHED_TO_AN_OWNER;
+
+    const branches: any[] = [];
+    if (projectIds.length > 0) branches.push({ projectId: { in: projectIds } });
+    // Mirrors "if (scope.projectId) ... else leadAccess": the lead branch is
+    // only reached when there is no project, hence `projectId: null` here.
+    if (hasPermission(user, "leadAccess")) branches.push({ projectId: null, leadId: { not: null } });
+    if (branches.length === 0) return MATCHES_NO_ESTIMATE;
+    return { OR: branches };
+}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -20,7 +20,7 @@ import { isHttpUrl } from "./url-safety";
 // estimate-item-upsert.ts, which is now its only caller on the save path.
 import { selectedBillableRows } from "./estimate-item-payload";
 import { LEGACY_MARKUP_MARGIN_PCT, roundMoney, sellFromMargin } from "./budget-math";
-import { canUseDevAuthFallback, getCurrentUserWithPermissions, getUserWithPermissionsByEmail, hasPermission, canAccessProject, accessibleProjectIds, PortalAuthError } from "./permissions";
+import { canUseDevAuthFallback, getCurrentUserWithPermissions, getUserWithPermissionsByEmail, hasPermission, canAccessProject, canAccessEstimate, estimateScopeWhere, PortalAuthError } from "./permissions";
 import { logActivity } from "./activity-log";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { upsertEstimateItems, assertEstimateItemParentsInScope, EstimateStaleSaveError } from "./estimate-item-upsert";
@@ -4181,7 +4181,15 @@ export async function unrecordEstimatePayment(paymentId: string, estimateId: str
     return { success: true };
 }
 
-async function assertActiveStaff(): Promise<any> {
+/**
+ * Resolve the acting staff user, or null if there genuinely isn't one.
+ *
+ * Deliberately has NO try/catch: a Prisma or session failure must propagate.
+ * Swallowing it would turn an outage into "no user", which the estimate scope
+ * filter reads as "show no estimates" — a page of zeroes that looks like real
+ * data. Only a real absence of a signed-in staff user returns null.
+ */
+async function currentStaffUserOrNull(): Promise<any | null> {
     const user = await getCurrentUserWithPermissions();
     if (user) return user;
 
@@ -4189,21 +4197,13 @@ async function assertActiveStaff(): Promise<any> {
         const devSession = await getSessionOrDev();
         if ((devSession?.user as { role?: string } | undefined)?.role) return devSession.user;
     }
-    throw new Error("Unauthorized");
+    return null;
 }
 
-/**
- * assertActiveStaff without the throw. For readers that are not themselves
- * estimate actions but embed estimates — they must not start rejecting callers
- * they used to serve, they just have nobody to scope the embedded estimates
- * against, which estimateScopeWhere() treats as "show none".
- */
-async function currentStaffUserOrNull(): Promise<any | null> {
-    try {
-        return await assertActiveStaff();
-    } catch {
-        return null;
-    }
+async function assertActiveStaff(): Promise<any> {
+    const user = await currentStaffUserOrNull();
+    if (!user) throw new Error("Unauthorized");
+    return user;
 }
 
 async function assertStaffPermission(permission: "estimates" | "invoices" | "changeOrders" | "financialReports" | "companySettings" | "contracts" | "manageVendors") {
@@ -4240,53 +4240,20 @@ async function assertChangeOrderPermission() {
 function assertEstimateScope(user: any, scope: { projectId?: string | null; leadId?: string | null }) {
     // Fail CLOSED on an ownerless estimate. Both ownership columns are optional
     // in the schema, so "no project and no lead" would otherwise fall straight
-    // through this function and be authorized by default.
+    // through this function and be authorized by default. Reported distinctly
+    // from "Forbidden" because it is a data problem, not a permissions one.
     if (!scope.projectId && !scope.leadId) {
         throw new Error("This estimate is not attached to a project or lead, so access cannot be checked");
     }
-    if (scope.projectId) {
-        if (!canAccessProject(user, scope.projectId)) throw new Error("Forbidden");
-        return;
-    }
-    if (!hasPermission(user, "leadAccess")) throw new Error("Forbidden");
+    // The decision itself lives in access-rules.ts, shared verbatim with the
+    // list filter (estimateScopeWhere) so the two can never disagree.
+    if (!canAccessEstimate(user, scope)) throw new Error("Forbidden");
 }
 
 /**
- * The filter form of assertEstimateScope. The assertion above answers "may this
- * user touch THIS estimate"; a list has to ask the same question of every row it
- * is about to return, and it has to get the same answer — a list that shows rows
- * whose detail page throws Forbidden is worse than either extreme.
- *
- * Every branch below is the mirror image of a branch in assertEstimateScope:
- *   - ADMIN/MANAGER pass unconditionally there, so they get an empty (no-op) where.
- *   - project-owned rows go through canAccessProject there, so here they are
- *     restricted to accessibleProjectIds() — the set form of that same function.
- *   - the leadAccess fallback is reached there ONLY when projectId is null, so
- *     the OR branch carries `projectId: null` too. Without it a user holding
- *     leadAccess would list another job's project-owned estimate and then be
- *     refused on click-through.
- *   - an ownerless estimate (no project, no lead) throws there, so it matches no
- *     branch here and is filtered out — both directions fail closed.
- * FINANCE is deliberately not exempt, same as in assertEstimateScope.
- */
-const MATCHES_NO_ESTIMATE = { id: { in: [] as string[] } };
-
-function estimateScopeWhere(user: any | null | undefined) {
-    if (!user?.role) return MATCHES_NO_ESTIMATE;
-    const projectIds = accessibleProjectIds(user);
-    if (projectIds === "ALL") return {};
-
-    const branches: any[] = [];
-    if (projectIds.length > 0) branches.push({ projectId: { in: projectIds } });
-    if (hasPermission(user, "leadAccess")) branches.push({ projectId: null, leadId: { not: null } });
-    if (branches.length === 0) return MATCHES_NO_ESTIMATE;
-    return { OR: branches };
-}
-
-/**
- * The nested-relation form. Prisma relation filters take the same where shape,
- * so a lead/project getter that embeds estimates can reuse the predicate rather
- * than growing its own copy of the rules.
+ * The nested-relation form of estimateScopeWhere. Prisma relation filters take
+ * the same where shape, so a lead/project getter that embeds estimates can
+ * reuse the predicate rather than growing its own copy of the rules.
  */
 function scopedEstimateRelation<T extends object>(relation: T, user: any | null | undefined): T & { where: any } {
     return { ...relation, where: estimateScopeWhere(user) };

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -20,7 +20,7 @@ import { isHttpUrl } from "./url-safety";
 // estimate-item-upsert.ts, which is now its only caller on the save path.
 import { selectedBillableRows } from "./estimate-item-payload";
 import { LEGACY_MARKUP_MARGIN_PCT, roundMoney, sellFromMargin } from "./budget-math";
-import { canUseDevAuthFallback, getCurrentUserWithPermissions, getUserWithPermissionsByEmail, hasPermission, canAccessProject, PortalAuthError } from "./permissions";
+import { canUseDevAuthFallback, getCurrentUserWithPermissions, getUserWithPermissionsByEmail, hasPermission, canAccessProject, accessibleProjectIds, PortalAuthError } from "./permissions";
 import { logActivity } from "./activity-log";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { upsertEstimateItems, assertEstimateItemParentsInScope, EstimateStaleSaveError } from "./estimate-item-upsert";
@@ -243,12 +243,12 @@ export async function generatePdfUploadToken(estimateId: string): Promise<string
 }
 
 export async function getLeads() {
-    await assertActiveStaff();
+    const user = await assertActiveStaff();
     const leads = await prisma.lead.findMany({
         orderBy: { createdAt: "desc" },
         include: {
             client: true,
-            estimates: safeEstimateInclude,
+            estimates: scopedEstimateRelation(safeEstimateInclude, user),
             manager: true,
             project: { select: { id: true } },
             tasks: {
@@ -272,11 +272,12 @@ export async function getLeads() {
 }
 
 export const getLead = cache(async function getLead(id: string) {
+    const user = await currentStaffUserOrNull();
     const lead = await prisma.lead.findUnique({
         where: { id },
         include: {
             client: true,
-            estimates: safeEstimateInclude,
+            estimates: scopedEstimateRelation(safeEstimateInclude, user),
             contracts: true,
             manager: true,
             tasks: {
@@ -284,12 +285,13 @@ export const getLead = cache(async function getLead(id: string) {
             },
             roomDesigns: true,
             // Pull the linked project + its estimates so the lead estimates page
-            // can surface project estimates alongside lead-direct ones.
+            // can surface project estimates alongside lead-direct ones. These are
+            // project-owned, so they are scoped by project access, not leadAccess.
             project: {
                 select: {
                     id: true,
                     name: true,
-                    estimates: safeEstimateInclude,
+                    estimates: scopedEstimateRelation(safeEstimateInclude, user),
                 }
             }
         },
@@ -623,11 +625,12 @@ export async function updateLeadInfo(id: string, data: any) {
 }
 
 export async function getClients() {
+    const user = await currentStaffUserOrNull();
     const clients = await prisma.client.findMany({
         orderBy: { name: "asc" },
         include: {
             projects: {
-                include: { estimates: safeEstimateInclude }
+                include: { estimates: scopedEstimateRelation(safeEstimateInclude, user) }
             },
             leads: true
         }
@@ -1096,12 +1099,12 @@ export async function deleteLeadMeeting(meetingId: string) {
 }
 
 export async function getProjects() {
-    await assertActiveStaff();
+    const user = await assertActiveStaff();
     const projects = await prisma.project.findMany({
         orderBy: { viewedAt: "desc" },
         include: {
             client: true,
-            estimates: { select: { totalAmount: true, status: true } },
+            estimates: scopedEstimateRelation({ select: { totalAmount: true, status: true } }, user),
         },
     });
     return JSON.parse(JSON.stringify(projects.map((p: any) => ({
@@ -1110,10 +1113,10 @@ export async function getProjects() {
     }))));
 }
 export const getProject = cache(async function getProject(id: string) {
-    await assertActiveStaff();
+    const user = await assertActiveStaff();
     const include = {
         client: true,
-        estimates: {
+        estimates: scopedEstimateRelation({
             select: {
                 id: true,
                 number: true,
@@ -1134,8 +1137,8 @@ export const getProject = cache(async function getProject(id: string) {
                 contractId: true,
                 viewedAt: true,
             }
-        },
-    } as const;
+        }, user),
+    };
 
     // Support both CUID and friendly numeric ID in URL params
     const numericId = /^\d+$/.test(id) ? parseInt(id, 10) : null;
@@ -1657,10 +1660,13 @@ export async function updateEstimateStatus(id: string, status: string, leadId?: 
 }
 
 export const getEstimateForPortal = cache(async function getEstimateForPortal(id: string) {
-    // Staff members (any user with a role on their session) can preview any estimate.
-    // Portal clients must pass the IDOR ownership check below.
+    // Staff members can preview an estimate they are scoped to; portal clients
+    // must pass the IDOR ownership check below.
     const staffSession = await getServerSession(authOptions);
     const isStaff = !!(staffSession?.user as any)?.role;
+    // The session carries a role but not projectAccess/assignedProjects, so the
+    // horizontal check needs the full user row.
+    const staffUser = isStaff ? await currentStaffUserOrNull() : null;
 
     if (!isStaff) {
         // IDOR #2 fix: require a resolvable portal session and gate the fetch by
@@ -1764,11 +1770,14 @@ export const getEstimateForPortal = cache(async function getEstimateForPortal(id
         }));
     }
 
-    // Staff path: no ownership restriction — just fetch by id
+    // Staff path: fetch by id, narrowed to the estimates this staff user is
+    // scoped to. AND-composed rather than spread so a match-nothing predicate
+    // cannot overwrite the id it is meant to narrow.
+    const staffFilter = { AND: [{ id }, estimateScopeWhere(staffUser)] };
     let estimate: any;
     try {
         estimate = await prisma.estimate.findFirst({
-            where: { id },
+            where: staffFilter,
             include: {
                 project: { include: { client: true } },
                 lead: { include: { client: true } },
@@ -1796,7 +1805,7 @@ export const getEstimateForPortal = cache(async function getEstimateForPortal(id
         console.error("[getEstimateForPortal] Primary query failed:", err);
         try {
             estimate = await prisma.estimate.findFirst({
-                where: { id },
+                where: staffFilter,
                 select: {
                     id: true, number: true, title: true, projectId: true, leadId: true,
                     code: true, status: true, privacy: true, createdAt: true,
@@ -1898,8 +1907,10 @@ export async function ensureEstimatePayInFullSchedule(estimateId: string): Promi
 }
 
 export const getAllEstimates = cache(async function getAllEstimates() {
-    await assertEstimatePermission();
+    const user = await assertEstimatePermission();
+    // Same rule the estimate detail page applies — see estimateScopeWhere.
     return await prisma.estimate.findMany({
+        where: estimateScopeWhere(user),
         orderBy: { createdAt: "desc" },
         select: {
             id: true,
@@ -4181,6 +4192,20 @@ async function assertActiveStaff(): Promise<any> {
     throw new Error("Unauthorized");
 }
 
+/**
+ * assertActiveStaff without the throw. For readers that are not themselves
+ * estimate actions but embed estimates — they must not start rejecting callers
+ * they used to serve, they just have nobody to scope the embedded estimates
+ * against, which estimateScopeWhere() treats as "show none".
+ */
+async function currentStaffUserOrNull(): Promise<any | null> {
+    try {
+        return await assertActiveStaff();
+    } catch {
+        return null;
+    }
+}
+
 async function assertStaffPermission(permission: "estimates" | "invoices" | "changeOrders" | "financialReports" | "companySettings" | "contracts" | "manageVendors") {
     const user = await assertActiveStaff();
     if (!hasPermission(user, permission)) throw new Error("Forbidden");
@@ -4224,6 +4249,47 @@ function assertEstimateScope(user: any, scope: { projectId?: string | null; lead
         return;
     }
     if (!hasPermission(user, "leadAccess")) throw new Error("Forbidden");
+}
+
+/**
+ * The filter form of assertEstimateScope. The assertion above answers "may this
+ * user touch THIS estimate"; a list has to ask the same question of every row it
+ * is about to return, and it has to get the same answer — a list that shows rows
+ * whose detail page throws Forbidden is worse than either extreme.
+ *
+ * Every branch below is the mirror image of a branch in assertEstimateScope:
+ *   - ADMIN/MANAGER pass unconditionally there, so they get an empty (no-op) where.
+ *   - project-owned rows go through canAccessProject there, so here they are
+ *     restricted to accessibleProjectIds() — the set form of that same function.
+ *   - the leadAccess fallback is reached there ONLY when projectId is null, so
+ *     the OR branch carries `projectId: null` too. Without it a user holding
+ *     leadAccess would list another job's project-owned estimate and then be
+ *     refused on click-through.
+ *   - an ownerless estimate (no project, no lead) throws there, so it matches no
+ *     branch here and is filtered out — both directions fail closed.
+ * FINANCE is deliberately not exempt, same as in assertEstimateScope.
+ */
+const MATCHES_NO_ESTIMATE = { id: { in: [] as string[] } };
+
+function estimateScopeWhere(user: any | null | undefined) {
+    if (!user?.role) return MATCHES_NO_ESTIMATE;
+    const projectIds = accessibleProjectIds(user);
+    if (projectIds === "ALL") return {};
+
+    const branches: any[] = [];
+    if (projectIds.length > 0) branches.push({ projectId: { in: projectIds } });
+    if (hasPermission(user, "leadAccess")) branches.push({ projectId: null, leadId: { not: null } });
+    if (branches.length === 0) return MATCHES_NO_ESTIMATE;
+    return { OR: branches };
+}
+
+/**
+ * The nested-relation form. Prisma relation filters take the same where shape,
+ * so a lead/project getter that embeds estimates can reuse the predicate rather
+ * than growing its own copy of the rules.
+ */
+function scopedEstimateRelation<T extends object>(relation: T, user: any | null | undefined): T & { where: any } {
+    return { ...relation, where: estimateScopeWhere(user) };
 }
 
 /** Permission + scope for actions that reach estimates through a project id. */

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -3,25 +3,21 @@ import { getServerSession } from "next-auth/next";
 import { cookies } from "next/headers";
 import { authOptions } from "@/lib/auth";
 
-export type PermissionKey =
-    // Administrative
-    | "manageTeamMembers" | "manageSubs" | "manageVendors"
-    | "companySettings" | "costCodesCategories"
-    // Project screens
-    | "schedules" | "estimates" | "invoices" | "contracts"
-    | "roomDesigner" | "changeOrders" | "financialReports"
-    | "timeClock" | "dailyLogs" | "files" | "takeoffs"
-    // Leads
-    | "createLead" | "clientCommunication" | "leadAccess";
+// The pure rules live in access-rules.ts (no Prisma / next-auth / next-headers
+// imports) so they can be unit-tested for real. Re-exported here so every
+// existing `from "./permissions"` import keeps working unchanged.
+export {
+    ADMIN_ROLES,
+    isAdminOrManager,
+    hasPermission,
+    accessibleProjectIds,
+    canAccessProject,
+    canAccessEstimate,
+    estimateScopeWhere,
+} from "./access-rules";
+export type { PermissionKey, ProjectScopedUser, EstimateOwner } from "./access-rules";
 
-const ADMIN_ROLES = ["ADMIN", "MANAGER"];
-
-/** ADMIN_ROLES above is module-private — this is the exported check for
- * callers outside permissions.ts (e.g. decision-template-crud-core.ts's
- * "GTR admin" CRUD/override gate) instead of duplicating the role list. */
-export function isAdminOrManager(user: { role: string }): boolean {
-    return ADMIN_ROLES.includes(user.role);
-}
+import { hasPermission, type PermissionKey } from "./access-rules";
 
 /** Typed marker for the "Unauthorized" errors thrown by the portal access
  * assertions in actions.ts, so callers can detect an auth failure with
@@ -73,22 +69,6 @@ export async function getUserWithPermissionsByEmail(email: string) {
     return user?.status === "DISABLED" ? null : user;
 }
 
-// Check if user has a specific permission
-export function hasPermission(
-    user: { role: string; permissions?: any | null },
-    key: PermissionKey
-): boolean {
-    // Admins and Managers always have full access
-    if (ADMIN_ROLES.includes(user.role)) return true;
-
-    // If no permissions record, use defaults based on role
-    if (!user.permissions) {
-        return getDefaultPermission(user.role, key);
-    }
-
-    return !!user.permissions[key];
-}
-
 // All permission keys (single source of truth)
 export const ALL_PERMISSION_KEYS: PermissionKey[] = [
     // Administrative
@@ -112,40 +92,6 @@ export function getEffectivePermissions(
         result[key] = hasPermission(user, key);
     }
     return result;
-}
-
-type ProjectScopedUser = { role: string; projectAccess?: { projectId: string }[]; assignedProjects?: { id: string }[] };
-
-/**
- * The set form of canAccessProject: every project id this user may reach, or
- * "ALL" for the roles that pass unconditionally. Exists so a list query can be
- * filtered by exactly the same rule that canAccessProject() applies to a single
- * id — a second hand-rolled predicate is how a list and its detail page drift
- * apart. Invariant: canAccessProject(u, p) === (ids === "ALL" || ids.includes(p)).
- */
-export function accessibleProjectIds(user: ProjectScopedUser): string[] | "ALL" {
-    if (ADMIN_ROLES.includes(user.role)) return "ALL";
-    return Array.from(new Set([
-        ...(user.projectAccess ?? []).map(pa => pa.projectId),
-        ...(user.assignedProjects ?? []).map(p => p.id),
-    ]));
-}
-
-// Check if user can access a specific project
-export function canAccessProject(user: ProjectScopedUser, projectId: string): boolean {
-    const ids = accessibleProjectIds(user);
-    return ids === "ALL" || ids.includes(projectId);
-}
-
-// Default permissions by role (used when no UserPermission record exists)
-function getDefaultPermission(role: string, key: PermissionKey): boolean {
-    const defaults: Record<string, PermissionKey[]> = {
-        FIELD_CREW: ["schedules", "roomDesigner", "timeClock", "dailyLogs", "files", "costCodesCategories"],
-        FINANCE: ["estimates", "invoices", "financialReports", "timeClock", "changeOrders", "costCodesCategories"],
-        EMPLOYEE: ["schedules", "roomDesigner", "timeClock", "dailyLogs", "files", "costCodesCategories"],
-    };
-
-    return (defaults[role] || defaults.EMPLOYEE)?.includes(key) ?? false;
 }
 
 // Ensure a user has a permissions record (create with defaults if missing)

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -114,15 +114,27 @@ export function getEffectivePermissions(
     return result;
 }
 
+type ProjectScopedUser = { role: string; projectAccess?: { projectId: string }[]; assignedProjects?: { id: string }[] };
+
+/**
+ * The set form of canAccessProject: every project id this user may reach, or
+ * "ALL" for the roles that pass unconditionally. Exists so a list query can be
+ * filtered by exactly the same rule that canAccessProject() applies to a single
+ * id — a second hand-rolled predicate is how a list and its detail page drift
+ * apart. Invariant: canAccessProject(u, p) === (ids === "ALL" || ids.includes(p)).
+ */
+export function accessibleProjectIds(user: ProjectScopedUser): string[] | "ALL" {
+    if (ADMIN_ROLES.includes(user.role)) return "ALL";
+    return Array.from(new Set([
+        ...(user.projectAccess ?? []).map(pa => pa.projectId),
+        ...(user.assignedProjects ?? []).map(p => p.id),
+    ]));
+}
+
 // Check if user can access a specific project
-export function canAccessProject(
-    user: { role: string; projectAccess?: { projectId: string }[]; assignedProjects?: { id: string }[] },
-    projectId: string
-): boolean {
-    if (ADMIN_ROLES.includes(user.role)) return true;
-    if (user.projectAccess?.some(pa => pa.projectId === projectId)) return true;
-    if (user.assignedProjects?.some(p => p.id === projectId)) return true;
-    return false;
+export function canAccessProject(user: ProjectScopedUser, projectId: string): boolean {
+    const ids = accessibleProjectIds(user);
+    return ids === "ALL" || ids.includes(projectId);
 }
 
 // Default permissions by role (used when no UserPermission record exists)


### PR DESCRIPTION
Follow-up to #333, which scoped every id-addressed estimate action but deliberately left the readers alone. The result was the worst of both worlds: the list showed every estimate in the company, and the scoped detail page then threw Forbidden on click-through.

## What changed

`src/lib/access-rules.ts` (new, pure leaf module — no Prisma / next-auth / next-headers imports) now holds the one estimate scope rule in two forms:

- `canAccessEstimate(user, {projectId, leadId})` — the decision. `assertEstimateScope` delegates to it instead of re-deciding.
- `estimateScopeWhere(user)` — the same decision as a Prisma where-fragment, for lists.

Applied to `getAllEstimates`, the staff branch of `getEstimateForPortal` (the main query **and** its degraded fallback), and every nested estimates embed: `getLeads`, `getLead`, `getProjects`, `getProject`, `getClients`.

`permissions.ts` re-exports everything it moved, so no call site changed.

Product decision carried over from #333: **FINANCE is not exempt** from project scoping for estimates, unlike `assertFinancialProjectScope` which exempts it for company-wide financial reports.

## Codex review

Reviewed at xhigh; 3 of 4 findings fixed in the second commit:

1. **High** — the ADMIN/MANAGER branch returned an empty `where`, which admitted ownerless estimates (both ownership columns null) that `assertEstimateScope` rejects for *every* role. Same list-vs-detail disagreement this PR exists to remove. The `ALL` branch now still requires the row to be attached to a project or lead.
2. **Medium** — the first spec was source-grep only, so it would pass against a gutted predicate. That drove the move to a pure leaf module: `e2e/estimate-scope-rules.spec.ts` imports the real functions and runs a truth table of 8 users x 7 ownership shapes, asserting the filter and the assertion agree on every cell. Verified load-bearing — restoring finding 1 fails 3 of its tests.
3. **Medium** — `currentStaffUserOrNull` wrapped `assertActiveStaff` in a bare catch, so a Prisma or session failure would render as "no user" and therefore a page of plausible zeroes. It now resolves the user directly and returns null only on genuine absence.

## Known follow-up (not in this PR)

Two aggregates now compute from a filtered array while their surrounding UI still claims completeness: the `/projects` total-revenue stat ([ProjectsClient.tsx:184](src/app/projects/ProjectsClient.tsx:184)) lists every project row but sums only accessible ones, and the converted-lead estimate cards ([leads/[id]/estimates/page.tsx:28](src/app/leads/[id]/estimates/page.tsx:28)) do the same. The root cause is that the project list itself is unscoped — a product decision, tracked separately.

## Verification

- `npm run build` — 0 errors
- `financial-action-auth.spec.ts` + `estimate-scope-rules.spec.ts` — 13/13
- Mutation-tested both specs (gutting the predicate fails them)
- `/estimates`, `/projects`, `/leads`, `/settings/contacts` all 200 locally, no server errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)