### PR TITLE
fix(estimates): stop two cards labelling a scoped sum as company-wide

### DIFF
--- a/e2e/estimate-scope-rules.spec.ts
+++ b/e2e/estimate-scope-rules.spec.ts
@@ -4,6 +4,7 @@ import {
     estimateScopeWhere,
     canAccessProject,
     accessibleProjectIds,
+    estimateTotalsAreComplete,
     type EstimateOwner,
     type ProjectScopedUser,
 } from "../src/lib/access-rules";
@@ -126,6 +127,72 @@ test("a missing user is treated as no access, never as full access", () => {
         for (const [label, row] of ROWS) {
             expect(whereAdmits(where, row), `absent user must not see ${label}`).toBe(false);
         }
+    }
+});
+
+/**
+ * estimateTotalsAreComplete decides whether a card may label its number as
+ * company-wide. It must say "complete" exactly when the scope filter would have
+ * dropped nothing from the projects the aggregate covered — a label that
+ * overstates a partial sum is the bug it exists to prevent.
+ */
+test("a total is complete exactly when the filter admits every owner it covered", () => {
+    // THE invariant, over the whole table. Includes the ownerless row (which
+    // the filter rejects for everyone, admins included) and the dual-owned ones,
+    // so a rule that special-cases "no project" as a free pass fails here.
+    for (const [userLabel, user] of USERS) {
+        const where = estimateScopeWhere(user);
+        for (const [rowLabel, row] of ROWS) {
+            expect(
+                estimateTotalsAreComplete(user, [row]),
+                `${userLabel} / ${rowLabel}: completeness must match what the filter admits`,
+            ).toBe(whereAdmits(where, row));
+        }
+    }
+});
+
+test("one dropped owner makes the whole total partial", () => {
+    // Completeness is over the SET: it only survives if every owner survives.
+    for (const [userLabel, user] of USERS) {
+        const where = estimateScopeWhere(user);
+        const rows = ROWS.map(([, row]) => row);
+        for (const size of [2, 3, rows.length]) {
+            const subset = rows.slice(0, size);
+            const allAdmitted = subset.every(row => whereAdmits(where, row));
+            expect(
+                estimateTotalsAreComplete(user, subset),
+                `${userLabel} / first ${size} rows`,
+            ).toBe(allAdmitted);
+        }
+    }
+});
+
+test("an unattached owner is never complete, and neither is an absent user", () => {
+    // `{}` is the ownerless case the schema permits. canAccessEstimate fails it
+    // closed for every role, so a total drawn from it can never claim to be all.
+    for (const [label, user] of USERS) {
+        expect(estimateTotalsAreComplete(user, [{}]), `${label} / unattached`).toBe(false);
+        expect(estimateTotalsAreComplete(user, [{ projectId: null, leadId: null }]), `${label} / explicit nulls`).toBe(false);
+    }
+    // Spelt out for the shapes the UI actually hands this.
+    expect(estimateTotalsAreComplete(LEADS_ONLY, [{ leadId: "l1" }])).toBe(true);
+    expect(estimateTotalsAreComplete(ESTIMATOR_LEADS, [{ leadId: "l1" }, { projectId: "p1" }])).toBe(true);
+    expect(estimateTotalsAreComplete(ESTIMATOR_LEADS, [{ leadId: "l1" }, { projectId: "p9" }])).toBe(false);
+    // FINANCE / crew / nobody hold no leadAccess, so a lead total is partial.
+    for (const user of [FINANCE_NO_ACCESS, CREW_ON_P2, NOBODY]) {
+        expect(estimateTotalsAreComplete(user, [{ leadId: "l1" }])).toBe(false);
+    }
+    // Fail closed: no user means the filter matched nothing, so claim nothing.
+    for (const noUser of [null, undefined, {} as any]) {
+        expect(estimateTotalsAreComplete(noUser, [])).toBe(false);
+        expect(estimateTotalsAreComplete(noUser, [{ projectId: "p1" }])).toBe(false);
+    }
+});
+
+test("only ADMIN and MANAGER may claim a company-wide total over arbitrary projects", () => {
+    for (const [label, user] of USERS) {
+        const claimsAll = estimateTotalsAreComplete(user, [{ projectId: "p1" }, { projectId: "p2" }, { projectId: "p9" }]);
+        expect(claimsAll, `${label}`).toBe(accessibleProjectIds(user) === "ALL");
     }
 });
 

--- a/e2e/financial-action-auth.spec.ts
+++ b/e2e/financial-action-auth.spec.ts
@@ -466,6 +466,52 @@ test("lead → project conversion is gated for staff and session-free for pre-au
     .toMatch(/const accessError = await assertLeadAccess\(user, leadId\);[\s\S]{0,120}if \(accessError\) return accessError;/);
 });
 
+test("pages that sum scoped estimates label the total by what the reader can see", () => {
+  const source = readFileSync(join(process.cwd(), "src/lib/actions.ts"), "utf8");
+  const projectsPage = readFileSync(join(process.cwd(), "src/app/projects/page.tsx"), "utf8");
+  const projectsClient = readFileSync(join(process.cwd(), "src/app/projects/ProjectsClient.tsx"), "utf8");
+  const leadEstimates = readFileSync(join(process.cwd(), "src/app/leads/[id]/estimates/page.tsx"), "utf8");
+
+  // Estimate READS are scoped per caller; the project LIST is not. So a card
+  // summing embedded estimates can hold a partial number under a label that
+  // claims the whole company. The number stays scoped — the label must move.
+  // NOTE ON REACH: like the rest of this spec these are source assertions, so
+  // they prove the data PATH, not the runtime value — the decision itself is
+  // verified behaviourally in estimate-scope-rules.spec.ts. What they must
+  // therefore rule out is the hardcode: an action that authenticates and then
+  // returns a literal, or a page that computes the flag and passes a constant.
+  {
+    const action = exportSource(source, "estimateTotalsComplete");
+    expect(action, "the completeness reader must authenticate first")
+      .toContain("await assertActiveStaff()");
+    expect(action, "it must RETURN the shared rule's answer, not a literal")
+      .toMatch(/return estimateTotalsAreComplete\(user, owners\);/);
+    expect(action, "it must not short-circuit to a constant verdict")
+      .not.toMatch(/return (true|false)\b/);
+  }
+
+  // Both readers must ASK, naming the owners their aggregate actually covered.
+  expect(projectsPage, "the projects page must ask whether its revenue sum is complete")
+    .toMatch(/const revenueIsComplete = await estimateTotalsComplete\(projects\.map/);
+  expect(projectsPage, "the answer must reach the client, not a literal")
+    .toContain("revenueIsComplete={revenueIsComplete}");
+  expect(leadEstimates, "the lead estimates page must ask over its lead and its linked project")
+    .toMatch(/const totalsAreComplete = await estimateTotalsComplete\(/);
+  expect(leadEstimates, "the lead's own estimates must be asked about as a lead, not as a null project")
+    .toMatch(/\{ leadId: lead\.id \}/);
+
+  // ...and must USE the answer. A page could import it and still print the
+  // unconditional label, which is the exact bug this pair of assertions guards.
+  expect(projectsClient, "the revenue label must depend on completeness")
+    .toMatch(/revenueIsComplete \?[^\n]*Total Revenue/);
+  expect(projectsClient, "revenueIsComplete must be a required prop, so a caller cannot omit it")
+    .toMatch(/revenueIsComplete: boolean/);
+  for (const claim of ["Across all estimates", "Total created"]) {
+    expect(leadEstimates, `"${claim}" must be conditional on completeness`)
+      .toMatch(new RegExp(`totalsAreComplete \\?[^\\n]*${claim}`));
+  }
+});
+
 test("dual-auth financial actions keep explicit portal or machine authorization", () => {
   const source = readFileSync(join(process.cwd(), "src/lib/actions.ts"), "utf8");
   const billingCore = readFileSync(join(process.cwd(), "src/lib/billing-core.ts"), "utf8");

--- a/src/app/leads/[id]/estimates/page.tsx
+++ b/src/app/leads/[id]/estimates/page.tsx
@@ -1,4 +1,4 @@
-import { getLead, createDraftLeadEstimate, getProjects } from "@/lib/actions";
+import { getLead, createDraftLeadEstimate, getProjects, estimateTotalsComplete } from "@/lib/actions";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import StatusBadge from "@/components/StatusBadge";
@@ -32,6 +32,19 @@ export default async function LeadEstimatesPage({ params }: { params: Promise<{ 
     const totalApproved = approvedEstimates.reduce((sum: number, e: any) => sum + Number(e.totalAmount || 0), 0);
     const totalAll = allEstimates.reduce((sum: number, e: any) => sum + Number(e.totalAmount || 0), 0);
 
+    // This page only requires `leadAccess`, but a converted lead's estimates are
+    // owned by its linked PROJECT and are scoped by project access. So a reader
+    // without access to that project gets a lead view whose totals silently omit
+    // them — the labels below say so rather than claiming completeness.
+    // Two owners feed these totals: the lead itself, and the linked project if
+    // there is one. Named as owners, not ids, so the lead branch is checked as
+    // `leadAccess` and cannot be confused with an unattached estimate.
+    const totalsAreComplete = await estimateTotalsComplete(
+        linkedProject
+            ? [{ leadId: lead.id }, { projectId: linkedProject.id }]
+            : [{ leadId: lead.id }],
+    );
+
     // Active projects for "Copy to project" bulk action — exclude Archived
     let allActiveProjects: { id: string; name: string }[] = [];
     try {
@@ -60,7 +73,7 @@ export default async function LeadEstimatesPage({ params }: { params: Promise<{ 
                                 </Link>
                             </div>
                             <h1 className="text-2xl font-bold text-hui-textMain">Estimates</h1>
-                            <p className="text-sm text-hui-textMuted mt-1">{allEstimates.length} estimate{allEstimates.length !== 1 ? "s" : ""} for {lead.name}</p>
+                            <p className="text-sm text-hui-textMuted mt-1">{allEstimates.length} estimate{allEstimates.length !== 1 ? "s" : ""} for {lead.name}{totalsAreComplete || !linkedProject ? "" : ` · you don't have access to ${linkedProject.name}, so its estimates aren't included`}</p>
                         </div>
                         <form action={handleNewEstimate}>
                             <button type="submit" className="px-5 py-2.5 bg-green-600 hover:bg-green-700 text-white text-sm font-semibold rounded-lg transition shadow-sm flex items-center gap-2">
@@ -76,19 +89,19 @@ export default async function LeadEstimatesPage({ params }: { params: Promise<{ 
                             <div className="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-green-400 to-emerald-500" />
                             <p className="text-xs text-slate-500 font-semibold uppercase tracking-wider mb-2">Total Approved</p>
                             <p className="text-2xl font-bold text-slate-900">{formatCurrency(totalApproved)}</p>
-                            <p className="text-[10px] text-slate-400 mt-1">{approvedEstimates.length} approved</p>
+                            <p className="text-[10px] text-slate-400 mt-1">{approvedEstimates.length} approved{totalsAreComplete ? "" : " that you can see"}</p>
                         </div>
                         <div className="bg-white p-5 rounded-xl border border-slate-200/80 shadow-sm relative overflow-hidden">
                             <div className="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-blue-400 to-indigo-500" />
                             <p className="text-xs text-slate-500 font-semibold uppercase tracking-wider mb-2">Total Value</p>
                             <p className="text-2xl font-bold text-blue-600">{formatCurrency(totalAll)}</p>
-                            <p className="text-[10px] text-slate-400 mt-1">Across all estimates</p>
+                            <p className="text-[10px] text-slate-400 mt-1">{totalsAreComplete ? "Across all estimates" : "Across the estimates you can see"}</p>
                         </div>
                         <div className="bg-white p-5 rounded-xl border border-slate-200/80 shadow-sm relative overflow-hidden">
                             <div className="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-purple-400 to-violet-500" />
                             <p className="text-xs text-slate-500 font-semibold uppercase tracking-wider mb-2">Estimates</p>
                             <p className="text-2xl font-bold text-purple-600">{allEstimates.length}</p>
-                            <p className="text-[10px] text-slate-400 mt-1">Total created</p>
+                            <p className="text-[10px] text-slate-400 mt-1">{totalsAreComplete ? "Total created" : "Visible to you"}</p>
                         </div>
                     </div>
 

--- a/src/app/projects/ProjectsClient.tsx
+++ b/src/app/projects/ProjectsClient.tsx
@@ -32,7 +32,7 @@ function getStatusDot(status: string, statuses: ProjectStatus[]) {
     return statuses.find(s => s.value === status)?.dot || "bg-slate-400";
 }
 
-export default function ProjectsClient({ projects: initialProjects, initialStatuses }: { projects: any[], initialStatuses?: ProjectStatus[] | null }) {
+export default function ProjectsClient({ projects: initialProjects, initialStatuses, revenueIsComplete }: { projects: any[], initialStatuses?: ProjectStatus[] | null, revenueIsComplete: boolean }) {
     const router = useRouter();
     const [projects, setProjects] = useState(initialProjects);
     const [statuses, setStatuses] = useState<ProjectStatus[]>(initialStatuses || DEFAULT_PROJECT_STATUSES);
@@ -220,8 +220,13 @@ export default function ProjectsClient({ projects: initialProjects, initialStatu
                     <p className="text-3xl font-bold text-amber-600 mt-1">{substantialCount}</p>
                 </div>
                 <div className="hui-card p-4">
-                    <p className="text-xs text-hui-textMuted font-medium">Total Revenue</p>
+                    {/* Estimates are scoped to the caller while this project list is
+                        not, so an unscoped label here would overstate a partial sum. */}
+                    <p className="text-xs text-hui-textMuted font-medium">{revenueIsComplete ? "Total Revenue" : "Revenue (your projects)"}</p>
                     <p className="text-3xl font-bold text-hui-textMain mt-1">{totalRevenue.toLocaleString("en-US", { style: "currency", currency: "USD", minimumFractionDigits: 0, maximumFractionDigits: 0 })}</p>
+                    {!revenueIsComplete && (
+                        <p className="text-[10px] text-hui-textMuted mt-1">Excludes projects you don&apos;t have access to</p>
+                    )}
                 </div>
             </div>
 

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,5 +1,5 @@
 export const dynamic = "force-dynamic";
-import { getProjects, getCompanySettings } from "@/lib/actions";
+import { getProjects, getCompanySettings, estimateTotalsComplete } from "@/lib/actions";
 import ProjectsClient from "./ProjectsClient";
 
 export default async function ProjectsPage() {
@@ -7,5 +7,10 @@ export default async function ProjectsPage() {
     const settings = await getCompanySettings();
     const customStatuses = settings?.projectStatuses ? JSON.parse(settings.projectStatuses) : null;
 
-    return <ProjectsClient projects={projects} initialStatuses={customStatuses} />;
+    // This list is company-wide, but the estimates embedded in each row are
+    // scoped to the caller — so the revenue card can be a partial sum sitting
+    // next to a company-wide project count. Tell the client which it is.
+    const revenueIsComplete = await estimateTotalsComplete(projects.map((p: any) => ({ projectId: p.id })));
+
+    return <ProjectsClient projects={projects} initialStatuses={customStatuses} revenueIsComplete={revenueIsComplete} />;
 }

--- a/src/lib/access-rules.ts
+++ b/src/lib/access-rules.ts
@@ -104,6 +104,37 @@ export function canAccessEstimate(user: ProjectScopedUser, scope: EstimateOwner)
     return hasPermission(user, "leadAccess");
 }
 
+/**
+ * The completeness companion to estimateScopeWhere: given the owners an
+ * aggregate was computed over, would the scope filter have dropped any of them?
+ *
+ * Estimate reads are scoped per caller, but the pages that sum them are not
+ * necessarily scoped the same way (the project LIST is company-wide), so a
+ * "Total Revenue" card can otherwise sit a partial number under a label that
+ * claims completeness. Readers ask this and label themselves honestly instead.
+ *
+ * Takes OWNERS, not project ids. A bare id list cannot express the difference
+ * between "lead-owned" and "attached to nothing", so a null in it would have to
+ * mean both — and those two answer differently (leadAccess vs fail-closed).
+ * Asking canAccessEstimate per owner makes the invariant hold by construction:
+ * complete === "the filter admits every one of these".
+ *
+ * Deliberately CONSERVATIVE about WHAT the caller passes: a page names the
+ * owners its aggregate could have drawn from, not the rows that actually
+ * existed. So an inaccessible project holding no matching row still reads as
+ * partial. It under-claims, never over-claims — a hedged label on a complete
+ * number misleads nobody, the reverse is the bug this exists to prevent.
+ */
+export function estimateTotalsAreComplete(
+    user: ProjectScopedUser | null | undefined,
+    owners: readonly EstimateOwner[]
+): boolean {
+    // No user means the scope filter matched nothing at all, so any non-empty
+    // total is partial by definition — and an empty one is not worth claiming.
+    if (!user?.role) return false;
+    return owners.every(owner => canAccessEstimate(user, owner));
+}
+
 /** Matches no estimate at all. Used where the caller has no accessible scope. */
 const MATCHES_NO_ESTIMATE = { id: { in: [] as string[] } };
 

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -20,7 +20,7 @@ import { isHttpUrl } from "./url-safety";
 // estimate-item-upsert.ts, which is now its only caller on the save path.
 import { selectedBillableRows } from "./estimate-item-payload";
 import { LEGACY_MARKUP_MARGIN_PCT, roundMoney, sellFromMargin } from "./budget-math";
-import { canUseDevAuthFallback, getCurrentUserWithPermissions, getUserWithPermissionsByEmail, hasPermission, canAccessProject, canAccessEstimate, estimateScopeWhere, canWriteDocumentTemplateType, PortalAuthError } from "./permissions";
+import { canUseDevAuthFallback, getCurrentUserWithPermissions, getUserWithPermissionsByEmail, hasPermission, canAccessProject, canAccessEstimate, estimateScopeWhere, estimateTotalsAreComplete, canWriteDocumentTemplateType, PortalAuthError } from "./permissions";
 import { logActivity } from "./activity-log";
 import { withTxRetry, lockMoneyParents } from "./tx-retry";
 import { upsertEstimateItems, assertEstimateItemParentsInScope, EstimateStaleSaveError } from "./estimate-item-upsert";
@@ -4191,6 +4191,21 @@ function assertEstimateScope(user: any, scope: { projectId?: string | null; lead
  */
 function scopedEstimateRelation<T extends object>(relation: T, user: any | null | undefined): T & { where: any } {
     return { ...relation, where: estimateScopeWhere(user) };
+}
+
+/**
+ * Session-bound form of estimateTotalsAreComplete, for pages that sum estimates
+ * embedded in an UNSCOPED parent list (the project list is company-wide, so its
+ * revenue card would otherwise label a scoped sum as company-wide truth).
+ *
+ * Pass the OWNERS the aggregate could have drawn from — `{ projectId }` for a
+ * project's estimates, `{ leadId }` for a lead's. Not a bare id list: null in
+ * one cannot distinguish lead-owned from attached-to-nothing, and those two
+ * answer differently.
+ */
+export async function estimateTotalsComplete(owners: { projectId?: string | null; leadId?: string | null }[]): Promise<boolean> {
+    const user = await assertActiveStaff();
+    return estimateTotalsAreComplete(user, owners);
 }
 
 /** Permission + scope for actions that reach estimates through a project id. */

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -14,6 +14,7 @@ export {
     canAccessProject,
     canAccessEstimate,
     estimateScopeWhere,
+    estimateTotalsAreComplete,
     canWriteDocumentTemplateType,
     ESTIMATOR_WRITABLE_TEMPLATE_TYPES,
 } from "./access-rules";


### PR DESCRIPTION
Closes the consequence Codex flagged on #341 and that was deliberately left open as a product decision.

## The problem
#341 scoped estimate READS to the caller. The project LIST was left company-wide on purpose, so two aggregates ended up summing a filtered array under a label that still claimed completeness:

- **`/projects` "Total Revenue"** sums approved estimates embedded in every project row. `getProjects()` is not scoped, so a non-ADMIN/MANAGER user still sees every project — but rows they can't access now contribute $0. A company-wide count sat beside a partial dollar figure.
- **`/leads/[id]/estimates`** computes "Total Approved", "Across all estimates" and "Total created" from lead-owned + linked-project estimates. The lead layout only requires `leadAccess`, and a converted estimate carries BOTH ids with project ownership winning — so those rows vanish from totals whose labels claim everything.

## The decision
Justin chose **(b)**: leave the project list company-wide, make the labels honest. Option (a) — scoping `getProjects` too — would have stopped crew and limited users seeing jobs they aren't on, a visible change to what staff can see. Prior art (#295, #333) says that call is his, not a silent side effect of a labelling fix.

## What changed
- New pure rule `estimateTotalsAreComplete(user, owners)` in `src/lib/access-rules.ts`, beside the filter it mirrors. It takes **owners, not project ids**: a bare id list cannot distinguish "lead-owned" from "attached to nothing", and those answer differently (`leadAccess` vs fail-closed). It asks `canAccessEstimate` per owner, so the invariant holds by construction — *complete* means *the scope filter admits every one of these*.
- Session-bound wrapper `estimateTotalsComplete()` in `actions.ts` (authenticates, then delegates; returns only a boolean).
- `/projects`: the card reads **"Revenue (your projects)"** with "Excludes projects you don't have access to" when partial; unchanged otherwise. `revenueIsComplete` is a required prop so no caller can omit it.
- `/leads/[id]/estimates`: the three card subtitles and the header say what they cover when the linked project is out of reach.

No totals math changed — only labels.

## Verification
- `npm run build` clean, `tsc --noEmit` clean.
- 18 specs pass (`estimate-scope-rules` + `financial-action-auth`). The truth table now runs completeness over **every (user, row) pair** against what `estimateScopeWhere` admits, including the ownerless and dual-owned rows.
- **Mutation-checked**: reinstating the "no project means fine" shortcut fails 3 tests; an earlier `return true` stub failed 3.
- Browser-verified on a dev server against real data: both pages render unchanged for an admin, and the partial branch renders correctly when forced.

## Codex review
Two rounds at `xhigh`. Round 1 found a real blocker — the rule treated lead-owned rows as always visible, wrong for FINANCE/crew who hold no `leadAccess`. Round 2 found the deeper version of it: with a bare id list, `null` had to mean both "lead-owned" and "ownerless", and the ownerless case must fail closed. That is what drove the owners-not-ids signature.

**Left open for Justin:** Codex's third round-2 point is that the wiring assertions are source-level, so an action that authenticates and returns a hardcoded `true` would be caught (assertions tightened for that), but a fully behavioural test of the partial branch needs a seeded non-ADMIN session, which this repo's e2e setup does not have. Same limitation the rest of `financial-action-auth.spec.ts` documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)