### PR TITLE
fix(security): authorize getClients before it reads every client row

### DIFF
--- a/e2e/financial-action-auth.spec.ts
+++ b/e2e/financial-action-auth.spec.ts
@@ -35,7 +35,9 @@ function expectGuardBeforeDatabase(source: string, actionName: string, guard: st
 }
 
 test("all staff financial actions authorize inside the exported action", () => {
-  const source = readFileSync(join(process.cwd(), "src/lib/actions.ts"), "utf8");
+  // Comments stripped for the same reason the later tests strip them: a guard
+  // quoted in a comment would satisfy every indexOf below while gating nobody.
+  const source = stripComments(readFileSync(join(process.cwd(), "src/lib/actions.ts"), "utf8"));
 
   // The `estimates` permission answers "may this user touch estimates at all",
   // NOT "may this user touch THIS estimate". Every action addressed by an
@@ -179,7 +181,7 @@ test("all staff financial actions authorize inside the exported action", () => {
     expect(exportSource(source, name)).toContain("assertFinancialProjectScope(");
   }
 
-  for (const name of ["getLeads", "getProjects", "getProject"]) {
+  for (const name of ["getLeads", "getProjects", "getProject", "getClients"]) {
     expectGuardBeforeDatabase(source, name, "await assertActiveStaff(");
   }
 
@@ -188,6 +190,19 @@ test("all staff financial actions authorize inside the exported action", () => {
   }
   for (const name of ["saveCompanySettings", "updateCompanyProjectStatuses", "saveCompanySubcontractorTrades"]) {
     expectGuardBeforeDatabase(source, name, "await assertCompanySettingsPermission(");
+  }
+
+  // Every assertion above only proves the guard is CALLED. A guard whose body
+  // stopped throwing would satisfy all of them while authorizing nobody, so pin
+  // the helper itself: resolve the staff user, and throw when there is none.
+  {
+    const start = source.indexOf("async function assertActiveStaff");
+    expect(start, "assertActiveStaff must exist").toBeGreaterThanOrEqual(0);
+    const body = source.slice(start, start + 300);
+    expect(body, "assertActiveStaff must resolve the current staff user")
+      .toContain("await currentStaffUserOrNull()");
+    expect(body, "assertActiveStaff must throw when there is no staff user")
+      .toMatch(/if\s*\(!user\)\s*throw new Error\("Unauthorized"\)/);
   }
 });
 

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -625,6 +625,13 @@ export async function updateLeadInfo(id: string, data: any) {
 }
 
 export async function getClients() {
+    // Server Actions are remotely invokable, so the getSessionOrDev() check in
+    // /settings/contacts guards the page render, not this getter. Without a gate
+    // here anyone who can reach the app could read every client's internalNotes
+    // and QuickBooks fields plus the full leads relation. The contacts page and
+    // its settings nav entry are gated on "logged in" only — no permission key —
+    // so the matching rule is active staff, not a per-role scope.
+    await assertActiveStaff();
     const clients = await prisma.client.findMany({
         orderBy: { name: "asc" },
         include: {


### PR DESCRIPTION
## What

`getClients()` in `src/lib/actions.ts` is an exported Server Action — remotely invokable by anything that can reach the app — and had **no authorization gate**. It returned every `Client` row's scalars (including `internalNotes` and the QuickBooks fields) plus the full `leads` relation.

The `getSessionOrDev()` check in `src/app/settings/contacts/page.tsx` protects the page render, not the action.

Found by Codex while reviewing #345.

## Not a regression from #345

#345 deleted a `const user = await currentStaffUserOrNull()` line from this getter. That line never gated anything: it returns `null` for missing/disabled users and the query ran regardless. It only fed the estimate scope filter that #345 removed. The gap predates both PRs.

## The gate

`assertActiveStaff()`. `/settings/contacts` and its entry in the settings nav are gated on "logged in" only — no permission key — so **active staff** is the rule that matches how this data is already exposed. A narrower per-role scope would break the page it serves. Codex confirmed no checked-in caller breaks (`ClientCombobox`'s two host modals sit on pages already behind `getLeads`/`getProjects`; no portal, mobile, or MCP caller references it).

## Verification

Against the dev server with a bogus `next-auth.session-token` cookie, which defeats the dev-auth fallback:

| | status | body |
|---|---|---|
| guard removed | 200 | rendered contact list |
| guard in place | 500 | `Unauthorized` |

`npm run build` passes. `financial-action-auth.spec.ts` 9/9.

## Test

`getClients` joins the `assertActiveStaff` loop in `e2e/financial-action-auth.spec.ts`.

That loop only proves the guard is *called*, so this also pins the helper body — Codex's one finding was that a gutted `assertActiveStaff` would satisfy every call-site assertion in the file. Both controls were run and both fail as intended: removing the guard, and gutting the helper.

The first test now strips comments like the later ones do, so a guard quoted in a comment can't pass it.

## Follow-ups (not in this PR)

- `ContactsClient` only renders `projects.length`; `_count` would be a smaller payload than `projects: { select: { id: true } }`, but it changes the prop shape.
- `ClientCombobox` should have its own narrow action selecting id/name/email/phone rather than reusing `getClients`.
- Codex's residual note: every staff role still receives `internalNotes` and QuickBooks fields. Current behavior, worth a product decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)