### PR TITLE
chore(skills): version-control the four ProBuild skills, keep the rest ignored

### DIFF
--- a/.claude/skills/deploy-probuild/SKILL.md
+++ b/.claude/skills/deploy-probuild/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: deploy-probuild
+description: Deploy ProBuild to Vercel production. Git auto-deploy is ON, so merging a PR ships it live; the CLI is for shipping ahead of a merge. Use when deploying to prod, running the pre-deploy checklist, rotating the Vercel token, or troubleshooting a deploy that shipped ahead of its schema migration.
+allowed-tools: Read, Bash, Grep, Glob
+---
+
+# Deploying ProBuild to Vercel
+
+Git auto-deploy is **ON** (verified 2026-08-10, PR #342). `vercel.json` holds only `crons` — there is
+no `git.deploymentEnabled` key and no dashboard override, so Vercel's default `true` applies.
+**Merging a PR ships it live.** Run the pre-deploy checklist before merging, not just before the CLI.
+
+## Production deploy command
+
+```powershell
+vercel --prod --yes --cwd "C:\Users\jat00\workspaces\golden-touch\active\gtr-probuild-site"
+```
+
+## Hard rule: never pass `--token`
+
+On success the Vercel CLI prints a "next steps" block that replays your command line back —
+including the token value — into the terminal and the session transcript. That has leaked the
+production token at least twice (PR-209, and again 2026-08-09), each time forcing a rotation.
+
+The flag is unnecessary. The CLI authenticates on its own, in this precedence order:
+
+1. `--token` on the command line (never use it);
+2. a **non-empty** `VERCEL_TOKEN` in the environment;
+3. otherwise the persisted login at `%APPDATA%\com.vercel.cli\Data\auth.json` (from `vercel login`).
+
+2 and 3 are read silently and never echoed. This applies to every authenticating subcommand
+(`deploy`, `env`, `logs`, `inspect`), not just `--prod`.
+
+A stale `VERCEL_TOKEN` fails every **authenticated** command — `Error: The token provided via
+VERCEL_TOKEN environment variable is not valid` — even when the persisted login is healthy. An
+invalid explicit credential does not fall back. Local-only commands like `vercel --version` still
+succeed, so don't use those to test auth.
+
+Verify auth before deploying — this should print `jadkins-4713`:
+
+```powershell
+vercel whoami
+```
+
+## Rotating the token
+
+Never put the value on a command line. `setx VERCEL_TOKEN "<value>"` is the same leak class this
+page exists to prevent — it lands the secret in argv, shell history, and any agent transcript.
+Justin does this himself, in his own terminal:
+
+- Windows GUI: Settings → *Edit environment variables for your account* → edit `VERCEL_TOKEN`; or
+- PowerShell, value read from a prompt instead of argv. It **must** be `-AsSecureString`: a bare
+  `Read-Host` echoes the pasted token to the screen and into terminal scrollback, and PowerShell 5.1
+  (this machine) has no `-MaskInput`.
+
+  ```powershell
+  $s = Read-Host 'Paste token' -AsSecureString
+  $b = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($s)
+  try {
+    [Environment]::SetEnvironmentVariable('VERCEL_TOKEN', [Runtime.InteropServices.Marshal]::PtrToStringBSTR($b), 'User')
+  } finally {
+    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($b)
+  }
+  ```
+
+Only new shells see the change, and it is Windows-only — WSL needs its own copy. Claude must never
+be given the token value.
+
+## Scope of the guard hook
+
+`~/.claude/hooks/block-vercel-token.mjs` (wired as a `PreToolUse` hook in `~/.claude/settings.json`)
+blocks `vercel` commands carrying `--token`/`-t`/an inline `VERCEL_TOKEN=`. It is defence-in-depth
+only: it covers Claude's Bash/PowerShell calls **on this machine** and nothing else — not a manual
+terminal, not CI, not Codex, not another machine.
+
+It also does not cover other secret-bearing paths: `--env KEY=VALUE` and `--build-env KEY=VALUE`
+put values in argv, and `vercel env pull` / `vercel pull` write every production env var in
+plaintext to `.env*` and `.vercel/.env.production.local`. Those files are gitignored but readable
+by any tool or backup — treat them as live secrets.
+
+## Pre-deploy checklist (in order)
+
+1. `npm run build` passes locally with 0 errors.
+2. **Schema changed?** If the branch edits `prisma/schema.prisma` and ships a `scripts/apply-*.mjs`, run it against prod BEFORE deploying:
+   ```bash
+   node scripts/apply-<name>.mjs
+   ```
+   These scripts are additive and idempotent (`IF NOT EXISTS`, guarded FKs) and safe to run while the old build is still live. But the new build's Prisma client selects the new columns immediately, so any page querying them throws P2022 "column does not exist" until the script runs.
+
+   > 2026-07-20: the company-schedule deploy went out before `apply-company-schedule-schema.mjs` ran. Project pages hit the route error boundary until it was applied.
+3. Deploy with the command above, then click through the affected pages on prod.
+
+## Why the flags are what they are
+
+- `--archive=tgz` is **optional**, not required (corrected 2026-08-10, PR #342). With the current
+  `.vercelignore` the source upload measures ~1,389 files against a 15,000-file cap. Archive mode
+  bundles everything into one tarball, which defeats per-file upload caching and can make repeat
+  deploys slower — add it only if an upload actually stalls.
+- `--cwd` points at the main repo. Deploy from there, never from a worktree — worktrees lack the `.vercel` link.
+- Only deploy when changes are verified locally via `npm run build`.
+
+## Cost note
+
+An older note here claimed auto-deploy had been turned off after a ~$250 bill from frequent builds.
+It was never actually disabled (see the top of this page). No checked-in config throttles build
+volume — no `ignoreCommand`, no Ignored Build Step — so keep pushes deliberate.
+
+## Reference
+
+- Vercel project ID: `prj_sd7R3WIYZCRMnu5IhAudBdc4vuIL`
+- Production: https://probuild.goldentouchremodeling.com
+- Vercel preview: https://probuild-amber.vercel.app

--- a/.claude/skills/probuild-dev-server/SKILL.md
+++ b/.claude/skills/probuild-dev-server/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: probuild-dev-server
+description: Start the ProBuild Next.js dev server cleanly, or recover one that won't boot. Use when the dev server is stuck, the port is held by a dead process, or a fresh local run is needed.
+allowed-tools: Read, Bash, Glob
+---
+
+# ProBuild dev server — clean start
+
+Prefer the Browser pane's `preview_start` (config in `.claude/launch.json`) over running the server by hand. Use the recipe below only when you need a raw clean start or the preview won't come up.
+
+```bash
+kill -9 $(lsof -ti tcp:3000,3001,3002) 2>/dev/null; rm -f .next/dev/lock; sleep 2
+npm run dev > /tmp/devserver.log 2>&1 &
+sleep 15 && curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/
+```
+
+## Rules
+
+- **Always use port 3000.** If it's taken, kill the holder — don't switch ports.
+- If it still won't start: `rm -rf .next && npm run dev`.

--- a/.claude/skills/probuild-diagnostics/SKILL.md
+++ b/.claude/skills/probuild-diagnostics/SKILL.md
@@ -8,19 +8,30 @@ allowed-tools: Read, Bash, Grep, Glob
 
 ## Sentry — production error triage
 
-Org is `golden-touch-remodeling` (us.sentry.io). Auth is already configured via `$SENTRY_AUTH_TOKEN`.
+Org is `golden-touch-remodeling` (us.sentry.io). Auth is via `$SENTRY_AUTH_TOKEN`.
 
 ```bash
-sentry-cli issues list --org golden-touch-remodeling --project <project> --output json
+sentry-cli issues list --org golden-touch-remodeling --project <project> --query "is:unresolved"
 ```
+
+`issues list` has **no** JSON output — there is no `--output`/`--format` flag on this
+subcommand (verified against sentry-cli 3.3.5; passing `--output json` hard-errors with
+`unexpected argument '--output' found`). It prints a table. Useful flags are `--query`,
+`--status {resolved,muted,unresolved}`, `--max-rows`, `--pages`, and `-i/--id`.
+
+If `$SENTRY_AUTH_TOKEN` is stale every command fails auth — triage from the Sentry web UI
+instead rather than trying to work around it.
 
 ## Stripe — local webhook testing
 
 Auth is already configured via `$STRIPE_API_KEY`.
 
 ```bash
-stripe listen --forward-to localhost:3000/api/webhooks/stripe --output json
+stripe listen --forward-to localhost:3000/api/webhooks/stripe --format JSON
 ```
+
+The flag is `--format JSON` (uppercase), **not** `--output json` — `stripe listen` has no
+`--output` flag. Verified against Stripe CLI 1.40.0.
 
 ```bash
 stripe trigger payment_intent.succeeded

--- a/.claude/skills/probuild-diagnostics/SKILL.md
+++ b/.claude/skills/probuild-diagnostics/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: probuild-diagnostics
+description: Diagnose ProBuild production errors via Sentry, and test Stripe webhooks locally. Use when investigating a prod error or exception, or when verifying payment webhook handling against the local dev server.
+allowed-tools: Read, Bash, Grep, Glob
+---
+
+# ProBuild diagnostics
+
+## Sentry — production error triage
+
+Org is `golden-touch-remodeling` (us.sentry.io). Auth is already configured via `$SENTRY_AUTH_TOKEN`.
+
+```bash
+sentry-cli issues list --org golden-touch-remodeling --project <project> --output json
+```
+
+## Stripe — local webhook testing
+
+Auth is already configured via `$STRIPE_API_KEY`.
+
+```bash
+stripe listen --forward-to localhost:3000/api/webhooks/stripe --output json
+```
+
+```bash
+stripe trigger payment_intent.succeeded
+```
+
+Dev server must be on port 3000 — see the `probuild-dev-server` skill.
+
+> Money-path changes (payments, signing, payment mirrors, notifications) also need `e2e/money-pipeline.spec.ts` green and a codex-peer-review pass on the diff.

--- a/.claude/skills/probuild-schema-migration/SKILL.md
+++ b/.claude/skills/probuild-schema-migration/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: probuild-schema-migration
+description: Apply a Prisma/Postgres schema change in ProBuild. The normal Prisma migration commands do not work against this Supabase setup, so schema changes go through a PowerShell SQL script instead. Use when adding columns or tables, editing prisma/schema.prisma, or regenerating the Prisma client.
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob
+---
+
+# ProBuild schema migrations
+
+## Why the standard commands don't work
+
+- `npx prisma db push` hangs interactively.
+- `prisma migrate dev` fails — port 5432 is blocked on the free tier.
+
+## Working approach
+
+1. Edit the SQL in `C:\Users\jat00\AppData\Local\Temp\apply_schema.ps1`.
+2. Run it:
+   ```powershell
+   powershell -ExecutionPolicy Bypass -File "C:\Users\jat00\AppData\Local\Temp\apply_schema.ps1"
+   ```
+3. Regenerate the client **from PowerShell**, never Git Bash:
+   ```powershell
+   powershell -Command "cd 'C:\Users\jat00\workspaces\golden-touch\active\gtr-probuild-site'; node_modules\.bin\prisma generate"
+   ```
+   Git Bash triggers `copyEngine: false`, which breaks the local dev engine.
+4. Update `prisma/schema.prisma` to match the SQL you just applied.
+
+## Shipping the change
+
+If the branch will deploy, also add a `scripts/apply-<name>.mjs` (additive, idempotent — `IF NOT EXISTS`, guarded FKs) and run it against prod **before** deploying. See the `deploy-probuild` skill.
+
+## Connection gotcha
+
+`DATABASE_URL` must include `?pgbouncer=true` — Supabase transaction pooler (port 6543) plus Prisma requires it. Without it you get `42P05 prepared statement already exists` and the site goes down.
+
+```
+postgresql://...@aws-0-us-west-2.pooler.supabase.com:6543/postgres?pgbouncer=true
+```
+
+`DIRECT_URL` uses port 5432 on `db.ghzdbzdnwjxazvmcefbh.supabase.co`, for migrations only.

--- a/.gitignore
+++ b/.gitignore
@@ -76,12 +76,12 @@ scripts/vendor/*
 
 # Per-machine Claude Code + Supabase CLI artifacts (not source)
 .claude/settings.local.json
-# .claude/skills/ is ignored BY DEFAULT, with the ProBuild-specific skills
-# allowlisted below. Those four are project docs describing how to deploy and
-# migrate THIS app, so they belong in version control: while they were ignored,
-# every git worktree kept its own drifting copy and 9 of them spent two weeks
-# telling agents that auto-deploy was off (it is ON) and that the token-rotation
-# snippet could use a bare Read-Host (it echoes the token to scrollback).
+# .claude/skills/ is ignored BY DEFAULT. Exactly four SKILL.md files are
+# allowlisted below, and nothing else in the tree is tracked. Those four are
+# project docs for deploying and migrating THIS app, so they belong in version
+# control: while ignored, every git worktree kept its own drifting copy, and 9
+# of them spent two weeks telling agents auto-deploy was off (it is ON) and that
+# the token-rotation snippet could use a bare Read-Host (it echoes the token).
 #
 # The rest of the tree stays ignored on purpose, and this is NOT merely a
 # per-machine-artifact call:
@@ -97,7 +97,14 @@ scripts/vendor/*
 !.claude/skills/probuild-dev-server/
 !.claude/skills/probuild-diagnostics/
 !.claude/skills/probuild-schema-migration/
-.claude/skills/*/state/
+# Re-ignore the CONTENTS of the four allowlisted dirs, then admit SKILL.md only.
+# Without these two lines the negations above reopen the whole directory, so a
+# future scripts/*.sh or nested doc dropped into an allowlisted skill would be
+# tracked silently, including shell scripts, which would then need a
+# .gitattributes eol=lf rule to survive core.autocrlf=true on the dev machines.
+.claude/skills/*/*
+!.claude/skills/*/SKILL.md
+
 docs/superpowers/
 supabase/.temp/
 

--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,28 @@ scripts/vendor/*
 
 # Per-machine Claude Code + Supabase CLI artifacts (not source)
 .claude/settings.local.json
-.claude/skills/
+# .claude/skills/ is ignored BY DEFAULT, with the ProBuild-specific skills
+# allowlisted below. Those four are project docs describing how to deploy and
+# migrate THIS app, so they belong in version control: while they were ignored,
+# every git worktree kept its own drifting copy and 9 of them spent two weeks
+# telling agents that auto-deploy was off (it is ON) and that the token-rotation
+# snippet could use a bare Read-Host (it echoes the token to scrollback).
+#
+# The rest of the tree stays ignored on purpose, and this is NOT merely a
+# per-machine-artifact call:
+#   - bank-recon/ and email-triage/ carry live operational data (bank account
+#     suffix, Drive folder ids, staff and external-partner email addresses).
+#     Do not commit these; git history is forever.
+#   - 17 skills are vendored from ByBren, LLC / J. Scott Graham under MIT and
+#     require attribution via /LICENSE and /NOTICE, neither of which this repo
+#     carries. They also describe a different stack (master/Coolify/yarn/Clerk).
+# Adding a new skill here means opting it in deliberately, after checking both.
+.claude/skills/*
+!.claude/skills/deploy-probuild/
+!.claude/skills/probuild-dev-server/
+!.claude/skills/probuild-diagnostics/
+!.claude/skills/probuild-schema-migration/
+.claude/skills/*/state/
 docs/superpowers/
 supabase/.temp/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,12 +62,12 @@ Sessions 1–2 + Gantt polish are complete. Each session lists specific files, a
 
 **Error diagnosis (Sentry)**
 ```bash
-sentry-cli issues list --org golden-touch-remodeling --project <project> --output json
+sentry-cli issues list --org golden-touch-remodeling --project <project> --query "is:unresolved"
 ```
 
 **Stripe webhook testing**
 ```bash
-stripe listen --forward-to localhost:3000/api/webhooks/stripe --output json
+stripe listen --forward-to localhost:3000/api/webhooks/stripe --format JSON
 stripe trigger payment_intent.succeeded
 ```
 


### PR DESCRIPTION
## Why

`.claude/skills/` was gitignored, so **every git worktree carried its own independent copy of every SKILL.md with no sync mechanism**. Skills are loaded into agent context as fact, so a stale copy silently feeds agents wrong information.

An audit across all 24 worktrees found **9 live worktrees** still holding a July copy of `deploy-probuild/SKILL.md`, wrong in three ways:

| Claim in the stale copy | Reality |
|---|---|
| "Auto-deploy is **off**, production only ships via CLI" | Auto-deploy is **ON** — merging a PR ships to prod (verified #342) |
| "`--archive=tgz` is **required**, project exceeds the 15,000-file limit" | Optional — ~1,389 source files against that cap; archive mode defeats upload caching |
| Rotation snippet used a bare `Read-Host` | Echoes the pasted token to screen and scrollback; PS 5.1 has no `-MaskInput`. Must be `-AsSecureString` with the BSTR zeroed in `finally` |

The auto-deploy error was also in the frontmatter `description:`, which is what gets injected into context during skill selection. Second time stale worktree copies have bitten — see #340.

Only that one file had actually drifted; every other skill matched. The 9 copies were byte-identical to each other, so there were no in-flight edits to preserve. They have been synced on disk and every copy in the tree now hashes identically.

## What changed

Ignore `.claude/skills/*` by default, allowlist the four ProBuild-specific skills:

- `deploy-probuild`, `probuild-dev-server`, `probuild-diagnostics`, `probuild-schema-migration`

These describe how to deploy and migrate *this* app. Tracking them makes drift show up in `git status` and puts them through PR review like the rest of the docs.

## What is deliberately still ignored

The reasons are documented inline in `.gitignore` so the next person doesn't helpfully un-ignore them. **The first draft of this PR committed all 55 files; Codex review caught that as a blocker and the scope was narrowed.**

- **`bank-recon/` and `email-triage/`** carry live operational data: bank account suffix, Google Drive folder ids, staff and external-partner email addresses. Git history is forever.
- **17 skills are vendored** from ByBren, LLC / J. Scott Graham under MIT, requiring attribution via `/LICENSE` and `/NOTICE` — neither exists in this repo. They also document a different stack (`master`/Coolify/yarn/Clerk/`prisma migrate dev`) and directly contradict CLAUDE.md.
- **`*/state/`** is per-run scratch from the codex-review skills (74 files).

No `.gitattributes` is needed — none of the four contain shell scripts, so the CRLF hazard that would apply to the wider tree doesn't arise.

## Verification

- Truth table over `git check-ignore`: the four resolve as tracked; `bank-recon`, `email-triage`, all vendored skills, `README.md`, `*/state/`, `.claude/settings.local.json` and `.claude/worktrees/` all still ignored.
- Grepped the four for secrets, emails, folder ids and account digits — clean.
- Confirmed none of the four instruct passing `--token` to the Vercel CLI, and none still claim auto-deploy is off.
- **Docs and config only. No application source touched, so there is nothing browser-observable and no runtime risk.** Auto-deploy will build on merge; the build output is unchanged.

## Follow-ups (not in this PR)

Codex flagged that the vendored skills are stale for this project and that the `codex-*` review skills reference missing files. Spinning those off separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)