### PR TITLE
docs(deploy): correct the auto-deploy and --archive=tgz claims in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,9 +53,9 @@ Sessions 1–2 + Gantt polish are complete. Each session lists specific files, a
 1. Pick next session from ProbuildTodo.md
 2. Make changes
 3. npm run build          # must pass 0 errors
-4. git push origin main
-5. Schema changed? Run the branch's scripts/apply-*.mjs against prod FIRST (see "Deploying to Vercel")
-6. vercel --prod --token $env:VERCEL_TOKEN   # deploy only when ready
+4. Schema changed? Run the branch's scripts/apply-*.mjs against prod NOW, before main moves (see "Deploying to Vercel")
+5. git push origin main   # auto-deploy is ON — this ships to prod
+6. Shipping ahead of a merge? vercel --prod --token $env:VERCEL_TOKEN
 7. Click through affected pages on prod to verify
 8. Mark items done in ProbuildTodo.md
 ```
@@ -74,17 +74,20 @@ stripe trigger payment_intent.succeeded
 ## Deploying to Vercel (manual CLI deploy — note auto-deploy also ships `main`)
 ```powershell
 # Production deploy (from the main repo dir, not a worktree):
-vercel --prod --token $env:VERCEL_TOKEN --yes --archive=tgz --cwd "C:\Users\jat00\workspaces\golden-touch\active\gtr-probuild-site"
+vercel --prod --token $env:VERCEL_TOKEN --yes --cwd "C:\Users\jat00\workspaces\golden-touch\active\gtr-probuild-site"
+# add --archive=tgz only as a fallback if the source upload stalls (see notes below)
 ```
+This builds a **new** production deployment. To make an existing staged deployment live instead, use `vercel promote <deployment-url>` — `--prod` does not re-promote.
 **Pre-deploy checklist (in order):**
 1. `npm run build` passes locally with 0 errors
 2. **Schema changed?** If the branch edits `prisma/schema.prisma` and ships a `scripts/apply-*.mjs`, run it against prod BEFORE deploying (`node scripts/apply-<name>.mjs`). These scripts are additive + idempotent (`IF NOT EXISTS`, guarded FKs) and safe while the old build is live — but the new build's Prisma client selects the new columns immediately, so any page querying them throws P2022 "column does not exist" until the script runs. (2026-07-20: the company-schedule deploy went out before `apply-company-schedule-schema.mjs` ran; project pages hit the route error boundary until it was applied.)
 3. Deploy with the command above, then click through the affected pages on prod
 
-- **Git auto-deploy is ON, despite older notes here.** It is not disabled anywhere: `vercel.json` holds only `crons` (no `git.deploymentEnabled`), and the project has no `deploymentEnabled` override, so Vercel's default `true` applies. Verified 2026-08-10 against the project API — every branch push builds a preview and every `main` merge auto-promotes to production
-- Consequence: **merging a PR ships it.** Do the pre-deploy checklist before merging, not just before running the CLI. The manual deploy below is for shipping ahead of a merge, or re-promoting
-- The $250 runaway-build bill came from frequent pushes. Nothing structural prevents a repeat — keep pushes deliberate. If you do want it off, it has to be set in the Vercel dashboard (Settings → Git) or added to `vercel.json`; and even then, dashboard redeploy/promote, Deploy Hooks, the REST API, and CI can all still ship
-- `--archive=tgz` is optional, not required — the upload is ~1,389 files (measured 2026-08-10), far under Vercel's 15,000-file cap. It bundles everything into one tarball, which negates per-file upload caching and can make repeat deploys slower. Reach for it only if an upload actually stalls
+- **Git auto-deploy is ON, despite older notes here.** It is not disabled in `vercel.json` (that file holds only `crons` — there is no `git.deploymentEnabled` key), and the project carries no `deploymentEnabled` override, so Vercel's default `true` applies. Verified 2026-08-10: recent production deployments off `main` report `source: "git"`, `readySubstate: "PROMOTED"`, and hold `probuild.goldentouchremodeling.com`. Branch pushes build previews the same way
+- Consequence: **merging a PR ships it live.** Run the pre-deploy checklist before merging, not just before running the CLI
+- To turn it off, set it in the Vercel dashboard (Settings → Git) or add `git.deploymentEnabled` to `vercel.json` — it is not currently set in either. Note that disabling Git deploys still leaves dashboard redeploy/promote, Deploy Hooks, the REST API, and CI able to ship
+- No checked-in config throttles build volume (no `ignoreCommand`, no Ignored Build Step in the repo); dashboard/team spend controls were not checked. An older note attributes a ~$250 bill to frequent builds, so keep pushes deliberate
+- `--archive=tgz` is **optional, not required** — with the current `.vercelignore` the CLI source upload measures ~1,389 files (2026-08-10), far under Vercel's 15,000-file cap. That cap counts uploaded source files, not build output. Archive mode bundles everything into one tarball, which negates per-file upload caching and can make repeat deploys slower, so add it only if an upload actually stalls
 - `--cwd` points to the main repo — deploy from there, not from worktrees (worktrees lack the `.vercel` link)
 - Only deploy when changes are verified locally via `npm run build`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@
 ## Stack
 - Next.js 16 (App Router, Server Components, Server Actions), npm, Prisma 5, Tailwind
 - Supabase (PostgreSQL, auth, storage) — project ref: `ghzdbzdnwjxazvmcefbh`
-- Auto-deploy is **disabled**. Deploy manually via `vercel --prod`
+- Auto-deploy is **ON** — pushes build previews, merges to `main` ship to prod. See "Deploying to Vercel"
 
 ## Room Studio (3D room designer)
 - Lives in `src/components/studio/` + `src/lib/studio/` (react-three-fiber). The legacy `room-designer` modules are gone — don't recreate them.
@@ -71,7 +71,7 @@ stripe listen --forward-to localhost:3000/api/webhooks/stripe --output json
 stripe trigger payment_intent.succeeded
 ```
 
-## Deploying to Vercel (CLI only — auto-deploy is OFF)
+## Deploying to Vercel (manual CLI deploy — note auto-deploy also ships `main`)
 ```powershell
 # Production deploy (from the main repo dir, not a worktree):
 vercel --prod --token $env:VERCEL_TOKEN --yes --archive=tgz --cwd "C:\Users\jat00\workspaces\golden-touch\active\gtr-probuild-site"
@@ -81,11 +81,12 @@ vercel --prod --token $env:VERCEL_TOKEN --yes --archive=tgz --cwd "C:\Users\jat0
 2. **Schema changed?** If the branch edits `prisma/schema.prisma` and ships a `scripts/apply-*.mjs`, run it against prod BEFORE deploying (`node scripts/apply-<name>.mjs`). These scripts are additive + idempotent (`IF NOT EXISTS`, guarded FKs) and safe while the old build is live — but the new build's Prisma client selects the new columns immediately, so any page querying them throws P2022 "column does not exist" until the script runs. (2026-07-20: the company-schedule deploy went out before `apply-company-schedule-schema.mjs` ran; project pages hit the route error boundary until it was applied.)
 3. Deploy with the command above, then click through the affected pages on prod
 
-- Auto-deploy was disabled in `vercel.json` to avoid runaway build costs ($250 bill from frequent pushes)
-- `--archive=tgz` is required — project exceeds Vercel's 15,000-file limit without it
+- **Git auto-deploy is ON, despite older notes here.** It is not disabled anywhere: `vercel.json` holds only `crons` (no `git.deploymentEnabled`), and the project has no `deploymentEnabled` override, so Vercel's default `true` applies. Verified 2026-08-10 against the project API — every branch push builds a preview and every `main` merge auto-promotes to production
+- Consequence: **merging a PR ships it.** Do the pre-deploy checklist before merging, not just before running the CLI. The manual deploy below is for shipping ahead of a merge, or re-promoting
+- The $250 runaway-build bill came from frequent pushes. Nothing structural prevents a repeat — keep pushes deliberate. If you do want it off, it has to be set in the Vercel dashboard (Settings → Git) or added to `vercel.json`; and even then, dashboard redeploy/promote, Deploy Hooks, the REST API, and CI can all still ship
+- `--archive=tgz` is optional, not required — the upload is ~1,389 files (measured 2026-08-10), far under Vercel's 15,000-file cap. It bundles everything into one tarball, which negates per-file upload caching and can make repeat deploys slower. Reach for it only if an upload actually stalls
 - `--cwd` points to the main repo — deploy from there, not from worktrees (worktrees lack the `.vercel` link)
 - Only deploy when changes are verified locally via `npm run build`
-- Do NOT re-enable auto-deploy in vercel.json or the Vercel dashboard
 
 ## E2E testing — never against the live DB
 See **docs/TESTING.md**. E2E creates leads/estimates/invoices, so:

--- a/ProbuildTodo.md
+++ b/ProbuildTodo.md
@@ -59,7 +59,7 @@ Built: estimate gen, schedule gen, punchlist, daily-log enhance, mood boards, le
 ---
 
 ### Standing rules (unchanged)
-- Build must pass with 0 errors before push; deploy manually via `vercel --prod` from the canonical checkout
+- Build must pass with 0 errors before push — auto-deploy is ON, so pushing/merging `main` ships to prod (see CLAUDE.md "Deploying to Vercel"). `vercel --prod` from the canonical checkout is for shipping ahead of a merge
 - Schema changes via the PowerShell SQL script, then `prisma generate` from PowerShell
 - Money-path changes: codex review + `e2e/money-pipeline.spec.ts` green
 - Every feature answers: which remodeling role does this serve, and what can AI automate?


### PR DESCRIPTION
Fixes the two pre-existing inaccuracies Codex flagged during #340, which were deliberately left out of scope there.

## 1. Auto-deploy — the doc was wrong twice over

CLAUDE.md said *"Auto-deploy was disabled in `vercel.json`"*. Two problems:

- **Wrong location.** `vercel.json` contains only a `crons` array. There is no `git.deploymentEnabled` key, and the Vercel project carries no `deploymentEnabled` override either, so Vercel's documented default (`true`) applies.
- **Wrong fact.** Auto-deploy is not disabled *anywhere*. It is ON.

Codex correctly pushed back on my first pass here: `meta.githubDeployment` is not proof of provenance (Vercel documents setting it manually on CLI deploys), and a production-target build can be staged rather than live. So I re-checked via the v13 deployment endpoint, which exposes the authoritative `source` field:

```
2026-08-10T17:41 | source=cli | PROMOTED | ref=HEAD | prodDomain=YES
2026-08-10T17:40 | source=git | PROMOTED | ref=main | prodDomain=YES
2026-08-10T17:14 | source=git | PROMOTED | ref=main | prodDomain=YES
2026-08-09T23:49 | source=git | PROMOTED | ref=main | prodDomain=YES
```

`source=git` + `PROMOTED` + holding `probuild.goldentouchremodeling.com` settles it: **merging a PR ships it live.**

The knock-on fix matters more than the wording. The dev workflow said *push `main` (step 4), then apply the prod schema script (step 5)*. With auto-deploy on, that ordering races the exact P2022 "column does not exist" outage the checklist itself warns about. Reordered so the schema script runs before `main` moves.

Also recorded: turning Git auto-deploy off would still leave dashboard redeploy/promote, Deploy Hooks, the REST API, and CI able to ship.

## 2. `--archive=tgz` was not required

The doc claimed the project *"exceeds Vercel's 15,000-file limit"*. Walking the tree under the current `.vercelignore` gives **1,389 files** — an order of magnitude under the cap. (A naive walk counts 5,485, but that includes `.git`, which the CLI excludes.)

Tested rather than assumed: deployed to production **without** the flag.

```
Production: https://probuild-6m1sb62mw-...vercel.app
readyState READY, PROMOTED, holding probuild.goldentouchremodeling.com
real  2m30s
```

Prod verified after: `/login` 200 and renders, `/` 307 as expected. Flag demoted from required to a stall fallback, and removed from the canonical command — leaving it there while calling it optional would have archived every deploy anyway.

## Scope notes

- Leaves the `--token` lines alone; #340 owns those. Both PRs touch the same bullet block, so expect a small conflict on whichever merges second.
- Fixed the matching standing rule in `ProbuildTodo.md`.
- The dated `SESSION-HANDOFF-*` docs still say auto-deploy is off. Left as-is — they are point-in-time records, not active instructions.

## Open question for you

This corrects the doc to match reality. It does not decide whether reality is what you want. Auto-deploy being on is why a merge can ship without anyone running the checklist, and it is the same exposure behind the $250 build bill. Worth deciding separately whether to actually turn it off in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)