### PR TITLE
fix(estimates): serialize Prisma Decimals in server actions returned to client components

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -5288,10 +5288,13 @@ export async function saveEstimateAsTemplate(estimateId: string, templateName: s
 
 export async function getEstimateTemplates() {
     await assertEstimatePermission();
-    return await prisma.estimateTemplate.findMany({
+    const templates = await prisma.estimateTemplate.findMany({
         orderBy: { createdAt: "desc" },
         include: { items: { orderBy: [{ order: "asc" }, { id: "asc" }] } },
     });
+    // Item baseCost/unitCost are Prisma Decimals, which can't cross the server->client
+    // boundary; consumers already coerce with Number(...).
+    return JSON.parse(JSON.stringify(templates));
 }
 
 export async function createEstimateFromTemplate(projectId: string, templateId: string) {
@@ -9826,7 +9829,8 @@ export async function createPurchaseOrderFromEstimate(projectId: string, estimat
     }
 
     revalidatePath(`/projects/${projectId}/purchase-orders`);
-    return newPo;
+    // totalAmount is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(newPo));
 }
 
 export async function updatePurchaseOrder(id: string, data: any) {
@@ -13639,7 +13643,8 @@ export async function linkPOToEstimateItem(estimateItemId: string, purchaseOrder
     }));
 
     revalidatePath(`/projects/${item.estimate.projectId}/estimates`);
-    return po;
+    // totalAmount is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(po));
 }
 
 export async function unlinkPOFromEstimateItem(estimateItemId: string, purchaseOrderId: string) {
@@ -13722,7 +13727,8 @@ export async function quickCreatePOAndLink(estimateItemId: string, data: { vendo
 
     revalidatePath(`/projects/${projectId}/purchase-orders`);
     revalidatePath(`/projects/${projectId}/estimates`);
-    return po;
+    // totalAmount is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(po));
 }
 
 // Result of restoreEstimateItemAssociations — reports exactly what was (and wasn't) restored
@@ -13937,11 +13943,13 @@ export async function restoreEstimateItemAssociations({
 export async function getProjectPurchaseOrdersForLinking(projectId: string) {
     await assertFinancialProjectAccess(projectId);
 
-    return prisma.purchaseOrder.findMany({
+    const pos = await prisma.purchaseOrder.findMany({
         where: { projectId },
         select: { id: true, code: true, totalAmount: true, status: true, vendor: { select: { id: true, name: true } } },
         orderBy: { createdAt: "desc" },
     });
+    // totalAmount is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(pos));
 }
 
 export async function createEstimateFromRoomDesign(roomId: string) {


### PR DESCRIPTION
## What

The estimate editor page (`/projects/[id]/estimates/[estimateId]`) logged many React dev-console errors: **"Only plain objects can be passed to Client Components from Server Components. Decimal objects are not supported."** The offending payloads were estimate template items and purchase orders returned by server actions with raw Prisma `Decimal` fields.

Wraps the returns of 5 server actions in `src/lib/actions.ts` with `JSON.parse(JSON.stringify(...))`:

- `getEstimateTemplates` (EstimateTemplateItem.baseCost/unitCost)
- `getProjectPurchaseOrdersForLinking` (PurchaseOrder.totalAmount)
- `linkPOToEstimateItem`
- `quickCreatePOAndLink`
- `createPurchaseOrderFromEstimate`

## Why this is safe

- React already fell back to `Decimal.toJSON()` (a string) while logging the dev error, so the client receives **identical values** before and after — this only makes the serialization explicit.
- All callers of these 5 actions are client components that coerce via `Number(...)` / `formatCurrency` (verified: EstimateEditor, POQuickCreateModal, EstimatesListClient).
- Serialization-only: no persistence, `markupPercent`, or gross-margin math touched.

## Review

Codex (gpt-5.6-sol, xhigh): no blockers or real issues in this change. Nit acknowledged and deliberately not taken: JSON round-trip is broader than a per-field `.toString()` projection, but it matches the established pattern in this codebase (estimate page, bid-packages, product-library) and is behavior-preserving; `Number()` conversion was rejected for precision reasons.

## Verified

- `npm run build` — 0 errors
- Dev browser test: estimate editor (Shop / EST-00309) loads with **zero Decimal console errors**; items, totals, and payment schedule render correctly.

Sweep note: an Explore sweep found ~17 more actions in `actions.ts` with the same defect on other pages (POs, change orders, retainers, bids, catalog, product library, leads) — spun off as a follow-up to keep this diff reviewable.

Observed 2026-08-13 while browser-testing #363; pre-existing and unrelated to that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
