### PR TITLE
fix(security): authorize lead conversion and document-template CRUD

### DIFF
--- a/e2e/financial-action-auth.spec.ts
+++ b/e2e/financial-action-auth.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { canWriteDocumentTemplateType } from "../src/lib/access-rules";
 
 function exportSource(source: string, name: string): string {
   const marker = new RegExp(`export\\s+(?:async function|const)\\s+${name}\\b`);
@@ -10,6 +11,17 @@ function exportSource(source: string, name: string): string {
   const remainder = source.slice(start + match![0].length);
   const next = /\nexport\s+(?:async function|const)\s+/.exec(remainder);
   return source.slice(start, next ? start + match![0].length + next.index : undefined);
+}
+
+// Comments are not code. `expectGuardBeforeDatabase` matches with indexOf, so a
+// guard that has been commented out — or a comment that merely quotes the guard
+// it is describing — would satisfy a textual assertion while authorizing
+// nobody. Blank the comments out (preserving newlines and length so any offset
+// comparison still lines up with the real source) before asserting.
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, " "))
+    .replace(/(^|[^:])\/\/[^\n]*/g, (m, lead) => lead + " ".repeat(m.length - lead.length));
 }
 
 function expectGuardBeforeDatabase(source: string, actionName: string, guard: string) {
@@ -246,6 +258,195 @@ test("estimate readers filter by the same scope the detail page asserts", () => 
   expect(resolverStart, "currentStaffUserOrNull must exist").toBeGreaterThanOrEqual(0);
   const resolver = source.slice(resolverStart, source.indexOf("async function assertActiveStaff("));
   expect(resolver, "currentStaffUserOrNull must not catch and flatten errors").not.toContain("catch");
+});
+test("document template CRUD authorizes reads and writes", () => {
+  const source = stripComments(readFileSync(join(process.cwd(), "src/lib/actions.ts"), "utf8"));
+
+  // These templates hold the terms & conditions snapshotted onto estimates and
+  // contracts when they are sent, so an unauthenticated write edits the legal
+  // text on future client-facing documents. Company-wide, hence no per-project
+  // scope — but never open.
+  for (const name of ["getDocumentTemplates", "getDocumentTemplate"]) {
+    expectGuardBeforeDatabase(source, name, "await assertDocumentTemplateReadAccess(");
+  }
+  for (const name of ["createDocumentTemplate", "updateDocumentTemplate", "deleteDocumentTemplate"]) {
+    expectGuardBeforeDatabase(source, name, "await assertDocumentTemplateWritePermission(");
+  }
+
+  // The permission alone is not the whole write gate: `estimates` is accepted
+  // so estimators can author terms/overview/notes, so every write must ALSO
+  // scope the type or an estimates-only user (the FINANCE default) could
+  // rewrite contract and lien-release language.
+  for (const name of ["createDocumentTemplate", "updateDocumentTemplate", "deleteDocumentTemplate"]) {
+    expect(exportSource(source, name), `${name} must scope the template type`)
+      .toContain("assertDocumentTemplateTypeScope(");
+  }
+
+  // Ordering: EVERY scope call must precede the write, so the last one is the
+  // one to compare — checking only the first would let a retype check drift
+  // below the mutation and still pass.
+  {
+    const create = exportSource(source, "createDocumentTemplate");
+    expect(create.lastIndexOf("assertDocumentTemplateTypeScope("), "type scope must precede the create")
+      .toBeLessThan(create.indexOf("prisma.documentTemplate."));
+  }
+  {
+    const update = exportSource(source, "updateDocumentTemplate");
+    expect(update, "updateDocumentTemplate must scope the row's existing type")
+      .toContain("assertDocumentTemplateTypeScope(user, existing.type)");
+    expect(update, "updateDocumentTemplate must scope an incoming retype")
+      .toContain("assertDocumentTemplateTypeScope(user, data.type)");
+    expect(update.lastIndexOf("assertDocumentTemplateTypeScope("), "every type scope must precede the write")
+      .toBeLessThan(update.indexOf("tx.documentTemplate.updateMany("));
+    // The authorized type must be re-asserted by the write itself — a
+    // concurrent retype must not hand this caller a protected row.
+    expect(update, "the update must pin the authorized type in its own filter")
+      .toContain("where: { id, type: existing.type }");
+    expect(update, "a lost type pin must refuse, not silently no-op")
+      .toMatch(/claimed\.count === 0[\s\S]{0,80}throw new Error/);
+  }
+  {
+    const del = exportSource(source, "deleteDocumentTemplate");
+    expect(del.lastIndexOf("assertDocumentTemplateTypeScope("), "type scope must precede the delete")
+      .toBeLessThan(del.indexOf("prisma.documentTemplate.deleteMany("));
+    expect(del, "the delete must pin the authorized type in its own filter")
+      .toContain("where: { id, type: existing.type }");
+    expect(del, "a lost type pin must refuse, not silently no-op")
+      .toMatch(/removed\.count === 0[\s\S]{0,80}throw new Error/);
+  }
+
+  // The scope helper must actually delegate to the real predicate and throw.
+  const scopeStart = source.indexOf("function assertDocumentTemplateTypeScope(");
+  expect(scopeStart, "assertDocumentTemplateTypeScope must exist").toBeGreaterThanOrEqual(0);
+  const scopeBody = source.slice(scopeStart, scopeStart + 300);
+  expect(scopeBody).toContain("canWriteDocumentTemplateType(user, type)");
+  expect(scopeBody).toContain("throw new Error");
+
+  // The helpers must keep doing the work — otherwise the assertions above pass
+  // against a gutted no-op.
+  const helperBodies: Record<string, string[]> = {
+    assertDocumentTemplateReadAccess: [
+      "await assertActiveStaff()", 'hasPermission(user, "estimates")',
+      'hasPermission(user, "contracts")', 'hasPermission(user, "companySettings")', "throw new Error",
+    ],
+    assertDocumentTemplateWritePermission: [
+      "await assertActiveStaff()", 'hasPermission(user, "companySettings")',
+      'hasPermission(user, "estimates")', "throw new Error",
+    ],
+  };
+  for (const [helper, required] of Object.entries(helperBodies)) {
+    const start = source.indexOf(`function ${helper}(`);
+    expect(start, `${helper} must exist`).toBeGreaterThanOrEqual(0);
+    const nextFn = /\nasync function |\nfunction |\nexport /.exec(source.slice(start + helper.length));
+    const body = source.slice(start, nextFn ? start + helper.length + nextFn.index : undefined);
+    for (const needle of required) {
+      expect(body, `${helper} must still contain ${needle}`).toContain(needle);
+    }
+  }
+
+  // Field crew have none of the three permissions, and the /templates hub is a
+  // plain nav page for any staffer — its count read must stay fail-soft rather
+  // than throwing them into the route error boundary.
+  const hub = readFileSync(join(process.cwd(), "src/app/templates/page.tsx"), "utf8");
+  expect(hub, "the templates hub must tolerate a forbidden template read")
+    .toMatch(/getDocumentTemplates\(\)\.catch\(/);
+});
+
+// Most of this file can only assert that guard TEXT is present in the right
+// order — invert a condition inside a helper and every string match still
+// passes. The template type rule lives in access-rules.ts (pure, no Prisma or
+// next-auth) precisely so this one can be executed against real decisions.
+test("document template type scope is enforced, not merely present", () => {
+  const u = (role: string, permissions: any = null) => ({ role, permissions });
+  const ESTIMATOR_TYPES = ["terms", "overview", "notes"];
+  const PROTECTED_TYPES = ["contract", "lien_release", "warranty", "addendum", "disclaimer", "change_order", "draw_request", "punch_list"];
+
+  for (const type of [...ESTIMATOR_TYPES, ...PROTECTED_TYPES]) {
+    // companySettings owns the whole library; ADMIN/MANAGER hold every key.
+    expect(canWriteDocumentTemplateType(u("ADMIN"), type), `ADMIN must write ${type}`).toBe(true);
+    expect(canWriteDocumentTemplateType(u("MANAGER"), type), `MANAGER must write ${type}`).toBe(true);
+    expect(canWriteDocumentTemplateType(u("FINANCE", { companySettings: true }), type)).toBe(true);
+    // No relevant permission at all is always a refusal.
+    expect(canWriteDocumentTemplateType(u("FIELD_CREW"), type), `FIELD_CREW must not write ${type}`).toBe(false);
+    expect(canWriteDocumentTemplateType(u("EMPLOYEE"), type), `EMPLOYEE must not write ${type}`).toBe(false);
+  }
+
+  // FINANCE defaults to estimates-without-companySettings — the exact role this
+  // scope exists to contain, asserted against the real default table.
+  for (const type of ESTIMATOR_TYPES) {
+    expect(canWriteDocumentTemplateType(u("FINANCE"), type), `FINANCE may author ${type}`).toBe(true);
+  }
+  for (const type of PROTECTED_TYPES) {
+    expect(canWriteDocumentTemplateType(u("FINANCE"), type), `FINANCE must NOT rewrite ${type}`).toBe(false);
+  }
+
+  // An explicit grant behaves the same as the role default, in both directions.
+  expect(canWriteDocumentTemplateType(u("FIELD_CREW", { estimates: true }), "terms")).toBe(true);
+  expect(canWriteDocumentTemplateType(u("FIELD_CREW", { estimates: true }), "contract")).toBe(false);
+  expect(canWriteDocumentTemplateType(u("FINANCE", { estimates: false }), "terms")).toBe(false);
+
+  // Malformed and near-miss types fail closed rather than matching loosely.
+  for (const bad of [null, undefined, "", "TERMS", "terms ", "unknown_type"]) {
+    expect(canWriteDocumentTemplateType(u("FINANCE"), bad as any), `must fail closed on ${JSON.stringify(bad)}`).toBe(false);
+  }
+});
+
+test("lead → project conversion is gated for staff and session-free for pre-authorized callers", () => {
+  const source = stripComments(readFileSync(join(process.cwd(), "src/lib/actions.ts"), "utf8"));
+  const core = stripComments(readFileSync(join(process.cwd(), "src/lib/lead-conversion-core.ts"), "utf8"));
+
+  // The conversion moves every estimate off a lead and onto a brand new
+  // project, so the exported Server Action must authorize before it runs, and
+  // the unguarded body must live in a module that is not itself a remotely
+  // invokable endpoint.
+  const action = exportSource(source, "convertLeadToProject");
+  const authIndex = action.indexOf("await assertActiveStaff()");
+  // The whole conditional, not just the call: a bare `hasPermission(...)` whose
+  // result is discarded reads like a guard and enforces nothing.
+  const permIndex = action.search(/if \(!hasPermission\(user, "leadAccess"\)\) throw new Error\(/);
+  const coreIndex = action.indexOf("convertLeadToProjectCore(leadId)");
+  expect(authIndex, "convertLeadToProject must authenticate").toBeGreaterThanOrEqual(0);
+  expect(permIndex, "convertLeadToProject must throw when leadAccess is missing").toBeGreaterThanOrEqual(0);
+  expect(coreIndex, "convertLeadToProject must delegate to the core").toBeGreaterThanOrEqual(0);
+  expect(authIndex, "authentication must precede the conversion").toBeLessThan(coreIndex);
+  expect(permIndex, "the permission check must precede the conversion").toBeLessThan(coreIndex);
+  expect(action, "the exported action must not carry the conversion body itself")
+    .not.toContain("prisma.$transaction");
+
+  expect(core, "the core must exist").toContain("export async function convertLeadToProjectCore(");
+  // Either quote spelling turns this file into a server-action module and would
+  // re-expose the unguarded body as a remote endpoint.
+  expect(core, "the core must not be a server-action module").not.toMatch(/^\s*(['"])use server\1/m);
+  expect(core, "the core must still perform the conversion").toContain("prisma.$transaction");
+
+  // Portal approval already proved client ownership via resolveSessionClientId,
+  // and a portal client is not staff — it must call the core, not the gate.
+  const postApproval = source.slice(source.indexOf("async function ensureProjectAndDepositInvoiceForEstimate("));
+  const postApprovalBody = postApproval.slice(0, postApproval.indexOf("\nexport "));
+  expect(postApprovalBody, "portal approval must use the session-free core")
+    .toContain("convertLeadToProjectCore(estimate.leadId)");
+
+  // approveEstimate's own ownership check must survive untouched.
+  const approve = exportSource(source, "approveEstimate");
+  expect(approve, "approveEstimate must still resolve the portal client").toContain("resolveSessionClientId(");
+
+  // createProject builds a Client and a Lead before converting — it cannot be
+  // left open either.
+  expectGuardBeforeDatabase(source, "createProject", "await assertActiveStaff(");
+
+  // /api/manager/jobs authenticates a mobile token OR a session and then runs
+  // assertLeadAccess; a mobile-token caller has no NextAuth staff session, so it
+  // must go through the core with its own gate intact.
+  const jobsRoute = stripComments(readFileSync(join(process.cwd(), "src/app/api/manager/jobs/route.ts"), "utf8"));
+  const routeAccess = jobsRoute.indexOf("await assertLeadAccess(user, leadId)");
+  const routeConvert = jobsRoute.indexOf("convertLeadToProjectCore(leadId)");
+  expect(routeConvert, "the manager jobs route must use the core").toBeGreaterThanOrEqual(0);
+  expect(routeAccess, "the manager jobs route must keep its own lead-access check").toBeGreaterThanOrEqual(0);
+  expect(routeAccess, "lead access must be checked before the conversion runs").toBeLessThan(routeConvert);
+  // assertLeadAccess RETURNS the denial rather than throwing, so ignoring the
+  // return value would leave the check decorative.
+  expect(jobsRoute, "the manager jobs route must return the lead-access denial")
+    .toMatch(/const accessError = await assertLeadAccess\(user, leadId\);[\s\S]{0,120}if \(accessError\) return accessError;/);
 });
 
 test("dual-auth financial actions keep explicit portal or machine authorization", () => {

--- a/src/app/api/manager/jobs/route.ts
+++ b/src/app/api/manager/jobs/route.ts
@@ -162,10 +162,14 @@ export async function POST(req: Request) {
             );
         }
 
-        const { convertLeadToProject } = await import("@/lib/actions");
+        // The session-free core, not the actions.ts server action: this route
+        // authenticates a mobile token OR a web session and then runs
+        // assertLeadAccess above, and the action's gate assumes a NextAuth staff
+        // session — which a mobile-token caller does not have.
+        const { convertLeadToProjectCore } = await import("@/lib/lead-conversion-core");
         let projectId: string;
         try {
-            const result = await convertLeadToProject(leadId);
+            const result = await convertLeadToProjectCore(leadId);
             projectId = result.id;
         } catch (e: any) {
             // Two concurrent requests can both pass the precheck above; the loser

--- a/src/app/templates/page.tsx
+++ b/src/app/templates/page.tsx
@@ -9,7 +9,11 @@ export default async function TemplatesHubPage() {
     const session = await getSessionOrDev();
     if (!session?.user) return redirect("/login");
 
-    const docTemplates = await getDocumentTemplates();
+    // Same fail-soft treatment as the selections count below: this hub is a nav
+    // page for any signed-in staffer, but reading document templates now needs
+    // estimates/contracts/companySettings — a field-crew visitor still gets the
+    // card, just without a count, instead of the route error boundary.
+    const docTemplates = await getDocumentTemplates().catch(() => [] as { id: string }[]);
     // Decision Templates are ADMIN/MANAGER-only (see /templates/selections'
     // own server gate) — a non-admin staffer viewing this hub still sees the
     // card (clicking it redirects them back here), just without a count.

--- a/src/lib/access-rules.ts
+++ b/src/lib/access-rules.ts
@@ -133,3 +133,26 @@ export function estimateScopeWhere(user: ProjectScopedUser | null | undefined): 
     if (branches.length === 0) return MATCHES_NO_ESTIMATE;
     return { OR: branches };
 }
+
+/**
+ * Which document-template TYPES a caller may write.
+ *
+ * Document templates hold the terms, contract, lien-release, warranty and
+ * disclaimer language snapshotted onto client-facing documents when they are
+ * sent. `companySettings` owns the whole library. `estimates` is also accepted
+ * for writes, but only for the types an estimator's own screens author (the
+ * estimate editor's "save as template" and the /estimates Terms & Conditions
+ * tab) — /company/templates offers a full type selector, so an unscoped
+ * `estimates` grant would let an estimates-only user, which is the FINANCE
+ * default, rewrite contract and lien-release language.
+ */
+export const ESTIMATOR_WRITABLE_TEMPLATE_TYPES = ["terms", "overview", "notes"] as const;
+
+export function canWriteDocumentTemplateType(
+    user: { role: string; permissions?: any | null },
+    type: string | null | undefined
+): boolean {
+    if (hasPermission(user, "companySettings")) return true;
+    if (!hasPermission(user, "estimates")) return false;
+    return !!type && (ESTIMATOR_WRITABLE_TEMPLATE_TYPES as readonly string[]).includes(type);
+}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -20,7 +20,7 @@ import { isHttpUrl } from "./url-safety";
 // estimate-item-upsert.ts, which is now its only caller on the save path.
 import { selectedBillableRows } from "./estimate-item-payload";
 import { LEGACY_MARKUP_MARGIN_PCT, roundMoney, sellFromMargin } from "./budget-math";
-import { canUseDevAuthFallback, getCurrentUserWithPermissions, getUserWithPermissionsByEmail, hasPermission, canAccessProject, canAccessEstimate, estimateScopeWhere, PortalAuthError } from "./permissions";
+import { canUseDevAuthFallback, getCurrentUserWithPermissions, getUserWithPermissionsByEmail, hasPermission, canAccessProject, canAccessEstimate, estimateScopeWhere, canWriteDocumentTemplateType, PortalAuthError } from "./permissions";
 import { logActivity } from "./activity-log";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { upsertEstimateItems, assertEstimateItemParentsInScope, EstimateStaleSaveError } from "./estimate-item-upsert";
@@ -107,7 +107,7 @@ import {
     type CreateScheduleTaskInput,
     type UpdateScheduleTaskInput,
 } from "./schedule-task-core";
-import { ensureStandardFolders } from "./project-folders";
+import { convertLeadToProjectCore } from "./lead-conversion-core";
 import { createDailyLogCore } from "./daily-log-core";
 import { normalizeSelectionItemNote } from "./selection-item-notes";
 // Import the -core module, not the "server-only" wrapper: actions.ts is in the
@@ -1152,99 +1152,21 @@ export const getProject = cache(async function getProject(id: string) {
     return project ? JSON.parse(JSON.stringify(project)) : null;
 });
 
+// Staff entry point for lead → project conversion. The conversion itself moves
+// every estimate, contract, schedule task and file off the lead and onto a brand
+// new project, so as a remotely invokable Server Action it must not run for an
+// unauthenticated caller. Mirrors the /leads/[id] layout gate (`leadAccess`),
+// which is the only UI that offers "Convert to project".
+//
+// Callers that authorize the conversion themselves — the portal's
+// approveEstimate (client ownership via resolveSessionClientId) and
+// /api/manager/jobs (mobile token or session + assertLeadAccess) — call
+// convertLeadToProjectCore directly instead; a portal client is not staff and
+// would always fail this gate.
 export async function convertLeadToProject(leadId: string) {
-    const lead = await prisma.lead.findUnique({ 
-        where: { id: leadId },
-        include: { client: true }
-    });
-    if (!lead) throw new Error("Lead not found");
-
-    // Idempotency: if this lead was already converted, return existing project
-    const existingProject = await prisma.project.findUnique({ where: { leadId } });
-    if (existingProject) return { id: existingProject.id };
-
-    // Normalize the job-site address (outside the transaction — external call).
-    // Also catches legacy leads saved before geocode-on-save existed; a precise
-    // match seeds the project's time-clock geofence coordinates.
-    const geo = await geocodeJobSiteAddress(lead.location);
-
-    // Wrap entire conversion in a transaction for atomicity
-    const project = await prisma.$transaction(async (tx) => {
-        const project = await tx.project.create({
-            data: {
-                name: lead.name,
-                clientId: lead.clientId,
-                location: geo?.formattedAddress ?? lead.location,
-                ...(geo?.lat != null && geo?.lng != null ? { locationLat: geo.lat, locationLng: geo.lng } : {}),
-                status: "Waiting to Start",
-                startDate: lead.expectedStartDate ?? null,
-                type: lead.projectType || "Unknown",
-                managerId: lead.managerId || null,
-                tags: lead.tags || null,
-                leadId,
-            },
-        });
-
-        // Relink child records to the new project.
-        // Estimate has no onDelete:Cascade on its lead FK — keep leadId so it
-        // remains visible from both the lead view and the project view.
-        await tx.estimate.updateMany({ where: { leadId }, data: { projectId: project.id } });
-        // RoomDesign has an owner-XOR CHECK constraint (projectId XOR leadId), so we must
-        // clear leadId when setting projectId in the same transaction.
-        await tx.roomDesign.updateMany({ where: { leadId }, data: { projectId: project.id, leadId: null } });
-        // Contract.lead FK is onDelete:SetNull — keep leadId so contracts remain visible from
-        // both the lead view and the project view (same pattern as Estimate).
-        await tx.contract.updateMany({ where: { leadId }, data: { projectId: project.id } });
-        // The remaining models still have onDelete:Cascade on their lead FK — clear leadId.
-        await tx.projectFile.updateMany({ where: { leadId }, data: { projectId: project.id, leadId: null } });
-        await tx.fileFolder.updateMany({ where: { leadId }, data: { projectId: project.id, leadId: null } });
-        await tx.scheduleTask.updateMany({ where: { leadId }, data: { projectId: project.id, leadId: null } });
-        await tx.takeoff.updateMany({ where: { leadId }, data: { projectId: project.id, leadId: null } });
-        await tx.clientMessage.updateMany({ where: { leadId }, data: { projectId: project.id, leadId: null } });
-
-        await tx.lead.update({ where: { id: leadId }, data: { stage: "Won" } });
-
-        return project;
-    });
-
-    // Auto-grant access to eligible team members
-    const { autoGrantProjectAccessToEligibleUsers } = await import("@/lib/auto-grant-project-access");
-    await autoGrantProjectAccessToEligibleUsers(project.id);
-
-    // The ProBuild Files tab gets its own canonical scaffold. This is
-    // deliberately independent of Drive provisioning and never rolls back a
-    // successfully-created project.
-    try {
-        await ensureStandardFolders(project.id);
-    } catch (folderErr) {
-        console.error("[Project folders] Failed to create the standard scaffold:", folderErr);
-    }
-
-    // Provision Google Drive Folders in the background/async after project creation
-    try {
-        const { createProjectDriveFolder } = await import("./google-drive");
-        const driveResult = await createProjectDriveFolder(project.name, lead.client?.email);
-        
-        if (driveResult.success) {
-            // Create a FileFolder record in ProBuild representing this Google Drive folder
-            await prisma.fileFolder.create({
-                data: {
-                    name: `📁 Google Drive - Client Shared Folder`,
-                    projectId: project.id,
-                    visibility: "shared", // Shared with client
-                }
-            });
-            console.log(`[Google Drive] Successfully provisioned Google Drive for project: ${project.id}`);
-        }
-    } catch (driveErr) {
-        console.error("[Google Drive] Failed to provision Google Drive folder during conversion:", driveErr);
-    }
-
-    revalidatePath("/leads");
-    revalidatePath("/projects");
-    revalidatePath(`/leads/${leadId}`);
-
-    return { id: project.id };
+    const user = await assertActiveStaff();
+    if (!hasPermission(user, "leadAccess")) throw new Error("Forbidden");
+    return convertLeadToProjectCore(leadId);
 }
 
 // Create a project directly (e.g. a repeat customer with another job).
@@ -1265,6 +1187,11 @@ export async function createProject(data: {
     projectType?: string;
     status?: string;
 }) {
+    // Same conversion path as convertLeadToProject, and it creates a Client and
+    // a Lead on the way — it cannot be left open to an unauthenticated caller.
+    // Gated on staff (not `leadAccess`) because the lead here is an internal
+    // implementation detail of "new project", offered on /projects.
+    await assertActiveStaff();
     if (!data.name?.trim()) throw new Error("Project name is required.");
 
     // Resolve the customer: prefer an existing client by id; otherwise find-or-create by name.
@@ -1310,7 +1237,9 @@ export async function createProject(data: {
         },
     });
 
-    const { id: projectId } = await convertLeadToProject(lead.id);
+    // Core, not the gated wrapper: this action already authorized the caller
+    // above, and it owns the lead it just created.
+    const { id: projectId } = await convertLeadToProjectCore(lead.id);
 
     // Apply project-specific fields the conversion doesn't carry (it defaults status to "Waiting to Start").
     // A provided status always applies — including "In Progress" for callers
@@ -2319,7 +2248,12 @@ async function ensureProjectAndDepositInvoiceForEstimate(estimateId: string): Pr
     // 1) Ensure a project exists (idempotent — conversion returns the existing one).
     let projectId = estimate.projectId;
     if (!projectId && estimate.leadId) {
-        const converted = await convertLeadToProject(estimate.leadId);
+        // Core, not the gated wrapper: the caller here is approveEstimate, which
+        // has already proven the signed-in PORTAL CLIENT owns this estimate
+        // (resolveSessionClientId + project.clientId/lead.clientId). A portal
+        // client is not staff, so the staff gate would reject a legitimate
+        // client approval.
+        const converted = await convertLeadToProjectCore(estimate.leadId);
         projectId = converted.id;
     }
     if (!projectId) return null;
@@ -4414,6 +4348,48 @@ async function assertVendorPermission() {
     return assertStaffPermission("manageVendors");
 }
 
+// Document templates hold the terms & conditions, contract language and
+// disclaimers that get SNAPSHOTTED onto estimates and contracts when they are
+// sent — an unauthenticated write changes the legal text on future
+// client-facing documents. Company-wide, so there is no per-project scope to
+// apply; the split below follows the screens that actually use them.
+//
+// Reads: every consumer is an estimates or contracts surface (the estimate
+// editor's T&C picker, SendEstimateModal, the lead/project contracts tabs) plus
+// the company settings library itself.
+async function assertDocumentTemplateReadAccess() {
+    const user = await assertActiveStaff();
+    if (!hasPermission(user, "estimates") && !hasPermission(user, "contracts") && !hasPermission(user, "companySettings")) {
+        throw new Error("Forbidden");
+    }
+    return user;
+}
+
+// Writes: `companySettings` is the permission that owns the library at
+// /company/templates, and it alone may touch EVERY type. `estimates` is
+// accepted too, but only for the types an estimator actually authors — the
+// estimate editor's "save as template" and the /estimates Terms & Conditions
+// tab. Without the type scope below, an estimates-only user (which is the
+// FINANCE default) could rewrite contract, lien-release, warranty, addendum and
+// disclaimer language through /company/templates' full type selector, which is
+// a far bigger grant than the estimator surfaces justify.
+async function assertDocumentTemplateWritePermission() {
+    const user = await assertActiveStaff();
+    if (!hasPermission(user, "companySettings") && !hasPermission(user, "estimates")) {
+        throw new Error("Forbidden");
+    }
+    return user;
+}
+
+// Second half of the write gate: which TYPE this caller may write. Split from
+// the permission check so the permission still runs before any database access
+// — update/delete have to load the row to learn its type, and an edit that
+// changes `type` must clear the scope on BOTH the old and the new value or a
+// caller could launder a contract template out of its protected type.
+function assertDocumentTemplateTypeScope(user: any, type: string | null | undefined) {
+    if (!canWriteDocumentTemplateType(user, type)) throw new Error("Forbidden");
+}
+
 // Creating a vendor is also part of the PO flow — SelectVendorModal and
 // POQuickCreateModal let an estimator add one inline, and those screens gate on
 // financialReports (see quickCreatePOAndLink). So either permission is enough to
@@ -5377,6 +5353,7 @@ export async function deleteAssembly(templateId: string) {
 // =============================================
 
 export async function getDocumentTemplates(type?: string) {
+    await assertDocumentTemplateReadAccess();
     return await prisma.documentTemplate.findMany({
         where: type ? { type } : undefined,
         orderBy: { updatedAt: "desc" },
@@ -5384,10 +5361,13 @@ export async function getDocumentTemplates(type?: string) {
 }
 
 export async function getDocumentTemplate(id: string) {
+    await assertDocumentTemplateReadAccess();
     return await prisma.documentTemplate.findUnique({ where: { id } });
 }
 
 export async function createDocumentTemplate(data: { name: string; type: string; body: string; isDefault?: boolean }) {
+    const user = await assertDocumentTemplateWritePermission();
+    assertDocumentTemplateTypeScope(user, data.type);
     // If setting as default, unset all other defaults of same type
     if (data.isDefault) {
         await prisma.documentTemplate.updateMany({
@@ -5402,23 +5382,46 @@ export async function createDocumentTemplate(data: { name: string; type: string;
 }
 
 export async function updateDocumentTemplate(id: string, data: { name?: string; type?: string; body?: string; isDefault?: boolean }) {
-    if (data.isDefault) {
-        const existing = await prisma.documentTemplate.findUnique({ where: { id } });
-        if (existing) {
-            await prisma.documentTemplate.updateMany({
+    const user = await assertDocumentTemplateWritePermission();
+    const existing = await prisma.documentTemplate.findUnique({ where: { id } });
+    if (!existing) throw new Error("Template not found");
+    // Scope the type this row ALREADY has, and — when the edit retypes it — the
+    // one it is moving to, so neither end of a retype escapes the estimator set.
+    assertDocumentTemplateTypeScope(user, existing.type);
+    if (data.type !== undefined) assertDocumentTemplateTypeScope(user, data.type);
+    // The type was authorized from a separately-loaded row, so the write must
+    // re-assert it or a concurrent retype (by someone who IS allowed to retype)
+    // could hand an estimates-only caller a now-protected row. Pinning the
+    // observed type in the mutation's own filter closes that window; count 0
+    // means the row changed type underneath us, which is a refusal, not a 404.
+    const template = await prisma.$transaction(async (tx) => {
+        const claimed = await tx.documentTemplate.updateMany({
+            where: { id, type: existing.type },
+            data,
+        });
+        if (claimed.count === 0) throw new Error("Forbidden");
+        if (data.isDefault) {
+            await tx.documentTemplate.updateMany({
                 where: { type: data.type || existing.type, isDefault: true, NOT: { id } },
                 data: { isDefault: false }
             });
         }
-    }
-    const template = await prisma.documentTemplate.update({ where: { id }, data });
+        return tx.documentTemplate.findUnique({ where: { id } });
+    });
     revalidatePath("/company/templates");
     revalidatePath("/estimates");
     return template;
 }
 
 export async function deleteDocumentTemplate(id: string) {
-    await prisma.documentTemplate.delete({ where: { id } });
+    const user = await assertDocumentTemplateWritePermission();
+    const existing = await prisma.documentTemplate.findUnique({ where: { id }, select: { type: true } });
+    if (!existing) throw new Error("Template not found");
+    assertDocumentTemplateTypeScope(user, existing.type);
+    // Same TOCTOU pin as the update path: delete only the row whose type was
+    // actually authorized, never "whatever this id is now".
+    const removed = await prisma.documentTemplate.deleteMany({ where: { id, type: existing.type } });
+    if (removed.count === 0) throw new Error("Forbidden");
     revalidatePath("/company/templates");
     revalidatePath("/estimates");
     return { success: true };

--- a/src/lib/lead-conversion-core.ts
+++ b/src/lib/lead-conversion-core.ts
@@ -1,0 +1,126 @@
+import { revalidatePath as nextRevalidatePath } from "next/cache";
+import { prisma } from "@/lib/prisma";
+import { geocodeJobSiteAddress } from "./geocode";
+import { ensureStandardFolders } from "./project-folders";
+
+// Session-free core of lead → project conversion, shared by the permission-gated
+// `convertLeadToProject` server action in actions.ts and by callers that have
+// ALREADY authorized the conversion some other way (the portal's
+// approveEstimate, which validated client ownership via resolveSessionClientId,
+// and /api/manager/jobs, which authenticates a mobile token or session and then
+// runs assertLeadAccess). actions.ts is a server-action module, so every export
+// there is a remotely invokable endpoint — auth-free logic must live here, NOT
+// there. (This file deliberately carries no server-action directive.)
+//
+// The body of convertLeadToProjectCore is moved verbatim from actions.ts;
+// behavior is unchanged for every existing path.
+
+// Cache revalidation is best-effort: it throws outside a Next request context
+// (e.g. verification scripts), and a stale cache page is never worth failing a
+// conversion whose transaction already committed. This IS a behavior change
+// from the pre-extraction action, where a revalidate failure propagated out of
+// an already-successful conversion — so the failure is logged rather than
+// silently dropped, otherwise a real invalidation outage would look like a
+// clean conversion with stale /leads and /projects pages.
+function revalidatePath(path: string) {
+    try {
+        nextRevalidatePath(path);
+    } catch (err) {
+        console.warn(`[Lead conversion] revalidatePath(${path}) failed:`, err);
+    }
+}
+
+export async function convertLeadToProjectCore(leadId: string) {
+    const lead = await prisma.lead.findUnique({
+        where: { id: leadId },
+        include: { client: true }
+    });
+    if (!lead) throw new Error("Lead not found");
+
+    // Idempotency: if this lead was already converted, return existing project
+    const existingProject = await prisma.project.findUnique({ where: { leadId } });
+    if (existingProject) return { id: existingProject.id };
+
+    // Normalize the job-site address (outside the transaction — external call).
+    // Also catches legacy leads saved before geocode-on-save existed; a precise
+    // match seeds the project's time-clock geofence coordinates.
+    const geo = await geocodeJobSiteAddress(lead.location);
+
+    // Wrap entire conversion in a transaction for atomicity
+    const project = await prisma.$transaction(async (tx) => {
+        const project = await tx.project.create({
+            data: {
+                name: lead.name,
+                clientId: lead.clientId,
+                location: geo?.formattedAddress ?? lead.location,
+                ...(geo?.lat != null && geo?.lng != null ? { locationLat: geo.lat, locationLng: geo.lng } : {}),
+                status: "Waiting to Start",
+                startDate: lead.expectedStartDate ?? null,
+                type: lead.projectType || "Unknown",
+                managerId: lead.managerId || null,
+                tags: lead.tags || null,
+                leadId,
+            },
+        });
+
+        // Relink child records to the new project.
+        // Estimate has no onDelete:Cascade on its lead FK — keep leadId so it
+        // remains visible from both the lead view and the project view.
+        await tx.estimate.updateMany({ where: { leadId }, data: { projectId: project.id } });
+        // RoomDesign has an owner-XOR CHECK constraint (projectId XOR leadId), so we must
+        // clear leadId when setting projectId in the same transaction.
+        await tx.roomDesign.updateMany({ where: { leadId }, data: { projectId: project.id, leadId: null } });
+        // Contract.lead FK is onDelete:SetNull — keep leadId so contracts remain visible from
+        // both the lead view and the project view (same pattern as Estimate).
+        await tx.contract.updateMany({ where: { leadId }, data: { projectId: project.id } });
+        // The remaining models still have onDelete:Cascade on their lead FK — clear leadId.
+        await tx.projectFile.updateMany({ where: { leadId }, data: { projectId: project.id, leadId: null } });
+        await tx.fileFolder.updateMany({ where: { leadId }, data: { projectId: project.id, leadId: null } });
+        await tx.scheduleTask.updateMany({ where: { leadId }, data: { projectId: project.id, leadId: null } });
+        await tx.takeoff.updateMany({ where: { leadId }, data: { projectId: project.id, leadId: null } });
+        await tx.clientMessage.updateMany({ where: { leadId }, data: { projectId: project.id, leadId: null } });
+
+        await tx.lead.update({ where: { id: leadId }, data: { stage: "Won" } });
+
+        return project;
+    });
+
+    // Auto-grant access to eligible team members
+    const { autoGrantProjectAccessToEligibleUsers } = await import("@/lib/auto-grant-project-access");
+    await autoGrantProjectAccessToEligibleUsers(project.id);
+
+    // The ProBuild Files tab gets its own canonical scaffold. This is
+    // deliberately independent of Drive provisioning and never rolls back a
+    // successfully-created project.
+    try {
+        await ensureStandardFolders(project.id);
+    } catch (folderErr) {
+        console.error("[Project folders] Failed to create the standard scaffold:", folderErr);
+    }
+
+    // Provision Google Drive Folders in the background/async after project creation
+    try {
+        const { createProjectDriveFolder } = await import("./google-drive");
+        const driveResult = await createProjectDriveFolder(project.name, lead.client?.email);
+
+        if (driveResult.success) {
+            // Create a FileFolder record in ProBuild representing this Google Drive folder
+            await prisma.fileFolder.create({
+                data: {
+                    name: `📁 Google Drive - Client Shared Folder`,
+                    projectId: project.id,
+                    visibility: "shared", // Shared with client
+                }
+            });
+            console.log(`[Google Drive] Successfully provisioned Google Drive for project: ${project.id}`);
+        }
+    } catch (driveErr) {
+        console.error("[Google Drive] Failed to provision Google Drive folder during conversion:", driveErr);
+    }
+
+    revalidatePath("/leads");
+    revalidatePath("/projects");
+    revalidatePath(`/leads/${leadId}`);
+
+    return { id: project.id };
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -14,6 +14,8 @@ export {
     canAccessProject,
     canAccessEstimate,
     estimateScopeWhere,
+    canWriteDocumentTemplateType,
+    ESTIMATOR_WRITABLE_TEMPLATE_TYPES,
 } from "./access-rules";
 export type { PermissionKey, ProjectScopedUser, EstimateOwner } from "./access-rules";
 


### PR DESCRIPTION
Follow-up to #333. Two exported Server Actions in `src/lib/actions.ts` had **no authorization check at all** — both pre-existing, both found by Codex during #333 and left out of that PR to keep it reviewable. Server Actions are remotely invokable, so "no check" means any caller.

## 1. `convertLeadToProject`

Moved every estimate, contract, schedule task and file off a forged `leadId` onto a brand new project, unauthenticated.

A guard in place would have broken two legitimate callers, so the body moves verbatim to a session-free `src/lib/lead-conversion-core.ts` (the `billing-core.ts` pattern) and the exported action becomes a **staff + `leadAccess`** gate over it, mirroring the `/leads/[id]` layout that offers the button:

- **portal approval** calls the core — `approveEstimate` already proved client ownership via `resolveSessionClientId`, and a portal client is not staff
- **`/api/manager/jobs`** calls the core — it authenticates a **mobile token**, which has no NextAuth session, and runs its own `assertLeadAccess`
- **`createProject`** walks the same path and creates a `Client` and a `Lead` on the way, so it now asserts active staff too

## 2. Document-template CRUD

These hold the terms and conditions snapshotted onto estimates when they are sent, so an unauthenticated write changed the **legal text on future client-facing documents**.

- **Reads**: `estimates` / `contracts` / `companySettings`
- **Writes**: `companySettings` for any type; `estimates` only for the types an estimator's own screens author (`terms`/`overview`/`notes`)

The type scope matters: `/company/templates` renders a full type selector, so an unscoped `estimates` grant would let an estimates-only user — **which is the FINANCE default** — rewrite contract, lien-release and warranty language. `update()` scopes both the row's current type and any incoming retype, and both writes pin the authorized type in their own filter (`where: { id, type: existing.type }`, `count === 0` ⇒ refuse) so a concurrent retype can't hand the caller a protected row.

The rule lives in `access-rules.ts` alongside the ones #341 just moved there, so it is executed by a test rather than grepped for.

## Tests

`e2e/financial-action-auth.spec.ts` gains both contracts plus a behavioral test of the type rule across every role/type combination. Its static assertions now strip comments, accept either quote spelling of the server-action directive, and check guard-**before**-write ordering.

Red-green verified on 8 mutations: commented-out guard, widened type set (×2), removed `leadAccess`, removed retype scope, inverted predicate, dropped update pin, dropped delete refusal. All fail; restored is green.

## Review

Codex `gpt-5.6-sol` at xhigh, two rounds. Round 1 raised 5, round 2 raised 3 — all addressed except two deliberate calls:

- **Defended**: Codex wanted lead *ownership* enforced on the web conversion the way the mobile route does. `hasPermission` returns true for every key for ADMIN/MANAGER, so the whole web app already treats MANAGER as globally privileged; binding it on this one action is a product policy change, not a fix.
- **Deferred**: `createContractFromTemplate` and `createContractBlank` are unauthenticated (different action family, needs `buildMergeData` extracted, has a shared-secret MCP caller). Raised separately.

`npm run typecheck` and `npm run build` clean; auth specs 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)