### PR TITLE
docs: correct the prisma db push claim — it does not hang, it dials DIRECT_URL

### DIFF
--- a/.claude/skills/probuild-schema-migration/SKILL.md
+++ b/.claude/skills/probuild-schema-migration/SKILL.md
@@ -8,7 +8,10 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 
 ## Why the standard commands don't work
 
-- `npx prisma db push` hangs interactively.
+- `npx prisma db push` does **not** hang — that claim was never verified and is wrong. It fails for
+  the *same* reason `migrate dev` does: `db push` reads `directUrl` from the datasource block, so it
+  dials `DIRECT_URL` and never touches `DATABASE_URL`. It errors out in ~3 seconds with
+  `P1001: Can't reach database server at db.ghzdbzdnwjxazvmcefbh.supabase.co:5432`.
 - `prisma migrate dev` fails because it connects over `DIRECT_URL`, and this project's direct
   endpoint `db.ghzdbzdnwjxazvmcefbh.supabase.co` resolves to an **AAAA record only** — Supabase
   direct connections are IPv6-only unless the project buys the IPv4 add-on. This machine has no
@@ -27,6 +30,22 @@ just isn't what breaks the command.) Verified 2026-08-10 from this machine:
 
 Those handshakes prove reachability only — nobody has tested authenticated Postgres access on the
 session pooler.
+
+### `db push` evidence (verified 2026-08-10)
+
+Run against a throwaway `postgres:16` container, never prod, since `db push` mutates the database.
+Prisma CLI 5.22.0.
+
+| Test | Result |
+|---|---|
+| Both URLs → throwaway container | **Succeeds in 9s**, no prompt. So there is no inherent hang. |
+| `DATABASE_URL` → throwaway, `DIRECT_URL` → real direct host | Banner names **the direct host**, then `P1001` in 3.3s. Proves `db push` uses `directUrl` and ignores `DATABASE_URL`. |
+| Destructive change (drop a column holding data), stdin not a TTY | **Errors in 2.5s** with *"Use the --accept-data-loss flag"*. It does not block waiting for input. |
+
+The only prompt `db push` has is that destructive-change confirmation, and it only appears on a real
+TTY — under an agent or any non-TTY stdin it is an immediate error, not a hang. The IPv6 problem is
+also not WSL-specific: from WSL, `getent ahosts` on the direct host returns the same lone AAAA
+address and `ip -6 route show default` is empty, exactly as on Windows.
 
 Repointing `DIRECT_URL` at the session pooler is therefore **not** a tested workaround. `prisma
 migrate dev` also wants to create and drop a shadow database, which needs `CREATEDB` on the

--- a/.claude/skills/probuild-schema-migration/SKILL.md
+++ b/.claude/skills/probuild-schema-migration/SKILL.md
@@ -41,7 +41,7 @@ Prisma CLI 5.22.0.
 | Test | Result |
 |---|---|
 | Both URLs → throwaway container | **Succeeds in 9s**, no prompt. So there is no inherent hang. |
-| `DATABASE_URL` → throwaway, `DIRECT_URL` → real direct host | Banner names **the direct host**, then `P1001` in 3.3s. Proves `db push` uses `directUrl` and ignores `DATABASE_URL`. |
+| `DATABASE_URL` → throwaway, `DIRECT_URL` → real direct host | Banner names **the direct host**, then `P1001` in 3.3s. Proves `db push` connects over `directUrl`, ignoring `DATABASE_URL` **as the connection target**. |
 | `DIRECT_URL` set, `DATABASE_URL` unset | `P1012: Environment variable not found: DATABASE_URL`. So `url` is still *validated* — `directUrl` only overrides which one is dialled. |
 | Destructive change (drop a column holding data), stdin not a TTY | **Errors in 2.5s** with *"Use the --accept-data-loss flag"*. It does not block waiting for input. |
 

--- a/.claude/skills/probuild-schema-migration/SKILL.md
+++ b/.claude/skills/probuild-schema-migration/SKILL.md
@@ -9,9 +9,11 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 ## Why the standard commands don't work
 
 - `npx prisma db push` does **not** hang — that claim was never verified and is wrong. It fails for
-  the *same* reason `migrate dev` does: `db push` reads `directUrl` from the datasource block, so it
-  dials `DIRECT_URL` and never touches `DATABASE_URL`. It errors out in ~3 seconds with
-  `P1001: Can't reach database server at db.ghzdbzdnwjxazvmcefbh.supabase.co:5432`.
+  the *same* reason `migrate dev` does: when the datasource block sets `directUrl`, Prisma uses
+  `DIRECT_URL` — not `DATABASE_URL` — as the connection target for `db push`. It errors out in ~3
+  seconds with `P1001: Can't reach database server at db.ghzdbzdnwjxazvmcefbh.supabase.co:5432`.
+  (`DATABASE_URL` must still be **set**, it just isn't the one dialled: Prisma validates `url` first
+  and fails with `P1012: Environment variable not found: DATABASE_URL` before it connects.)
 - `prisma migrate dev` fails because it connects over `DIRECT_URL`, and this project's direct
   endpoint `db.ghzdbzdnwjxazvmcefbh.supabase.co` resolves to an **AAAA record only** — Supabase
   direct connections are IPv6-only unless the project buys the IPv4 add-on. This machine has no
@@ -40,10 +42,13 @@ Prisma CLI 5.22.0.
 |---|---|
 | Both URLs → throwaway container | **Succeeds in 9s**, no prompt. So there is no inherent hang. |
 | `DATABASE_URL` → throwaway, `DIRECT_URL` → real direct host | Banner names **the direct host**, then `P1001` in 3.3s. Proves `db push` uses `directUrl` and ignores `DATABASE_URL`. |
+| `DIRECT_URL` set, `DATABASE_URL` unset | `P1012: Environment variable not found: DATABASE_URL`. So `url` is still *validated* — `directUrl` only overrides which one is dialled. |
 | Destructive change (drop a column holding data), stdin not a TTY | **Errors in 2.5s** with *"Use the --accept-data-loss flag"*. It does not block waiting for input. |
 
-The only prompt `db push` has is that destructive-change confirmation, and it only appears on a real
-TTY — under an agent or any non-TTY stdin it is an immediate error, not a hang. The IPv6 problem is
+That destructive-change confirmation is the prompt we tested. `db push` has a second one (a change
+it can't execute without a full database reset) that we did **not** test. On a real TTY both do
+genuinely prompt; when stdin is not a TTY — which is how CI and Claude Code's Bash tool invoke it —
+the tested one errors immediately instead of blocking. The IPv6 problem is
 also not WSL-specific: from WSL, `getent ahosts` on the direct host returns the same lone AAAA
 address and `ip -6 route show default` is empty, exactly as on Windows.
 
@@ -80,4 +85,5 @@ If the branch will deploy, also add a `scripts/apply-<name>.mjs` (additive, idem
 postgresql://...@aws-0-us-west-2.pooler.supabase.com:6543/postgres?pgbouncer=true
 ```
 
-`DIRECT_URL` uses port 5432 on `db.ghzdbzdnwjxazvmcefbh.supabase.co`, for migrations only.
+`DIRECT_URL` uses port 5432 on `db.ghzdbzdnwjxazvmcefbh.supabase.co`, for the Prisma CLI operations
+that need a direct connection (`migrate`, `db push`, Studio) — not just migrations.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,8 @@ canonical recipe, kept in one place so a second copy here can't drift from it.
 - If still failing, `rm -rf .next && npm run dev`
 
 ## Schema migrations
-> `npx prisma db push` hangs interactively. `prisma migrate dev` fails because it dials `DIRECT_URL`,
+> `npx prisma db push` does **not** hang — it fails for the same reason `migrate dev` does, because
+> `db push` also reads `directUrl` and never touches `DATABASE_URL`. Both dial `DIRECT_URL`,
 > whose host `db.ghzdbzdnwjxazvmcefbh.supabase.co` publishes an **AAAA record only** (IPv6-only without
 > Supabase's IPv4 add-on) and this machine has no IPv6 default route. **5432 is not a blocked port** and
 > the free tier is not the cause — the shared session pooler listens on 5432 too and completes a TCP
@@ -203,7 +204,7 @@ If a feature doesn't map to a real workflow step for a real role (estimator, PM,
 - **Server components by default** — only add `"use client"` when strictly needed (event handlers, hooks, browser APIs)
 - **No dummy UI** — every button, link, and form must be fully wired before committing
 - **Database** — always use Prisma (`src/lib/prisma.ts`), not direct Supabase client, for data access; Supabase is auth/storage only
-- **Schema changes** — do NOT use `npx prisma db push` (hangs in WSL) or `prisma migrate dev` (its `DIRECT_URL` host is IPv6-only and unreachable here; 5432 itself is fine — see "Schema migrations"). Instead: apply SQL via `C:\Users\jat00\AppData\Local\Temp\apply_schema.ps1`, then regenerate client via **PowerShell** (never Git Bash — Git Bash triggers `copyEngine: false` which breaks the local dev engine)
+- **Schema changes** — do NOT use `npx prisma db push` or `prisma migrate dev`. Both dial `DIRECT_URL` (yes, `db push` too — it reads `directUrl` and ignores `DATABASE_URL`), whose host is IPv6-only and unreachable here; 5432 itself is fine, and neither command hangs — see "Schema migrations". Instead: apply SQL via `C:\Users\jat00\AppData\Local\Temp\apply_schema.ps1`, then regenerate client via **PowerShell** (never Git Bash — Git Bash triggers `copyEngine: false` which breaks the local dev engine)
 - **DATABASE_URL must include `?pgbouncer=true`** — Supabase transaction pooler (port 6543) + Prisma requires this flag. Without it you get `42P05 prepared statement already exists` and the site goes down. Correct format: `postgresql://...@aws-0-us-west-2.pooler.supabase.com:6543/postgres?pgbouncer=true`
 - **Auth roles** — ADMIN, MANAGER, FIELD_CREW, FINANCE — check `src/lib/permissions.ts` before adding role-gated UI
 - **Toasts** — use `sonner` (already in layout), not any other toast library

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ canonical recipe, kept in one place so a second copy here can't drift from it.
 
 ## Schema migrations
 > `npx prisma db push` does **not** hang — it fails for the same reason `migrate dev` does, because
-> `db push` also reads `directUrl` and never touches `DATABASE_URL`. Both dial `DIRECT_URL`,
+> when the datasource sets `directUrl` that is the URL `db push` connects over too. Both dial `DIRECT_URL`,
 > whose host `db.ghzdbzdnwjxazvmcefbh.supabase.co` publishes an **AAAA record only** (IPv6-only without
 > Supabase's IPv4 add-on) and this machine has no IPv6 default route. **5432 is not a blocked port** and
 > the free tier is not the cause — the shared session pooler listens on 5432 too and completes a TCP
@@ -162,7 +162,7 @@ canonical recipe, kept in one place so a second copy here can't drift from it.
 ## Critical database config
 - **DATABASE_URL must include `?pgbouncer=true`** — Supabase transaction pooler (port 6543) + Prisma requires this. Without it: `42P05 prepared statement already exists` and the site goes down.
 - Correct format: `postgresql://...@aws-0-us-west-2.pooler.supabase.com:6543/postgres?pgbouncer=true`
-- DIRECT_URL uses port 5432 on `db.ghzdbzdnwjxazvmcefbh.supabase.co` (for migrations only)
+- DIRECT_URL uses port 5432 on `db.ghzdbzdnwjxazvmcefbh.supabase.co` (used by the Prisma CLI operations needing a direct connection — `migrate`, `db push`, Studio — not the app at runtime)
 
 ## compare.py (optional — QA tool, not daily workflow)
 Legacy Houzz Pro visual comparison tool. Useful for quarterly sanity checks only.
@@ -204,7 +204,7 @@ If a feature doesn't map to a real workflow step for a real role (estimator, PM,
 - **Server components by default** — only add `"use client"` when strictly needed (event handlers, hooks, browser APIs)
 - **No dummy UI** — every button, link, and form must be fully wired before committing
 - **Database** — always use Prisma (`src/lib/prisma.ts`), not direct Supabase client, for data access; Supabase is auth/storage only
-- **Schema changes** — do NOT use `npx prisma db push` or `prisma migrate dev`. Both dial `DIRECT_URL` (yes, `db push` too — it reads `directUrl` and ignores `DATABASE_URL`), whose host is IPv6-only and unreachable here; 5432 itself is fine, and neither command hangs — see "Schema migrations". Instead: apply SQL via `C:\Users\jat00\AppData\Local\Temp\apply_schema.ps1`, then regenerate client via **PowerShell** (never Git Bash — Git Bash triggers `copyEngine: false` which breaks the local dev engine)
+- **Schema changes** — do NOT use `npx prisma db push` or `prisma migrate dev`. Both connect over `DIRECT_URL` (yes, `db push` too — a datasource `directUrl` overrides `url` as the connection target), whose host is IPv6-only and unreachable here; 5432 itself is fine, and neither command hangs on this machine — see "Schema migrations". Instead: apply SQL via `C:\Users\jat00\AppData\Local\Temp\apply_schema.ps1`, then regenerate client via **PowerShell** (never Git Bash — Git Bash triggers `copyEngine: false` which breaks the local dev engine)
 - **DATABASE_URL must include `?pgbouncer=true`** — Supabase transaction pooler (port 6543) + Prisma requires this flag. Without it you get `42P05 prepared statement already exists` and the site goes down. Correct format: `postgresql://...@aws-0-us-west-2.pooler.supabase.com:6543/postgres?pgbouncer=true`
 - **Auth roles** — ADMIN, MANAGER, FIELD_CREW, FINANCE — check `src/lib/permissions.ts` before adding role-gated UI
 - **Toasts** — use `sonner` (already in layout), not any other toast library


### PR DESCRIPTION
Codex flagged this contradiction reviewing #352. CLAUDE.md said `npx prisma db push` "hangs interactively" in one section and "hangs in WSL" in another; the skill said "hangs interactively". Nobody had verified any of it, and #352 deliberately left it alone.

**Both wordings are wrong, and so was the premise that `db push` differs from `migrate dev`.**

`prisma/schema.prisma` declares `directUrl = env("DIRECT_URL")`, and a datasource `directUrl` overrides `url` as the connection target for `db push` too. So `db push` fails for the *exact* same reason `migrate dev` does — the IPv6-only direct host from #352 — rather than hanging.

## Evidence

Prisma CLI 5.22.0, against a throwaway `postgres:16` container. Never prod: `db push` mutates the database.

| Test | Result |
|---|---|
| Both URLs → throwaway container | Succeeds in 9s, no prompt, exit 0. No inherent hang. |
| `DATABASE_URL` → throwaway, `DIRECT_URL` → real direct host | CLI banner names **the direct host**, then `P1001` in 3.3s. |
| `DIRECT_URL` set, `DATABASE_URL` unset | `P1012: Environment variable not found: DATABASE_URL` — `url` is still validated, it just isn't dialled. |
| Destructive change (drop a column holding data), stdin not a TTY | Errors in 2.5s with "Use the --accept-data-loss flag". Does not block. |

The direct host resolves AAAA-only with zero IPv6 default routes on **both** Windows and WSL, so the "hangs in WSL" qualifier had no basis either.

## Changes

Narrowed the claim in all three places (CLAUDE.md ×2, SKILL.md), and added the evidence table to the skill. Also corrected two neighbouring lines that said `DIRECT_URL` is "for migrations only" — `db push` and Studio use it too, which is the whole point of this PR.

## Review

Codex (gpt-5.6-sol, xhigh), two rounds. Round 1 caught three overclaims in my first draft: "never touches DATABASE_URL" (false — P1012 proves `url` is still validated), "the only prompt db push has" (there is a second, untested reset-confirmation path), and the "migrations only" contradiction. Round 2 caught one leftover contradictory phrase in the evidence table. All fixed; round 2 confirmed 2 and 3 resolved and nothing newly broken.

Docs-only — no build or runtime surface to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)