### PR TITLE
fix(money): mirror estimate/invoice milestones on the Stripe rails

### DIFF
--- a/e2e/money-pipeline.spec.ts
+++ b/e2e/money-pipeline.spec.ts
@@ -9,6 +9,12 @@ import {
   type SignatureStorageBucket,
 } from "../src/lib/signature-storage";
 import {
+  mirrorInvoiceSettleToEstimate,
+  mirrorInvoiceUnsettleToEstimate,
+  mirrorEstimateUnsettleToInvoice,
+  findInvoiceMirrorOfEstimateSchedule,
+} from "../src/lib/payment-mirror";
+import {
   approveChangeOrderWithSignature,
   type ChangeOrderApprovalDependencies,
   type ChangeOrderSignatureCleanupEvent,
@@ -1095,5 +1101,260 @@ test.describe.serial("Money pipeline: change-order lifecycle invariants", () => 
     expect(actionSource).toContain("await approveChangeOrderWithSignature(");
     expect(actionSource).not.toContain("await persistSignature(");
     expect(actionSource).not.toContain("await approveChangeOrderCore(");
+  });
+});
+
+/**
+ * Stripe-rail mirror regression â€” the invoice-side Stripe rails (webhook settle,
+ * portal `verifyStripeSession` fallback, and the two full-refund branches) did no
+ * mirroring at all, so a client paying a Stripe invoice left the estimate copy
+ * showing unpaid. These tests drive the shared helpers those rails now call
+ * (`src/lib/payment-mirror.ts`) directly against real rows: the webhook itself
+ * cannot be exercised here because it needs a signed Stripe payload.
+ */
+const S = {
+  client: "mp3-e2e-client",
+  project: "mp3-e2e-project",
+  estimate: "mp3-e2e-estimate",
+  invoice: "mp3-e2e-invoice",
+  estDeposit: "mp3-e2e-eps-deposit",
+  invDeposit: "mp3-e2e-ps-deposit",
+  estAmbigA: "mp3-e2e-eps-ambig-a",
+  estAmbigB: "mp3-e2e-eps-ambig-b",
+  estAmbigDecoy: "mp3-e2e-eps-ambig-decoy",
+  invAmbig: "mp3-e2e-ps-ambig",
+  estOther: "mp3-e2e-eps-other",
+  invOtherCharge: "mp3-e2e-ps-other-charge",
+};
+const S_NAME = "Stripe Mirror Drill - MP3TEST";
+const sPrisma = new PrismaClient();
+const INTENT = "pi_mp3_e2e_intent";
+const OTHER_INTENT = "pi_mp3_e2e_other_intent";
+
+test.describe.serial("Money pipeline: Stripe rails mirror both sides", () => {
+  test.beforeAll(async () => {
+    await sPrisma.client.upsert({
+      where: { id: S.client },
+      update: {},
+      create: { id: S.client, name: "MP3 Drill Client", initials: "M3" },
+    });
+    await sPrisma.project.upsert({
+      where: { id: S.project },
+      update: {},
+      create: { id: S.project, name: S_NAME, clientId: S.client, status: "In Progress" },
+    });
+    await sPrisma.estimate.upsert({
+      where: { id: S.estimate },
+      update: { status: "Invoiced", totalAmount: 1000, balanceDue: 1000, statusBeforePayment: null },
+      create: {
+        id: S.estimate, title: S_NAME, code: "EST-MP3TEST", projectId: S.project,
+        status: "Invoiced", taxExempt: true, totalAmount: 1000, balanceDue: 1000,
+      },
+    });
+    await sPrisma.invoice.upsert({
+      where: { id: S.invoice },
+      update: { status: "Issued", totalAmount: 1000, balanceDue: 1000 },
+      create: {
+        id: S.invoice, code: "INV-MP3TEST", projectId: S.project, clientId: S.client,
+        estimateId: S.estimate, status: "Issued", totalAmount: 1000, balanceDue: 1000,
+        issueDate: new Date(),
+      },
+    });
+    // Linked pair (the normal converted-estimate shape).
+    await sPrisma.estimatePaymentSchedule.upsert({
+      where: { id: S.estDeposit },
+      update: { status: "Pending", paidAt: null, paymentDate: null, paymentMethod: null, stripeSessionId: null, stripePaymentIntentId: null },
+      create: { id: S.estDeposit, estimateId: S.estimate, name: "MP3 Deposit", amount: 600, status: "Pending", order: 1 },
+    });
+    await sPrisma.paymentSchedule.upsert({
+      where: { id: S.invDeposit },
+      update: { status: "Pending", paidAt: null, paymentDate: null },
+      create: { id: S.invDeposit, invoiceId: S.invoice, name: "MP3 Deposit", amount: 600, status: "Pending", sourceScheduleId: S.estDeposit },
+    });
+    // Two UNLINKED estimate rows with the same name+amount: the legacy fallback
+    // must refuse to guess between them. A THIRD same-name row with a different
+    // amount sits alongside them — with the old `take: 2` window that row could
+    // displace one of the real matches and make an ambiguous pair look unique,
+    // so its presence is what makes this case a regression test.
+    for (const id of [S.estAmbigA, S.estAmbigB]) {
+      await sPrisma.estimatePaymentSchedule.upsert({
+        where: { id },
+        update: { status: "Pending", paidAt: null, paymentDate: null },
+        create: { id, estimateId: S.estimate, name: "MP3 Ambiguous", amount: 200, status: "Pending", order: 3 },
+      });
+    }
+    await sPrisma.estimatePaymentSchedule.upsert({
+      where: { id: S.estAmbigDecoy },
+      update: { status: "Pending", paidAt: null, paymentDate: null },
+      create: { id: S.estAmbigDecoy, estimateId: S.estimate, name: "MP3 Ambiguous", amount: 999, status: "Pending", order: 2 },
+    });
+    await sPrisma.paymentSchedule.upsert({
+      where: { id: S.invAmbig },
+      update: { status: "Pending", paidAt: null, paymentDate: null },
+      create: { id: S.invAmbig, invoiceId: S.invoice, name: "MP3 Ambiguous", amount: 200, status: "Pending" },
+    });
+    // An estimate milestone whose ONLY linked invoice clone was paid through a
+    // DIFFERENT charge — refunding this milestone's charge must not release it.
+    await sPrisma.estimatePaymentSchedule.upsert({
+      where: { id: S.estOther },
+      update: { status: "Paid", stripePaymentIntentId: INTENT },
+      create: {
+        id: S.estOther, estimateId: S.estimate, name: "MP3 Other", amount: 200,
+        status: "Paid", order: 4, stripePaymentIntentId: INTENT,
+      },
+    });
+    await sPrisma.paymentSchedule.upsert({
+      where: { id: S.invOtherCharge },
+      update: { status: "Paid", stripePaymentIntentId: OTHER_INTENT },
+      create: {
+        id: S.invOtherCharge, invoiceId: S.invoice, name: "MP3 Other", amount: 200,
+        status: "Paid", sourceScheduleId: S.estOther, stripePaymentIntentId: OTHER_INTENT,
+      },
+    });
+  });
+
+  test.afterAll(async () => {
+    try {
+      await sPrisma.paymentSchedule.deleteMany({ where: { invoiceId: S.invoice } });
+      await sPrisma.invoice.deleteMany({ where: { id: S.invoice } });
+      await sPrisma.estimatePaymentSchedule.deleteMany({ where: { estimateId: S.estimate } });
+      await sPrisma.estimate.deleteMany({ where: { id: S.estimate } });
+      await sPrisma.project.deleteMany({ where: { id: S.project } });
+      await sPrisma.client.deleteMany({ where: { id: S.client } });
+    } finally {
+      await sPrisma.$disconnect();
+    }
+  });
+
+  test("S1: settling the invoice copy mirrors onto the estimate milestone", async () => {
+    const now = new Date();
+    // Stand in for what the Stripe rail's own transaction does before it mirrors:
+    // claim the invoice-side row and recompute the invoice. The assertion below is
+    // that the ESTIMATE ends up agreeing with that invoice, which is the invariant.
+    await sPrisma.paymentSchedule.update({
+      where: { id: S.invDeposit },
+      data: { status: "Paid", paidAt: now, paymentDate: now, stripePaymentIntentId: INTENT },
+    });
+    await sPrisma.invoice.update({
+      where: { id: S.invoice },
+      data: { balanceDue: 400, status: "Partially Paid" },
+    });
+    const payment = await sPrisma.paymentSchedule.findUniqueOrThrow({ where: { id: S.invDeposit } });
+
+    const mirrored = await sPrisma.$transaction((tx) =>
+      mirrorInvoiceSettleToEstimate(tx, {
+        estimateId: S.estimate,
+        payment,
+        data: { paymentDate: now, paidAt: now, paymentMethod: "card", stripePaymentIntentId: INTENT },
+      }),
+    );
+
+    expect(mirrored, "the estimate copy was claimed").toBe(true);
+    const estCopy = await sPrisma.estimatePaymentSchedule.findUniqueOrThrow({ where: { id: S.estDeposit } });
+    expect(estCopy.status, "estimate milestone mirrors the Stripe invoice payment").toBe("Paid");
+
+    const estimate = await sPrisma.estimate.findUniqueOrThrow({ where: { id: S.estimate } });
+    const invoice = await sPrisma.invoice.findUniqueOrThrow({ where: { id: S.invoice } });
+    expect(Number(estimate.balanceDue), "estimate balance drops by the paid milestone").toBe(400);
+    expect(Number(estimate.balanceDue), "the two documents agree on what is owed")
+      .toBe(Number(invoice.balanceDue));
+    expect(estimate.status).toBe("Partially Paid");
+    expect(estimate.statusBeforePayment, "pre-payment status captured for undo").toBe("Invoiced");
+  });
+
+  test("S2: mirroring is at-most-once â€” a replay claims nothing and moves no balance", async () => {
+    const now = new Date();
+    const payment = await sPrisma.paymentSchedule.findUniqueOrThrow({ where: { id: S.invDeposit } });
+    const before = await sPrisma.estimate.findUniqueOrThrow({ where: { id: S.estimate } });
+
+    const mirrored = await sPrisma.$transaction((tx) =>
+      mirrorInvoiceSettleToEstimate(tx, {
+        estimateId: S.estimate,
+        payment,
+        data: { paymentDate: now, paidAt: now, paymentMethod: "card", stripePaymentIntentId: INTENT },
+      }),
+    );
+
+    expect(mirrored, "an already-Paid mirror is not re-claimed").toBe(false);
+    const after = await sPrisma.estimate.findUniqueOrThrow({ where: { id: S.estimate } });
+    expect(Number(after.balanceDue)).toBe(Number(before.balanceDue));
+  });
+
+  test("S3: a full refund unwinds the estimate mirror and keeps its Stripe ids", async () => {
+    const payment = await sPrisma.paymentSchedule.findUniqueOrThrow({ where: { id: S.invDeposit } });
+
+    const unwound = await sPrisma.$transaction((tx) =>
+      mirrorInvoiceUnsettleToEstimate(tx, { estimateId: S.estimate, payment }),
+    );
+
+    expect(unwound, "the estimate copy was released").toBe(true);
+    const estCopy = await sPrisma.estimatePaymentSchedule.findUniqueOrThrow({ where: { id: S.estDeposit } });
+    expect(estCopy.status).toBe("Pending");
+    // The Stripe ids MUST survive the reset: they are how a redelivered refund
+    // re-finds this exact row. Clearing them would let a duplicate delivery land
+    // on a different clone sharing the intent and unset a real payment.
+    expect(estCopy.stripePaymentIntentId, "the charge link survives the reset").toBe(INTENT);
+
+    const estimate = await sPrisma.estimate.findUniqueOrThrow({ where: { id: S.estimate } });
+    expect(Number(estimate.balanceDue), "estimate balance restored in full").toBe(1000);
+    expect(estimate.status, "pre-payment status restored").toBe("Invoiced");
+    expect(estimate.statusBeforePayment).toBeNull();
+  });
+
+  test("S4: an ambiguous unlinked pair is left alone rather than guessed at", async () => {
+    const now = new Date();
+    const payment = await sPrisma.paymentSchedule.findUniqueOrThrow({ where: { id: S.invAmbig } });
+
+    const mirrored = await sPrisma.$transaction((tx) =>
+      mirrorInvoiceSettleToEstimate(tx, {
+        estimateId: S.estimate,
+        payment,
+        data: { paymentDate: now, paidAt: now, paymentMethod: "card" },
+      }),
+    );
+
+    expect(mirrored, "two identical candidates must not resolve to one").toBe(false);
+    const rows = await sPrisma.estimatePaymentSchedule.findMany({
+      where: { id: { in: [S.estAmbigA, S.estAmbigB, S.estAmbigDecoy] } },
+    });
+    expect(rows.every((r) => r.status === "Pending"), "no candidate was touched").toBe(true);
+  });
+
+  test("S5: refunding an estimate milestone never releases a clone paid by another charge", async () => {
+    const schedule = await sPrisma.estimatePaymentSchedule.findUniqueOrThrow({ where: { id: S.estOther } });
+
+    const mirror = await sPrisma.$transaction((tx) =>
+      findInvoiceMirrorOfEstimateSchedule(tx, schedule),
+    );
+
+    expect(mirror, "the sole linked clone carries a different PaymentIntent").toBeNull();
+    const clone = await sPrisma.paymentSchedule.findUniqueOrThrow({ where: { id: S.invOtherCharge } });
+    expect(clone.status, "the other charge's payment stays Paid").toBe("Paid");
+  });
+
+  test("S6: refunding an estimate milestone unwinds its invoice clone and balance", async () => {
+    // Re-point the clone at THIS charge, which is the ordinary settled pair.
+    await sPrisma.paymentSchedule.update({
+      where: { id: S.invOtherCharge },
+      data: { stripePaymentIntentId: INTENT, status: "Paid" },
+    });
+    await sPrisma.invoice.update({
+      where: { id: S.invoice },
+      data: { balanceDue: 800, status: "Partially Paid" },
+    });
+    const schedule = await sPrisma.estimatePaymentSchedule.findUniqueOrThrow({ where: { id: S.estOther } });
+
+    const unwound = await sPrisma.$transaction(async (tx) => {
+      const mirror = await findInvoiceMirrorOfEstimateSchedule(tx, schedule);
+      expect(mirror?.id, "the same-charge clone is the mirror").toBe(S.invOtherCharge);
+      return mirror ? await mirrorEstimateUnsettleToInvoice(tx, mirror) : false;
+    });
+
+    expect(unwound, "the invoice clone was released").toBe(true);
+    const clone = await sPrisma.paymentSchedule.findUniqueOrThrow({ where: { id: S.invOtherCharge } });
+    expect(clone.status).toBe("Pending");
+    const invoice = await sPrisma.invoice.findUniqueOrThrow({ where: { id: S.invoice } });
+    expect(Number(invoice.balanceDue), "invoice balance restored by the refunded amount").toBe(1000);
+    expect(invoice.status).toBe("Issued");
   });
 });

--- a/e2e/money-pipeline.spec.ts
+++ b/e2e/money-pipeline.spec.ts
@@ -1123,6 +1123,10 @@ const S = {
   estAmbigB: "mp3-e2e-eps-ambig-b",
   estAmbigDecoy: "mp3-e2e-eps-ambig-decoy",
   invAmbig: "mp3-e2e-ps-ambig",
+  // S5/S6 live on their OWN estimate+invoice pair so their paid milestone
+  // can't move the balances S1-S4 assert on.
+  estimate2: "mp3-e2e-estimate-2",
+  invoice2: "mp3-e2e-invoice-2",
   estOther: "mp3-e2e-eps-other",
   invOtherCharge: "mp3-e2e-ps-other-charge",
 };
@@ -1193,21 +1197,40 @@ test.describe.serial("Money pipeline: Stripe rails mirror both sides", () => {
       update: { status: "Pending", paidAt: null, paymentDate: null },
       create: { id: S.invAmbig, invoiceId: S.invoice, name: "MP3 Ambiguous", amount: 200, status: "Pending" },
     });
-    // An estimate milestone whose ONLY linked invoice clone was paid through a
-    // DIFFERENT charge — refunding this milestone's charge must not release it.
+    // Second pair, fully paid by a single charge. Its ONLY linked invoice clone
+    // starts out settled through a DIFFERENT charge — refunding this milestone's
+    // charge must not release it (S5), and once the clone does belong to this
+    // charge the refund must unwind it (S6).
+    await sPrisma.estimate.upsert({
+      where: { id: S.estimate2 },
+      update: { status: "Invoiced", totalAmount: 200, balanceDue: 0, statusBeforePayment: null },
+      create: {
+        id: S.estimate2, title: `${S_NAME} 2`, code: "EST-MP3TEST-2", projectId: S.project,
+        status: "Invoiced", taxExempt: true, totalAmount: 200, balanceDue: 0,
+      },
+    });
+    await sPrisma.invoice.upsert({
+      where: { id: S.invoice2 },
+      update: { status: "Paid", totalAmount: 200, balanceDue: 0 },
+      create: {
+        id: S.invoice2, code: "INV-MP3TEST-2", projectId: S.project, clientId: S.client,
+        estimateId: S.estimate2, status: "Paid", totalAmount: 200, balanceDue: 0,
+        issueDate: new Date(),
+      },
+    });
     await sPrisma.estimatePaymentSchedule.upsert({
       where: { id: S.estOther },
       update: { status: "Paid", stripePaymentIntentId: INTENT },
       create: {
-        id: S.estOther, estimateId: S.estimate, name: "MP3 Other", amount: 200,
-        status: "Paid", order: 4, stripePaymentIntentId: INTENT,
+        id: S.estOther, estimateId: S.estimate2, name: "MP3 Other", amount: 200,
+        status: "Paid", order: 1, stripePaymentIntentId: INTENT,
       },
     });
     await sPrisma.paymentSchedule.upsert({
       where: { id: S.invOtherCharge },
       update: { status: "Paid", stripePaymentIntentId: OTHER_INTENT },
       create: {
-        id: S.invOtherCharge, invoiceId: S.invoice, name: "MP3 Other", amount: 200,
+        id: S.invOtherCharge, invoiceId: S.invoice2, name: "MP3 Other", amount: 200,
         status: "Paid", sourceScheduleId: S.estOther, stripePaymentIntentId: OTHER_INTENT,
       },
     });
@@ -1215,10 +1238,10 @@ test.describe.serial("Money pipeline: Stripe rails mirror both sides", () => {
 
   test.afterAll(async () => {
     try {
-      await sPrisma.paymentSchedule.deleteMany({ where: { invoiceId: S.invoice } });
-      await sPrisma.invoice.deleteMany({ where: { id: S.invoice } });
-      await sPrisma.estimatePaymentSchedule.deleteMany({ where: { estimateId: S.estimate } });
-      await sPrisma.estimate.deleteMany({ where: { id: S.estimate } });
+      await sPrisma.paymentSchedule.deleteMany({ where: { invoiceId: { in: [S.invoice, S.invoice2] } } });
+      await sPrisma.invoice.deleteMany({ where: { id: { in: [S.invoice, S.invoice2] } } });
+      await sPrisma.estimatePaymentSchedule.deleteMany({ where: { estimateId: { in: [S.estimate, S.estimate2] } } });
+      await sPrisma.estimate.deleteMany({ where: { id: { in: [S.estimate, S.estimate2] } } });
       await sPrisma.project.deleteMany({ where: { id: S.project } });
       await sPrisma.client.deleteMany({ where: { id: S.client } });
     } finally {
@@ -1338,10 +1361,6 @@ test.describe.serial("Money pipeline: Stripe rails mirror both sides", () => {
       where: { id: S.invOtherCharge },
       data: { stripePaymentIntentId: INTENT, status: "Paid" },
     });
-    await sPrisma.invoice.update({
-      where: { id: S.invoice },
-      data: { balanceDue: 800, status: "Partially Paid" },
-    });
     const schedule = await sPrisma.estimatePaymentSchedule.findUniqueOrThrow({ where: { id: S.estOther } });
 
     const unwound = await sPrisma.$transaction(async (tx) => {
@@ -1353,8 +1372,8 @@ test.describe.serial("Money pipeline: Stripe rails mirror both sides", () => {
     expect(unwound, "the invoice clone was released").toBe(true);
     const clone = await sPrisma.paymentSchedule.findUniqueOrThrow({ where: { id: S.invOtherCharge } });
     expect(clone.status).toBe("Pending");
-    const invoice = await sPrisma.invoice.findUniqueOrThrow({ where: { id: S.invoice } });
-    expect(Number(invoice.balanceDue), "invoice balance restored by the refunded amount").toBe(1000);
+    const invoice = await sPrisma.invoice.findUniqueOrThrow({ where: { id: S.invoice2 } });
+    expect(Number(invoice.balanceDue), "invoice balance restored by the refunded amount").toBe(200);
     expect(invoice.status).toBe("Issued");
   });
 });

--- a/src/app/api/webhook/stripe/route.ts
+++ b/src/app/api/webhook/stripe/route.ts
@@ -8,6 +8,12 @@ import { sendNotification } from "@/lib/email";
 import { toNum } from "@/lib/prisma-helpers";
 import { formatCurrency } from "@/lib/utils";
 import { settleStripeEstimatePayment } from "@/lib/stripe-estimate-settlement";
+import {
+    mirrorInvoiceSettleToEstimate,
+    mirrorInvoiceUnsettleToEstimate,
+    mirrorEstimateUnsettleToInvoice,
+    findInvoiceMirrorOfEstimateSchedule,
+} from "@/lib/payment-mirror";
 
 // Helper function to process a single event by eventId asynchronously
 async function processEvent(eventId: string) {
@@ -65,12 +71,15 @@ async function processEvent(eventId: string) {
                     const scheduleId = metadata.paymentScheduleId;
                     const invoiceId = metadata.invoiceId;
                     const tx = await withTxRetry(() => prisma.$transaction(async (t) => {
-                        // Lock the parent invoice FIRST (canonical Estimate → Invoice → schedules
-                        // order; this branch touches only the invoice). Two concurrent webhooks
-                        // settling different milestones of the same invoice would otherwise each
-                        // read a stale sibling set and overwrite each other's balanceDue — the lock
-                        // serializes the recompute so the second waits and reads fresh state.
-                        await lockMoneyParents(t, { invoiceId });
+                        // Lock the parents in canonical Estimate → Invoice → schedules order.
+                        // Two concurrent webhooks settling different milestones of the same
+                        // invoice would otherwise each read a stale sibling set and overwrite
+                        // each other's balanceDue — the lock serializes the recompute so the
+                        // second waits and reads fresh state. The estimate is locked too because
+                        // this branch mirrors onto the estimate-side milestone copy below; the
+                        // link is read non-locking first so the order can never invert.
+                        const invLink = await t.invoice.findUnique({ where: { id: invoiceId }, select: { estimateId: true } });
+                        await lockMoneyParents(t, { estimateId: invLink?.estimateId, invoiceId });
                         const claim = await t.paymentSchedule.updateMany({
                             where: { id: scheduleId, status: { not: "Paid" } },
                             data: {
@@ -95,11 +104,28 @@ async function processEvent(eventId: string) {
                             where: { id: invoiceId },
                             data: { balanceDue: newBalance, status: newStatus },
                         });
+                        const paidSchedule = siblings.find(s => s.id === scheduleId) ?? null;
+                        // Mirror onto the estimate-side copy so the estimate editor and the
+                        // client portal don't keep showing this milestone as unpaid.
+                        if (!alreadyPaid && paidSchedule) {
+                            await mirrorInvoiceSettleToEstimate(t, {
+                                estimateId: invLink?.estimateId,
+                                payment: paidSchedule,
+                                data: {
+                                    paymentDate: paidSchedule.paymentDate ?? new Date(),
+                                    paidAt: paidSchedule.paidAt ?? new Date(),
+                                    paymentMethod,
+                                    // Same metadata the portal fallback writes, so the mirror
+                                    // looks identical whichever rail wins the settle claim.
+                                    stripeSessionId: session.id,
+                                    stripePaymentIntentId: (session.payment_intent as string | null) ?? null,
+                                },
+                            });
+                        }
                         // Durable notification enqueued in-tx (delivered by the drainer below).
                         if (!alreadyPaid) {
                             await enqueueMilestonePaid(t, { scheduleId, scheduleType: "invoice" });
                         }
-                        const paidSchedule = siblings.find(s => s.id === scheduleId) ?? null;
                         return { alreadyPaid, invoice, paidSchedule, newBalance };
                     }));
                     if (!tx.alreadyPaid) {
@@ -184,29 +210,54 @@ async function processEvent(eventId: string) {
                 const isFullyRefunded = chargeAmount > 0
                     && Math.abs(chargeAmount - refundedAmount) < 0.005;
 
-                // Try invoice payment schedule first
-                const invoiceSchedule = await prisma.paymentSchedule.findFirst({
-                    where: { stripePaymentIntentId: paymentIntentId },
-                    include: { invoice: true },
-                });
+                // Try invoice payment schedule first. `stripePaymentIntentId` is NOT unique —
+                // invoice creation copies it onto every clone of an already-paid estimate
+                // milestone — so prefer a row that is actually Paid (the one a refund is
+                // about) and pick deterministically among ties instead of taking whatever
+                // the planner returns first.
+                const invoiceSchedule =
+                    (await prisma.paymentSchedule.findFirst({
+                        where: { stripePaymentIntentId: paymentIntentId, status: "Paid" },
+                        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+                        include: { invoice: true },
+                    }))
+                    ?? (await prisma.paymentSchedule.findFirst({
+                        where: { stripePaymentIntentId: paymentIntentId },
+                        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+                        include: { invoice: true },
+                    }));
 
                 if (invoiceSchedule) {
+                    // Whether THIS delivery actually reset the schedule — the office email
+                    // must not claim a reset the claim guard refused.
+                    let didReset = false;
                     if (isFullyRefunded) {
                         // Full refund: reset the schedule and recompute the invoice in one transaction
                         // so we don't race with a concurrent payment settlement on a sibling schedule.
-                        await withTxRetry(() => prisma.$transaction(async (t) => {
-                            // Canonical Estimate → Invoice → schedules order; this branch touches
-                            // only the invoice. Lock it first so a concurrent settle on a sibling
-                            // milestone can't have its balanceDue effect lost to this recompute.
-                            await lockMoneyParents(t, { invoiceId: invoiceSchedule.invoiceId });
+                        const outcome = await withTxRetry(() => prisma.$transaction(async (t) => {
+                            // Canonical Estimate → Invoice → schedules order. Lock the parents
+                            // first so a concurrent settle on a sibling milestone can't have its
+                            // balanceDue effect lost to this recompute. The estimate is locked
+                            // too because the estimate-side mirror is unwound below.
+                            await lockMoneyParents(t, {
+                                estimateId: invoiceSchedule.invoice.estimateId,
+                                invoiceId: invoiceSchedule.invoiceId,
+                            });
                             // Re-read the parent AFTER the lock — the outer query's snapshot of
                             // totalAmount/status may be stale if a concurrent flow changed it.
                             const invoice = await t.invoice.findUnique({ where: { id: invoiceSchedule.invoiceId } });
                             if (invoice) {
-                                await t.paymentSchedule.update({
-                                    where: { id: invoiceSchedule.id },
+                                // CLAIMED reset: the schedule row was read before the locks were
+                                // taken, so a settlement that landed while this worker waited may
+                                // have re-pointed it at a NEWER charge. Guarding on both the Paid
+                                // status and this refund's PaymentIntent means a stale refund can
+                                // never reset a payment it isn't about. The Stripe ids stay on the
+                                // row: they are how a redelivered refund re-finds it.
+                                const reset = await t.paymentSchedule.updateMany({
+                                    where: { id: invoiceSchedule.id, status: "Paid", stripePaymentIntentId: paymentIntentId },
                                     data: { status: "Pending", paidAt: null, paymentDate: null },
                                 });
+                                if (reset.count === 0) return { claimed: false };
                                 const siblings = await t.paymentSchedule.findMany({
                                     where: { invoiceId: invoiceSchedule.invoiceId },
                                 });
@@ -220,17 +271,28 @@ async function processEvent(eventId: string) {
                                     where: { id: invoice.id },
                                     data: { balanceDue: newBalance, status: newStatus },
                                 });
+                                // Unwind the estimate-side mirror too, or the estimate keeps
+                                // claiming money the invoice no longer shows as received.
+                                await mirrorInvoiceUnsettleToEstimate(t, {
+                                    estimateId: invoice.estimateId,
+                                    payment: invoiceSchedule,
+                                });
+                                return { claimed: true };
                             }
+                            return { claimed: false };
                         }));
+                        didReset = outcome.claimed;
                     }
 
                     const refundSettings = await prisma.companySettings.findUnique({ where: { id: "singleton" } });
                     if (refundSettings?.notificationEmail) {
                         // `charge.amount_refunded` is the CUMULATIVE refund total, so this message reflects
                         // total-refunded-so-far, not this delivery's delta. We frame it that way explicitly.
-                        const summary = isFullyRefunded
+                        const summary = !isFullyRefunded
+                            ? `This is a <strong>partial refund</strong>. The schedule remains marked Paid; please reconcile the invoice balance manually in the Stripe dashboard.`
+                            : didReset
                             ? `The schedule has been reset to Pending and the invoice balance restored.`
-                            : `This is a <strong>partial refund</strong>. The schedule remains marked Paid; please reconcile the invoice balance manually in the Stripe dashboard.`;
+                            : `This milestone was <strong>not</strong> reset automatically — it no longer matched this charge when the refund was processed. Please reconcile the invoice balance manually in the Stripe dashboard.`;
                         await sendNotification(
                             refundSettings.notificationEmail,
                             `${isFullyRefunded ? "Refund Issued" : "Partial Refund Issued"}: Invoice ${invoiceSchedule.invoice.code}`,
@@ -245,26 +307,47 @@ async function processEvent(eventId: string) {
                 }
 
                 // Try estimate payment schedule
-                const estSchedule = await prisma.estimatePaymentSchedule.findFirst({
-                    where: { stripePaymentIntentId: paymentIntentId },
-                    include: { estimate: true },
-                });
+                const estSchedule =
+                    (await prisma.estimatePaymentSchedule.findFirst({
+                        where: { stripePaymentIntentId: paymentIntentId, status: "Paid" },
+                        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+                        include: { estimate: true },
+                    }))
+                    ?? (await prisma.estimatePaymentSchedule.findFirst({
+                        where: { stripePaymentIntentId: paymentIntentId },
+                        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+                        include: { estimate: true },
+                    }));
 
                 if (estSchedule) {
+                    let didReset = false;
                     if (isFullyRefunded) {
-                        await withTxRetry(() => prisma.$transaction(async (t) => {
-                            // Canonical Estimate → Invoice → schedules order; this branch touches
-                            // only the estimate. Lock it first so a concurrent settle on a sibling
-                            // milestone can't have its balanceDue effect lost to this recompute.
+                        const outcome = await withTxRetry(() => prisma.$transaction(async (t) => {
+                            // Canonical Estimate → Invoice → schedules order. Lock the estimate
+                            // first so a concurrent settle on a sibling milestone can't have its
+                            // balanceDue effect lost to this recompute; the invoice-side mirror
+                            // (unwound below) is located and then locked in that same order.
                             await lockMoneyParents(t, { estimateId: estSchedule.estimateId });
+                            let invoiceMirror = await findInvoiceMirrorOfEstimateSchedule(t, estSchedule);
+                            if (invoiceMirror) {
+                                await lockMoneyParents(t, { invoiceId: invoiceMirror.invoiceId });
+                                // The candidate was chosen BEFORE its Invoice row was locked, so
+                                // re-resolve under the lock and only keep it if it still resolves
+                                // to the same row. Anything else means the mirror group moved and
+                                // this refund should not touch it.
+                                const confirmed = await findInvoiceMirrorOfEstimateSchedule(t, estSchedule);
+                                invoiceMirror = confirmed && confirmed.id === invoiceMirror.id ? confirmed : null;
+                            }
                             // Re-read the parent AFTER the lock — the outer query's snapshot of
                             // totalAmount/status may be stale if a concurrent flow changed it.
                             const estimate = await t.estimate.findUnique({ where: { id: estSchedule.estimateId } });
                             if (estimate) {
-                                await t.estimatePaymentSchedule.update({
-                                    where: { id: estSchedule.id },
+                                // CLAIMED reset — same reasoning as the invoice branch above.
+                                const reset = await t.estimatePaymentSchedule.updateMany({
+                                    where: { id: estSchedule.id, status: "Paid", stripePaymentIntentId: paymentIntentId },
                                     data: { status: "Pending", paidAt: null, paymentDate: null },
                                 });
+                                if (reset.count === 0) return { claimed: false };
                                 const siblings = await t.estimatePaymentSchedule.findMany({
                                     where: { estimateId: estSchedule.estimateId },
                                 });
@@ -283,15 +366,25 @@ async function processEvent(eventId: string) {
                                         ...(totalPaid === 0 && { statusBeforePayment: null }),
                                     },
                                 });
+                                // Unwind the invoice-side mirror too, or the invoice keeps
+                                // showing a milestone the estimate no longer counts as paid.
+                                if (invoiceMirror) {
+                                    await mirrorEstimateUnsettleToInvoice(t, invoiceMirror);
+                                }
+                                return { claimed: true };
                             }
+                            return { claimed: false };
                         }));
+                        didReset = outcome.claimed;
                     }
 
                     const refundSettings = await prisma.companySettings.findUnique({ where: { id: "singleton" } });
                     if (refundSettings?.notificationEmail) {
-                        const summary = isFullyRefunded
+                        const summary = !isFullyRefunded
+                            ? `This is a <strong>partial refund</strong>. The schedule remains marked Paid; please reconcile manually.`
+                            : didReset
                             ? `The schedule has been reset to Pending and the estimate balance restored.`
-                            : `This is a <strong>partial refund</strong>. The schedule remains marked Paid; please reconcile manually.`;
+                            : `This milestone was <strong>not</strong> reset automatically — it no longer matched this charge when the refund was processed. Please reconcile manually.`;
                         await sendNotification(
                             refundSettings.notificationEmail,
                             `${isFullyRefunded ? "Refund Issued" : "Partial Refund Issued"}: Estimate ${estSchedule.estimate.code}`,

--- a/src/app/portal/invoices/[id]/page.tsx
+++ b/src/app/portal/invoices/[id]/page.tsx
@@ -7,6 +7,7 @@ import { stripe } from "@/lib/stripe";
 import { toNum } from "@/lib/prisma-helpers";
 import { withTxRetry, lockMoneyParents } from "@/lib/tx-retry";
 import { enqueueMilestonePaid, drainPaymentNotifications } from "@/lib/payment-outbox";
+import { mirrorInvoiceSettleToEstimate } from "@/lib/payment-mirror";
 
 // Fallback settlement for when the client lands back on the portal invoice page with a
 // Stripe session_id before the webhook has processed it. Mirrors the webhook's invoice
@@ -46,7 +47,11 @@ async function verifyStripeSession(sessionId: string, invoiceId: string): Promis
         }
 
         const result = await withTxRetry(() => prisma.$transaction(async (t) => {
-            await lockMoneyParents(t, { invoiceId });
+            // Canonical Estimate → Invoice lock order. The estimate is locked too because
+            // the estimate-side milestone copy is mirrored below; the link is read
+            // non-locking first so the order can never invert against another flow.
+            const invLink = await t.invoice.findUnique({ where: { id: invoiceId }, select: { estimateId: true } });
+            await lockMoneyParents(t, { estimateId: invLink?.estimateId, invoiceId });
             const claim = await t.paymentSchedule.updateMany({
                 where: { id: scheduleId, invoiceId, status: { not: "Paid" } },
                 data: {
@@ -71,6 +76,25 @@ async function verifyStripeSession(sessionId: string, invoiceId: string): Promis
                 where: { id: invoice.id },
                 data: { balanceDue: newBalance, status: newStatus },
             });
+            // Mirror onto the estimate-side copy so the estimate and the portal don't keep
+            // showing this milestone as unpaid. Only the winner of the claim mirrors; the
+            // loser's mirror write would be a no-op against an already-Paid row anyway.
+            if (won) {
+                const paidSchedule = allSchedules.find(s => s.id === scheduleId) ?? null;
+                if (paidSchedule) {
+                    await mirrorInvoiceSettleToEstimate(t, {
+                        estimateId: invLink?.estimateId,
+                        payment: paidSchedule,
+                        data: {
+                            paymentDate: paidSchedule.paymentDate ?? new Date(),
+                            paidAt: paidSchedule.paidAt ?? new Date(),
+                            paymentMethod,
+                            stripeSessionId: sessionId,
+                            stripePaymentIntentId: session.payment_intent as string | null,
+                        },
+                    });
+                }
+            }
             // Durable notification enqueued in-tx; delivered by the drainer below (single
             // canonical writer, exactly-once with the webhook via the outbox + settle claim).
             if (won) {

--- a/src/lib/payment-mirror.ts
+++ b/src/lib/payment-mirror.ts
@@ -1,0 +1,239 @@
+import { Prisma } from "@prisma/client";
+import { toNum } from "@/lib/prisma-helpers";
+
+/**
+ * Mirror helpers for the estimate/invoice milestone pair.
+ *
+ * Estimate and invoice milestones are mirrored copies linked by
+ * `PaymentSchedule.sourceScheduleId` (see CLAUDE.md). Settling or unsettling
+ * either side must move the other, or the two documents disagree about how much
+ * the client has paid. The manual (`recordPaymentCore` / `unrecordPayment`),
+ * QuickBooks (`quickbooks-payments.ts`) and estimate-side Stripe
+ * (`stripe-estimate-settlement.ts`) rails each carried their own copy of this
+ * logic; the invoice-side Stripe rails carried none, which is what these helpers
+ * fix.
+ *
+ * All of them run INSIDE an existing money-path transaction whose caller has
+ * already taken the canonical Estimate → Invoice row locks (`lockMoneyParents`).
+ * They only touch the MIRROR side and its parent aggregate — the caller still
+ * owns the primary side it settled.
+ */
+
+type Tx = Prisma.TransactionClient;
+
+type ScheduleRef = {
+    id: string;
+    name: string;
+    amount: unknown;
+    sourceScheduleId?: string | null;
+    stripePaymentIntentId?: string | null;
+};
+
+export type MirrorSettleData = {
+    paymentDate: Date;
+    paidAt: Date;
+    paymentMethod?: string | null;
+    stripeSessionId?: string | null;
+    stripePaymentIntentId?: string | null;
+    referenceNumber?: string | null;
+};
+
+/**
+ * Locate the estimate-side original of an invoice milestone. Link-first via
+ * `sourceScheduleId`; a name+amount match is accepted only when EXACTLY one
+ * unpaid/paid candidate exists, which is the same pre-link legacy fallback the
+ * manual and QuickBooks rails use.
+ */
+async function findEstimateMirror(
+    tx: Tx,
+    estimateId: string,
+    payment: ScheduleRef,
+    wantStatus: "Paid" | "Unpaid",
+): Promise<{ id: string } | null> {
+    const statusFilter = wantStatus === "Paid" ? { status: "Paid" } : { status: { not: "Paid" } };
+    // Unsettling additionally requires the mirror to belong to the SAME charge:
+    // a row settled through some other intent must never be released by this
+    // refund. A null intent is accepted because manual and legacy settlements
+    // carry none.
+    const intentFilter = wantStatus === "Paid" && payment.stripePaymentIntentId
+        ? { OR: [{ stripePaymentIntentId: payment.stripePaymentIntentId }, { stripePaymentIntentId: null }] }
+        : {};
+    if (payment.sourceScheduleId) {
+        return await tx.estimatePaymentSchedule.findFirst({
+            where: { id: payment.sourceScheduleId, estimateId, ...statusFilter, ...intentFilter },
+            select: { id: true },
+        });
+    }
+    // No `take` here: the ambiguity check must see EVERY same-name row, or a
+    // third non-matching row can push a second amount-match out of the window
+    // and make a genuinely ambiguous fallback look unique. Milestone counts are
+    // small (tens per estimate), so the unbounded read is cheap.
+    const candidates = await tx.estimatePaymentSchedule.findMany({
+        where: { estimateId, name: payment.name, ...statusFilter, ...intentFilter },
+    });
+    const matching = candidates.filter((c) => toNum(c.amount) === toNum(payment.amount));
+    return matching.length === 1 ? { id: matching[0].id } : null;
+}
+
+/**
+ * Recompute an estimate's balance/status from its own milestones. `zeroPaid`
+ * decides what the estimate reverts to once nothing is paid: `"restore"` puts
+ * back the captured pre-payment status (unsettle), `"keep"` leaves the current
+ * status alone (settle, where a zero total means nothing changed).
+ */
+async function recomputeEstimate(tx: Tx, estimateId: string, zeroPaid: "restore" | "keep"): Promise<void> {
+    const estimate = await tx.estimate.findUnique({ where: { id: estimateId } });
+    if (!estimate) return;
+    const siblings = await tx.estimatePaymentSchedule.findMany({ where: { estimateId } });
+    const paid = siblings
+        .filter((s) => s.status === "Paid")
+        .reduce((sum, s) => sum + toNum(s.amount), 0);
+    const balance = Math.max(0, toNum(estimate.totalAmount) - paid);
+    // Captured so a later unsettle can restore the pre-payment status.
+    const capturePriorStatus = paid > 0 && !["Paid", "Partially Paid"].includes(estimate.status);
+    const status = paid === 0
+        ? (zeroPaid === "restore" ? estimate.statusBeforePayment ?? "Invoiced" : estimate.status)
+        : balance <= 0 ? "Paid"
+        : "Partially Paid";
+    await tx.estimate.update({
+        where: { id: estimateId },
+        data: {
+            balanceDue: balance,
+            status,
+            ...(capturePriorStatus && { statusBeforePayment: estimate.status }),
+            ...(paid === 0 && zeroPaid === "restore" && { statusBeforePayment: null }),
+        },
+    });
+}
+
+/** Recompute an invoice's balance/status from its own milestones. */
+async function recomputeInvoice(tx: Tx, invoiceId: string): Promise<void> {
+    const invoice = await tx.invoice.findUnique({ where: { id: invoiceId } });
+    if (!invoice) return;
+    const siblings = await tx.paymentSchedule.findMany({ where: { invoiceId } });
+    const paid = siblings
+        .filter((s) => s.status === "Paid")
+        .reduce((sum, s) => sum + toNum(s.amount), 0);
+    const balance = Math.max(0, toNum(invoice.totalAmount) - paid);
+    await tx.invoice.update({
+        where: { id: invoiceId },
+        data: {
+            balanceDue: balance,
+            status: balance <= 0 ? "Paid" : paid > 0 ? "Partially Paid" : "Issued",
+        },
+    });
+}
+
+/**
+ * Settle the estimate-side copy of an invoice milestone that was just paid, and
+ * recompute the estimate. Returns true when a mirror was actually claimed.
+ */
+export async function mirrorInvoiceSettleToEstimate(
+    tx: Tx,
+    args: { estimateId: string | null | undefined; payment: ScheduleRef; data: MirrorSettleData },
+): Promise<boolean> {
+    if (!args.estimateId) return false;
+    const mirror = await findEstimateMirror(tx, args.estimateId, args.payment, "Unpaid");
+    if (!mirror) return false;
+    const claim = await tx.estimatePaymentSchedule.updateMany({
+        where: { id: mirror.id, estimateId: args.estimateId, status: { not: "Paid" } },
+        data: {
+            status: "Paid",
+            paymentDate: args.data.paymentDate,
+            paidAt: args.data.paidAt,
+            paymentMethod: args.data.paymentMethod,
+            ...(args.data.stripeSessionId !== undefined && { stripeSessionId: args.data.stripeSessionId }),
+            ...(args.data.stripePaymentIntentId !== undefined && { stripePaymentIntentId: args.data.stripePaymentIntentId }),
+            ...(args.data.referenceNumber !== undefined && { referenceNumber: args.data.referenceNumber }),
+        },
+    });
+    if (claim.count === 0) return false;
+    await recomputeEstimate(tx, args.estimateId, "keep");
+    return true;
+}
+
+/**
+ * Unsettle the estimate-side copy of an invoice milestone that was just fully
+ * refunded, and recompute the estimate.
+ */
+export async function mirrorInvoiceUnsettleToEstimate(
+    tx: Tx,
+    args: { estimateId: string | null | undefined; payment: ScheduleRef },
+): Promise<boolean> {
+    if (!args.estimateId) return false;
+    const mirror = await findEstimateMirror(tx, args.estimateId, args.payment, "Paid");
+    if (!mirror) return false;
+    const claim = await tx.estimatePaymentSchedule.updateMany({
+        where: { id: mirror.id, estimateId: args.estimateId, status: "Paid" },
+        // Deliberately leaves the Stripe ids in place, matching the primary
+        // refund reset. They are how a redelivered `charge.refunded` re-finds
+        // this row; clearing them would let a duplicate delivery land on a
+        // DIFFERENT clone sharing the same intent and unset a real payment.
+        // (That a Pending row still carrying an intent is refused by progress
+        // billing is a real, pre-existing gap — tracked separately, because
+        // fixing it means fixing the refund row-identity problem first.)
+        data: { status: "Pending", paidAt: null, paymentDate: null },
+    });
+    if (claim.count === 0) return false;
+    await recomputeEstimate(tx, args.estimateId, "restore");
+    return true;
+}
+
+/**
+ * Find the invoice-side copy of an estimate milestone.
+ *
+ * `sourceScheduleId` identifies a mirror GROUP, not a single row — one estimate
+ * milestone can have several invoice-side clones (progress billing clones them,
+ * and `convertEstimateToInvoice` copies the whole schedule). So the link alone
+ * is not enough to pick the row a specific charge settled. Order of preference:
+ *
+ *  1. The Paid clone carrying this charge's PaymentIntent — exact, when unique.
+ *     (The intent is copied onto clones at creation, so it is NOT unique on its
+ *     own; combining it with the link is what makes the match safe.)
+ *  2. The Paid linked clone, but ONLY when exactly one exists.
+ *
+ * Anything ambiguous returns null and the mirror is left alone rather than
+ * guessed at — a wrong unsettle would silently move a client-visible balance.
+ */
+export async function findInvoiceMirrorOfEstimateSchedule(
+    tx: Tx,
+    schedule: ScheduleRef,
+): Promise<{ id: string; invoiceId: string } | null> {
+    const linked = await tx.paymentSchedule.findMany({
+        where: { sourceScheduleId: schedule.id, status: "Paid" },
+        select: { id: true, invoiceId: true, stripePaymentIntentId: true },
+    });
+    if (schedule.stripePaymentIntentId) {
+        // Same-charge only. A clone carrying a DIFFERENT non-null intent was
+        // settled by another payment and must never be released by this refund,
+        // so it is excluded rather than accepted as a sole fallback.
+        const sameCharge = linked.filter((row) =>
+            row.stripePaymentIntentId === schedule.stripePaymentIntentId
+            || row.stripePaymentIntentId === null
+        );
+        const exact = sameCharge.filter((row) => row.stripePaymentIntentId === schedule.stripePaymentIntentId);
+        if (exact.length === 1) return { id: exact[0].id, invoiceId: exact[0].invoiceId };
+        if (exact.length > 1) return null;
+        return sameCharge.length === 1 ? { id: sameCharge[0].id, invoiceId: sameCharge[0].invoiceId } : null;
+    }
+    return linked.length === 1 ? { id: linked[0].id, invoiceId: linked[0].invoiceId } : null;
+}
+
+/**
+ * Unsettle a located invoice-side mirror and recompute its invoice. The caller
+ * must already hold the Invoice row lock (canonical Estimate → Invoice order).
+ */
+export async function mirrorEstimateUnsettleToInvoice(
+    tx: Tx,
+    mirror: { id: string; invoiceId: string },
+): Promise<boolean> {
+    const claim = await tx.paymentSchedule.updateMany({
+        where: { id: mirror.id, invoiceId: mirror.invoiceId, status: "Paid" },
+        // Stripe ids left in place for the same reason as the estimate-side
+        // unsettle above.
+        data: { status: "Pending", paidAt: null, paymentDate: null },
+    });
+    if (claim.count === 0) return false;
+    await recomputeInvoice(tx, mirror.invoiceId);
+    return true;
+}


### PR DESCRIPTION
## The bug is real

A Codex review flagged during #364 that the money-path invariant in CLAUDE.md — *"estimate/invoice milestones are mirrored pairs linked by `PaymentSchedule.sourceScheduleId`; settling or unsettling either side must update both"* — is not enforced everywhere. Verified against the code: it holds on the manual rail (`payment-record-core.ts`, `unrecordPayment`), the QuickBooks rail (`quickbooks-payments.ts`) and the **estimate-side** Stripe rail (`stripe-estimate-settlement.ts`), and nowhere on the **invoice-side** Stripe rails. Nothing reconciles it later: the outbox only delivers notifications, and no cron or read path derives mirror status.

Live consequences on prod:

| Path | Before |
|---|---|
| Client pays a Stripe invoice (webhook) | invoice milestone Paid, mirrored estimate milestone still **unpaid** |
| Same, portal `session_id` fallback wins the race | same |
| Full refund of an invoice payment | invoice released, estimate still **claims the money** |
| Full refund of an estimate payment | estimate released, invoice clone still **shows Paid** |

## The fix

One shared helper, `src/lib/payment-mirror.ts`, called from all four sites. Each:

- takes the canonical **Estimate → Invoice** locks — the invoice branches previously locked only the invoice, which is not enough once they touch an estimate;
- claims the mirror with a guarded `updateMany`, so mirroring is **at most once** across the webhook/portal race;
- recomputes the mirror's parent aggregate, including the `statusBeforePayment` capture/restore the existing undo rail uses.

**Row identity is the hard part.** One estimate milestone can have several invoice-side clones (progress billing clones them), and `convertEstimateToInvoice` copies the `stripePaymentIntentId` onto every clone — so neither the link nor the intent identifies a payment on its own. The helper uses the link first, and for an unsettle additionally requires the row to belong to the **same charge**; a clone carrying a different intent is excluded rather than accepted. Anything still ambiguous returns null and the mirror is left alone: a wrong unsettle moves a client-visible balance.

Both full-refund branches now also claim their **primary** reset on `status: "Paid"` + this refund's PaymentIntent (they previously updated by id from a row read before the locks), and the office email says plainly when the claim was refused instead of announcing a reset that did not happen.

## Review

Codex `gpt-5.6-sol` at `xhigh`, two rounds.

Round 1 raised 6 blockers; all addressed — the `take: 2` ambiguity window, the group-vs-row link problem, the unguarded primary resets, the mid-transaction invoice lock, and the arbitrary `findFirst` refund dispatch.

Round 2 **falsified one of my own round-1 fixes**: clearing the Stripe ids on a refunded row (added so progress billing would stop treating a reopened milestone as "payment in progress") lets a duplicate Stripe delivery — Stripe can send the same charge as a distinct Event id — land on a *different* clone sharing that intent and unset a real payment. The ids now stay put, and that progress-billing gap is tracked separately rather than traded for a worse bug.

### Left open deliberately

When several **Paid** clones share one PaymentIntent, a refund still resets only the one it selects; the others keep showing the refunded money. That is pre-existing behaviour of the refund dispatcher, not a regression from this PR — fixing it means giving refunds a real row identity, which is a bigger change than this one. Flagged for follow-up.

## Tests

`e2e/money-pipeline.spec.ts` gains S1–S6: the settle mirror and the two documents agreeing on what is owed, at-most-once replay, the refund unwind (asserting the charge link **survives**), the ambiguous-pair refusal with a decoy row that the old `take: 2` window would have mis-resolved, and both estimate→invoice cases (same-charge clone released, different-charge clone untouched).

The webhook itself can't be driven from the spec — it needs a signed Stripe payload — so the tests exercise the shared helper those rails call.

`npm run build` (typecheck + Next build) passes locally; e2e runs here in CI against the throwaway Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
