### PR TITLE
fix: serialize Prisma Decimals across the remaining server->client boundaries

### DIFF
--- a/src/app/invoices/page.tsx
+++ b/src/app/invoices/page.tsx
@@ -3,7 +3,8 @@ import { getAllInvoices } from "@/lib/actions";
 import GlobalInvoiceListClient from "./GlobalInvoiceListClient";
 
 export default async function GlobalInvoicesPage() {
-    const invoices = await getAllInvoices();
+    // Invoice money fields are Prisma Decimals — serialize before crossing the server->client boundary.
+    const invoices = JSON.parse(JSON.stringify(await getAllInvoices()));
 
     return (
         <div className="flex h-full bg-hui-background">

--- a/src/app/leads/[id]/schedule/page.tsx
+++ b/src/app/leads/[id]/schedule/page.tsx
@@ -22,5 +22,6 @@ export default async function LeadSchedulePage({ params }: Props) {
 
     if (!lead) return redirect("/leads");
 
-    return <LeadScheduleClient leadId={id} leadName={lead.name} initialTasks={tasks} />;
+    // Task total is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return <LeadScheduleClient leadId={id} leadName={lead.name} initialTasks={JSON.parse(JSON.stringify(tasks))} />;
 }

--- a/src/app/projects/[id]/change-orders/[coId]/page.tsx
+++ b/src/app/projects/[id]/change-orders/[coId]/page.tsx
@@ -19,11 +19,13 @@ export default async function ChangeOrderPage({
         notFound();
     }
 
-    const initialData = {
+    // totalAmount/balanceDue are Prisma Decimals — serialize before crossing the
+    // server->client boundary (the portal twin already JSON-serializes the same shape).
+    const initialData = JSON.parse(JSON.stringify({
         ...co,
         clientSignatureUrl: await resolveDocUrl((co as any).clientSignatureUrl),
         companySignatureUrl: await resolveDocUrl((co as any).companySignatureUrl),
-    };
+    }));
 
     return (
         <div className="flex h-[calc(100%+48px)] -m-6 overflow-hidden">

--- a/src/app/projects/[id]/invoices/page.tsx
+++ b/src/app/projects/[id]/invoices/page.tsx
@@ -5,7 +5,8 @@ export default async function ProjectInvoices({ params }: { params: Promise<{ id
     const { id } = await params;
     const project = await getProject(id);
     if (!project) return <div className="p-6 text-hui-textMain">Project not found</div>;
-    const invoices = await getProjectInvoices(id);
+    // Invoice money fields are Prisma Decimals — serialize before crossing the server->client boundary.
+    const invoices = JSON.parse(JSON.stringify(await getProjectInvoices(id)));
 
     return (
         <div className="flex h-full bg-hui-background">

--- a/src/app/projects/[id]/purchase-orders/[poId]/page.tsx
+++ b/src/app/projects/[id]/purchase-orders/[poId]/page.tsx
@@ -43,7 +43,9 @@ export default async function PurchaseOrderDetailPage({
         });
 
         if (!po) redirect(`/projects/${projectId}/purchase-orders`);
-        initialData = po;
+        // totalAmount and item unitCost/total are Prisma Decimals — serialize before
+        // crossing the server->client boundary.
+        initialData = JSON.parse(JSON.stringify(po));
     }
 
     return (

--- a/src/app/projects/[id]/tasks/page.tsx
+++ b/src/app/projects/[id]/tasks/page.tsx
@@ -18,5 +18,6 @@ export default async function ProjectTasksPage({ params }: Props) {
         getTeamMembers(),
     ]);
 
-    return <TasksClient projectId={id} initialTasks={tasks} teamMembers={teamMembers} />;
+    // Task total is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return <TasksClient projectId={id} initialTasks={JSON.parse(JSON.stringify(tasks))} teamMembers={teamMembers} />;
 }

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -912,7 +912,8 @@ export async function updateLead(leadId: string, data: { name?: string; source?:
 
     revalidatePath(`/leads/${leadId}`);
     revalidatePath(`/leads`);
-    return lead;
+    // targetRevenue/expectedProfit are Prisma Decimals — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(lead));
 }
 
 // =============================================
@@ -9104,7 +9105,8 @@ export async function updateChangeOrder(id: string, data: ChangeOrderUpdateInput
 
     revalidatePath(`/projects/${co.projectId}/change-orders/${id}`);
     revalidatePath(`/projects/${co.projectId}/change-orders`);
-    return co;
+    // totalAmount/balanceDue are Prisma Decimals — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(co));
 }
 
 export async function previewCostPlusChangeOrder(changeOrderId: string, throughDate: string) {
@@ -9214,7 +9216,8 @@ export async function approveChangeOrder(id: string, signatureName: string, user
 
     revalidatePath(`/projects/${co.projectId}/change-orders/${id}`);
     revalidatePath(`/projects/${co.projectId}/change-orders`);
-    return co;
+    // totalAmount/balanceDue are Prisma Decimals — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(co));
 }
 
 // Company-side countersignature. Distinct from approveChangeOrder (the customer's
@@ -9775,7 +9778,8 @@ export async function createPurchaseOrder(projectId: string, data: any) {
         }
     });
     revalidatePath(`/projects/${projectId}/purchase-orders`);
-    return po;
+    // totalAmount is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(po));
 }
 
 export async function createPurchaseOrderFromEstimate(projectId: string, estimateId: string, itemIds: string[], vendorId: string) {
@@ -9929,8 +9933,9 @@ export async function updatePurchaseOrder(id: string, data: any) {
 
     revalidatePath(`/projects/${po.projectId}/purchase-orders/${id}`);
     revalidatePath(`/projects/${po.projectId}/purchase-orders`);
-    
-    return po;
+
+    // totalAmount is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(po));
 }
 
 export async function deletePurchaseOrder(id: string) {
@@ -10022,7 +10027,8 @@ export async function approvePurchaseOrder(id: string, signatureName: string) {
     
     revalidatePath(`/projects/${po.projectId}/purchase-orders/${id}`);
     revalidatePath(`/projects/${po.projectId}/purchase-orders`);
-    return po;
+    // totalAmount is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(po));
 }
 
 export async function uploadPurchaseOrderFile(purchaseOrderId: string, formData: FormData) {
@@ -10738,7 +10744,8 @@ export async function createProductLibraryItem(data: {
         },
     });
     revalidatePath("/company/product-library");
-    return item;
+    // price is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(item));
 }
 
 export async function updateProductLibraryItem(id: string, data: {
@@ -10764,7 +10771,8 @@ export async function updateProductLibraryItem(id: string, data: {
         },
     });
     revalidatePath("/company/product-library");
-    return item;
+    // price is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(item));
 }
 
 export async function deleteProductLibraryItem(id: string) {
@@ -12345,7 +12353,8 @@ export async function addTeamCandidate(decisionId: string | null, data: {
         entityName: candidate.name,
     });
 
-    return candidate;
+    // price is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(candidate));
 }
 
 export async function importBoardPicksAsDecisions(projectId: string) {
@@ -13020,7 +13029,8 @@ export async function createCatalogItem(data: {
         include: { costCode: { select: { code: true, name: true } } },
     });
     revalidatePath("/company/my-items");
-    return item;
+    // unitCost is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(item));
 }
 
 export async function updateCatalogItem(id: string, data: {
@@ -13038,7 +13048,8 @@ export async function updateCatalogItem(id: string, data: {
         include: { costCode: { select: { code: true, name: true } } },
     });
     revalidatePath("/company/my-items");
-    return item;
+    // unitCost is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(item));
 }
 
 export async function deleteCatalogItem(id: string) {
@@ -13207,7 +13218,8 @@ export async function createBidPackage(projectId: string, data: {
         },
     });
     revalidatePath(`/projects/${projectId}/bid-packages`);
-    return pkg;
+    // totalBudget is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(pkg));
 }
 
 export async function updateBidPackage(id: string, projectId: string, data: {
@@ -13232,7 +13244,8 @@ export async function updateBidPackage(id: string, projectId: string, data: {
     });
     revalidatePath(`/projects/${projectId}/bid-packages`);
     revalidatePath(`/projects/${projectId}/bid-packages/${id}/edit`);
-    return pkg;
+    // totalBudget is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(pkg));
 }
 
 export async function deleteBidPackage(id: string, projectId: string) {
@@ -13261,7 +13274,8 @@ export async function addBidScope(packageId: string, projectId: string, data: {
         },
     });
     revalidatePath(`/projects/${projectId}/bid-packages/${packageId}/edit`);
-    return scope;
+    // budgetAmount is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(scope));
 }
 
 export async function deleteBidScope(scopeId: string, packageId: string, projectId: string) {
@@ -13315,7 +13329,8 @@ export async function recordBidResponse(invitationId: string, packageId: string,
         },
     });
     revalidatePath(`/projects/${projectId}/bid-packages/${packageId}/edit`);
-    return inv;
+    // bidAmount is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(inv));
 }
 
 export async function awardBid(packageId: string, invitationId: string, projectId: string) {
@@ -13368,7 +13383,8 @@ export async function createRetainer(projectId: string, data: {
     });
 
     revalidatePath(`/projects/${projectId}/retainers`);
-    return retainer;
+    // totalAmount/balanceDue/amountPaid are Prisma Decimals — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(retainer));
 }
 
 export async function updateRetainer(id: string, data: {
@@ -13396,7 +13412,8 @@ export async function updateRetainer(id: string, data: {
     const retainer = await prisma.retainer.update({ where: { id }, data: updateData });
     revalidatePath(`/projects/${existing.projectId}/retainers`);
     revalidatePath(`/projects/${existing.projectId}/retainers/${id}`);
-    return retainer;
+    // totalAmount/balanceDue/amountPaid are Prisma Decimals — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(retainer));
 }
 
 export async function deleteRetainer(id: string) {

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -5288,10 +5288,13 @@ export async function saveEstimateAsTemplate(estimateId: string, templateName: s
 
 export async function getEstimateTemplates() {
     await assertEstimatePermission();
-    return await prisma.estimateTemplate.findMany({
+    const templates = await prisma.estimateTemplate.findMany({
         orderBy: { createdAt: "desc" },
         include: { items: { orderBy: [{ order: "asc" }, { id: "asc" }] } },
     });
+    // Item baseCost/unitCost are Prisma Decimals, which can't cross the server->client
+    // boundary; consumers already coerce with Number(...).
+    return JSON.parse(JSON.stringify(templates));
 }
 
 export async function createEstimateFromTemplate(projectId: string, templateId: string) {
@@ -9826,7 +9829,8 @@ export async function createPurchaseOrderFromEstimate(projectId: string, estimat
     }
 
     revalidatePath(`/projects/${projectId}/purchase-orders`);
-    return newPo;
+    // totalAmount is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(newPo));
 }
 
 export async function updatePurchaseOrder(id: string, data: any) {
@@ -13639,7 +13643,8 @@ export async function linkPOToEstimateItem(estimateItemId: string, purchaseOrder
     }));
 
     revalidatePath(`/projects/${item.estimate.projectId}/estimates`);
-    return po;
+    // totalAmount is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(po));
 }
 
 export async function unlinkPOFromEstimateItem(estimateItemId: string, purchaseOrderId: string) {
@@ -13722,7 +13727,8 @@ export async function quickCreatePOAndLink(estimateItemId: string, data: { vendo
 
     revalidatePath(`/projects/${projectId}/purchase-orders`);
     revalidatePath(`/projects/${projectId}/estimates`);
-    return po;
+    // totalAmount is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(po));
 }
 
 // Result of restoreEstimateItemAssociations — reports exactly what was (and wasn't) restored
@@ -13937,11 +13943,13 @@ export async function restoreEstimateItemAssociations({
 export async function getProjectPurchaseOrdersForLinking(projectId: string) {
     await assertFinancialProjectAccess(projectId);
 
-    return prisma.purchaseOrder.findMany({
+    const pos = await prisma.purchaseOrder.findMany({
         where: { projectId },
         select: { id: true, code: true, totalAmount: true, status: true, vendor: { select: { id: true, name: true } } },
         orderBy: { createdAt: "desc" },
     });
+    // totalAmount is a Prisma Decimal — serialize before crossing the server->client boundary.
+    return JSON.parse(JSON.stringify(pos));
 }
 
 export async function createEstimateFromRoomDesign(roomId: string) {


### PR DESCRIPTION
## Summary

Completes the sweep started by #368: every remaining server->client boundary that shipped raw Prisma `Decimal` fields now JSON-serializes first, eliminating the React dev error "Only plain objects can be passed to Client Components... Decimal objects are not supported."

**17 server actions in `src/lib/actions.ts`** (same pattern and comment style as #368):
- PO family: `createPurchaseOrder`, `updatePurchaseOrder`, `approvePurchaseOrder`
- CO family: `updateChangeOrder`, `approveChangeOrder`
- Retainers: `createRetainer`, `updateRetainer`
- Bids: `createBidPackage`, `updateBidPackage`, `addBidScope`, `recordBidResponse`
- Catalog: `createCatalogItem`, `updateCatalogItem`
- Product library: `createProductLibraryItem`, `updateProductLibraryItem`
- Selections: `addTeamCandidate`
- Leads: `updateLead`

**5 server pages passing Prisma rows to client components:**
- `projects/[id]/tasks/page.tsx` (getScheduleTasks -> TasksClient)
- `invoices/page.tsx` (getAllInvoices -> GlobalInvoiceListClient)
- `projects/[id]/invoices/page.tsx` (getProjectInvoices -> InvoiceListClient)
- `projects/[id]/change-orders/[coId]/page.tsx` (getChangeOrder -> ChangeOrderEditor)
- `projects/[id]/purchase-orders/[poId]/page.tsx` (inline query -> PurchaseOrderEditor)

## Safety

- **Serialization only** — every wrap happens after all DB writes and `revalidatePath` calls; no totals math, no `markupPercent` semantics, no persistence changes.
- **Call-site audit**: all consumers of the 17 actions are `"use client"` components or read only `.id` (string). The one server-side caller, `api/purchase-orders/route.ts`, already emitted `toJSON` strings via `NextResponse.json` — output byte-identical.
- The MCP route uses `updateChangeOrderCore` directly and is untouched.

## Verification

- `npm run build` passes with 0 errors.
- Codex peer review (gpt-5.6-codex, xhigh reasoning): no blockers, no real issues. It verified every consumer re-wraps dates (`new Date(...)`) and coerces money (`Number(...)`), so ISO-string dates and string decimals are behavior-preserving.
- Browser-verified on a local dev server against the Shop test project: PO editor hydrates (vendor/items/totals), Save through `updatePurchaseOrder` persists and round-trips; CO editor hydrates $201.00 + $16.48 tax = $217.48 and Save through `updateChangeOrder` leaves totals byte-identical; global/project invoice lists and tasks page load — zero Decimal console errors anywhere.

Merging ships to prod via auto-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
