### PR TITLE
chore(skills): delete the 17 vendored ByBren skills, ignore the second skill tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,9 +88,13 @@ scripts/vendor/*
 #   - bank-recon/ and email-triage/ carry live operational data (bank account
 #     suffix, Drive folder ids, staff and external-partner email addresses).
 #     Do not commit these; git history is forever.
-#   - 17 skills are vendored from ByBren, LLC / J. Scott Graham under MIT and
-#     require attribution via /LICENSE and /NOTICE, neither of which this repo
-#     carries. They also describe a different stack (master/Coolify/yarn/Clerk).
+#   - 17 skills vendored from ByBren, LLC / J. Scott Graham used to sit here.
+#     They were deleted on 2026-08-10: nothing in tracked source referenced
+#     them, they described a different stack (master/Coolify/yarn/Clerk/RLS
+#     helpers) and so fed agents instructions that contradict CLAUDE.md, and
+#     their MIT terms wanted attribution via /LICENSE and /NOTICE that this
+#     repo does not carry. Deleting them retired that obligation outright.
+#     Do not re-vendor them; the four probuild-* skills are the real ones.
 # Adding a new skill here means opting it in deliberately, after checking both.
 .claude/skills/*
 !.claude/skills/deploy-probuild/
@@ -104,6 +108,19 @@ scripts/vendor/*
 # .gitattributes eol=lf rule to survive core.autocrlf=true on the dev machines.
 .claude/skills/*/*
 !.claude/skills/*/SKILL.md
+
+# .agents/skills/ is a SECOND skill tree, and the rules above never covered it.
+# It held its own untracked copies of bank-recon/ and email-triage/ - the same
+# live bank + staff-email data the block above exists to keep out of history -
+# sitting in `git status` as plain untracked dirs on a checkout that is usually
+# mid-WIP. One `git add -A` would have committed them. Ignore by default and
+# allowlist only the two Supabase skills, which are already fully tracked and
+# carry no operational data. Unlike .claude/skills above, these negations are
+# meant to reopen the whole directory: both skills track references/ and
+# assets/ subtrees, not just a bare SKILL.md.
+.agents/skills/*
+!.agents/skills/supabase/
+!.agents/skills/supabase-postgres-best-practices/
 
 docs/superpowers/
 supabase/.temp/


### PR DESCRIPTION
Closes the two problems Codex raised against #349's vendored skills.

## Decision: delete (option a)

Checked first whether anything used them. **Nothing in tracked source references them.** The only referrers are other files from the same vendored harness (`AGENTS.md`, `.claude/agents/*.md`, `.claude/commands/*.md`, `.claude/README.md`, `.claude/SETUP.md`) — all themselves untracked.

They were not inert, though. Claude Code loads `.claude/skills/` every session, so every agent was being handed instructions that contradict `CLAUDE.md`:

| Skill | Told agents | Reality |
|---|---|---|
| `migration-patterns` | run `prisma migrate dev` | CLAUDE.md expressly forbids it (port 5432 blocked); DDL goes via a PowerShell SQL script |
| `deployment-sop` | prod is `master` on Coolify, yarn | `main` on Vercel, npm, and merging `main` auto-deploys |
| `release-patterns`, `git-advanced` | `origin/dev`, `yarn ci:validate` | neither exists |
| `frontend-patterns` | mandates Clerk + PostHog + shadcn, imports `@clerk/nextjs` | none are dependencies; auth is NextAuth + Supabase |

Deleting also retires the MIT attribution obligation their READMEs asserted via `/LICENSE` and `/NOTICE`, neither of which this repo carries — rather than incurring it. Adapting (option b) would have meant rewriting 17 documents to restate what `CLAUDE.md` and the four `probuild-*` skills already say; a banner (option c) leaves the wrong instructions loaded in every agent's context and still needs the license files.

Removed from `.claude/skills/`, from a duplicate copy in `.agents/skills/`, and from all 20 worktrees. They were never tracked, so this is a working-tree deletion with no history impact; a backup was taken first, and they remain available from the upstream ByBren repo.

## The finding this turned up: PII was one `git add -A` from history

`.agents/skills/` is a **second** skill tree that #349's allowlist never covered. It held its own untracked **and un-ignored** copies of `bank-recon/` and `email-triage/` — the live bank-account suffix, Drive folder ids, and staff and external-partner email addresses that the `.claude/skills` block exists to keep out of git. They sat in `git status` as plain `??` directories on a checkout that is usually mid-WIP.

Now ignored by default, allowlisting only `supabase/` and `supabase-postgres-best-practices/`, which are already fully tracked and carry no operational data. Those negations deliberately reopen the whole directory (both track `references/`/`assets/` subtrees), unlike the `.claude/skills` block above which admits only a bare `SKILL.md`.

A `.gitignore` lives on a branch, so the primary checkout and 20+ worktrees on older branches would stay exposed until this merges. Added the same two paths to `.git/info/exclude`, which is read from the **common** git dir and so applies to every worktree on every branch immediately. Verified the PII no longer appears in `git status` in the primary checkout.

## Verification

- `npm run build` — exit 0, compiled successfully, 102/102 pages.
- Codex (gpt-5.6-sol, xhigh) reviewed and confirmed the ignore-pattern logic: `.agents/skills/*` excludes children but not the parent, so the directory negations validly reopen the Supabase skills including nested files; ignoring already-tracked files drops nothing and hides no future changes.
- Codex's "trailing whitespace" flag is **pre-existing** — #349's own added lines fail `git diff --check` identically and the file has been `i/mixed` since before this branch. The added lines match the CRLF convention of the block they sit in; normalizing the whole file is a separate cleanup.
- Confirmed live: the session's available-skills list dropped to the four `probuild-*` skills plus the codex ones.

**No application code, dependency, or build-output changes.** The only tracked change is `.gitignore`, so there is nothing browser-testable here.

## Follow-up (not in this PR)

The rest of the vendored harness is still on disk and still active: root `AGENTS.md` steers Codex directly and at line 94 still says `npx prisma migrate dev`, and `.claude/agents/*` and `.claude/commands/*` remain invokable and still carry Clerk imports, `origin/dev` and `yarn ci:validate`. Retiring those removes live agent types, so it is a deliberate separate call. Spun off as its own task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)