### PR TITLE
docs(skills): correct the migrate-dev cause and harden the dev-server check

### DIFF
--- a/.claude/skills/probuild-dev-server/SKILL.md
+++ b/.claude/skills/probuild-dev-server/SKILL.md
@@ -8,13 +8,132 @@ allowed-tools: Read, Bash, Glob
 
 Prefer the Browser pane's `preview_start` (config in `.claude/launch.json`) over running the server by hand. Use the recipe below only when you need a raw clean start or the preview won't come up.
 
+Wrapped in a function on purpose: a failed check must not kill an interactive shell, and a
+half-started server must not be left running on the wrong port.
+
 ```bash
-kill -9 $(lsof -ti tcp:3000,3001,3002) 2>/dev/null; rm -f .next/dev/lock; sleep 2
-npm run dev > /tmp/devserver.log 2>&1 &
-sleep 15 && curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/
+# Listener PIDs on a port. Git Bash has no lsof, so fall back to PowerShell there —
+# without this the port checks silently evaluate to "nothing is holding 3000" and
+# step 1 becomes a no-op. Returns OS-native PIDs (Windows PIDs under Git Bash).
+port_pids() {
+  if command -v lsof >/dev/null 2>&1; then
+    # -sTCP:LISTEN matters: plain `lsof -ti tcp:3000` also matches established
+    # connections whose REMOTE port is 3000, so it can SIGKILL bystanders.
+    lsof -nP -tiTCP:"$1" -sTCP:LISTEN
+  elif command -v powershell.exe >/dev/null 2>&1; then
+    powershell.exe -NoProfile -Command \
+      "Get-NetTCPConnection -LocalPort $1 -State Listen -ErrorAction SilentlyContinue |
+       Select-Object -ExpandProperty OwningProcess" 2>/dev/null | tr -d '\r'
+  else
+    echo "port_pids: need lsof or powershell.exe" >&2
+    return 1
+  fi
+}
+
+# Kill PIDs *and their children*. Only ever pass PIDs that came from port_pids —
+# they are OS-native. Never pass a shell job id ($!); under Git Bash that is an
+# MSYS pid and taskkill would resolve it to an unrelated Windows process.
+kill_tree() {
+  local p
+  for p in "$@"; do
+    [ -n "$p" ] || continue
+    if command -v taskkill.exe >/dev/null 2>&1; then
+      taskkill.exe //PID "$p" //T //F >/dev/null 2>&1
+    else
+      pkill -9 -P "$p" 2>/dev/null
+      kill -9 "$p" 2>/dev/null
+    fi
+  done
+}
+
+# Kill whatever WE started, wherever it landed. The port is read back out of OUR
+# OWN log, so this never touches an unrelated process that happens to hold 3001.
+kill_our_server() {
+  local bound
+  bound=$(grep -oE 'http://localhost:[0-9]+' /tmp/devserver.log | head -1 | grep -oE '[0-9]+$')
+  [ -n "$bound" ] && kill_tree $(port_pids "$bound")
+  kill "$1" 2>/dev/null   # the npm shell job
+  wait "$1" 2>/dev/null
+}
+
+probuild_dev_start() {
+  local pids dev_pid probe code
+
+  # 1. Free port 3000.
+  pids=$(port_pids 3000) || return 1
+  [ -n "$pids" ] && kill_tree $pids && sleep 2
+  if [ -n "$(port_pids 3000)" ]; then
+    echo "FAIL: port 3000 still held by pid $(port_pids 3000 | tr '\n' ' ')"
+    return 1
+  fi
+  rm -f .next/dev/lock
+
+  # 2. Start it.
+  npm run dev > /tmp/devserver.log 2>&1 &
+  dev_pid=$!
+
+  # 3. Wait for OUR server to report it bound 3000. With 3000 taken, Next instead logs
+  #    "Port 3000 is in use by process N, using available port 3001 instead." — which
+  #    does not contain this string, so a fallback can never pass as success.
+  for _ in $(seq 60); do
+    grep -q "http://localhost:3000" /tmp/devserver.log && break
+    kill -0 "$dev_pid" 2>/dev/null || break   # it exited; stop waiting
+    sleep 1
+  done
+  if ! grep -q "http://localhost:3000" /tmp/devserver.log; then
+    echo "FAIL: never bound 3000 (fell back to another port, or died)"
+    tail -30 /tmp/devserver.log
+    kill_our_server "$dev_pid"
+    return 1
+  fi
+
+  # 4. Confirm ProBuild is what answers on 3000. Require BOTH a real 200 and ProBuild's
+  #    own markup — `curl -s` alone reports success on a 404/500, and any process can
+  #    return a bare 200. Binding is not the same as being ready to serve, hence the retry.
+  probe=$(mktemp)
+  for _ in $(seq 30); do
+    code=$(curl -s --max-time 30 -o "$probe" -w '%{http_code}' http://localhost:3000/login)
+    [ "$code" = "200" ] && grep -q "Golden Touch Remodeling" "$probe" && break
+    sleep 2
+  done
+  if [ "$code" = "200" ] && grep -q "Golden Touch Remodeling" "$probe"; then
+    rm -f "$probe"
+    echo "OK: ProBuild dev server up on 3000 (npm job $dev_pid)"
+    return 0
+  fi
+  echo "FAIL: :3000 returned $code and did not look like ProBuild"
+  head -20 "$probe"; rm -f "$probe"
+  kill_our_server "$dev_pid"
+  return 1
+}
+
+probuild_dev_start
 ```
+
+## Where to run this
+
+**Git Bash.** That is the supported shell here, and the recipe runs there as written — `port_pids`
+falls back to `powershell.exe` for the port lookup and `kill_tree` uses `taskkill`. No `lsof`
+needed.
+
+**Not WSL.** `node_modules` on this machine is installed for **Windows**. Run the dev server from
+WSL against the Windows checkout and it boots, then 500s on every page with
+`Cannot find module '../lightningcss.linux-x64-gnu.node'` — the native binaries are win32.
+Confirmed 2026-08-10; the recipe's step 4 correctly reports FAIL rather than passing it. WSL2 also
+has its own network namespace, so its `lsof` cannot see Windows-side listeners even for the port
+check. Run it in the environment that owns `node_modules`.
 
 ## Rules
 
-- **Always use port 3000.** If it's taken, kill the holder — don't switch ports.
+- **Always use port 3000.** If it's taken, kill the holder — don't switch ports, and don't
+  kill 3001/3002; they are not ours to take.
+- **Never treat a bare HTTP 200 as success.** A surviving process on 3000 will happily return
+  200 while Next quietly falls back to 3001. The probe must see a 200 *and* ProBuild's own
+  markup (`Golden Touch Remodeling`, the `<title>` from `src/app/layout.tsx`).
+- Step 4 is a **content** check, not proof of identity — anything serving that string would
+  pass it. It is there to catch the unrelated-process case, not a determined impostor.
+- On failure the recipe cleans up after **itself**: `kill_our_server` reads the port Next actually
+  bound out of our own log and kills that listener's whole process tree, so a fallback server on
+  3001 doesn't survive — and no unrelated process on 3001 is ever touched, because the port comes
+  from our log rather than a guess.
 - If it still won't start: `rm -rf .next && npm run dev`.

--- a/.claude/skills/probuild-schema-migration/SKILL.md
+++ b/.claude/skills/probuild-schema-migration/SKILL.md
@@ -9,7 +9,31 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 ## Why the standard commands don't work
 
 - `npx prisma db push` hangs interactively.
-- `prisma migrate dev` fails — port 5432 is blocked on the free tier.
+- `prisma migrate dev` fails because it connects over `DIRECT_URL`, and this project's direct
+  endpoint `db.ghzdbzdnwjxazvmcefbh.supabase.co` resolves to an **AAAA record only** — Supabase
+  direct connections are IPv6-only unless the project buys the IPv4 add-on. This machine has no
+  IPv6 default route, so the TCP connection to that host fails.
+
+**It is not a blocked port, and not a free-tier port block.** There is no host-wide outbound block
+on 5432: Supabase's shared **session** pooler also listens on 5432 and completes a TCP handshake
+over IPv4 from this machine. (Plan tier does affect whether the IPv4 add-on is *purchasable* — it
+just isn't what breaks the command.) Verified 2026-08-10 from this machine:
+
+| Endpoint | DNS | TCP handshake |
+|---|---|---|
+| `db.ghzdbzdnwjxazvmcefbh.supabase.co:5432` (direct) | AAAA only, no A record | fails |
+| `aws-0-us-west-2.pooler.supabase.com:5432` (session pooler) | A records | succeeds |
+| `aws-0-us-west-2.pooler.supabase.com:6543` (transaction pooler) | A records | succeeds |
+
+Those handshakes prove reachability only — nobody has tested authenticated Postgres access on the
+session pooler.
+
+Repointing `DIRECT_URL` at the session pooler is therefore **not** a tested workaround. `prisma
+migrate dev` also wants to create and drop a shadow database, which needs `CREATEDB` on the
+database role used through the pooler. Untested here. Use the PowerShell script below instead.
+
+See <https://supabase.com/docs/guides/database/connecting-to-postgres> and
+<https://supabase.com/docs/guides/platform/ipv4-address>.
 
 ## Working approach
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,16 +137,19 @@ See **docs/TESTING.md**. E2E creates leads/estimates/invoices, so:
 - History: QA runs against prod once filled /leads with "Master Bath Renovation - Henderson" junk (cleaned 2026-06-11)
 
 ## Dev server — clean start
-```bash
-kill -9 $(lsof -ti tcp:3000,3001,3002) 2>/dev/null; rm -f .next/dev/lock; sleep 2
-npm run dev > /tmp/devserver.log 2>&1 &
-sleep 15 && curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/
-```
-- Always use port 3000 — if it's taken, kill it, don't switch ports
+Prefer the Browser pane's `preview_start`. For a raw clean start, follow the
+`probuild-dev-server` skill (`.claude/skills/probuild-dev-server/SKILL.md`) — that is the
+canonical recipe, kept in one place so a second copy here can't drift from it.
+- Always use port 3000 — if it's taken, kill the holder, don't switch ports
+- Verify the new server actually answers (assert the kill worked, then match ProBuild's own markup) — a bare HTTP 200 can come from the surviving process while Next falls back to 3001
 - If still failing, `rm -rf .next && npm run dev`
 
 ## Schema migrations
-> `npx prisma db push` hangs interactively. `prisma migrate dev` fails (port 5432 blocked on free tier).
+> `npx prisma db push` hangs interactively. `prisma migrate dev` fails because it dials `DIRECT_URL`,
+> whose host `db.ghzdbzdnwjxazvmcefbh.supabase.co` publishes an **AAAA record only** (IPv6-only without
+> Supabase's IPv4 add-on) and this machine has no IPv6 default route. **5432 is not a blocked port** and
+> the free tier is not the cause — the shared session pooler listens on 5432 too and completes a TCP
+> handshake over IPv4. Full evidence table in the `probuild-schema-migration` skill.
 
 **Working approach:**
 1. Edit SQL in `C:\Users\jat00\AppData\Local\Temp\apply_schema.ps1`
@@ -199,7 +202,7 @@ If a feature doesn't map to a real workflow step for a real role (estimator, PM,
 - **Server components by default** — only add `"use client"` when strictly needed (event handlers, hooks, browser APIs)
 - **No dummy UI** — every button, link, and form must be fully wired before committing
 - **Database** — always use Prisma (`src/lib/prisma.ts`), not direct Supabase client, for data access; Supabase is auth/storage only
-- **Schema changes** — do NOT use `npx prisma db push` (hangs in WSL) or `prisma migrate dev` (port 5432 blocked). Instead: apply SQL via `C:\Users\jat00\AppData\Local\Temp\apply_schema.ps1`, then regenerate client via **PowerShell** (never Git Bash — Git Bash triggers `copyEngine: false` which breaks the local dev engine)
+- **Schema changes** — do NOT use `npx prisma db push` (hangs in WSL) or `prisma migrate dev` (its `DIRECT_URL` host is IPv6-only and unreachable here; 5432 itself is fine — see "Schema migrations"). Instead: apply SQL via `C:\Users\jat00\AppData\Local\Temp\apply_schema.ps1`, then regenerate client via **PowerShell** (never Git Bash — Git Bash triggers `copyEngine: false` which breaks the local dev engine)
 - **DATABASE_URL must include `?pgbouncer=true`** — Supabase transaction pooler (port 6543) + Prisma requires this flag. Without it you get `42P05 prepared statement already exists` and the site goes down. Correct format: `postgresql://...@aws-0-us-west-2.pooler.supabase.com:6543/postgres?pgbouncer=true`
 - **Auth roles** — ADMIN, MANAGER, FIELD_CREW, FINANCE — check `src/lib/permissions.ts` before adding role-gated UI
 - **Toasts** — use `sonner` (already in layout), not any other toast library


### PR DESCRIPTION
Fixes the two nit-level inaccuracies Codex flagged during #349. Docs only — no application code.

## 1. The `prisma migrate dev` reason was wrong

The docs said it fails because "port 5432 is blocked on the free tier". Not true. Measured on this machine 2026-08-10:

| Endpoint | DNS | TCP handshake |
|---|---|---|
| `db.ghzdbzdnwjxazvmcefbh.supabase.co:5432` (direct) | **AAAA only, no A record** | fails |
| `aws-0-us-west-2.pooler.supabase.com:5432` (session pooler) | A records | succeeds |
| `aws-0-us-west-2.pooler.supabase.com:6543` (transaction pooler) | A records | succeeds |

The real cause: `migrate dev` dials `DIRECT_URL`, whose host is IPv6-only without Supabase's IPv4 add-on, and this host has no IPv6 default route. **Port 5432 is not blocked** — the session pooler answers on it over IPv4. The practical guidance (use the PowerShell SQL script; don't use `db push` / `migrate dev`) is unchanged.

The shadow-database note is explicitly labelled untested — verifying it would mean issuing DDL against the production database, which repo policy forbids.

## 2. The dev-server check could pass while talking to the wrong process

Reproduced live against Next 16.2.11 (Turbopack). With an unrelated node server genuinely holding 3000 (owner pid confirmed):

```
⚠ Port 3000 is in use by process 37856, using available port 3001 instead.
- Local:  http://localhost:3001
```

The old check `curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/` returned **200 from the impostor** — a false success. It also killed holders of 3001/3002 unnecessarily and suppressed kill failures.

The recipe now:
- asserts the kill actually worked before continuing
- kills **LISTENers only** (`lsof -nP -tiTCP:3000 -sTCP:LISTEN`) so a bystander holding a *connection* to port 3000 isn't SIGKILLed
- leaves 3001/3002 alone
- waits for **our** server to report it bound 3000 (a fallback logs a different port, so it can't match)
- requires **both** HTTP 200 and ProBuild's own markup, with a timeout and retries
- runs as a function returning non-zero rather than `exit 1`, which would kill a sourced shell
- on failure kills its own server at whatever port **our log** says it bound, so a fallback child isn't orphaned and no unrelated process is guessed at
- works in Git Bash: `port_pids` falls back to PowerShell. Git Bash has no `lsof`, which previously would have made every port check silently read as "port free" and turned the kill step into a no-op

## Both files, one change

The same wrong 5432 claim and a **duplicate copy of the recipe** were in `CLAUDE.md`. Fixed together; `CLAUDE.md` now points at the skill as the canonical recipe so the two can't drift.

## Testing

- `bash -n` clean on the extracted recipe.
- **Happy path, exact documented recipe, Git Bash, real checkout:** `OK: ProBuild dev server up on 3000`, exit 0. It killed the previous holder and a fresh server took the port.
- **Browser:** `/login` renders the real page — "ProBuild / Sign in to your dashboard or client portal / Continue with Google".
- **Old-recipe false pass reproduced**, new steps 3 and 4 both correctly FAIL on it.
- **Step-1 guard** fires correctly when the holder survives the kill.
- **Cleanup targeting** extracts 3001 from the real fallback log and 3000 from the happy-path log.
- **Bonus catch:** running it from WSL against the Windows checkout returns HTTP 500 (`Cannot find module '../lightningcss.linux-x64-gnu.node'` — win32 native binaries). The old bare-200 check would have shrugged; the new 200-plus-markup assertion caught it. Documented in a "Where to run this" section.

## Review

Codex `gpt-5.6-sol` at `xhigh`, two rounds. Round 1 raised the `-sTCP:LISTEN` bystander kill (high), the missing 200 assertion / timeout / retry, the uncontained `exit 1` and missing cleanup, and overstated Supabase wording — all fixed. Round 2 raised that the recipe couldn't run in any supported shell and that cleanup could orphan a fallback child — both fixed and tested above. Stopped at round 2 per protocol.

One thing left alone deliberately: `CLAUDE.md` says `db push` "hangs interactively" in one place and "hangs in WSL" in another. Pre-existing, unverified by me, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)