### PR TITLE
docs(deploy): fix the token-rotation snippet that echoes the token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,13 +80,14 @@ vercel --prod --yes --cwd "C:\Users\jat00\workspaces\golden-touch\active\gtr-pro
 This builds a **new** production deployment. To make an existing staged deployment live instead, use `vercel promote <deployment-url>` — `--prod` does not re-promote.
 
 > **NEVER pass `--token` to any `vercel` command.** On success the CLI prints a "next steps"
-> block that replays your whole command line back, token value and all — straight into the
-> terminal and the session transcript. That has leaked the production token at least twice
-> (PR-209, and again 2026-08-09), each time forcing a rotation. The flag is unnecessary: the CLI
+> block that reconstructs follow-up commands for you, copying your global flags through verbatim —
+> so the token value lands straight in the terminal and the session transcript. That has leaked the
+> production token **three times** (PR-209, 2026-08-09, and again 2026-08-10), each time forcing a
+> rotation. The flag is unnecessary: the CLI
 > already authenticates on its own. Precedence is `--token` → a **non-empty** `VERCEL_TOKEN` in the
 > environment → the persisted login at `%APPDATA%\com.vercel.cli\Data\auth.json` (from
 > `vercel login`). The latter two are read silently and never echoed. This applies to every
-> subcommand (`deploy`, `env`, `logs`, `inspect`), not just `--prod`.
+> *authenticating* subcommand (`deploy`, `env`, `logs`, `inspect`), not just `--prod`.
 >
 > A stale `VERCEL_TOKEN` fails every *authenticated* command with *"The token provided via
 > VERCEL_TOKEN environment variable is not valid"* — an invalid explicit credential does **not**
@@ -97,8 +98,18 @@ This builds a **new** production deployment. To make an existing staged deployme
 > is the same leak class this rule exists to prevent: it lands the secret in argv, shell history,
 > and any agent transcript. Justin sets it himself, in his own terminal, one of these two ways:
 > - Windows GUI: Settings → *Edit environment variables for your account* → edit `VERCEL_TOKEN`.
-> - PowerShell, value read from a prompt rather than argv:
->   `[Environment]::SetEnvironmentVariable('VERCEL_TOKEN', (Read-Host 'Paste token'), 'User')`
+> - PowerShell, value read from a prompt rather than argv. It **must** be `-AsSecureString`: a bare
+>   `Read-Host` echoes the pasted token to the screen and into terminal scrollback, and PowerShell
+>   5.1 (this machine) has no `-MaskInput`.
+>   ```powershell
+>   $s = Read-Host 'Paste token' -AsSecureString
+>   $b = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($s)
+>   try {
+>     [Environment]::SetEnvironmentVariable('VERCEL_TOKEN', [Runtime.InteropServices.Marshal]::PtrToStringBSTR($b), 'User')
+>   } finally {
+>     [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($b)
+>   }
+>   ```
 >
 > Either way it only affects **new** shells, and is Windows-only — WSL needs its own copy. Confirm
 > in a fresh shell with `vercel whoami`. Claude must never be given the token value.
@@ -202,7 +213,7 @@ If a feature doesn't map to a real workflow step for a real role (estimator, PM,
 - **Run parallel sub-agents** for independent work (e.g. building 3 report pages simultaneously in separate agents)
 - **Don't re-read large files** — if you already know the structure, reference it. GanttChart.tsx is 17k tokens — don't read it unless editing it.
 - **Batch tool calls** — make independent reads/greps/globs in parallel, not sequential
-- **Auth is already configured** — gh (keyring), vercel ($VERCEL_TOKEN), supabase ($SUPABASE_ACCESS_TOKEN), stripe ($STRIPE_API_KEY), sentry ($SENTRY_AUTH_TOKEN). Don't re-authenticate or verify credentials unless something fails.
+- **Auth is already configured** — gh (keyring), vercel ($VERCEL_TOKEN), supabase ($SUPABASE_ACCESS_TOKEN), stripe ($STRIPE_API_KEY), sentry ($SENTRY_AUTH_TOKEN). Don't re-authenticate or verify credentials unless something fails. **One exception:** run `vercel whoami` before a production deploy — a stale `VERCEL_TOKEN` fails mid-deploy and does not fall back to the persisted login, so checking first is cheaper than a half-shipped release.
 
 ## Dead buttons / unlinked UI
 - While working on any page, audit all buttons, links, and nav items for dead ends

--- a/FIX_PORTALPAYBUTTON_TOTAL.md
+++ b/FIX_PORTALPAYBUTTON_TOTAL.md
@@ -90,8 +90,8 @@ export const stripe = new Stripe(stripeKey, {
 **Also:** Sync the Preview `STRIPE_SECRET_KEY` with Production if the key was rotated:
 
 ```bash
-vercel env rm STRIPE_SECRET_KEY preview --token $VERCEL_TOKEN
-vercel env add STRIPE_SECRET_KEY preview --token $VERCEL_TOKEN
+vercel env rm STRIPE_SECRET_KEY preview
+vercel env add STRIPE_SECRET_KEY preview
 ```
 
 ## Verification
@@ -100,4 +100,4 @@ vercel env add STRIPE_SECRET_KEY preview --token $VERCEL_TOKEN
 2. `npm run build`
 3. Push to main
 4. Open estimate portal → Pay Now → should redirect to Stripe Checkout without connection error
-5. If error persists, check Vercel function logs: `vercel logs --token $VERCEL_TOKEN`
+5. If error persists, check Vercel function logs: `vercel logs` (never pass `--token` — the CLI echoes it back; see CLAUDE.md)


### PR DESCRIPTION
#340 landed the `--token` rule while this branch was in flight. Rebased, so this is now just the delta on top of it — three findings, one of them a live leak.

## Blocker: the rotation procedure itself echoes the token

#340 documents rotation as:

```powershell
[Environment]::SetEnvironmentVariable('VERCEL_TOKEN', (Read-Host 'Paste token'), 'User')
```

A bare `Read-Host` echoes the pasted value to the screen and into terminal scrollback. That's the same class of exposure the rule exists to prevent — smaller blast radius than argv, but it's still the secret rendered in a place that gets screenshotted, scrolled back through, and screen-shared.

Windows PowerShell 5.1 (this machine — confirmed `5.1.26100.8972`) has no `-MaskInput`, so the fix is `-AsSecureString` with a BSTR marshal zeroed in `finally`.

## Also

- **Leak count is three, not "at least twice."** `VERCEL_TOKEN` died again today — `GET /v2/user` returns 403 `invalidToken`. That's PR-209, 2026-08-09, and 2026-08-10.
- **"Replays your whole command line" overstates the mechanism.** The CLI reconstructs follow-up commands and copies your global flags through verbatim. Same leak, but the imprecision invites someone to test the literal claim, see it not happen that way, and conclude the whole rule is folklore.
- **"Every subcommand" → every *authenticating* subcommand.** Local-only commands never authenticate.
- **`vercel whoami` preflight vs. the efficiency rule.** CLAUDE.md's "don't re-authenticate or verify credentials unless something fails" directly contradicted #340's advice to verify with `whoami`. Carved out an explicit exception.
- **`FIX_PORTALPAYBUTTON_TOTAL.md`** still carried three `--token` commands. #340 didn't cover it.

## Correction to the ticket's premise

The report said the CLI "still works — it falls back to the persisted login." It does **not**:

```
> vercel whoami
Error: The token provided via VERCEL_TOKEN environment variable is not valid.
```

A non-empty but invalid `VERCEL_TOKEN` poisons the CLI too — an invalid explicit credential doesn't fall back to `auth.json`. So production deploys are blocked right now, not just API scripts. (#340 documents this correctly; flagging it because the ticket's framing would lead someone to think deploys were fine.)

## Not in this PR

- **The rotation itself.** Minting needs the Vercel dashboard, and per the runbook Justin sets the value himself — Claude is never given it. Still outstanding.
- **`.claude/skills/deploy-probuild/SKILL.md`** is gitignored, so its fixes can't ship here. Applied locally: same `-AsSecureString` fix, plus two claims #342 corrected in CLAUDE.md but not there (auto-deploy is ON, `--archive=tgz` is optional). Its frontmatter still advertised "Auto-deploy is off" to every agent that loads it. Each worktree keeps its own copy, so the other worktrees are still stale.
- **`docs/FIELD-APP-HANDOFF.md`** has the same pattern but lives on the unrelated `feat/unified-money-register` WIP branch.

## A gap this surfaced

The `PreToolUse` guard hook blocked the first attempt to open this PR — it matched the example command quoted in the PR body. Right instinct, wrong target: it inspects any Bash call mentioning `vercel`, not just executions. Worth narrowing.

## Review

Codex (`gpt-5.6-sol`, xhigh), 2 rounds. Round 1 raised the `Read-Host` echo and the `whoami` contradiction as blockers — both fixed. Round 2: CLEAN, and it verified the marshal snippet against PowerShell 5.1 semantics.

Docs-only; no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
