### PR TITLE
fix(schema): adopt what production actually has into schema.prisma

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,39 +9,40 @@ datasource db {
 }
 
 model User {
-  id               String           @id @default(cuid())
-  email            String           @unique
-  name             String?
-  role             String           @default("FIELD_CREW") // ADMIN, MANAGER, FIELD_CREW, FINANCE
-  status           String           @default("PENDING") // PENDING, ACTIVATED, DISABLED
-  hourlyRate       Decimal            @default(0)
-  burdenRate       Decimal            @default(0)
-  pinCode          String? // Used for mobile app quick login
-  invitedAt        DateTime?        @default(now())
-  timeEntries      TimeEntry[]
-  assignedProjects Project[]        @relation("CrewAssignments")
-  taskAssignments  TaskAssignment[]
-  taskComments     TaskComment[]
-  uploadedFiles    ProjectFile[]
-  permissions      UserPermission?
-  projectAccess    ProjectAccess[]
-  leadTasks        LeadTask[]
-  managedLeads     Lead[]           @relation("LeadManager")
-  managedProjects  Project[]        @relation("ProjectManager")
-  dailyLogs        DailyLog[]
-  documentComments DocumentComment[]
-  teamMessages     TeamMessage[]
-  fieldUpdatesSeenAt DateTime?
-  clippedImports   ClippedImport[]
-  officeTasks        OfficeTask[]      @relation("OfficeTaskAssignee")
-  createdOfficeTasks OfficeTask[]      @relation("OfficeTaskCreator")
-  dispatchPublications DispatchPublication[] @relation("DispatchPublisher")
-  createdTaskMaterials TaskMaterial[] @relation("TaskMaterialCreator")
-  taskMaterialStatusChanges TaskMaterial[] @relation("TaskMaterialStatusChanger")
-  createdPunchItems TaskPunchItem[] @relation("TaskPunchItemCreator")
-  clippedProducts    ProductLibraryItem[]
-  addedFavorites     ProjectProductFavorite[]
-  decidedProposals   SelectionProposal[]
+  id                        String                   @id @default(cuid())
+  email                     String                   @unique
+  name                      String?
+  role                      String                   @default("FIELD_CREW") // ADMIN, MANAGER, FIELD_CREW, FINANCE
+  status                    String                   @default("PENDING") // PENDING, ACTIVATED, DISABLED
+  hourlyRate                Decimal                  @default(0)
+  burdenRate                Decimal                  @default(0)
+  pinCode                   String? // Used for mobile app quick login
+  invitedAt                 DateTime?                @default(now())
+  timeEntries               TimeEntry[]
+  assignedProjects          Project[]                @relation("CrewAssignments")
+  taskAssignments           TaskAssignment[]
+  taskComments              TaskComment[]
+  uploadedFiles             ProjectFile[]
+  permissions               UserPermission?
+  projectAccess             ProjectAccess[]
+  leadTasks                 LeadTask[]
+  managedLeads              Lead[]                   @relation("LeadManager")
+  managedProjects           Project[]                @relation("ProjectManager")
+  dailyLogs                 DailyLog[]
+  documentComments          DocumentComment[]
+  teamMessages              TeamMessage[]
+  fieldUpdatesSeenAt        DateTime?
+  clippedImports            ClippedImport[]
+  officeTasks               OfficeTask[]             @relation("OfficeTaskAssignee")
+  createdOfficeTasks        OfficeTask[]             @relation("OfficeTaskCreator")
+  dispatchPublications      DispatchPublication[]    @relation("DispatchPublisher")
+  createdTaskMaterials      TaskMaterial[]           @relation("TaskMaterialCreator")
+  taskMaterialStatusChanges TaskMaterial[]           @relation("TaskMaterialStatusChanger")
+  createdPunchItems         TaskPunchItem[]          @relation("TaskPunchItemCreator")
+  clippedProducts           ProductLibraryItem[]
+  addedFavorites            ProjectProductFavorite[]
+  decidedProposals          SelectionProposal[]
+  mcpKeys                   McpKey[]
 }
 
 model Client {
@@ -77,6 +78,13 @@ model Client {
   taxExemptCertExpiresAt DateTime?
   taxExemptCertNote      String?
 
+  // Soft-delete columns adopted from prod (0 non-null rows). Soft delete is NOT implemented:
+  // nothing filters on these. @ignore keeps them out of the generated client so no caller can
+  // set them and wrongly assume the row disappears. Un-ignore when soft delete actually ships.
+  deletedAt     DateTime? @ignore @db.Timestamp(6)
+  deletedById   String?   @ignore
+  deleteBatchId String?   @ignore
+
   projects       Project[]
   leads          Lead[]
   invoices       Invoice[]
@@ -85,6 +93,7 @@ model Client {
 
   @@index([primaryPhoneE164])
   @@index([additionalPhoneE164])
+  @@index([deletedAt])
 }
 
 model Lead {
@@ -117,6 +126,13 @@ model Lead {
   driveFolderId  String?
   driveFolderUrl String?
 
+  // Soft-delete columns adopted from prod (0 non-null rows). Soft delete is NOT implemented:
+  // nothing filters on these. @ignore keeps them out of the generated client so no caller can
+  // set them and wrongly assume the row disappears. Un-ignore when soft delete actually ships.
+  deletedAt     DateTime? @ignore @db.Timestamp(6)
+  deletedById   String?   @ignore
+  deleteBatchId String?   @ignore
+
   // Relations
   estimates      Estimate[]
   roomDesigns    RoomDesign[]
@@ -135,6 +151,7 @@ model Lead {
   @@index([createdAt])
   @@index([clientId])
   @@index([stage])
+  @@index([deletedAt])
 }
 
 model LeadNote {
@@ -162,23 +179,23 @@ model LeadTask {
 }
 
 model OfficeTask {
-  id          String    @id @default(cuid())
-  title       String
-  notes       String?
-  status      String    @default("To Do") // LEGACY — kept in sync with column.name on create/move for prod rollback safety until v2 deploys; reads should use columnId
-  columnId    String?
-  column      OfficeBoardColumn? @relation(fields: [columnId], references: [id], onDelete: SetNull)
-  position    Int       @default(0) // sort order within its column
-  archivedAt  DateTime?
-  dueDate     DateTime?
-  assigneeId  String?
-  assignee    User?     @relation("OfficeTaskAssignee", fields: [assigneeId], references: [id])
-  aiPrompt    String?   // suggested prompt the user can copy into Claude
+  id            String             @id @default(cuid())
+  title         String
+  notes         String?
+  status        String             @default("To Do") // LEGACY — kept in sync with column.name on create/move for prod rollback safety until v2 deploys; reads should use columnId
+  columnId      String?
+  column        OfficeBoardColumn? @relation(fields: [columnId], references: [id], onDelete: SetNull)
+  position      Int                @default(0) // sort order within its column
+  archivedAt    DateTime?
+  dueDate       DateTime?
+  assigneeId    String?
+  assignee      User?              @relation("OfficeTaskAssignee", fields: [assigneeId], references: [id])
+  aiPrompt      String? // suggested prompt the user can copy into Claude
   automationGap String? // what capability gap forced this to be handed off to a human
-  createdById String?
-  createdBy   User?     @relation("OfficeTaskCreator", fields: [createdById], references: [id])
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  createdById   String?
+  createdBy     User?              @relation("OfficeTaskCreator", fields: [createdById], references: [id])
+  createdAt     DateTime           @default(now())
+  updatedAt     DateTime           @default(now()) @updatedAt
 
   @@index([status, position])
   @@index([assigneeId])
@@ -212,88 +229,100 @@ model LeadMeeting {
 }
 
 model Project {
-  id                  String                       @id @default(cuid())
-  number              Int                          @default(autoincrement())
-  name                String
-  clientId            String
-  client              Client                       @relation(fields: [clientId], references: [id])
-  leadId              String?                      @unique
-  lead                Lead?                        @relation(fields: [leadId], references: [id], onDelete: Restrict)
-  viewedAt            DateTime                     @default(now())
-  createdAt           DateTime                     @default(now())
-  updatedAt           DateTime                     @default(now()) @updatedAt
-  location            String?
+  id                      String                       @id @default(cuid())
+  number                  Int                          @default(autoincrement())
+  name                    String
+  clientId                String
+  client                  Client                       @relation(fields: [clientId], references: [id])
+  leadId                  String?                      @unique
+  lead                    Lead?                        @relation(fields: [leadId], references: [id], onDelete: Restrict)
+  viewedAt                DateTime                     @default(now())
+  createdAt               DateTime                     @default(now())
+  updatedAt               DateTime                     @default(now()) @updatedAt
+  location                String?
   // Geofencing for mobile time-clock (added for gtr-probuild-mobile integration)
-  locationLat            Float?
-  locationLng            Float?
-  geofenceRadiusMeters   Int?     @default(100)
-  status              String                       @default("In Progress") // Waiting to Start, In Progress, Substantial Completion, Closed Complete, Closed Lost (see lib/project-status.ts)
+  locationLat             Float?
+  locationLng             Float?
+  geofenceRadiusMeters    Int?                         @default(100)
+  status                  String                       @default("In Progress") // Waiting to Start, In Progress, Substantial Completion, Closed Complete, Closed Lost (see lib/project-status.ts)
   // Company-level schedule markers (company dashboard): startDate = planned
   // project start shown on the start calendar; endDate reserved for Phase 2.
-  startDate           DateTime?
-  endDate             DateTime?
-  type                String? // Kitchen Remodeling, Patio, Water Damage
-  code                String?
-  tags                String?
-  color               String?                      @default("#3b82f6") // Added color field
-  paymentRemindersEnabled Boolean                  @default(false) // Settings → Client Dashboard: send automated payment-due reminder emails to the client. Opt-in — off by default, enabled per project.
-  portalStageOverride String? // Staff-pinned current stage on the portal project route (a CLIENT_STAGES label); null = derive position from schedule tasks
-  chatWebhookUrl      String? // Google Chat incoming webhook for the project's team space — treated as a credential: manager-only, never serialized to field crew
-  managerId           String?
-  manager             User?                        @relation("ProjectManager", fields: [managerId], references: [id])
-  estimates           Estimate[]
-  invoices            Invoice[]
-  budgets             Budget[]
-  timeEntries         TimeEntry[]
-  roomDesigns         RoomDesign[]
-  contracts           Contract[]
-  crew                User[]                       @relation("CrewAssignments")
-  scheduleTasks       ScheduleTask[]
-  files               ProjectFile[]
-  folders             FileFolder[]
-  userAccess          ProjectAccess[]
-  subcontractorAccess SubcontractorProjectAccess[]
-  takeoffs            Takeoff[]
-  portalVisibility    PortalVisibility?
-  messageThreads      MessageThread[]
-  clientMessages      ClientMessage[]
-  changeOrders        ChangeOrder[]
-  purchaseOrders      PurchaseOrder[]
-  selectionBoards     SelectionBoard[]
-  dailyLogs           DailyLog[]
-  moodBoards          MoodBoard[]
-  retainers           Retainer[]
-  bidPackages         BidPackage[]
-  teamMessages        TeamMessage[]
-  activityLogs        ActivityLog[]
-  productFavorites    ProjectProductFavorite[]
-  selectionProposals  SelectionProposal[]
-  decisions           Decision[]
-  permits             Permit[]
+  startDate               DateTime?
+  endDate                 DateTime?
+  type                    String? // Kitchen Remodeling, Patio, Water Damage
+  code                    String?
+  tags                    String?
+  color                   String?                      @default("#3b82f6") // Added color field
+  paymentRemindersEnabled Boolean                      @default(false) // Settings → Client Dashboard: send automated payment-due reminder emails to the client. Opt-in — off by default, enabled per project.
+  portalStageOverride     String? // Staff-pinned current stage on the portal project route (a CLIENT_STAGES label); null = derive position from schedule tasks
+  chatWebhookUrl          String? // Google Chat incoming webhook for the project's team space — treated as a credential: manager-only, never serialized to field crew
+  googleChatSpaceId       String?                      @unique
+  clientNextSteps         String?
+  clientNextStepsAt       DateTime?
+  qbProjectId             String?
+  qbSyncedAt              DateTime?                    @db.Timestamp(6)
+  // Soft-delete columns adopted from prod (0 non-null rows). Soft delete is NOT implemented:
+  // nothing filters on these. @ignore keeps them out of the generated client so no caller can
+  // set them and wrongly assume the row disappears. Un-ignore when soft delete actually ships.
+  deletedAt               DateTime?                    @ignore @db.Timestamp(6)
+  deletedById             String?                      @ignore
+  deleteBatchId           String?                      @ignore
+  managerId               String?
+  manager                 User?                        @relation("ProjectManager", fields: [managerId], references: [id])
+  estimates               Estimate[]
+  invoices                Invoice[]
+  budgets                 Budget[]
+  timeEntries             TimeEntry[]
+  roomDesigns             RoomDesign[]
+  contracts               Contract[]
+  crew                    User[]                       @relation("CrewAssignments")
+  scheduleTasks           ScheduleTask[]
+  files                   ProjectFile[]
+  folders                 FileFolder[]
+  userAccess              ProjectAccess[]
+  subcontractorAccess     SubcontractorProjectAccess[]
+  takeoffs                Takeoff[]
+  portalVisibility        PortalVisibility?
+  messageThreads          MessageThread[]
+  clientMessages          ClientMessage[]
+  changeOrders            ChangeOrder[]
+  purchaseOrders          PurchaseOrder[]
+  selectionBoards         SelectionBoard[]
+  dailyLogs               DailyLog[]
+  moodBoards              MoodBoard[]
+  retainers               Retainer[]
+  bidPackages             BidPackage[]
+  teamMessages            TeamMessage[]
+  activityLogs            ActivityLog[]
+  productFavorites        ProjectProductFavorite[]
+  selectionProposals      SelectionProposal[]
+  decisions               Decision[]
+  permits                 Permit[]
 
   @@index([viewedAt])
   @@index([clientId])
   @@index([status])
   @@index([createdAt])
   @@index([startDate])
+  @@index([deletedAt])
 }
 
 model RoomDesign {
-  id           String      @id @default(cuid())
+  id           String       @id @default(cuid())
   name         String
   roomType     String // kitchen | bathroom | laundry | bedroom | other
   projectId    String?
-  project      Project?    @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  project      Project?     @relation(fields: [projectId], references: [id], onDelete: Cascade)
   leadId       String?
-  lead         Lead?       @relation(fields: [leadId], references: [id], onDelete: Cascade)
+  lead         Lead?        @relation(fields: [leadId], references: [id], onDelete: Cascade)
   layoutJson   Json // walls, dimensions, camera, surfaces
-  shareToken   String?     @unique
-  shareEnabled Boolean     @default(false)
+  shareToken   String?      @unique
+  shareEnabled Boolean      @default(false)
   thumbnail    String?
   // USDZ export of the LiDAR scan - powers "View in AR" (Apple Quick Look).
   scanUsdzUrl  String?
-  createdAt    DateTime    @default(now())
-  updatedAt    DateTime    @updatedAt
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
   assets       RoomAsset[]
   renders      RoomRender[]
 
@@ -375,20 +404,28 @@ model Estimate {
   invoices         Invoice[] // invoices generated from this estimate (auto-created on signing)
 
   // Processing fee & expiration
-  processingFeeMarkup Decimal?
-  hideProcessingFee   Boolean   @default(true)
-  expirationDate      DateTime?
-  archivedAt          DateTime?
-  taxExempt           Boolean   @default(false)
-  taxRateName         String?
-  taxRatePercent      Decimal?
+  processingFeeMarkup    Decimal?
+  hideProcessingFee      Boolean   @default(true)
+  expirationDate         DateTime?
+  archivedAt             DateTime?
+  taxExempt              Boolean   @default(false)
+  taxRateName            String?
+  taxRatePercent         Decimal?  @db.Decimal
+  qbEstimateId           String?
+  qbSyncedAt             DateTime? @db.Timestamp(6)
+  // Soft-delete columns adopted from prod (0 non-null rows). Soft delete is NOT implemented:
+  // nothing filters on these. @ignore keeps them out of the generated client so no caller can
+  // set them and wrongly assume the row disappears. Un-ignore when soft delete actually ships.
+  deletedAt              DateTime? @ignore @db.Timestamp(6)
+  deletedById            String?   @ignore
+  deleteBatchId          String?   @ignore
   // Progress billing core: legacy estimates carry tax-inclusive milestone
   // amounts (the historical behavior); new estimates set this false once the
   // UI switches to tax-exclusive milestone entry. Read by progress-billing.ts.
-  taxInclusiveMilestones Boolean @default(true)
+  taxInclusiveMilestones Boolean   @default(true)
 
   // AI budget fill: target overall margin for the estimate (gross margin %, not markup)
-  targetMarginPercent Float     @default(25)
+  targetMarginPercent Float @default(25)
 
   // Phase 7: Contracts & Approvals
   approvedBy        String?
@@ -419,8 +456,8 @@ model Estimate {
   notesBody       String? // sanitized rich-text HTML
   notesPlacement  String  @default("after") // "before" | "after" line items
 
-  changeOrders       ChangeOrder[]
-  files              EstimateFile[]
+  changeOrders           ChangeOrder[]
+  files                  EstimateFile[]
   // Tasks generated from this estimate by generateScheduleFromEstimate.
   generatedScheduleTasks ScheduleTask[]
 
@@ -435,6 +472,7 @@ model Estimate {
   @@index([projectId])
   @@index([leadId])
   @@index([status])
+  @@index([deletedAt])
 }
 
 model EstimateFile {
@@ -465,84 +503,97 @@ model EstimatePaymentSchedule {
   referenceNumber       String? // check # / confirmation #
   notes                 String? // free-form memo
   receiptSentAt         DateTime? // last time admin sent the receipt email
-  paidAt                DateTime?
-  paymentDate           DateTime?
+  paidAt                DateTime? @db.Timestamptz(6)
+  paymentDate           DateTime? @db.Timestamptz(6)
+
+  // Soft-delete columns adopted from prod (0 non-null rows). Soft delete is NOT implemented:
+  // nothing filters on these. @ignore keeps them out of the generated client so no caller can
+  // set them and wrongly assume the row disappears. Un-ignore when soft delete actually ships.
+  deletedAt     DateTime? @ignore @db.Timestamp(6)
+  deleteBatchId String?   @ignore
 
   // Optional link to the schedule task this milestone follows (company
   // dashboard start-date moves shift the dueDate with the task).
-  scheduleTaskId        String?
-  scheduleTask          ScheduleTask? @relation(fields: [scheduleTaskId], references: [id], onDelete: SetNull)
+  scheduleTaskId String?
+  scheduleTask   ScheduleTask? @relation(fields: [scheduleTaskId], references: [id], onDelete: SetNull)
 
   @@index([estimateId])
   @@index([scheduleTaskId])
+  @@index([deletedAt])
 }
 
 model EstimateItem {
-  id            String         @id @default(cuid())
-  estimateId    String
-  estimate      Estimate       @relation(fields: [estimateId], references: [id], onDelete: Cascade)
-  name          String
-  description   String?
-  type          String         @default("Material") // Legacy fallback
-  quantity      Float          @default(1)
-  baseCost      Decimal? // Raw cost before margin (internal only)
-  markupPercent Float          @default(25) // Gross margin % on sell price (internal only; field name is legacy/misleading — see src/lib/budget-math.ts)
-  unitCost      Decimal          @default(0) // Sell price = baseCost / (1 - markupPercent/100)
-  total         Decimal          @default(0)
-  order         Int            @default(0)
-  parentId      String?
-  parent        EstimateItem?  @relation("SubItems", fields: [parentId], references: [id], onDelete: Cascade)
-  subItems      EstimateItem[] @relation("SubItems")
-  expenses      Expense[]
-  costCodeId    String?
-  costCode      CostCode?      @relation(fields: [costCodeId], references: [id])
-  costTypeId    String?
-  costType      CostType?      @relation(fields: [costTypeId], references: [id])
-  approvalStatus String?        // pending, approved, rejected
-  approvalNote   String?
+  id                 String                      @id @default(cuid())
+  estimateId         String
+  estimate           Estimate                    @relation(fields: [estimateId], references: [id], onDelete: Cascade)
+  name               String
+  description        String?
+  type               String                      @default("Material") // Legacy fallback
+  quantity           Float                       @default(1)
+  baseCost           Decimal? // Raw cost before margin (internal only)
+  markupPercent      Float                       @default(25) // Gross margin % on sell price (internal only; field name is legacy/misleading — see src/lib/budget-math.ts)
+  unitCost           Decimal                     @default(0) // Sell price = baseCost / (1 - markupPercent/100)
+  total              Decimal                     @default(0)
+  order              Int                         @default(0)
+  parentId           String?
+  parent             EstimateItem?               @relation("SubItems", fields: [parentId], references: [id], onDelete: Cascade)
+  subItems           EstimateItem[]              @relation("SubItems")
+  expenses           Expense[]
+  costCodeId         String?
+  costCode           CostCode?                   @relation(fields: [costCodeId], references: [id])
+  costTypeId         String?
+  costType           CostType?                   @relation(fields: [costTypeId], references: [id])
+  approvalStatus     String? // pending, approved, rejected
+  approvalNote       String?
   /// @deprecated legacy single-PO link. Superseded by purchaseOrderLinks; kept
   /// dual-written (syncLegacyPoLink) so a rollback to the pre-many-to-many build
   /// still reads correctly. Drop in a follow-up once this has been stable on prod.
-  purchaseOrderId  String?
-  purchaseOrder    PurchaseOrder? @relation(fields: [purchaseOrderId], references: [id], onDelete: SetNull)
+  purchaseOrderId    String?
+  purchaseOrder      PurchaseOrder?              @relation(fields: [purchaseOrderId], references: [id], onDelete: SetNull)
   purchaseOrderLinks EstimateItemPurchaseOrder[]
-  budgetQuantity   Float?
-  budgetUnit       String?
-  budgetRate       Decimal?
-  timeEntries    TimeEntry[]
-  scheduleTask   ScheduleTask?
-  createdAt      DateTime       @default(now())
+  budgetQuantity     Float?
+  budgetUnit         String?
+  budgetRate         Decimal?
+  timeEntries        TimeEntry[]
+  scheduleTask       ScheduleTask?
+  createdAt          DateTime                    @default(now())
+  // Soft-delete columns adopted from prod (0 non-null rows). Soft delete is NOT implemented:
+  // nothing filters on these. @ignore keeps them out of the generated client so no caller can
+  // set them and wrongly assume the row disappears. Un-ignore when soft delete actually ships.
+  deletedAt          DateTime?                   @ignore @db.Timestamp(6)
+  deleteBatchId      String?                     @ignore
 
   @@index([estimateId])
   @@index([purchaseOrderId])
+  @@index([deletedAt])
 }
 
 model Expense {
-  id          String        @id @default(cuid())
-  estimateId  String
-  estimate    Estimate      @relation(fields: [estimateId], references: [id], onDelete: Cascade)
-  itemId      String?
-  item        EstimateItem? @relation(fields: [itemId], references: [id], onDelete: SetNull)
-  costCodeId  String?
-  costCode    CostCode?     @relation(fields: [costCodeId], references: [id])
-  costTypeId  String?
-  costType    CostType?     @relation(fields: [costTypeId], references: [id])
-  amount      Decimal
-  vendor      String?
-  date        DateTime?
-  description String?
-  receiptUrl  String?
+  id            String        @id @default(cuid())
+  estimateId    String
+  estimate      Estimate      @relation(fields: [estimateId], references: [id], onDelete: Cascade)
+  itemId        String?
+  item          EstimateItem? @relation(fields: [itemId], references: [id], onDelete: SetNull)
+  costCodeId    String?
+  costCode      CostCode?     @relation(fields: [costCodeId], references: [id])
+  costTypeId    String?
+  costType      CostType?     @relation(fields: [costTypeId], references: [id])
+  amount        Decimal
+  vendor        String?
+  date          DateTime?
+  description   String?
+  receiptUrl    String?
   // Stable identity for finalized money-out imported from QuickBooks Online.
   // Nullable so existing/manual and receipt-intake expenses remain unchanged.
-  qbPurchaseId String?   @unique(map: "Expense_qbPurchaseId_key")
-  qbSyncToken  String?
-  qbSyncedAt   DateTime?
+  qbPurchaseId  String?       @unique(map: "Expense_qbPurchaseId_key")
+  qbSyncToken   String?
+  qbSyncedAt    DateTime?     @db.Timestamptz(6)
   changeOrderId String?
-  changeOrder   ChangeOrder? @relation(fields: [changeOrderId], references: [id], onDelete: SetNull)
-  isBillable    Boolean      @default(false)
+  changeOrder   ChangeOrder?  @relation(fields: [changeOrderId], references: [id], onDelete: SetNull)
+  isBillable    Boolean       @default(false)
   invoiceId     String?
   invoicedAt    DateTime?
-  status      String        @default("Pending") // Pending, Reviewed
+  status        String        @default("Pending") // Pending, Reviewed
 
   purchaseOrderId String?
   purchaseOrder   PurchaseOrder? @relation(fields: [purchaseOrderId], references: [id])
@@ -565,18 +616,20 @@ model Invoice {
   estimateId  String?
   estimate    Estimate? @relation(fields: [estimateId], references: [id], onDelete: SetNull)
   status      String    @default("Draft") // Draft, Issued, Paid, Overdue
-  totalAmount Decimal     @default(0)
-  subtotal    Decimal     @default(0)  // pre-tax
-  taxRate     Decimal     @default(0)  // percent, e.g. 8.8
-  taxAmount   Decimal     @default(0)  // dollars
-  balanceDue  Decimal     @default(0)
+  totalAmount Decimal   @default(0)
+  subtotal    Decimal   @default(0) // pre-tax
+  taxRate     Decimal   @default(0) // percent, e.g. 8.8
+  taxAmount   Decimal   @default(0) // dollars
+  balanceDue  Decimal   @default(0)
   notes       String?
   issueDate   DateTime?
   sentAt      DateTime?
   viewedAt    DateTime?
   createdAt   DateTime  @default(now())
+  qbInvoiceId String?
+  qbSyncedAt  DateTime? @db.Timestamp(6)
 
-  payments PaymentSchedule[]
+  payments         PaymentSchedule[]
   progressBillings ProgressBilling[]
 
   @@index([projectId])
@@ -601,23 +654,23 @@ model PaymentSchedule {
   referenceNumber       String? // check # / confirmation #
   notes                 String? // free-form memo
   receiptSentAt         DateTime? // last time admin sent the receipt email
-  lastReminderAt        DateTime? // last time the automated payment-reminder cron emailed the client for this milestone
+  lastReminderAt        DateTime? @db.Timestamptz(6) // last time the automated payment-reminder cron emailed the client for this milestone
   paidAt                DateTime?
   createdAt             DateTime  @default(now())
 
   // QuickBooks Payments rail: each milestone maps to one QBO invoice with its own pay link.
-  qbInvoiceId   String?
-  qbInvoiceLink String? // Intuit-hosted "Review & Pay" page (card/ACH)
-  qbPaymentId   String? // QBO Payment txn that settled this milestone (set by the sync poller)
-  qbSyncedAt    DateTime?
+  qbInvoiceId     String?
+  qbInvoiceLink   String? // Intuit-hosted "Review & Pay" page (card/ACH)
+  qbPaymentId     String? // QBO Payment txn that settled this milestone (set by the sync poller)
+  qbSyncedAt      DateTime?
   qbInvoiceSentAt DateTime? // last time the QBO invoice email was sent to the client
-  qbSyncError   String? // "voided" | "notFound" — set by the sync poller when the linked QBO invoice is gone/voided; cleared on a successful re-push
+  qbSyncError     String? // "voided" | "notFound" — set by the sync poller when the linked QBO invoice is gone/voided; cleared on a successful re-push
 
   // EstimatePaymentSchedule row this milestone was cloned from at invoicing time.
   // Payment mirrors settle/unwind by this link (name+amount matching is the legacy fallback).
   sourceScheduleId    String?
   sourceChangeOrderId String?
-  sourceCoScheduleId  String? @unique
+  sourceCoScheduleId  String?                     @unique
   sourceCoSchedule    ChangeOrderPaymentSchedule? @relation("CoScheduleBilling", fields: [sourceCoScheduleId], references: [id], onDelete: SetNull)
   coBilling           ChangeOrderBilling?
 
@@ -666,15 +719,15 @@ model DepositIngest {
   // for the QBO path): stamped immediately before recordPaymentCore runs. While any
   // boundary marker is set, retry reclaims preserve the reservation + extracted payload
   // so recovery goes through the exact reserved-row path, never a re-match.
-  settleStartedAt DateTime?
-  officeTaskId    String? // set once, on the first unmatched/reconcile — re-POSTs never create a second task
+  settleStartedAt   DateTime?
+  officeTaskId      String? // set once, on the first unmatched/reconcile — re-POSTs never create a second task
 
   attempts            Int       @default(0)
   lastError           String?
   processingStartedAt DateTime? // claim lease — stale after 5 min, like the notification outbox
 
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 
   @@index([status])
   @@index([paymentScheduleId])
@@ -691,46 +744,46 @@ model DepositIngest {
 // see src/lib/progress-billing.ts for the auto-split mechanic that keeps every
 // ProgressBillingLine mapped 1:1 to a whole milestone.
 model ProgressBilling {
-  id          String   @id @default(cuid())
-  invoiceId   String
-  invoice     Invoice  @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
-  code        String   // "INV-00171-P1" — sequential per invoice
-  description String   // client-facing: what this payment covers
-  status      String   @default("Draft") // Draft | Staged | Sent | Paid | Void
-  subtotal    Decimal  @default(0)  // pre-tax
-  taxExempt   Boolean  @default(false)
-  taxRate     Decimal  @default(0)  // percent snapshot at build time
-  taxAmount   Decimal  @default(0)
-  total       Decimal  @default(0)  // subtotal + taxAmount
+  id              String                @id @default(cuid())
+  invoiceId       String
+  invoice         Invoice               @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
+  code            String // "INV-00171-P1" — sequential per invoice
+  description     String // client-facing: what this payment covers
+  status          String                @default("Draft") // Draft | Staged | Sent | Paid | Void
+  subtotal        Decimal               @default(0) // pre-tax
+  taxExempt       Boolean               @default(false)
+  taxRate         Decimal               @default(0) // percent snapshot at build time
+  taxAmount       Decimal               @default(0)
+  total           Decimal               @default(0) // subtotal + taxAmount
   qbInvoiceId     String?
   qbInvoiceLink   String?
   qbInvoiceSentAt DateTime?
   qbPaymentId     String?
   qbSyncedAt      DateTime?
   qbSyncError     String?
-  sentAt      DateTime?
-  paidAt      DateTime?
-  createdAt   DateTime @default(now())
-  lines       ProgressBillingLine[]
+  sentAt          DateTime?
+  paidAt          DateTime?
+  createdAt       DateTime              @default(now())
+  lines           ProgressBillingLine[]
 
   @@index([invoiceId])
   @@index([status])
 }
 
 model ProgressBillingLine {
-  id            String @id @default(cuid())
-  billingId     String
-  billing       ProgressBilling @relation(fields: [billingId], references: [id], onDelete: Cascade)
-  scheduleId    String?  // PaymentSchedule this line bills (null = custom line)
-  description   String
-  amount        Decimal  // pre-tax — feeds the QuickBooks taxable line
+  id          String          @id @default(cuid())
+  billingId   String
+  billing     ProgressBilling @relation(fields: [billingId], references: [id], onDelete: Cascade)
+  scheduleId  String? // PaymentSchedule this line bills (null = custom line)
+  description String
+  amount      Decimal // pre-tax — feeds the QuickBooks taxable line
   // What was actually carved out of the milestone, in the milestone's own units
   // (gross on tax-inclusive/legacy jobs, pre-tax on new ones). Recorded rather
   // than recomputed from `amount`: reconstructing it re-applies tax to a rounded
   // number and can land a cent low, which let a second billing claim the
   // difference on an already fully-billed milestone.
-  splitAmount   Decimal  @default(0)
-  order         Int      @default(0)
+  splitAmount Decimal         @default(0)
+  order       Int             @default(0)
 
   @@index([billingId])
   @@index([scheduleId])
@@ -742,8 +795,8 @@ model Budget {
   project             Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
   estimateId          String   @unique
   estimate            Estimate @relation(fields: [estimateId], references: [id], onDelete: Cascade)
-  totalLaborBudget    Decimal    @default(0)
-  totalMaterialBudget Decimal    @default(0)
+  totalLaborBudget    Decimal  @default(0)
+  totalMaterialBudget Decimal  @default(0)
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt
 }
@@ -841,6 +894,13 @@ model TimeEntry {
   suggestionSource        String? // "daily_log" | "today_schedule" | "user_history"
   suggestionOverridden    Boolean @default(false)
 
+  mealSkipped        Boolean   @default(false)
+  mealDeductionHours Float?
+  needsReview        Boolean   @default(false)
+  reviewReason       String?
+  qbTimeActivityId   String?
+  qbSyncedAt         DateTime? @db.Timestamp(6)
+
   @@index([projectId])
   @@index([userId])
   @@index([costCodeId])
@@ -872,9 +932,9 @@ model Contract {
   signatureUrl      String? // Supabase Storage URL of the drawn signature (legacy rows may hold an inline data-URL)
 
   // Contractor signing fields
-  contractorSignedBy       String?
-  contractorSignedAt       DateTime?
-  contractorSignatureUrl   String? // Supabase Storage URL of the contractor's drawn signature (legacy rows may hold an inline data-URL)
+  contractorSignedBy     String?
+  contractorSignedAt     DateTime? @db.Timestamptz(6)
+  contractorSignatureUrl String? // Supabase Storage URL of the contractor's drawn signature (legacy rows may hold an inline data-URL)
 
   // Company countersignature (executed AFTER the customer signs — see countersignContractAsCompany)
   requiresCountersign Boolean   @default(false) // when true, contract isn't Finalized until the company countersigns
@@ -926,51 +986,51 @@ model ContractSigningRecord {
 }
 
 model CompanySettings {
-  id                  String  @id @default("singleton")
-  companyName         String  @default("My Construction Co.")
-  address             String?
-  phone               String?
-  email               String?
-  website             String?
-  logoUrl             String?
-  licenseNumber       String?
-  notificationEmail   String? // Where to send View/Sign alerts
-  timeZone           String  @default("America/Los_Angeles")
+  id                      String  @id @default("singleton")
+  companyName             String  @default("My Construction Co.")
+  address                 String?
+  phone                   String?
+  email                   String?
+  website                 String?
+  logoUrl                 String?
+  licenseNumber           String?
+  notificationEmail       String? // Where to send View/Sign alerts
+  timeZone                String  @default("America/Los_Angeles")
   // Google Drive (work account) - lead media folders. Set via Settings > Integrations.
   googleDriveRefreshToken String?
   googleDriveEmail        String?
-  projectStatuses     String? // JSON string array of custom statues [{label, value, color, dot}, ...]
-  subcontractorTrades String? // JSON string array of trades ["Architect", "Asphalt", "Bricklaying"]
-  stripeEnabled       Boolean @default(false)
-  enableCard          Boolean @default(true)
-  enableBankTransfer  Boolean @default(false)
-  enableAffirm        Boolean @default(false)
-  enableKlarna        Boolean @default(false)
+  projectStatuses         String? // JSON string array of custom statues [{label, value, color, dot}, ...]
+  subcontractorTrades     String? // JSON string array of trades ["Architect", "Asphalt", "Bricklaying"]
+  stripeEnabled           Boolean @default(false)
+  enableCard              Boolean @default(true)
+  enableBankTransfer      Boolean @default(false)
+  enableAffirm            Boolean @default(false)
+  enableKlarna            Boolean @default(false)
 
   // Processing Fees
   passProcessingFee  Boolean @default(false)
-  cardProcessingRate Decimal   @default(2.9)
-  cardProcessingFlat Decimal   @default(0.30)
+  cardProcessingRate Decimal @default(2.9)
+  cardProcessingFlat Decimal @default(0.30)
 
   // Company overhead per month (rent, insurance, owner salary, vehicles, software…)
   // Used by /reports/profitability to answer "are we profitable including overhead".
   monthlyOverhead Decimal @default(0)
 
   // Calendar settings
-  workDays      String? // JSON array: ["Mon","Tue","Wed","Thu","Fri"]
-  workdayStart  String? // e.g. "07:00"
-  workdayEnd    String? // e.g. "17:00"
+  workDays     String? // JSON array: ["Mon","Tue","Wed","Thu","Fri"]
+  workdayStart String? // e.g. "07:00"
+  workdayEnd   String? // e.g. "17:00"
 
   // Sales taxes
   salesTaxes String? // JSON array: [{name, rate, isDefault}]
 
   // Letterhead
-  letterheadMode         String?  @default("built_in") // 'built_in' | 'custom_image'
+  letterheadMode         String? @default("built_in") // 'built_in' | 'custom_image'
   letterheadImageUrl     String?
-  letterheadLogoPosition String?  @default("left") // 'left' | 'center' | 'right'
-  letterheadFields       String?  @default("[\"name\",\"address\",\"phone\",\"email\",\"license\"]")
-  letterheadAccentColor  String?  @default("#4F46E5")
-  letterheadDivider      Boolean  @default(true)
+  letterheadLogoPosition String? @default("left") // 'left' | 'center' | 'right'
+  letterheadFields       String? @default("[\"name\",\"address\",\"phone\",\"email\",\"license\"]")
+  letterheadAccentColor  String? @default("#4F46E5")
+  letterheadDivider      Boolean @default(true)
 
   // Notification event toggles
   notificationToggles String? // JSON: {newLead, estimateViewed, estimateSigned, contractSigned, invoiceViewed, paymentReceived, messageReceived}
@@ -992,45 +1052,46 @@ model DocumentTemplate {
 }
 
 model ScheduleTask {
-  id             String         @id @default(cuid())
-  projectId      String?
-  project        Project?       @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  leadId         String?
-  lead           Lead?          @relation(fields: [leadId], references: [id], onDelete: Cascade)
-  name           String
-  startDate      DateTime
-  endDate        DateTime
-  color          String         @default("#4c9a2a")
-  progress       Int            @default(0)
-  estimatedHours Float?
-  assignee       String?
-  parentId       String?
-  parent         ScheduleTask?  @relation("SubTasks", fields: [parentId], references: [id], onDelete: Cascade)
-  children       ScheduleTask[] @relation("SubTasks")
-  order          Int            @default(0)
-  status         String         @default("Not Started")
-  type           String         @default("task") // "task" | "milestone" | "appointment"
-  doneWhen       String?        // Completion criteria shown to the field crew
-  blockedReason  String?        // Required explanation while status is "Blocked"
+  id                         String         @id @default(cuid())
+  projectId                  String?
+  project                    Project?       @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  leadId                     String?
+  lead                       Lead?          @relation(fields: [leadId], references: [id], onDelete: Cascade)
+  name                       String
+  startDate                  DateTime
+  endDate                    DateTime
+  color                      String         @default("#4c9a2a")
+  progress                   Int            @default(0)
+  estimatedHours             Float?
+  assignee                   String?
+  parentId                   String?
+  parent                     ScheduleTask?  @relation("SubTasks", fields: [parentId], references: [id], onDelete: Cascade)
+  children                   ScheduleTask[] @relation("SubTasks")
+  order                      Int            @default(0)
+  status                     String         @default("Not Started")
+  type                       String         @default("task") // "task" | "milestone" | "appointment"
+  doneWhen                   String? // Completion criteria shown to the field crew
+  blockedReason              String? // Required explanation while status is "Blocked"
   // Client-facing stage on the portal tracker rail. Null = derive from the task
   // name/cost code (see lib/portal-tracker.ts). Set explicitly to override when
   // keyword matching guesses wrong — must be one of CLIENT_STAGES[].label.
-  clientStage    String?
-  scheduledTime  String?        // "HH:MM" in America/Los_Angeles; appointment tasks only
-  confirmationStatus String?    // "planned" | "requested" | "confirmed"; appointment tasks only
-  estimateItemId String?        @unique
-  estimateItem   EstimateItem?  @relation(fields: [estimateItemId], references: [id], onDelete: SetNull)
+  clientStage                String?
+  progressSource             String? // provenance of the last progress update (e.g. "daily_log", "manual")
+  scheduledTime              String? // "HH:MM" in America/Los_Angeles; appointment tasks only
+  confirmationStatus         String? // "planned" | "requested" | "confirmed"; appointment tasks only
+  estimateItemId             String?        @unique
+  estimateItem               EstimateItem?  @relation(fields: [estimateItemId], references: [id], onDelete: SetNull)
   // Generation provenance: set on every task kind created by
   // generateScheduleFromEstimate (phase parents, children, flat tasks,
   // milestones) so regenerate can identify them without touching manual tasks.
-  generatedFromEstimateId String?
-  generatedFromEstimate   Estimate? @relation(fields: [generatedFromEstimateId], references: [id], onDelete: SetNull)
+  generatedFromEstimateId    String?
+  generatedFromEstimate      Estimate?      @relation(fields: [generatedFromEstimateId], references: [id], onDelete: SetNull)
   // CO-task provenance: set on tasks created by applyChangeOrderToSchedule
   // (CO parent, children, milestones).
   generatedFromChangeOrderId String?
-  generatedFromChangeOrder   ChangeOrder? @relation(fields: [generatedFromChangeOrderId], references: [id], onDelete: SetNull)
-  createdAt      DateTime       @default(now())
-  updatedAt      DateTime       @updatedAt
+  generatedFromChangeOrder   ChangeOrder?   @relation(fields: [generatedFromChangeOrderId], references: [id], onDelete: SetNull)
+  createdAt                  DateTime       @default(now())
+  updatedAt                  DateTime       @updatedAt
 
   // Dependencies
   dependencies TaskDependency[] @relation("Dependent")
@@ -1047,8 +1108,8 @@ model ScheduleTask {
   subAssignments SubTaskAssignment[]
 
   // Payment milestones anchored to this task (company dashboard start moves).
-  estimatePaymentSchedules EstimatePaymentSchedule[]
-  paymentSchedules         PaymentSchedule[]
+  estimatePaymentSchedules    EstimatePaymentSchedule[]
+  paymentSchedules            PaymentSchedule[]
   changeOrderPaymentSchedules ChangeOrderPaymentSchedule[]
 
   @@index([projectId])
@@ -1096,14 +1157,14 @@ model TaskDependency {
 }
 
 model TaskComment {
-  id                String       @id @default(cuid())
+  id                String             @id @default(cuid())
   taskId            String
-  task              ScheduleTask @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  task              ScheduleTask       @relation(fields: [taskId], references: [id], onDelete: Cascade)
   userId            String?
-  user              User?        @relation(fields: [userId], references: [id], onDelete: SetNull)
-  subcontractorName String?      // display name for sub-portal comments
+  user              User?              @relation(fields: [userId], references: [id], onDelete: SetNull)
+  subcontractorName String? // display name for sub-portal comments
   text              String
-  createdAt         DateTime     @default(now())
+  createdAt         DateTime           @default(now())
   photos            TaskCommentPhoto[]
 }
 
@@ -1228,22 +1289,22 @@ model FileFolder {
 }
 
 model ProjectFile {
-  id           String      @id @default(cuid())
-  name         String
-  url          String
-  size         Int         @default(0)
-  mimeType     String      @default("application/octet-stream")
-  visibility   String?     // null = inherit from folder. Explicit: "team" | "shared" | "financial"
-  projectId    String?
-  project      Project?    @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  leadId       String?
-  lead         Lead?       @relation(fields: [leadId], references: [id], onDelete: Cascade)
-  folderId     String?
-  folder       FileFolder? @relation(fields: [folderId], references: [id], onDelete: SetNull)
-  uploadedById String?
-  uploadedBy   User?       @relation(fields: [uploadedById], references: [id])
-  uploadedByClient Boolean @default(false)
-  createdAt    DateTime    @default(now())
+  id               String      @id @default(cuid())
+  name             String
+  url              String
+  size             Int         @default(0)
+  mimeType         String      @default("application/octet-stream")
+  visibility       String? // null = inherit from folder. Explicit: "team" | "shared" | "financial"
+  projectId        String?
+  project          Project?    @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  leadId           String?
+  lead             Lead?       @relation(fields: [leadId], references: [id], onDelete: Cascade)
+  folderId         String?
+  folder           FileFolder? @relation(fields: [folderId], references: [id], onDelete: SetNull)
+  uploadedById     String?
+  uploadedBy       User?       @relation(fields: [uploadedById], references: [id])
+  uploadedByClient Boolean     @default(false)
+  createdAt        DateTime    @default(now())
 
   @@index([projectId])
   @@index([leadId])
@@ -1356,7 +1417,7 @@ model EstimateTemplateItem {
   quantity      Float            @default(1)
   baseCost      Decimal?
   markupPercent Float            @default(25) // Same semantic as EstimateItem.markupPercent: gross margin % on sell price, NOT markup on cost. saveEstimateAsTemplate/createEstimateFromTemplate copy it verbatim both ways; the MCP templateToPhases path drops it and rebuilds rows with baseCost null + the default 25.
-  unitCost      Decimal            @default(0) // Sell price. Where baseCost is present it is baseCost / (1 - markupPercent/100); seeded templates often carry a null baseCost, so that is not an invariant.
+  unitCost      Decimal          @default(0) // Sell price. Where baseCost is present it is baseCost / (1 - markupPercent/100); seeded templates often carry a null baseCost, so that is not an invariant.
   order         Int              @default(0)
   parentId      String?
   costCodeId    String?
@@ -1411,13 +1472,16 @@ model Message {
 }
 
 model ClientMessage {
-  id           String    @id @default(cuid())
+  // This table was renamed LeadMessage -> ClientMessage in code (commit 363b70c) but the
+  // Postgres constraints kept their original names. The map:s below record that, so the
+  // schema stays an accurate description of prod instead of proposing a rename.
+  id           String    @id(map: "LeadMessage_pkey") @default(cuid())
   // Client-level FK for unified conversation view (all messages for one client)
   clientId     String?
   client       Client?   @relation(fields: [clientId], references: [id], onDelete: SetNull)
   // Entity context: which lead/project the message was sent from/threaded to
   leadId       String?
-  lead         Lead?     @relation(fields: [leadId], references: [id], onDelete: Cascade)
+  lead         Lead?     @relation(fields: [leadId], references: [id], onDelete: Cascade, map: "LeadMessage_leadId_fkey")
   projectId    String?
   project      Project?  @relation(fields: [projectId], references: [id], onDelete: Cascade)
   direction    String // "INBOUND" (from client) or "OUTBOUND" (from team)
@@ -1433,7 +1497,7 @@ model ClientMessage {
   scheduledFor DateTime?
   ccEmails     String? // JSON array of emails
   createdAt    DateTime  @default(now())
-  readAt       DateTime? // Set when the recipient (team or client) reads the message
+  readAt       DateTime? @db.Timestamptz(6) // Set when the recipient (team or client) reads the message
 
   // Twilio MessageSid for inbound idempotency + outbound observability.
   // Partial-unique index in DB: WHERE "twilioMessageSid" IS NOT NULL.
@@ -1459,19 +1523,19 @@ model SubcontractorProjectAccess {
 }
 
 model ChangeOrder {
-  id          String   @id @default(cuid())
-  number      Int      @default(autoincrement())
-  projectId   String
-  project     Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  estimateId  String
-  estimate    Estimate @relation(fields: [estimateId], references: [id], onDelete: Cascade)
-  code        String
-  title       String
-  description String?
-  status      String   @default("Draft") // Draft, Sent, Approved, Declined
-  totalAmount Decimal    @default(0)
-  balanceDue  Decimal    @default(0)
-  pricingType String     @default("FIXED")
+  id            String   @id @default(cuid())
+  number        Int      @default(autoincrement())
+  projectId     String
+  project       Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  estimateId    String
+  estimate      Estimate @relation(fields: [estimateId], references: [id], onDelete: Cascade)
+  code          String
+  title         String
+  description   String?
+  status        String   @default("Draft") // Draft, Sent, Approved, Declined
+  totalAmount   Decimal  @default(0)
+  balanceDue    Decimal  @default(0)
+  pricingType   String   @default("FIXED")
   // COST_PLUS only: a TRUE markup on actuals — billing = (labor + expenses) * (1 + markupPercent/100), see lib/billing-core.ts.
   // Deliberately a different semantic from ChangeOrderItem.markupPercent / EstimateItem.markupPercent, which hold gross margin on sell.
   markupPercent Float?
@@ -1480,9 +1544,9 @@ model ChangeOrder {
   memos              String?
 
   // Customer approval (set by approveChangeOrder — portal/magic-link signer)
-  clientSignatureUrl  String? // Supabase Storage URL of the drawn signature (legacy rows may hold an inline data-URL)
-  approvedBy          String?
-  approvedAt          DateTime?
+  clientSignatureUrl String? // Supabase Storage URL of the drawn signature (legacy rows may hold an inline data-URL)
+  approvedBy         String?
+  approvedAt         DateTime?
 
   // Company countersignature (set by countersignChangeOrderAsCompany — ADMIN/MANAGER).
   // Separate fields so countersigning never overwrites the customer's approval/audit trail.
@@ -1490,14 +1554,14 @@ model ChangeOrder {
   companySignedBy     String?
   companySignedAt     DateTime?
 
-  sentAt              DateTime?
-  viewedAt            DateTime?
+  sentAt   DateTime?
+  viewedAt DateTime?
 
   items            ChangeOrderItem[]
   paymentSchedules ChangeOrderPaymentSchedule[]
-  timeEntries       TimeEntry[]
-  expenses          Expense[]
-  billings          ChangeOrderBilling[]
+  timeEntries      TimeEntry[]
+  expenses         Expense[]
+  billings         ChangeOrderBilling[]
 
   // Schedule tasks generated from this CO (provenance / idempotency).
   generatedScheduleTasks ScheduleTask[]
@@ -1523,8 +1587,8 @@ model ChangeOrderItem {
   // Not the same field as ChangeOrder.markupPercent, which IS live: a true cost-plus markup on actuals.
   baseCost      Decimal?
   markupPercent Float       @default(25)
-  unitCost      Decimal       @default(0) // Authoritative per-line sell price; `total` below is its quantity-derived mirror (line cents = quantity * unitCost).
-  total         Decimal       @default(0)
+  unitCost      Decimal     @default(0) // Authoritative per-line sell price; `total` below is its quantity-derived mirror (line cents = quantity * unitCost).
+  total         Decimal     @default(0)
   order         Int         @default(0)
   costCodeId    String?
   costCode      CostCode?   @relation(fields: [costCodeId], references: [id])
@@ -1534,14 +1598,14 @@ model ChangeOrderItem {
 }
 
 model ChangeOrderPaymentSchedule {
-  id            String      @id @default(cuid())
-  changeOrderId String
-  changeOrder   ChangeOrder @relation(fields: [changeOrderId], references: [id], onDelete: Cascade)
-  name          String
-  amount        Decimal
-  dueDate       DateTime?
-  order         Int         @default(0)
-  createdAt     DateTime    @default(now())
+  id              String           @id @default(cuid())
+  changeOrderId   String
+  changeOrder     ChangeOrder      @relation(fields: [changeOrderId], references: [id], onDelete: Cascade)
+  name            String
+  amount          Decimal
+  dueDate         DateTime?
+  order           Int              @default(0)
+  createdAt       DateTime         @default(now())
   billedMilestone PaymentSchedule? @relation("CoScheduleBilling")
 
   // Optional milestone anchor created by applyChangeOrderToSchedule.
@@ -1632,7 +1696,7 @@ model PurchaseOrder {
   // deleteVendor blocks with a count; this is the backstop for every other caller.
   vendor      Vendor  @relation(fields: [vendorId], references: [id], onDelete: Restrict)
   status      String  @default("Draft") // Draft, Sent, Received, Cancelled
-  totalAmount Decimal   @default(0)
+  totalAmount Decimal @default(0)
   notes       String?
   memos       String?
   terms       String?
@@ -1643,12 +1707,12 @@ model PurchaseOrder {
   approvedBy String?
   approvedAt DateTime?
 
-  items    PurchaseOrderItem[]
-  files    PurchaseOrderFile[]
-  expenses Expense[]
-  messages PurchaseOrderMessage[]
+  items             PurchaseOrderItem[]
+  files             PurchaseOrderFile[]
+  expenses          Expense[]
+  messages          PurchaseOrderMessage[]
   /// @deprecated back-relation for the legacy single-PO link. See EstimateItem.purchaseOrderId.
-  estimateItems EstimateItem[]
+  estimateItems     EstimateItem[]
   estimateItemLinks EstimateItemPurchaseOrder[]
 
   createdAt DateTime @default(now())
@@ -1676,17 +1740,17 @@ model PurchaseOrderMessage {
   id              String        @id @default(cuid())
   purchaseOrderId String
   purchaseOrder   PurchaseOrder @relation(fields: [purchaseOrderId], references: [id], onDelete: Cascade)
-  
-  gmailMessageId  String?       @unique
-  body            String        @db.Text
-  senderEmail     String
-  senderName      String?
-  senderType      String        @default("VENDOR") // TEAM, VENDOR, AI
-  
-  isAttachment    Boolean       @default(false)
-  attachmentUrl   String?
-  
-  createdAt       DateTime      @default(now())
+
+  gmailMessageId String? @unique
+  body           String  @db.Text
+  senderEmail    String
+  senderName     String?
+  senderType     String  @default("VENDOR") // TEAM, VENDOR, AI
+
+  isAttachment  Boolean @default(false)
+  attachmentUrl String?
+
+  createdAt DateTime @default(now())
 }
 
 model PurchaseOrderFile {
@@ -1706,10 +1770,10 @@ model PurchaseOrderItem {
   purchaseOrder   PurchaseOrder @relation(fields: [purchaseOrderId], references: [id], onDelete: Cascade)
 
   description String
-  quantity    Float  @default(1)
-  unitCost    Decimal  @default(0)
-  total       Decimal  @default(0)
-  order       Int    @default(0)
+  quantity    Float   @default(1)
+  unitCost    Decimal @default(0)
+  total       Decimal @default(0)
+  order       Int     @default(0)
 
   costCodeId String?
   costCode   CostCode? @relation(fields: [costCodeId], references: [id])
@@ -1759,24 +1823,23 @@ model SelectionOption {
   createdAt   DateTime          @default(now())
 }
 
-
 // Company-wide reusable product catalog, populated via the team "clipper" (paste a
 // vendor URL, parsed server-side) or manual entry. Approved client SelectionProposals
 // also mint a row here (source: "client_proposal"). See docs/specs/product-library-portal-selections.md.
 model ProductLibraryItem {
-  id          String   @id @default(cuid())
+  id          String                   @id @default(cuid())
   name        String
   description String?
   imageUrl    String?
-  price       Decimal? @db.Decimal(12, 2) // list price captured at clip time
+  price       Decimal?                 @db.Decimal(12, 2) // list price captured at clip time
   vendor      String?
-  vendorUrl   String?  // source/product URL
-  category    String?  // free text v1 (e.g. "Plumbing Fixtures")
-  source      String   @default("clip") // "clip" | "manual" | "client_proposal"
+  vendorUrl   String? // source/product URL
+  category    String? // free text v1 (e.g. "Plumbing Fixtures")
+  source      String                   @default("clip") // "clip" | "manual" | "client_proposal"
   clippedById String?
-  clippedBy   User?    @relation(fields: [clippedById], references: [id])
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  clippedBy   User?                    @relation(fields: [clippedById], references: [id])
+  createdAt   DateTime                 @default(now())
+  updatedAt   DateTime                 @updatedAt
   favorites   ProjectProductFavorite[]
 
   @@index([category])
@@ -1787,16 +1850,16 @@ model ProductLibraryItem {
 // list. Rows created by an approved client SelectionProposal carry addedByClient: true
 // and a null addedById (no team member picked it).
 model ProjectProductFavorite {
-  id            String   @id @default(cuid())
+  id            String             @id @default(cuid())
   projectId     String
-  project       Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  project       Project            @relation(fields: [projectId], references: [id], onDelete: Cascade)
   productId     String
   product       ProductLibraryItem @relation(fields: [productId], references: [id], onDelete: Cascade)
-  addedById     String?  // team member User, null when added via approved client proposal
-  addedBy       User?    @relation(fields: [addedById], references: [id])
-  addedByClient Boolean  @default(false)
+  addedById     String? // team member User, null when added via approved client proposal
+  addedBy       User?              @relation(fields: [addedById], references: [id])
+  addedByClient Boolean            @default(false)
   note          String?
-  createdAt     DateTime @default(now())
+  createdAt     DateTime           @default(now())
 
   @@unique([projectId, productId])
   @@index([projectId])
@@ -1806,33 +1869,33 @@ model ProjectProductFavorite {
 // approves (mints a ProductLibraryItem + optional favorite/board option) or declines.
 // Price is never shown to the client until the proposal is Approved.
 model SelectionProposal {
-  id           String   @id @default(cuid())
-  projectId    String
-  project      Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  name         String
-  description  String?
-  imageUrl     String?
-  price        Decimal? @db.Decimal(12, 2) // clipped list price; team-context only — NEVER returned by any portal read path, in any status (docs/specs/client-selections-playground.md)
-  vendorUrl    String?
-  clientNote   String?
-  status       String   @default("Idea") // "Idea" | "Chosen" | "Archived" (new, docs/specs/client-selections-playground.md); legacy "Pending" | "Approved" | "Declined" rows remain readable, never rewritten in place except by the migration script's remap
-  pmNote       String?  // decline reason / approval comment, client-visible
-  productId    String?  // ProductLibraryItem created on approval
-  boardId      String?  // optional: SelectionBoard the PM approved it into
-  categoryId   String?  // optional: SelectionCategory it became an option in
-  decidedById  String?
-  decidedBy    User?    @relation(fields: [decidedById], references: [id])
-  decidedAt    DateTime?
-  createdAt    DateTime @default(now())
-  decisionId   String?  // Decision this candidate sits in; null = "Unsorted" in the playground
-  decision     Decision? @relation("DecisionCandidates", fields: [decisionId], references: [id], onDelete: SetNull)
-  chosenForDecision Decision? @relation("DecisionChosenItem") // back-relation only; the FK lives on Decision.chosenItemId
+  id                  String                 @id @default(cuid())
+  projectId           String
+  project             Project                @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  name                String
+  description         String?
+  imageUrl            String?
+  price               Decimal?               @db.Decimal(12, 2) // clipped list price; team-context only — NEVER returned by any portal read path, in any status (docs/specs/client-selections-playground.md)
+  vendorUrl           String?
+  clientNote          String?
+  status              String                 @default("Idea") // "Idea" | "Chosen" | "Archived" (new, docs/specs/client-selections-playground.md); legacy "Pending" | "Approved" | "Declined" rows remain readable, never rewritten in place except by the migration script's remap
+  pmNote              String? // decline reason / approval comment, client-visible
+  productId           String? // ProductLibraryItem created on approval
+  boardId             String? // optional: SelectionBoard the PM approved it into
+  categoryId          String? // optional: SelectionCategory it became an option in
+  decidedById         String?
+  decidedBy           User?                  @relation(fields: [decidedById], references: [id])
+  decidedAt           DateTime?
+  createdAt           DateTime               @default(now())
+  decisionId          String? // Decision this candidate sits in; null = "Unsorted" in the playground
+  decision            Decision?              @relation("DecisionCandidates", fields: [decisionId], references: [id], onDelete: SetNull)
+  chosenForDecision   Decision?              @relation("DecisionChosenItem") // back-relation only; the FK lives on Decision.chosenItemId
   // Soft delete only, same rule as Decision.deletedAt — the client can delete
   // an archived item outright from their own playground, but "lose no customer
   // data" still holds: the row survives and the team can restore it for 30
   // days (getRecentlyDeletedItems / restoreItem). Filtered out of every read.
-  deletedAt    DateTime?
-  comments     SelectionItemComment[]
+  deletedAt           DateTime?
+  comments            SelectionItemComment[]
   // AI Auto-Sort (docs/superpowers/plans/2026-07-30-selection-ai-sort.md).
   // NOT an FK on purpose — suggestions are advisory, may go stale (decision
   // deleted/renamed), and stale values are filtered at read time rather than
@@ -1856,14 +1919,14 @@ model SelectionItemComment {
   id             String            @id @default(cuid())
   proposalId     String
   proposal       SelectionProposal @relation(fields: [proposalId], references: [id], onDelete: Cascade)
-  authorType     String            // "TEAM" | "CLIENT"
-  authorUserId   String?           // User.id when authorType TEAM
-  authorClientId String?           // Client.id when authorType CLIENT
+  authorType     String // "TEAM" | "CLIENT"
+  authorUserId   String? // User.id when authorType TEAM
+  authorClientId String? // Client.id when authorType CLIENT
   authorName     String
-  body           String            // server-enforced max 4000 chars, trimmed, non-empty (or an attachment)
-  attachments    String?           // JSON [{id, name, url}] — same shape as ClientMessage
-  readByTeamAt   DateTime?         // null on CLIENT posts until any staff opens the thread
-  readByClientAt DateTime?         // null on TEAM posts until the client opens the thread
+  body           String // server-enforced max 4000 chars, trimmed, non-empty (or an attachment)
+  attachments    String? // JSON [{id, name, url}] — same shape as ClientMessage
+  readByTeamAt   DateTime? // null on CLIENT posts until any staff opens the thread
+  readByClientAt DateTime? // null on TEAM posts until the client opens the thread
   createdAt      DateTime          @default(now())
 
   @@index([proposalId, createdAt])
@@ -1880,55 +1943,55 @@ model SelectionItemComment {
 // promotes it to the company's approved record. Additive alongside the legacy
 // SelectionBoard/SelectionCategory/SelectionOption flow, which is untouched.
 model Decision {
-  id              String              @id @default(cuid())
-  projectId       String
-  project         Project             @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  name            String              // "Sink Faucet"
-  area            String?             // "Master Bath" — grouping in the UI
-  status          String              @default("Open") // Open | Decided | Flagged | Ordered | Received
-  chosenItemId    String?             @unique
-  chosenItem      SelectionProposal?  @relation("DecisionChosenItem", fields: [chosenItemId], references: [id], onDelete: SetNull)
-  candidates      SelectionProposal[] @relation("DecisionCandidates")
-  sortOrder       Int                 @default(0)
-  templateKey     String?             // provenance when seeded from a template (Phase 3) or imported from a legacy board category ("board-import:<categoryId>") — per-item key "decision-template:<templateId>:<itemId>" when applied from a DecisionTemplate
+  id                String              @id @default(cuid())
+  projectId         String
+  project           Project             @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  name              String // "Sink Faucet"
+  area              String? // "Master Bath" — grouping in the UI
+  status            String              @default("Open") // Open | Decided | Flagged | Ordered | Received
+  chosenItemId      String?             @unique
+  chosenItem        SelectionProposal?  @relation("DecisionChosenItem", fields: [chosenItemId], references: [id], onDelete: SetNull)
+  candidates        SelectionProposal[] @relation("DecisionCandidates")
+  sortOrder         Int                 @default(0)
+  templateKey       String? // provenance when seeded from a template (Phase 3) or imported from a legacy board category ("board-import:<categoryId>") — per-item key "decision-template:<templateId>:<itemId>" when applied from a DecisionTemplate
   // Phase 3 — Decision Templates + Schedule-Driven Due Dates
   // (docs/superpowers/plans/2026-07-31-selection-templates-due-dates.md).
   // scheduleTaskId is advisory, NOT an FK — same rationale as
   // suggestedDecisionId on SelectionProposal: schedule tasks get deleted/
   // regenerated, and read paths validate against live tasks, treating a
   // dangling id as "not linked" rather than an error.
-  scheduleTaskId  String?             // linked ScheduleTask.id — advisory, no FK
-  leadTimeDays    Int?                // days before the linked task's startDate the decision is due
+  scheduleTaskId    String? // linked ScheduleTask.id — advisory, no FK
+  leadTimeDays      Int? // days before the linked task's startDate the decision is due
   // MANUAL OVERRIDE ONLY — written exclusively by setDecisionDueDateOverride.
   // Linking, unlinking, template apply, and schedule changes never touch this
   // column. effectiveDueDate is computed on read (dueDate ?? derived from the
   // linked task minus leadTimeDays) — see decision-due-date.ts.
-  dueDate         DateTime?
+  dueDate           DateTime?
   // Phase 4 — Selection Order Tracking + Delivery Risk
   // (docs/superpowers/plans/2026-07-31-selection-order-tracking.md). All
   // nullable, no FK, no backfill — `status` keeps driving the lifecycle.
   // Canonical writer: setDecisionOrderInfo (decision-order-actions-core.ts) —
   // no other path writes these three columns.
   orderedAt         DateTime? // when the order was placed
-  orderedBy         String?   // "TEAM" | "CLIENT" — who purchased
+  orderedBy         String? // "TEAM" | "CLIENT" — who purchased
   expectedArrivalAt DateTime? // ETA used for schedule-risk comparison
-  createdByClient Boolean             @default(false)
-  decidedAt       DateTime?
-  pmNote          String?             // client-visible note from the flag path
-  createdAt       DateTime            @default(now())
-  updatedAt       DateTime            @updatedAt
+  createdByClient   Boolean             @default(false)
+  decidedAt         DateTime?
+  pmNote            String? // client-visible note from the flag path
+  createdAt         DateTime            @default(now())
+  updatedAt         DateTime            @default(now()) @updatedAt
   // Soft delete only — deleteDecision never hard-deletes (Justin: "it's
   // their playground", clients can delete any decision on their project, but
   // "lose no customer data" still holds). Filtered out of every read below;
   // the team can restore within 30 days (getRecentlyDeletedDecisions /
   // restoreDecision).
-  deletedAt       DateTime?
+  deletedAt         DateTime?
 
-  @@index([projectId, status])
   // Authoritative idempotency guard for importBoardPicksAsDecisions — a
   // nullable templateKey is fine, Postgres treats each NULL as distinct so
   // ordinary (non-imported) decisions never collide with each other.
   @@unique([projectId, templateKey])
+  @@index([projectId, status])
 }
 
 // Decision Templates — Phase 3 (docs/superpowers/plans/2026-07-31-selection-templates-due-dates.md).
@@ -1940,11 +2003,11 @@ model Decision {
 // SelectionItemComment.
 model DecisionTemplate {
   id          String                 @id @default(cuid())
-  name        String                 // "Kitchen Remodel"
+  name        String                 @unique // "Kitchen Remodel"
   description String?
-  archivedAt  DateTime?              // archive, not delete — applied projects keep working
+  archivedAt  DateTime? // archive, not delete — applied projects keep working
   createdAt   DateTime               @default(now())
-  updatedAt   DateTime               @updatedAt
+  updatedAt   DateTime               @default(now()) @updatedAt
   items       DecisionTemplateItem[]
 }
 
@@ -1952,13 +2015,23 @@ model DecisionTemplateItem {
   id                  String           @id @default(cuid())
   templateId          String
   template            DecisionTemplate @relation(fields: [templateId], references: [id], onDelete: Cascade)
-  name                String           // "Cabinets"
+  name                String // "Cabinets"
   area                String?
-  defaultLeadTimeDays Int?             // suggested lead time when this decision links to a phase
-  scheduleHint        String?          // free text ("cabinet install", "05-PLUMBING") to help AI matching
+  defaultLeadTimeDays Int? // suggested lead time when this decision links to a phase
+  scheduleHint        String? // free text ("cabinet install", "05-PLUMBING") to help AI matching
   order               Int              @default(0)
 
+  // Superseded duplicates of scheduleHint/order, still present in prod holding identical data.
+  // @ignore keeps them out of the generated client so nothing can write them by accident,
+  // while still declaring them here so a migrate diff does not propose dropping them.
+  costCodeId String?  @ignore
+  stageHint  String?  @ignore
+  sortOrder  Int      @default(0) @ignore
+  createdAt  DateTime @default(now()) @ignore
+  updatedAt  DateTime @default(now()) @ignore
+
   @@index([templateId, order])
+  @@index([templateId])
 }
 
 model MoodBoard {
@@ -1974,19 +2047,19 @@ model MoodBoard {
 }
 
 model MoodBoardItem {
-  id          String    @id @default(cuid())
-  moodBoardId String
-  moodBoard   MoodBoard @relation(fields: [moodBoardId], references: [id], onDelete: Cascade)
-  type        String // "IMAGE", "TEXT", "SWATCH"
-  content     String // Image URL, text body, or hex code
-  x           Float     @default(0)
-  y           Float     @default(0)
-  width       Float     @default(200)
-  height      Float     @default(200)
-  zIndex      Int       @default(1)
-  addedByClient Boolean @default(false)
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  id            String    @id @default(cuid())
+  moodBoardId   String
+  moodBoard     MoodBoard @relation(fields: [moodBoardId], references: [id], onDelete: Cascade)
+  type          String // "IMAGE", "TEXT", "SWATCH"
+  content       String // Image URL, text body, or hex code
+  x             Float     @default(0)
+  y             Float     @default(0)
+  width         Float     @default(200)
+  height        Float     @default(200)
+  zIndex        Int       @default(1)
+  addedByClient Boolean   @default(false)
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
 }
 
 model DailyLog {
@@ -2006,6 +2079,8 @@ model DailyLog {
   aiSuggestionReason String?         @db.Text
   sharedToPortal     Boolean         @default(false)
   sharedContentHash  String?
+  source             String          @default("manual") // "manual" | Chat-ingest provenance
+  chatMessageName    String?         @unique
   photos             DailyLogPhoto[]
   createdAt          DateTime        @default(now())
   updatedAt          DateTime        @updatedAt
@@ -2014,13 +2089,15 @@ model DailyLog {
 }
 
 model DailyLogPhoto {
-  id         String   @id @default(cuid())
-  dailyLogId String
-  dailyLog   DailyLog @relation(fields: [dailyLogId], references: [id], onDelete: Cascade)
-  url        String
-  caption    String?
-  sharedToPortal Boolean @default(false)
-  createdAt  DateTime @default(now())
+  id             String   @id @default(cuid())
+  dailyLogId     String
+  dailyLog       DailyLog @relation(fields: [dailyLogId], references: [id], onDelete: Cascade)
+  url            String
+  caption        String?
+  sharedToPortal Boolean  @default(false)
+  createdAt      DateTime @default(now())
+
+  @@unique([dailyLogId, url])
 }
 
 model Permit {
@@ -2028,46 +2105,45 @@ model Permit {
   projectId        String
   project          Project   @relation(fields: [projectId], references: [id], onDelete: Cascade)
   permitNumber     String
-  type             String?   // e.g. Building, Electrical, Plumbing, Mechanical
+  type             String? // e.g. Building, Electrical, Plumbing, Mechanical
   status           String    @default("applied") // applied | issued | inspections | closed | expired
   issuingAuthority String?
   issueDate        DateTime?
   expirationDate   DateTime?
   notes            String?
   createdAt        DateTime  @default(now())
-  updatedAt        DateTime  @updatedAt
+  updatedAt        DateTime  @default(now()) @updatedAt
 
   @@index([projectId])
 }
 
 model Retainer {
-  id          String   @id @default(cuid())
+  id          String    @id @default(cuid())
   code        String
   projectId   String
-  project     Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  project     Project   @relation(fields: [projectId], references: [id], onDelete: Cascade)
   clientId    String
-  client      Client   @relation(fields: [clientId], references: [id], onDelete: Cascade)
-  status      String   @default("Draft") // Draft, Sent, Partially Paid, Paid
-  totalAmount Decimal    @default(0)
-  balanceDue  Decimal    @default(0)
-  amountPaid  Decimal    @default(0)
+  client      Client    @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  status      String    @default("Draft") // Draft, Sent, Partially Paid, Paid
+  totalAmount Decimal   @default(0)
+  balanceDue  Decimal   @default(0)
+  amountPaid  Decimal   @default(0)
   notes       String?
   issueDate   DateTime?
   dueDate     DateTime?
   sentAt      DateTime?
   viewedAt    DateTime?
-  createdAt   DateTime @default(now())
+  createdAt   DateTime  @default(now())
 
   @@index([projectId])
   @@index([clientId])
 }
 
-
 model CatalogItem {
   id          String    @id @default(cuid())
   name        String
   description String?
-  unitCost    Decimal     @default(0)
+  unitCost    Decimal   @default(0)
   unit        String    @default("each")
   costCodeId  String?
   costCode    CostCode? @relation(fields: [costCodeId], references: [id])
@@ -2078,16 +2154,16 @@ model CatalogItem {
 }
 
 model BidPackage {
-  id          String       @id @default(cuid())
+  id          String          @id @default(cuid())
   projectId   String
-  project     Project      @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  project     Project         @relation(fields: [projectId], references: [id], onDelete: Cascade)
   title       String
   description String?
   dueDate     DateTime?
-  status      String       @default("Draft") // Draft, Open, Awarded, Closed
+  status      String          @default("Draft") // Draft, Open, Awarded, Closed
   totalBudget Decimal?
-  createdAt   DateTime     @default(now())
-  updatedAt   DateTime     @updatedAt
+  createdAt   DateTime        @default(now())
+  updatedAt   DateTime        @updatedAt
   scopes      BidScope[]
   invitations BidInvitation[]
 
@@ -2106,30 +2182,30 @@ model BidScope {
 }
 
 model BidInvitation {
-  id               String     @id @default(cuid())
-  packageId        String
-  package          BidPackage @relation(fields: [packageId], references: [id], onDelete: Cascade)
-  subcontractorId  String?
-  email            String
-  status           String     @default("Invited") // Invited, Viewed, Submitted, Declined, Awarded
-  bidAmount        Decimal?
-  notes            String?
-  sentAt           DateTime?
-  respondedAt      DateTime?
-  createdAt        DateTime   @default(now())
-  updatedAt        DateTime   @updatedAt
+  id              String     @id @default(cuid())
+  packageId       String
+  package         BidPackage @relation(fields: [packageId], references: [id], onDelete: Cascade)
+  subcontractorId String?
+  email           String
+  status          String     @default("Invited") // Invited, Viewed, Submitted, Declined, Awarded
+  bidAmount       Decimal?
+  notes           String?
+  sentAt          DateTime?
+  respondedAt     DateTime?
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime   @updatedAt
 }
 
 model DocumentComment {
-  id             String   @id @default(cuid())
-  documentType   String   // estimate, invoice, change-order, purchase-order, contract
-  documentId     String
-  visibility     String   @default("team") // team, client
-  authorId       String?
-  author         User?    @relation(fields: [authorId], references: [id], onDelete: SetNull)
-  authorName     String?  // fallback for client/sub comments
-  text           String
-  createdAt      DateTime @default(now())
+  id           String   @id @default(cuid())
+  documentType String // estimate, invoice, change-order, purchase-order, contract
+  documentId   String
+  visibility   String   @default("team") // team, client
+  authorId     String?
+  author       User?    @relation(fields: [authorId], references: [id], onDelete: SetNull)
+  authorName   String? // fallback for client/sub comments
+  text         String
+  createdAt    DateTime @default(now())
 
   @@index([documentType, documentId])
 }
@@ -2139,12 +2215,12 @@ model DocumentComment {
 model ChatConversation {
   id         String    @id @default(cuid())
   userId     String
-  title      String?   // Auto-generated from first message
+  title      String? // Auto-generated from first message
   archivedAt DateTime? // Auto-archived after 7 days of inactivity
   createdAt  DateTime  @default(now())
   updatedAt  DateTime  @updatedAt
 
-  messages   ChatMessage[]
+  messages ChatMessage[]
 
   @@index([userId])
   @@index([userId, archivedAt])
@@ -2153,11 +2229,11 @@ model ChatConversation {
 model ChatMessage {
   id             String   @id @default(cuid())
   conversationId String
-  role           String   // "user" or "assistant"
+  role           String // "user" or "assistant"
   content        String
   createdAt      DateTime @default(now())
 
-  conversation   ChatConversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  conversation ChatConversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
 
   @@index([conversationId])
 }
@@ -2176,19 +2252,19 @@ model TeamMessage {
 }
 
 model ActivityLog {
-  id         String   @id @default(cuid())
-  projectId  String?
-  project    Project? @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  leadId     String?  // lead-stage events (estimate sent/viewed before conversion); no FK — log survives lead deletion
-  actorType  String   // "CLIENT", "TEAM", "SUBCONTRACTOR", "SYSTEM"
-  actorName  String
+  id          String   @id @default(cuid())
+  projectId   String?
+  project     Project? @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  leadId      String? // lead-stage events (estimate sent/viewed before conversion); no FK — log survives lead deletion
+  actorType   String // "CLIENT", "TEAM", "SUBCONTRACTOR", "SYSTEM"
+  actorName   String
   actorUserId String? // User.id of the acting team member, when known (e.g. MCP connector actor); no FK — log survives user deletion
-  action     String   // "viewed_estimate", "signed_contract", "paid_invoice", "sent_message", "viewed_portal"
-  entityType String?  // "estimate", "invoice", "contract", "change_order", "message"
-  entityId   String?
-  entityName String?  // e.g. "Estimate #E-001"
-  metadata   String?  // JSON for extra data
-  createdAt  DateTime @default(now())
+  action      String // "viewed_estimate", "signed_contract", "paid_invoice", "sent_message", "viewed_portal"
+  entityType  String? // "estimate", "invoice", "contract", "change_order", "message"
+  entityId    String?
+  entityName  String? // e.g. "Estimate #E-001"
+  metadata    String? // JSON for extra data
+  createdAt   DateTime @default(now())
 
   @@index([projectId, createdAt])
   @@index([entityType, entityId])
@@ -2197,8 +2273,8 @@ model ActivityLog {
 }
 
 model DispatchPublication {
-  id              String   @id @default(cuid())
-  clientRequestId String   @unique
+  id              String @id @default(cuid())
+  clientRequestId String @unique
   requestHash     String
 
   publishedById   String?
@@ -2206,8 +2282,8 @@ model DispatchPublication {
   publishedByName String
   publishedAt     DateTime @default(now())
 
-  changes         DispatchPublicationChange[]
-  deliveries      ChatDelivery[]
+  changes    DispatchPublicationChange[]
+  deliveries ChatDelivery[]
 
   @@index([publishedById])
   @@index([publishedAt])
@@ -2218,19 +2294,20 @@ model DispatchPublicationChange {
   publicationId String
   publication   DispatchPublication @relation(fields: [publicationId], references: [id], onDelete: Cascade)
 
-  position      Int
-  projectId     String
-  targetType    String // PROJECT | TASK
-  targetId      String
-  kind          String // PROJECT_START | TASK_DATES | TASK_CREW
-  before        Json
-  after         Json
-  summary       String
+  position   Int
+  projectId  String
+  targetType String // PROJECT | TASK
+  targetId   String
+  kind       String // PROJECT_START | TASK_DATES | TASK_CREW
+  before     Json
+  after      Json
+  summary    String
 
   @@unique([publicationId, position], map: "DispatchChange_pub_position_key")
   @@unique([publicationId, kind, targetType, targetId], map: "DispatchChange_pub_target_kind_key")
   @@index([projectId])
   @@index([targetType, targetId])
+  @@index([publicationId])
 }
 
 model ChatDelivery {
@@ -2242,24 +2319,25 @@ model ChatDelivery {
   kind        String @default("dispatch_publication")
   payload     Json
 
-  status              String   @default("PENDING") // PENDING | PROCESSING | PROCESSED | FAILED
-  attempts            Int      @default(0)
+  status              String    @default("PENDING") // PENDING | PROCESSING | PROCESSED | FAILED
+  attempts            Int       @default(0)
   lastError           String?
   claimToken          String?
   processingStartedAt DateTime?
   providerMessageId   String?
-  createdAt           DateTime @default(now())
+  createdAt           DateTime  @default(now())
   processedAt         DateTime?
 
   @@unique([publicationId, destination, kind], map: "ChatDelivery_pub_dest_kind_key")
   @@index([status, createdAt])
   @@index([status, processingStartedAt])
+  @@index([publicationId])
 }
 
 model Integration {
   id        String   @id
   settings  String
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 }
 
 // Command Center pause switches. SAFETY INVARIANT: these can only PAUSE a
@@ -2269,7 +2347,7 @@ model Integration {
 model AutomationSetting {
   key       String   @id
   value     String
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 }
 
 // One row per automation happening: a receipt pushed to QuickBooks by the
@@ -2278,20 +2356,22 @@ model AutomationSetting {
 // audit history. Append-only; writes are fire-and-forget so a logging
 // failure can never fail the automation it describes.
 model AutomationEvent {
-  id          String   @id @default(cuid())
-  kind        String   // "receipt-push" | "qbo-sync" | "receipt-stage"
-  stage       String?  // receipt-stage beacons: "intake" | "read" | "dedupe" | "email-book" (push events imply stage "push")
-  status      String   // push: "created" | "already-exists" | "fallback" | "error" · sync: "ok" | "error" · stage: "ok" | "parked" | "quarantined" | "emailed"
-  reason      String?  // fallback/decline/park reason or error name
-  source      String?  // sync: "cron" | "manual" | "backfill" · push/stage: "apps-script"
-  vendor      String?
-  projectName String?
-  docNumber   String?
-  fileName    String?
-  amountCents Int?
-  taxCents    Int?
-  detail      String?  // JSON extras (sync counts, decline context)
-  createdAt   DateTime @default(now())
+  id           String   @id @default(cuid())
+  kind         String // "receipt-push" | "qbo-sync" | "receipt-stage"
+  stage        String? // receipt-stage beacons: "intake" | "read" | "dedupe" | "email-book" (push events imply stage "push")
+  status       String // push: "created" | "already-exists" | "fallback" | "error" · sync: "ok" | "error" · stage: "ok" | "parked" | "quarantined" | "emailed"
+  reason       String? // fallback/decline/park reason or error name
+  source       String? // sync: "cron" | "manual" | "backfill" · push/stage: "apps-script"
+  vendor       String?
+  projectName  String?
+  docNumber    String?
+  fileName     String?
+  amountCents  Int?
+  taxCents     Int?
+  detail       String? // JSON extras (sync counts, decline context)
+  createdAt    DateTime @default(now())
+  qbPurchaseId String?
+  driveFileId  String?
 
   @@index([kind, createdAt])
   @@index([createdAt])
@@ -2341,7 +2421,7 @@ model CatalogProduct {
   heightIn    Float
   mount       String   @default("floor")
   elevationIn Float?
-  price       Decimal?
+  price       Decimal? @db.Decimal(12, 2)
   finishes    Json?
   sourceUrl   String?
   notes       String?
@@ -2376,4 +2456,168 @@ model PaymentNotification {
 
   @@index([status])
   @@index([scheduleId])
+}
+
+model AuditLog {
+  id         String   @id @default(cuid())
+  entity     String
+  entityId   String
+  action     String
+  actorId    String?
+  actorEmail String?
+  snapshot   Json?
+  createdAt  DateTime @default(now()) @db.Timestamp(6)
+
+  @@index([entity, entityId])
+  @@index([action])
+  @@index([createdAt])
+}
+
+model McpKey {
+  id         String    @id @default(cuid())
+  label      String
+  keyHash    String    @unique
+  userId     String
+  user       User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt  DateTime  @default(now())
+  lastUsedAt DateTime?
+  revokedAt  DateTime?
+
+  @@index([userId])
+}
+
+model Notification {
+  id          String    @id @default(cuid())
+  type        String
+  severity    String    @default("info")
+  title       String
+  body        String?
+  projectId   String?
+  timeEntryId String?
+  expenseId   String?
+  actorId     String?
+  dedupeKey   String?   @unique
+  channels    String?
+  readAt      DateTime?
+  createdAt   DateTime  @default(now())
+
+  @@index([projectId])
+  @@index([readAt])
+  @@index([createdAt])
+}
+
+// Read/written by src/app/api/help-chat/* via raw SQL.
+model HelpRequest {
+  id                String    @id @default(dbgenerated("(gen_random_uuid())::text"))
+  userId            String
+  type              String    @default("help")
+  question          String
+  response          String?
+  currentPage       String?
+  status            String?   @default("open")
+  slackMessageTs    String?
+  completedAt       DateTime? @db.Timestamptz(6)
+  verifiedAt        DateTime? @db.Timestamptz(6)
+  changeDescription String?
+  changeLocation    String?
+  externalIssueRef  String?
+  conversationId    String?
+  createdAt         DateTime? @default(now()) @db.Timestamptz(6)
+
+  @@index([conversationId])
+  @@index([externalIssueRef])
+}
+
+model RolloutGate {
+  key         String    @id
+  status      String    @default("pending")
+  claimToken  String?
+  claimedAt   DateTime?
+  startedAt   DateTime?
+  completedAt DateTime?
+  attempts    Int       @default(0)
+  lastError   String?
+  updatedAt   DateTime
+
+  @@index([status])
+}
+
+model QboPurchaseClassification {
+  qbPurchaseId   String   @id
+  classification String
+  reason         String?
+  qbSyncToken    String?
+  classifiedAt   DateTime @default(now())
+  updatedAt      DateTime
+
+  @@index([classification])
+}
+
+model ReviewIssue {
+  id                String               @id @default(cuid())
+  targetType        String
+  targetKey         String
+  version           Int                  @default(1)
+  reasonCodes       String
+  reasonHash        String
+  displayDetails    String?
+  acknowledgedCodes String               @default("[]")
+  acknowledgedAt    DateTime?
+  firstObservedAt   DateTime
+  clearedAt         DateTime?
+  currentGeneration Int                  @default(1)
+  createdAt         DateTime             @default(now())
+  updatedAt         DateTime
+  absentSince       DateTime?
+  episodes          ReviewAlertEpisode[]
+
+  @@unique([targetType, targetKey])
+  @@index([clearedAt])
+}
+
+model ReviewAlertBatch {
+  id              String               @id @default(cuid())
+  status          String               @default("PENDING")
+  claimToken      String?
+  claimedAt       DateTime?
+  attempts        Int                  @default(0)
+  lastError       String?
+  nextAttemptAt   DateTime?
+  sentAt          DateTime?
+  chatMessageName String?
+  createdAt       DateTime             @default(now())
+  episodes        ReviewAlertEpisode[]
+}
+
+model ReviewAlertEpisode {
+  id              String            @id @default(cuid())
+  issueId         String
+  issue           ReviewIssue       @relation(fields: [issueId], references: [id], onDelete: Cascade)
+  generation      Int
+  reasonCodes     String
+  reasonHash      String
+  displayDetails  String?
+  status          String            @default("PENDING")
+  claimToken      String?
+  claimedAt       DateTime?
+  attempts        Int               @default(0)
+  lastError       String?
+  nextAttemptAt   DateTime?
+  sentAt          DateTime?
+  chatMessageName String?
+  batchId         String?
+  batch           ReviewAlertBatch? @relation(fields: [batchId], references: [id], onDelete: Restrict)
+  createdAt       DateTime          @default(now())
+
+  @@unique([issueId, generation])
+  @@index([batchId])
+}
+
+// One-time pre-migration backup captured by scripts/apply-selections-playground.mjs. Scheduled for deletion; nothing reads it.
+model SelectionProposalStatusBackup {
+  id         String   @id @default(cuid())
+  status     String
+  capturedAt DateTime @default(now()) @db.Timestamptz(6)
+
+  @@map("_SelectionProposalStatusBackup")
 }


### PR DESCRIPTION
Production's Postgres had drifted from `prisma/schema.prisma` on `main`. A read-only `prisma migrate diff` over the Supabase session pooler returned **237 lines of DDL**, including **10 `DROP TABLE`** and **41 `DROP COLUMN`** — the synchronization `db push` would have *proposed*. Nothing was ever run; the drift was found while testing PR #365.

This PR audits every object and brings `schema.prisma` in line with what production legitimately has. **No DDL is run. Nothing is added to or dropped from the database.** Types were copied from a `prisma db pull` of production.

**Result: 237 lines → 51, and zero `DROP TABLE` / `DROP COLUMN` remain.**

## Root cause

`git log --all -S` traces every drifted object to one of five feature branches that ran their `scripts/apply-*.mjs` DDL **against production** and then never merged:

| Commit | Branch work | What it left in prod |
|---|---|---|
| `f4d30709` (Jun 9) | soft-delete + QuickBooks rescue snapshot | soft-delete set, `AuditLog`, `Invoice`/`Estimate`/`Project`/`TimeEntry` `qb*` columns |
| `44f97f1c` (May 29) | job-costing P1, WA meal-break | `Notification`, `TimeEntry.meal*` / `needsReview` / `reviewReason` |
| `06c2c947` (Jul 29) | MCP per-person connector keys | `McpKey` |
| `6c33d145` (Jul 31) | Chat → field-progress pipeline | `Project.googleChatSpaceId` / `clientNextSteps*`, `ScheduleTask.progressSource`, `DailyLog.source` / `chatMessageName` |
| `486cdbf0` (Aug 3) | unified money register | `ReviewIssue`, `ReviewAlert*`, `RolloutGate`, `QboPurchaseClassification`, `AutomationEvent.driveFileId` / `qbPurchaseId` |

None of the five is an ancestor of `origin/main`, and `rg` over main's `src/` and `scripts/` finds **zero** references to any drifted name. So on `main` today these are all invisible — which is exactly why `db push` would have silently proposed deleting them.

## Verdict table

Non-null counts are from a read-only query against production.

### Tables

| Object | Rows | Referenced on main? | Verdict |
|---|---|---|---|
| `HelpRequest` | 2 | **Yes** — `src/app/api/help-chat/*` reads/writes it via raw SQL | **Adopt.** Live on main and completely unmodelled. The clearest "schema.prisma is wrong" case in the set. |
| `QboPurchaseClassification` | 328 | No (money-register branch) | **Adopt.** Real backfilled data. |
| `_SelectionProposalStatusBackup` | 16 | No | **Adopt, marked for deletion.** One-time pre-migration backup written by `scripts/apply-selections-playground.mjs`. Genuinely scratch — but dropping it is destructive prod DDL, so it is modelled with a deprecation comment and split into a follow-up rather than dropped here. |
| `AuditLog` | 0 | No | **Adopt.** Empty, but belongs to in-flight branch work; dropping means re-running the apply script later for no gain. |
| `McpKey` | 0 | No | **Adopt** (same reasoning). |
| `Notification` | 0 | No | **Adopt** (same reasoning). |
| `RolloutGate` | 0 | No | **Adopt** (same reasoning). |
| `ReviewIssue` | 0 | No | **Adopt** (same reasoning). |
| `ReviewAlertBatch` | 0 | No | **Adopt** (same reasoning). |
| `ReviewAlertEpisode` | 0 | No | **Adopt** (same reasoning). |

### Columns

| Object | Non-null / rows | Verdict |
|---|---|---|
| soft-delete set: `deletedAt` / `deletedById` / `deleteBatchId` on `Client`, `Lead`, `Estimate`, `EstimateItem`, `EstimatePaymentSchedule`, `Project` (+ the six `_deletedAt_idx` indexes) | 0 everywhere | **Adopt.** Empty today, so nothing is hidden — but these are the columns whose loss would be least recoverable if the feature lands. Note: `EstimateItem` and `EstimatePaymentSchedule` have no `deletedById`. |
| `Invoice.qbInvoiceId`, `Invoice.qbSyncedAt` | 0 / 50 | **Adopt.** Distinct from `PaymentSchedule.qbInvoiceId`, which main already models. |
| `Estimate.qbEstimateId`, `Estimate.qbSyncedAt` | 0 / 116 | **Adopt.** |
| `Project.qbProjectId`, `qbSyncedAt` | 0 / 79 | **Adopt.** |
| `Project.googleChatSpaceId` (`@unique`) | 4 / 79 | **Adopt.** Holds real Chat space IDs. |
| `Project.clientNextSteps`, `clientNextStepsAt` | 1 / 79 | **Adopt.** |
| `TimeEntry.mealSkipped`, `needsReview` | 42 / 42 (NOT NULL, defaulted) | **Adopt.** |
| `TimeEntry.mealDeductionHours`, `reviewReason`, `qbTimeActivityId`, `qbSyncedAt` | 0 / 42 | **Adopt.** |
| `ScheduleTask.progressSource` | 2 / 320 (value `"ai"`) | **Adopt.** Real data. |
| `DailyLog.source` | 14 / 14 (all `"manual"`, NOT NULL default) | **Adopt.** |
| `DailyLog.chatMessageName` (`@unique`) | 0 / 14 | **Adopt.** |
| `AutomationEvent.driveFileId` | 216 / 322 | **Adopt.** Substantial live data. |
| `AutomationEvent.qbPurchaseId` | 70 / 322 | **Adopt.** Distinct from `Expense.qbPurchaseId`. |
| `DecisionTemplateItem.stageHint`, `sortOrder`, `costCodeId`, `createdAt`, `updatedAt` | `stageHint` 50/50, `sortOrder` 47 non-zero | **Adopt, marked superseded.** Prod holds *both* this set and the current `scheduleHint` / `order` pair, with identical data. Modelled with a "do not write to these" comment; consolidating them is a follow-up, not a drive-by. |

### Missing constraints and type annotations (adopted so the schema stops lying)

- `DecisionTemplate.name @unique`, `DailyLogPhoto @@unique([dailyLogId, url])`, `ChatDelivery @@index([publicationId])`, `DispatchPublicationChange @@index([publicationId])`, `DecisionTemplateItem @@index([templateId])`
- `CatalogProduct.price @db.Decimal(12, 2)`, `Estimate.taxRatePercent @db.Decimal` — these annotate the column's **actual** Postgres type; without them Prisma assumed `DECIMAL(65,30)`
- `@db.Timestamptz(6)` on `EstimatePaymentSchedule.paidAt` / `paymentDate`, `ClientMessage.readAt`, `Contract.contractorSignedAt`, `Expense.qbSyncedAt`, `PaymentSchedule.lastReminderAt`; `@db.Timestamp(6)` on the adopted `qbSyncedAt` / `deletedAt` columns
- `@updatedAt @default(now())` on `AutomationSetting`, `Decision`, `DecisionTemplate`, `DepositIngest`, `Integration`, `OfficeTask`, `Permit` — prod has a DB-level `DEFAULT now()` on those columns
- `ClientMessage`: `@id(map: "LeadMessage_pkey")` and `map: "LeadMessage_leadId_fkey"`. The table was renamed `LeadMessage` → `ClientMessage` in `363b70c` but the Postgres constraints kept their original names.

## `@ignore` on the columns nothing implements yet

Adopting a column makes it appear in the generated Prisma Client, and that is its own hazard: a future author could set `deletedAt` and reasonably assume the row stops showing up. It would not — **soft delete is not implemented, and no query filters on these fields.** A comment is not enforcement.

So the 16 adopted soft-delete fields and the 5 superseded `DecisionTemplateItem` duplicates carry `@ignore`. They stay declared (so `migrate diff` does not propose dropping them) but are excluded from the client, so no caller can write them by accident. Verified: the residual diff is **byte-identical** with and without `@ignore` — the guard is free.

## Deliberately NOT changed

**`ClientMessage.twilioMessageSid @unique`.** In prod this is a **partial** unique index (`WHERE "twilioMessageSid" IS NOT NULL`), which Prisma cannot express. It will always show up in a `migrate diff`. Left exactly as-is, comment intact.

## What still diverges — prod is BEHIND schema.prisma (follow-up)

The remaining 51 lines are all the *opposite* direction, and none is destructive. They need real DDL against prod and are split out rather than smuggled in here:

- `Project_managerId_fkey` does not exist in prod at all — the only one with real integrity impact.
- Three indexes prod lacks: `ClientMessage_leadId_idx`, `ClientMessage_createdAt_idx`, `EstimatePaymentSchedule_estimateId_idx` (perf only).
- Six FKs created without `ON UPDATE CASCADE` (`ClientMessage_projectId`, `OfficeTask` ×3, `Project_leadId`, `TaskCommentPhoto_commentId`). Cosmetic — Prisma never updates primary keys.
- The partial-index noise above.

Codex asked, fairly, that "zero DROP TABLE/COLUMN" not be taken on trust — `ALTER TYPE`, `SET NOT NULL`, and index drops can also lose or lock data. Here is the complete residual DDL, so the claim is checkable rather than asserted. It contains **no** `DROP TABLE`, `DROP COLUMN`, `DROP INDEX`, `ALTER TYPE`, or `SET NOT NULL`:

```sql
-- 6 FK drop/re-add pairs, differing only in ON UPDATE (prod NoAction, schema CASCADE)
ALTER TABLE "ClientMessage"    DROP CONSTRAINT "ClientMessage_projectId_fkey";
ALTER TABLE "OfficeTask"       DROP CONSTRAINT "OfficeTask_assigneeId_fkey";
ALTER TABLE "OfficeTask"       DROP CONSTRAINT "OfficeTask_columnId_fkey";
ALTER TABLE "OfficeTask"       DROP CONSTRAINT "OfficeTask_createdById_fkey";
ALTER TABLE "Project"          DROP CONSTRAINT "Project_leadId_fkey";
ALTER TABLE "TaskCommentPhoto" DROP CONSTRAINT "TaskCommentPhoto_commentId_fkey";

-- indexes prod lacks (the first is the unrepresentable partial unique index)
CREATE UNIQUE INDEX "ClientMessage_twilioMessageSid_key"  ON "ClientMessage"("twilioMessageSid");
CREATE INDEX "ClientMessage_leadId_idx"                   ON "ClientMessage"("leadId");
CREATE INDEX "ClientMessage_createdAt_idx"                ON "ClientMessage"("createdAt");
CREATE INDEX "EstimatePaymentSchedule_estimateId_idx"     ON "EstimatePaymentSchedule"("estimateId");

-- the 6 FKs re-added with ON UPDATE CASCADE, plus one FK prod is missing entirely
ALTER TABLE "OfficeTask"       ADD CONSTRAINT "OfficeTask_columnId_fkey"       FOREIGN KEY ("columnId")   REFERENCES "OfficeBoardColumn"("id") ON DELETE SET NULL ON UPDATE CASCADE;
ALTER TABLE "OfficeTask"       ADD CONSTRAINT "OfficeTask_assigneeId_fkey"     FOREIGN KEY ("assigneeId") REFERENCES "User"("id")              ON DELETE SET NULL ON UPDATE CASCADE;
ALTER TABLE "OfficeTask"       ADD CONSTRAINT "OfficeTask_createdById_fkey"    FOREIGN KEY ("createdById")REFERENCES "User"("id")              ON DELETE SET NULL ON UPDATE CASCADE;
ALTER TABLE "Project"          ADD CONSTRAINT "Project_leadId_fkey"            FOREIGN KEY ("leadId")     REFERENCES "Lead"("id")              ON DELETE RESTRICT ON UPDATE CASCADE;
ALTER TABLE "Project"          ADD CONSTRAINT "Project_managerId_fkey"         FOREIGN KEY ("managerId")  REFERENCES "User"("id")              ON DELETE SET NULL ON UPDATE CASCADE;  -- absent in prod
ALTER TABLE "TaskCommentPhoto" ADD CONSTRAINT "TaskCommentPhoto_commentId_fkey"FOREIGN KEY ("commentId")  REFERENCES "TaskComment"("id")       ON DELETE CASCADE  ON UPDATE CASCADE;
ALTER TABLE "ClientMessage"    ADD CONSTRAINT "ClientMessage_projectId_fkey"   FOREIGN KEY ("projectId")  REFERENCES "Project"("id")           ON DELETE CASCADE  ON UPDATE CASCADE;
```

Reconciling the migration **history** (`_prisma_migrations` holds `20260307033916_init`; local holds an unapplied `sprint5_baseline`; no common ancestor) is a separate follow-up — and the more urgent one, since a CI database built from committed migrations still would not match prod.

## Codex review (`gpt-5.6-sol`, reasoning effort xhigh)

Addressed:
- **Soft-delete write footgun** — fixed with `@ignore`, as described above. Codex's strongest finding.
- **"51 residual lines is not reviewable evidence"** — fair; the full DDL is now inline above.
- **Uniqueness asserted but not proven.** Verified against `pg_indexes`: all seven adopted indexes exist in prod, including `Project_googleChatSpaceId_key`, `DecisionTemplate_name_key`, `DailyLog_chatMessageName_key`, `DailyLogPhoto_dailyLogId_url_key`. `Project.googleChatSpaceId` holds 4 values, 4 distinct.
- **"Soft-delete prose and diff disagree."** Checked `information_schema`: `EstimateItem` and `EstimatePaymentSchedule` genuinely have only `deletedAt` + `deleteBatchId`, no `deletedById`. The diff is right; the description already said so.

Confirmed by Codex, no change needed:
- Decimal annotations do not change the money path — bare `@db.Decimal` is faithful to `numeric` with no typmod, and `@db.Decimal(12,2)` records a typmod Postgres was already enforcing. No client-side rounding is added.
- Timestamp annotations are runtime-inert; the database was already doing those conversions.
- `@default(now()) @updatedAt` is valid and behaves as intended in Prisma 5.22.
- No required-without-default field was added to any existing model.
- Leaving the partial unique index alone is correct.

Deferred (filed as follow-ups, not silently dropped):
- **Migration history reconciliation** — Codex's top blocker, and out of scope here by design.
- **`paymentDate` semantics.** `EstimatePaymentSchedule.paymentDate` is `timestamptz(6)` while its mirrored `PaymentSchedule.paymentDate` is zone-less `timestamp(3)`, and settle paths copy between the linked pair. This PR does not cause it — it makes a pre-existing money-path bug visible in the schema for the first time.
- **Redundant indexes.** `DecisionTemplateItem(templateId)` is covered by `(templateId, order)`; the `ChatDelivery` and `DispatchPublicationChange` `publicationId` indexes are covered by their leading-column composite uniques. They exist in prod, so they are adopted; dropping them is a deliberate cleanup, not a drive-by.

## Verification

- Full 237-line and 51-line diffs produced with **read-only** `prisma migrate diff` over the session pooler. `db push` and `migrate dev` were never run against production, and `--accept-data-loss` was never used.
- Row counts, non-null counts, index definitions and column types all come from read-only `SELECT`s against prod.
- `prisma format`, `prisma generate`, `npm run build` — clean (`✓ Compiled successfully`, TypeScript 0 errors, all routes collected).
- Ignoring `prisma format`'s column realignment, the substantive change is ~245 added / ~21 changed lines. The rest of the line count is whitespace realignment, since adding a longer field name re-pads a whole model block.

## Risk

Low, and worth stating plainly. No DDL runs. The only runtime-visible effect is that the generated Prisma Client gains optional fields and ten unused model delegates, and *loses* 21 fields to `@ignore` that were never in it to begin with. Every added field is nullable or defaulted, so no existing `create()` can regress. The real value is defensive: before this, a routine `prisma db push` from any checkout would have proposed deleting `HelpRequest` — a table the live app writes to on every help-chat request.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
