### PR TITLE
test(estimates): prove the scoped-total labels in a real browser

### DIFF
--- a/e2e/auth-scoped.setup.ts
+++ b/e2e/auth-scoped.setup.ts
@@ -1,0 +1,44 @@
+import { test as setup, expect } from "@playwright/test";
+
+/**
+ * Second storage state: a staff reader whose project scope is PARTIAL.
+ *
+ * Mirrors auth.setup.ts, which logs in the ADMIN. ADMIN is useless for scope
+ * assertions — accessibleProjectIds() short-circuits to "ALL" for it — so every
+ * "your projects" / "you can see" label was previously unreachable at runtime
+ * and only greppable in source. This session reaches those branches for real.
+ *
+ * The fixture (user, permissions, single ProjectAccess row, out-of-scope
+ * project) is seeded by data.setup.ts, which this project depends on.
+ */
+setup("authenticate scoped staff", async ({ page }) => {
+  const baseURL = "http://localhost:3000";
+  const email = "scoped-staff@test.local";
+
+  const csrfRes = await page.request.get(`${baseURL}/api/auth/csrf`);
+  const { csrfToken } = await csrfRes.json();
+
+  const authRes = await page.request.post(`${baseURL}/api/auth/callback/credentials`, {
+    form: {
+      csrfToken,
+      email,
+      secret: process.env.PLAYWRIGHT_TEST_SECRET || "",
+    },
+  });
+  expect(authRes.ok(), `Credentials callback failed at ${authRes.url()}`).toBeTruthy();
+
+  // In development the app falls back to a known ADMIN when there is no
+  // session. That fallback would make every assertion in the scoped spec pass
+  // for the wrong reason, so prove the session is this user and NOT an admin
+  // before saving the state.
+  const sessionRes = await page.request.get(`${baseURL}/api/auth/session`);
+  expect(sessionRes.ok()).toBeTruthy();
+  const session = await sessionRes.json();
+  expect(session.user).toMatchObject({ email, role: "EMPLOYEE" });
+  expect(session.user.id).toBeTruthy();
+
+  await page.goto("/projects", { waitUntil: "networkidle", timeout: 15_000 });
+  await expect(page).not.toHaveURL(/.*login.*/);
+
+  await page.context().storageState({ path: "e2e/.auth/scoped-user.json" });
+});

--- a/e2e/data.setup.ts
+++ b/e2e/data.setup.ts
@@ -27,6 +27,21 @@ const MOBILE_DAILYLOG_ID = "e2e-mob-dailylog";
 const MOBILE_DAILYLOG_PHOTO_ID = "e2e-mob-dailylog-photo";
 const MOBILE_TIME_ENTRY_HIST_ID = "e2e-mob-entry-hist";
 
+// --- Partial-scope fixtures (prefix e2e-scope-) ---
+// A staff reader who can see estimates and leads but only ONE project, plus a
+// SECOND project they cannot reach that carries an approved estimate. Together
+// these make every scoped aggregate in the app provably partial for this user
+// and provably complete for the ADMIN, which is what estimate-scope-labels.spec
+// asserts in a real browser. The ADMIN session can never exercise that branch —
+// accessibleProjectIds returns "ALL" for ADMIN — so this second user is the only
+// way to prove the label wiring at runtime rather than by grepping the source.
+const SCOPED_STAFF_EMAIL = "scoped-staff@test.local";
+const OOS_PROJECT_ID = "e2e-scope-oos-project";
+const OOS_PROJECT_NAME = "E2E Out-Of-Scope Project — DO NOT DELETE";
+const OOS_ESTIMATE_ID = "e2e-scope-oos-estimate";
+const OOS_LEAD_ID = "e2e-scope-oos-lead";
+const OOS_LEAD_ESTIMATE_ID = "e2e-scope-oos-lead-estimate";
+
 // Substrings that identify the LIVE database. The e2e suite creates leads,
 // estimates, and invoices — it must never do that against production data.
 // See docs/TESTING.md (the Henderson-lead incident, June 2026).
@@ -341,6 +356,145 @@ setup("guard prod DB + seed test data + probe anthropic", async () => {
             },
         });
         console.log("[data.setup] historical time entry upserted:", { id: MOBILE_TIME_ENTRY_HIST_ID });
+
+        // --- Partial-scope fixtures ---
+        // EMPLOYEE, not FIELD_CREW: the pages under test need `estimates` and
+        // `leadAccess`, and granting those to a role whose defaults withhold them
+        // keeps the fixture explicit about WHY this user can read the pages at all.
+        const scopedStaff = await prisma.user.upsert({
+            where: { email: SCOPED_STAFF_EMAIL },
+            update: { role: "EMPLOYEE", status: "ACTIVATED" },
+            create: {
+                email: SCOPED_STAFF_EMAIL,
+                name: "E2E Scoped Staff",
+                role: "EMPLOYEE",
+                status: "ACTIVATED",
+            },
+        });
+        const scopedPermissions = {
+            estimates: true,
+            leadAccess: true,
+            // Off deliberately: an auto-grant would hand this user every project
+            // and silently erase the partial scope the whole fixture exists for.
+            autoGrantNewProjects: false,
+        };
+        await prisma.userPermission.upsert({
+            where: { userId: scopedStaff.id },
+            update: scopedPermissions,
+            create: { userId: scopedStaff.id, ...scopedPermissions },
+        });
+        // Exactly one project. Access is granted via ProjectAccess only — the crew
+        // relation is left alone so a stray crew connect cannot widen the scope.
+        await prisma.projectAccess.upsert({
+            where: { userId_projectId: { userId: scopedStaff.id, projectId: PROJECT_ID } },
+            update: {},
+            create: { userId: scopedStaff.id, projectId: PROJECT_ID },
+        });
+        // ...and re-narrow on re-runs, in case an earlier run or another fixture
+        // granted more. Without this the spec would pass for the wrong reason
+        // (or fail confusingly) against a reused database.
+        await prisma.projectAccess.deleteMany({
+            where: { userId: scopedStaff.id, projectId: { not: PROJECT_ID } },
+        });
+        const scopedCrewProjects = await prisma.project.findMany({
+            where: { id: { not: PROJECT_ID }, crew: { some: { id: scopedStaff.id } } },
+            select: { id: true },
+        });
+        for (const p of scopedCrewProjects) {
+            await prisma.project.update({
+                where: { id: p.id },
+                data: { crew: { disconnect: { id: scopedStaff.id } } },
+            });
+        }
+        console.log("[data.setup] scoped staff user upserted:", { id: scopedStaff.id, email: scopedStaff.email });
+
+        // The lead must exist before the project that points at it (Project.leadId).
+        // Every `update` below restates the fields the fixture is DEFINED by,
+        // not just the ones that drift. On a reused database an earlier run (or
+        // a spec that reparents rows) can leave a closed project, a re-owned
+        // estimate, or a moved lead behind, and an empty `update` would adopt
+        // that state — the specs would then pass or fail for reasons unrelated
+        // to the labels under test.
+        await prisma.lead.upsert({
+            where: { id: OOS_LEAD_ID },
+            update: { clientId: TEST_CLIENT_ID, stage: "Won" },
+            create: {
+                id: OOS_LEAD_ID,
+                name: "E2E Out-Of-Scope Lead — DO NOT DELETE",
+                clientId: TEST_CLIENT_ID,
+                stage: "Won",
+            },
+        });
+        await prisma.project.upsert({
+            where: { id: OOS_PROJECT_ID },
+            update: {
+                name: OOS_PROJECT_NAME,
+                clientId: TEST_CLIENT_ID,
+                leadId: OOS_LEAD_ID,
+                // Not "Archived": the /projects list hides archived rows, and a
+                // hidden out-of-scope project makes the revenue sum complete.
+                status: "In Progress",
+            },
+            create: {
+                id: OOS_PROJECT_ID,
+                name: OOS_PROJECT_NAME,
+                clientId: TEST_CLIENT_ID,
+                leadId: OOS_LEAD_ID,
+                status: "In Progress",
+            },
+        });
+        // Approved, so it lands in the /projects revenue sum for a reader who can
+        // see it — that sum is the number whose label is under test.
+        await prisma.estimate.upsert({
+            where: { id: OOS_ESTIMATE_ID },
+            update: {
+                status: "Approved",
+                totalAmount: 5000,
+                balanceDue: 5000,
+                archivedAt: null,
+                // Ownership is the whole point of this row — restate it, or a
+                // reparented estimate quietly stops being out of scope.
+                projectId: OOS_PROJECT_ID,
+                leadId: null,
+            },
+            create: {
+                id: OOS_ESTIMATE_ID,
+                title: "E2E Out-Of-Scope Estimate — DO NOT DELETE",
+                code: "EST-E2E-OOS",
+                status: "Approved",
+                projectId: OOS_PROJECT_ID,
+                totalAmount: 5000,
+                balanceDue: 5000,
+            },
+        });
+        // A lead-owned estimate on the same lead: reachable via `leadAccess`, so
+        // the scoped reader sees a non-empty page whose totals are still partial.
+        await prisma.estimate.upsert({
+            where: { id: OOS_LEAD_ESTIMATE_ID },
+            update: {
+                status: "Approved",
+                totalAmount: 1000,
+                balanceDue: 1000,
+                archivedAt: null,
+                leadId: OOS_LEAD_ID,
+                // Must stay lead-OWNED: given a projectId it would resolve
+                // through project access instead of leadAccess and vanish for
+                // the scoped reader, emptying the page it is here to populate.
+                projectId: null,
+            },
+            create: {
+                id: OOS_LEAD_ESTIMATE_ID,
+                title: "E2E Out-Of-Scope Lead Estimate — DO NOT DELETE",
+                code: "EST-E2E-OOS-LEAD",
+                status: "Approved",
+                leadId: OOS_LEAD_ID,
+                totalAmount: 1000,
+                balanceDue: 1000,
+            },
+        });
+        console.log("[data.setup] partial-scope fixtures upserted:", {
+            project: OOS_PROJECT_ID, lead: OOS_LEAD_ID, estimates: [OOS_ESTIMATE_ID, OOS_LEAD_ESTIMATE_ID],
+        });
 
         const verify = await prisma.project.findUnique({ where: { id: PROJECT_ID }, select: { id: true, name: true } });
         console.log("[data.setup] verify project exists:", verify);

--- a/e2e/estimate-scope-labels.spec.ts
+++ b/e2e/estimate-scope-labels.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * RUNTIME proof for the scoped-total labels shipped in PR #346.
+ *
+ * Three layers guard this behaviour and they prove different things:
+ *   - estimate-scope-rules.spec.ts  — the pure rule, over a truth table.
+ *   - financial-action-auth.spec.ts — the wiring, by reading the source.
+ *   - this file                     — the rendered page, in a real browser.
+ *
+ * Only the third can catch a page that computes the flag correctly and then
+ * renders the wrong string, because only it looks at what the reader sees.
+ *
+ * The whole thing hinges on running as a NON-ADMIN: accessibleProjectIds()
+ * returns "ALL" for ADMIN and MANAGER, so under the default admin session every
+ * qualified label is dead code. e2e/auth-scoped.setup.ts provides the second
+ * session; e2e/data.setup.ts provides the one-project-of-two fixture.
+ *
+ * Creates no data — the fixtures are stable upserts owned by data.setup.ts —
+ * so there is nothing to tear down.
+ */
+
+const OOS_LEAD_ID = "e2e-scope-oos-lead";
+const OOS_PROJECT_ID = "e2e-scope-oos-project";
+const IN_SCOPE_PROJECT_ID = "cmml6vt3y000lpwrh0p9p3k12";
+const OOS_PROJECT_NAME = "E2E Out-Of-Scope Project — DO NOT DELETE";
+
+const ADMIN_STATE = "e2e/.auth/user.json";
+const SCOPED_STATE = "e2e/.auth/scoped-user.json";
+
+test.describe("scoped staff (one project of two)", () => {
+    test.use({ storageState: SCOPED_STATE });
+
+    test("/projects qualifies the revenue label while still counting every project", async ({ page }) => {
+        await page.goto("/projects", { waitUntil: "networkidle" });
+
+        // The list itself is NOT scoped: the out-of-scope project is on screen.
+        // That is the whole hazard — a company-wide row count sitting beside a
+        // per-caller revenue sum. If this ever stops being true the label
+        // question is moot and this spec should be revisited, not deleted.
+        // Attached, not visible: the page renders both the list and the kanban
+        // markup and hides the inactive one, so visibility would assert which
+        // view happens to be selected rather than what the query returned.
+        await expect(page.locator(`a[href="/projects/${OOS_PROJECT_ID}"]`).first()).toBeAttached();
+
+        await expect(page.getByText("Revenue (your projects)")).toBeVisible();
+        await expect(page.getByText("Excludes projects you don't have access to")).toBeVisible();
+        await expect(page.getByText("Total Revenue", { exact: true })).toHaveCount(0);
+    });
+
+    test("a converted lead whose project is out of scope qualifies all three cards", async ({ page }) => {
+        await page.goto(`/leads/${OOS_LEAD_ID}/estimates`, { waitUntil: "networkidle" });
+
+        await expect(page.getByText("Across the estimates you can see")).toBeVisible();
+        await expect(page.getByText("Visible to you")).toBeVisible();
+        await expect(page.getByText(`you don't have access to ${OOS_PROJECT_NAME}`)).toBeVisible();
+
+        // The exact figures, not just the strings: the lead-owned $1,000 is in,
+        // the project-owned $5,000 is out. A wildcard "N approved" would still
+        // pass if the fixture degraded to zero rows, which is precisely the
+        // state in which a hedged label proves nothing.
+        await expect(page.getByText("1 approved that you can see")).toBeVisible();
+        await expect(page.getByText("$1,000.00").first()).toBeVisible();
+        await expect(page.getByText("$6,000.00")).toHaveCount(0);
+
+        // The unqualified claims must be gone, not merely joined.
+        await expect(page.getByText("Across all estimates")).toHaveCount(0);
+        await expect(page.getByText("Total created")).toHaveCount(0);
+    });
+});
+
+test.describe("admin (sees everything)", () => {
+    test.use({ storageState: ADMIN_STATE });
+
+    test("/projects keeps the unqualified revenue label", async ({ page }) => {
+        await page.goto("/projects", { waitUntil: "networkidle" });
+
+        await expect(page.getByText("Total Revenue", { exact: true })).toBeVisible();
+        await expect(page.getByText("Revenue (your projects)")).toHaveCount(0);
+        await expect(page.getByText("Excludes projects you don't have access to")).toHaveCount(0);
+    });
+
+    test("the same lead's cards claim completeness", async ({ page }) => {
+        await page.goto(`/leads/${OOS_LEAD_ID}/estimates`, { waitUntil: "networkidle" });
+
+        await expect(page.getByText("Across all estimates")).toBeVisible();
+        await expect(page.getByText("Total created")).toBeVisible();
+        await expect(page.getByText("Across the estimates you can see")).toHaveCount(0);
+        await expect(page.getByText("Visible to you")).toHaveCount(0);
+        await expect(page.getByText(/approved that you can see/)).toHaveCount(0);
+
+        // Same two estimates, both in scope: $1,000 lead + $5,000 project. The
+        // scoped reader's $1,000 above is the same page missing this row.
+        await expect(page.getByText("2 approved", { exact: true })).toBeVisible();
+        await expect(page.getByText("$6,000.00").first()).toBeVisible();
+    });
+});
+
+test("both sessions list the same two projects, and only one of them hedges", async ({ browser }) => {
+    // This is what makes the differing revenue labels meaningful: it rules out
+    // the alternative explanation that the scoped reader simply sees fewer
+    // project rows, in which case a scoped total would need no hedge at all.
+    //
+    // Asserted over the two fixture ids rather than the "Total Projects" number:
+    // the suite is fully parallel and other specs create and delete projects, so
+    // that count is not stable between two sequential page loads.
+    for (const [label, storageState] of [["admin", ADMIN_STATE], ["scoped", SCOPED_STATE]] as const) {
+        const context = await browser.newContext({ storageState });
+        const page = await context.newPage();
+        await page.goto("/projects", { waitUntil: "networkidle" });
+
+        for (const id of [IN_SCOPE_PROJECT_ID, OOS_PROJECT_ID]) {
+            await expect(
+                page.locator(`a[href="/projects/${id}"]`).first(),
+                `${label} should see project ${id} in the company-wide list`,
+            ).toBeAttached();
+        }
+
+        const hedged = await page.getByText("Excludes projects you don't have access to").count();
+        expect(hedged, `${label} hedge`).toBe(label === "scoped" ? 1 : 0);
+
+        await context.close();
+    }
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,12 +29,24 @@ export default defineConfig({
       dependencies: ["data"],
     },
     {
+      // A SECOND session: staff with partial project scope. The admin can never
+      // exercise the scoped branches (accessibleProjectIds returns "ALL"), so
+      // estimate-scope-labels.spec.ts needs its own storage state.
+      name: "setup-scoped",
+      testMatch: /(^|[\\/])auth-scoped\.setup\.ts$/,
+      dependencies: ["data"],
+    },
+    {
       name: "chromium",
+      // The setup files are run by the setup projects above. Without this they
+      // would ALSO run here as ordinary tests and rewrite the storage-state
+      // files underneath the specs currently reading them.
+      testIgnore: ["**/mobile-app/**", "**/*.setup.ts"],
       use: {
         ...devices["Desktop Chrome"],
         storageState: "e2e/.auth/user.json",
       },
-      dependencies: ["data", "setup"],
+      dependencies: ["data", "setup", "setup-scoped"],
     },
   ],
   webServer: {


### PR DESCRIPTION
Closes the open gap left by #346.

## The gap

#346 made two aggregates hedge their labels when the reader's estimate scope is partial. Nothing exercised that branch at runtime. The e2e suite had only an ADMIN session, and `accessibleProjectIds()` returns `"ALL"` for ADMIN, so every "your projects" / "you can see" string was unreachable in a browser. The wiring was asserted by reading the source in `financial-action-auth.spec.ts`, which rules out a hardcode but cannot prove what the page renders.

## What this adds

A second Playwright session with genuinely partial scope: an EMPLOYEE holding `estimates` + `leadAccess` and `ProjectAccess` to exactly one of two projects, plus an out-of-scope project carrying an approved estimate and a converted lead.

Both readers are then asserted against the same fixtures:

| | scoped EMPLOYEE | ADMIN |
|---|---|---|
| /projects revenue card | "Revenue (your projects)" + the excludes note | "Total Revenue", no note |
| lead estimates cards | "Across the estimates you can see" / "Visible to you" / "1 approved that you can see" / $1,000.00 | "Across all estimates" / "Total created" / "2 approved" / $6,000.00 |

Both are pinned to the same two project rows in the company-wide list, so the differing revenue labels cannot be explained away by the scoped reader simply seeing fewer projects.

The `chromium` project now ignores `*.setup.ts`. Those files were being discovered twice, once by their setup project and once as ordinary tests, which with a second storage state would rewrite an auth file underneath a spec reading it. It also stops CI from running `prod-auth.setup.ts`.

## Verification

- Full suite against a throwaway Postgres: **420 passed**, 1 pre-existing unrelated flake (retried green). `money-pipeline` green.
- Mutation test: hardcoding both labels to their unqualified strings fails exactly the two scoped tests.
- Codex (gpt-5.6-sol, xhigh) raised two P2s, both fixed: a flaky cross-session project-count comparison (replaced with stable fixture ids), and `update` branches that did not restore fixture ownership on a reused database. The second was verified by corrupting the DB by hand (reparenting the lead estimate, archiving the project) and confirming setup repairs it.

Test-only change. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)