### PR TITLE
perf(clients): drop the dead estimate embed from getClients

### DIFF
--- a/e2e/financial-action-auth.spec.ts
+++ b/e2e/financial-action-auth.spec.ts
@@ -217,8 +217,20 @@ test("estimate readers filter by the same scope the detail page asserts", () => 
   // getClients is the other way to satisfy the rule: it embeds no estimates at
   // all. Nothing on the contacts page or the client picker ever read them, so
   // the safest scope filter is not fetching the rows in the first place.
-  expect(exportSource(source, "getClients"), "getClients must not embed estimates")
-    .not.toMatch(/estimates:/);
+  //
+  // Assert the positive shape as well as the absence. The negative alone is
+  // satisfied by any rewrite that stops naming the key — a nested `include`
+  // that pulls whole project rows would pass it while re-opening the
+  // over-fetch. Pinning the projects relation to an id-only select is what
+  // actually leaves no room for an estimates embed to come back.
+  {
+    const action = exportSource(source, "getClients");
+    // Tolerate reformatting: `estimates :`, `"estimates":`, newline-separated.
+    expect(action, "getClients must not embed estimates")
+      .not.toMatch(/["']?estimates["']?\s*:/);
+    expect(action, "getClients must select only project ids")
+      .toMatch(/projects\s*:\s*\{\s*select\s*:\s*\{\s*id\s*:\s*true\s*,?\s*\}\s*,?\s*\}/);
+  }
   expect(source, "no estimates relation may be embedded without the scope filter")
     .not.toMatch(/estimates: safeEstimateInclude/);
 

--- a/e2e/financial-action-auth.spec.ts
+++ b/e2e/financial-action-auth.spec.ts
@@ -210,10 +210,15 @@ test("estimate readers filter by the same scope the detail page asserts", () => 
 
   // Nested embeds are the same exposure by another route: a lead or project
   // getter that includes estimates hands back rows the caller may not open.
-  for (const name of ["getLeads", "getLead", "getProjects", "getProject", "getClients"]) {
+  for (const name of ["getLeads", "getLead", "getProjects", "getProject"]) {
     expect(exportSource(source, name), `${name} must scope the estimates it embeds`)
       .toContain("scopedEstimateRelation(");
   }
+  // getClients is the other way to satisfy the rule: it embeds no estimates at
+  // all. Nothing on the contacts page or the client picker ever read them, so
+  // the safest scope filter is not fetching the rows in the first place.
+  expect(exportSource(source, "getClients"), "getClients must not embed estimates")
+    .not.toMatch(/estimates:/);
   expect(source, "no estimates relation may be embedded without the scope filter")
     .not.toMatch(/estimates: safeEstimateInclude/);
 

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -625,13 +625,13 @@ export async function updateLeadInfo(id: string, data: any) {
 }
 
 export async function getClients() {
-    const user = await currentStaffUserOrNull();
     const clients = await prisma.client.findMany({
         orderBy: { name: "asc" },
         include: {
-            projects: {
-                include: { estimates: scopedEstimateRelation(safeEstimateInclude, user) }
-            },
+            // The contacts page only renders a project count and the combobox
+            // only needs id/name — no caller reads the project rows themselves,
+            // so keep this to ids instead of every column (and every estimate).
+            projects: { select: { id: true } },
             leads: true
         }
     });


### PR DESCRIPTION
## What

`getClients()` embedded every estimate of every project of every client, and `safeEstimateInclude` selects `items`, `expenses` and `paymentSchedules` — so the contacts page pulled full line-item detail for the whole company on a page that renders one number per client.

No caller ever read it:
- `src/app/settings/contacts/page.tsx` → `ContactsClient.tsx` reads only `c.projects.length`; its `Client` type already declares `projects: { id: string }[]`.
- `src/components/ClientCombobox.tsx` reads only name/email/phone.

#341 put a scope filter on the embed, which stopped it being an exposure. This removes it outright — the rows were never wanted. `projects` narrows to an id-only select, which is all the count needs.

## Test change

`e2e/financial-action-auth.spec.ts` had a loop asserting `getClients` contains `scopedEstimateRelation(`. `getClients` is dropped from that loop (the other four entries stay) and replaced with the stronger rule for this getter: it must embed no estimates at all, **and** its `projects` relation must be an id-only select. The positive half matters — the negative alone would pass a nested `include` that re-opens the over-fetch under a different key.

## Verification

- `npm run build` — 0 errors
- `npx playwright test e2e/financial-action-auth.spec.ts e2e/estimate-scope-rules.spec.ts --reporter=line --no-deps` — 13 passed
- **Control run**: re-adding `projects: { include: { estimates: safeEstimateInclude } }` fails the spec, so the guard is not vacuous
- `/settings/contacts` loaded locally — table renders, project counts unchanged
- Codex peer review (gpt-5.6-sol, xhigh): no blockers. Its assertion-brittleness finding is addressed in the second commit.

## Spotted, not fixed here

`getClients` is an unauthenticated client-invokable Server Action returning every client scalar plus full `leads`. The `currentStaffUserOrNull()` call removed here was never a gate (it returns `null` and the query runs anyway) — the page's session check does not protect direct action calls. Pre-existing, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
