### PR TITLE
fix(estimates): a takeoff-converted estimate no longer double-taxes the client

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:payment-date": "tsx --test tests/payment-date-display.test.ts",
     "test:budget-math": "tsx --test tests/budget-math.test.ts",
     "test:estimate-item-upsert": "tsx --test tests/estimate-item-upsert.test.ts",
-    "test:unit": "tsx --test --experimental-test-module-mocks tests/estimate-item-payload.test.ts tests/budget-math.test.ts tests/payment-date-display.test.ts tests/estimate-item-upsert.test.ts tests/geocode-zip-guard.test.ts tests/takeoff-tax-split.test.ts tests/takeoff-convert-tax.test.ts",
+    "test:unit": "tsx --test tests/estimate-item-payload.test.ts tests/budget-math.test.ts tests/payment-date-display.test.ts tests/estimate-item-upsert.test.ts tests/geocode-zip-guard.test.ts tests/takeoff-tax-split.test.ts tests/takeoff-convert-tax.test.ts",
     "test:e2e": "playwright test",
     "test:mobile-e2e": "node e2e/mobile-app/run-mobile-e2e.mjs",
     "test:qa": "npx playwright test e2e/quality-gate.spec.ts",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:payment-date": "tsx --test tests/payment-date-display.test.ts",
     "test:budget-math": "tsx --test tests/budget-math.test.ts",
     "test:estimate-item-upsert": "tsx --test tests/estimate-item-upsert.test.ts",
-    "test:unit": "tsx --test tests/estimate-item-payload.test.ts tests/budget-math.test.ts tests/payment-date-display.test.ts tests/estimate-item-upsert.test.ts tests/geocode-zip-guard.test.ts",
+    "test:unit": "tsx --test --experimental-test-module-mocks tests/estimate-item-payload.test.ts tests/budget-math.test.ts tests/payment-date-display.test.ts tests/estimate-item-upsert.test.ts tests/geocode-zip-guard.test.ts tests/takeoff-tax-split.test.ts tests/takeoff-convert-tax.test.ts",
     "test:e2e": "playwright test",
     "test:mobile-e2e": "node e2e/mobile-app/run-mobile-e2e.mjs",
     "test:qa": "npx playwright test e2e/quality-gate.spec.ts",

--- a/scripts/audit-takeoff-double-tax.mjs
+++ b/scripts/audit-takeoff-double-tax.mjs
@@ -1,0 +1,219 @@
+// READ-ONLY audit of estimates converted from an AI takeoff that carry sales tax
+// INSIDE their line items while still presenting as untaxed.
+//
+// Background: the AI takeoff prompt emits WA sales tax as its own line item
+// (cost code `99-TAX`) and reports a TAX-INCLUSIVE `totalEstimate`.
+// `convert-to-estimate` stored that total on the Estimate but never set
+// `taxRatePercent`. Downstream a null `taxRatePercent` means "this total is
+// tax-EXCLUSIVE" — the portal display adds the default rate on top of a subtotal
+// that already contains the 99-TAX row, and `ensureProjectAndDepositInvoiceForEstimate`
+// grosses `totalAmount` / `balanceDue` / pending milestones up by that rate at
+// approval. Either way the client sees and signs tax charged twice.
+//
+// THIS SCRIPT NEVER WRITES. There is no UPDATE, INSERT or DELETE in this file and
+// no --apply flag. Repairing affected rows is a money-path change that needs
+// explicit sign-off; this only answers "how many, and for how much?".
+//
+// DENOMINATOR — read this before quoting any number it prints. The population is
+// estimates reachable from a `Takeoff` row (`Takeoff.estimateId`), which is the
+// only durable marker that an estimate came out of the takeoff pipeline. An
+// estimate whose takeoff record was deleted is invisible here and is reported as
+// a caveat, not silently dropped.
+//
+// TAX-ROW DETECTION uses three independent signals, reported separately so a miss
+// in any one of them is visible rather than silent:
+//   1. the takeoff's own `aiEstimateData` JSON, which stores the raw `costCode`
+//      string the model produced. This is the closest thing to ground truth for
+//      "did this takeoff carry a 99-TAX line".
+//   2. the estimate item's resolved cost code `99-TAX` / `99-TAX-*`, via the same
+//      `isTaxCostCode` helper the app uses, so this can never drift from the app.
+//   3. the item NAME looking like a sales-tax line. `convert-to-estimate` resolves
+//      `costCodeId` through the company's cost-code table, so if `99-TAX` was never
+//      seeded as a cost code the row lands with costCodeId = null and signal 2
+//      cannot see it at all.
+//
+// Usage (must run under tsx — imports the TypeScript helper directly so there is
+// no second copy of the tax-row rule to drift):
+//   npx tsx scripts/audit-takeoff-double-tax.mjs
+//   npx tsx scripts/audit-takeoff-double-tax.mjs --limit 50
+//
+// Requires (read from env or .env / .env.local):
+//   DATABASE_URL   Supabase transaction pooler URL (must include ?pgbouncer=true)
+import { PrismaClient } from "@prisma/client";
+import dotenv from "dotenv";
+import fs from "node:fs";
+import * as takeoffCosting from "../src/lib/takeoff-costing.ts";
+
+// tsx transpiles the .ts helper to CJS while this .mjs stays native ESM, so the
+// named export can arrive under `.default` depending on interop. Same dance as
+// scripts/audit-stale-margins.mjs.
+const { isTaxCostCode } = takeoffCosting.isTaxCostCode ? takeoffCosting : takeoffCosting.default;
+
+for (const f of [".env.local", ".env", ".env.production.local"]) {
+  if (fs.existsSync(f)) dotenv.config({ path: f, override: false });
+}
+if (process.env.AUDIT_ENV_FILE && fs.existsSync(process.env.AUDIT_ENV_FILE)) {
+  dotenv.config({ path: process.env.AUDIT_ENV_FILE, override: true });
+}
+if (!process.env.DATABASE_URL) {
+  console.error("DATABASE_URL is not set. Point AUDIT_ENV_FILE at the env file, or export it.");
+  process.exit(1);
+}
+
+const limitArg = process.argv.indexOf("--limit");
+const SAMPLE_LIMIT = limitArg > -1 ? Number(process.argv[limitArg + 1]) || 25 : 25;
+
+const num = (v) => (v == null ? 0 : Number(v));
+const rmc = (n) => Math.round(n * 100) / 100;
+const money = (n) => `$${n.toFixed(2)}`;
+// Mirrors the AI prompt's tax line naming ("WA Sales Tax (8.4%)") without
+// sweeping in ordinary items that merely mention tax in prose.
+const looksLikeTaxName = (name) => /\b(sales\s*tax|wa\s*tax|use\s*tax)\b/i.test(String(name ?? ""));
+
+const prisma = new PrismaClient();
+
+(async () => {
+  const settings = await prisma.companySettings.findUnique({
+    where: { id: "singleton" },
+    select: { salesTaxes: true },
+  });
+  let defaultRate = 0;
+  try {
+    const taxes = settings?.salesTaxes ? JSON.parse(settings.salesTaxes) : [];
+    const def = Array.isArray(taxes) ? taxes.find((t) => t.isDefault) || taxes[0] : null;
+    defaultRate = typeof def?.rate === "number" ? def.rate : 0;
+  } catch {
+    defaultRate = 0;
+  }
+
+  const takeoffs = await prisma.takeoff.findMany({
+    where: { estimateId: { not: null } },
+    select: { id: true, name: true, estimateId: true, createdAt: true, aiEstimateData: true },
+  });
+  const orphanTakeoffs = await prisma.takeoff.count({ where: { estimateId: null } });
+
+  console.log("=== Takeoff double-tax audit (READ ONLY) ===");
+  console.log(`Company default sales tax rate: ${defaultRate}%`);
+  console.log(`Takeoffs linked to an estimate: ${takeoffs.length}`);
+  console.log(`Takeoffs with no linked estimate (out of scope): ${orphanTakeoffs}`);
+  console.log("");
+
+  if (takeoffs.length === 0) {
+    console.log("No takeoff-converted estimates exist. Nothing to audit, nothing to repair.");
+    console.log("Audit complete — no writes made (none possible).");
+    return;
+  }
+
+  const estimates = await prisma.estimate.findMany({
+    where: { id: { in: takeoffs.map((t) => t.estimateId) } },
+    select: {
+      id: true, code: true, title: true, status: true, approvedAt: true,
+      totalAmount: true, balanceDue: true, taxRatePercent: true, taxExempt: true,
+      items: { select: { id: true, name: true, total: true, parentId: true, costCode: { select: { code: true } } } },
+      paymentSchedules: { select: { id: true, name: true, amount: true, status: true } },
+      invoices: { select: { id: true, code: true, totalAmount: true } },
+    },
+  });
+
+  const affected = [];
+  const cleanRows = [];
+
+  const takeoffByEstimate = new Map(takeoffs.map((t) => [t.estimateId, t]));
+
+  for (const est of estimates) {
+    // Signal 1 — the raw AI payload the estimate was built from.
+    let aiTaxRows = 0;
+    try {
+      const ai = JSON.parse(takeoffByEstimate.get(est.id)?.aiEstimateData ?? "null");
+      aiTaxRows = Array.isArray(ai?.items) ? ai.items.filter((i) => isTaxCostCode(i?.costCode)).length : 0;
+    } catch {
+      aiTaxRows = 0;
+    }
+
+    // Section headers roll up into their children, so only LEAVES carry money.
+    // A row is a header iff some other row names it as parent.
+    const parentIds = new Set(est.items.map((i) => i.parentId).filter(Boolean));
+    const leaves = est.items.filter((i) => !parentIds.has(i.id));
+
+    const byCode = leaves.filter((i) => isTaxCostCode(i.costCode?.code));
+    const byName = leaves.filter((i) => !isTaxCostCode(i.costCode?.code) && looksLikeTaxName(i.name));
+    const taxRows = [...byCode, ...byName];
+
+    if (taxRows.length === 0) {
+      cleanRows.push({
+        code: est.code,
+        reason: aiTaxRows > 0
+          ? `AI payload had ${aiTaxRows} tax row(s) but the estimate has none — REVIEW BY HAND`
+          : "no tax line item",
+      });
+      continue;
+    }
+
+    const taxAmount = rmc(taxRows.reduce((s, i) => s + num(i.total), 0));
+    const preTax = rmc(leaves.filter((i) => !taxRows.includes(i)).reduce((s, i) => s + num(i.total), 0));
+    const correctTotal = rmc(preTax + taxAmount);
+    const stored = rmc(num(est.totalAmount));
+    const rate = est.taxRatePercent == null ? null : Number(est.taxRatePercent);
+
+    // What the client is actually shown / billed today.
+    // rate == null  -> portal adds defaultRate on top of a subtotal that already
+    //                  contains the tax row, and approval grosses the stored total
+    //                  up by the same factor. Both land on the same number.
+    // rate != null  -> the gross-up already ran (or an editor save set a rate);
+    //                  the stored total is what it is.
+    const exposedTotal = rate == null && !est.taxExempt && defaultRate > 0
+      ? rmc(stored * (1 + defaultRate / 100))
+      : stored;
+    const overstatement = rmc(exposedTotal - correctTotal);
+
+    const row = {
+      code: est.code, title: est.title, status: est.status,
+      approved: !!est.approvedAt,
+      rate, taxExempt: est.taxExempt,
+      preTax, taxAmount, correctTotal, stored, exposedTotal, overstatement,
+      invoices: est.invoices.map((v) => `${v.code} ${money(rmc(num(v.totalAmount)))}`),
+      pendingMilestones: est.paymentSchedules.filter((p) => p.status === "Pending").length,
+      detectedBy: `${byCode.length > 0 ? (byName.length > 0 ? "code+name" : "cost code") : "name only"} (ai payload tax rows: ${aiTaxRows})`,
+    };
+
+    if (Math.abs(overstatement) >= 0.01) affected.push(row);
+    else cleanRows.push({ code: est.code, reason: `tax line present but total already ties out (${money(stored)})` });
+  }
+
+  console.log(`Takeoff-converted estimates examined: ${estimates.length}`);
+  console.log(`  with a tax line AND an overstated client-facing total: ${affected.length}`);
+  console.log(`  clean: ${cleanRows.length}`);
+  console.log("");
+
+  if (affected.length === 0) {
+    console.log("ZERO affected estimates. The defect is real in code but has no production footprint.");
+    console.log("Do NOT ship a data repair.");
+  } else {
+    const totalImpact = rmc(affected.reduce((s, r) => s + r.overstatement, 0));
+    const signed = affected.filter((r) => r.approved);
+    const signedImpact = rmc(signed.reduce((s, r) => s + r.overstatement, 0));
+    console.log(`TOTAL OVERSTATEMENT: ${money(totalImpact)} across ${affected.length} estimate(s)`);
+    console.log(`  of which already approved/signed: ${signed.length} estimate(s), ${money(signedImpact)}`);
+    console.log("");
+    console.log(`Detail (up to ${SAMPLE_LIMIT}):`);
+    for (const r of affected.slice(0, SAMPLE_LIMIT)) {
+      console.log(`  ${r.code} — ${r.title}`);
+      console.log(`      status=${r.status} approved=${r.approved} storedRate=${r.rate ?? "null"} exempt=${r.taxExempt} detectedBy=${r.detectedBy}`);
+      console.log(`      pre-tax ${money(r.preTax)} + tax line ${money(r.taxAmount)} = correct ${money(r.correctTotal)}`);
+      console.log(`      stored ${money(r.stored)} -> client-facing ${money(r.exposedTotal)}  OVERSTATED BY ${money(r.overstatement)}`);
+      console.log(`      invoices: ${r.invoices.length ? r.invoices.join(", ") : "none"} | pending milestones: ${r.pendingMilestones}`);
+    }
+    if (affected.length > SAMPLE_LIMIT) console.log(`  ...and ${affected.length - SAMPLE_LIMIT} more.`);
+  }
+
+  console.log("");
+  console.log("Caveat: estimates whose Takeoff row was deleted are not reachable and are not counted.");
+  console.log("Audit complete — no writes made (none possible).");
+})()
+  .catch((e) => {
+    console.error("Audit failed:", e);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app/api/takeoffs/convert-to-estimate/route.ts
+++ b/src/app/api/takeoffs/convert-to-estimate/route.ts
@@ -1,10 +1,46 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { derivedMarginPct } from "@/lib/budget-math";
-import { isTaxCostCode, numOr, numOrNull } from "@/lib/takeoff-costing";
+import { isTaxCostCode, numOr, numOrNull, rmc, splitTakeoffTax } from "@/lib/takeoff-costing";
 
 /** The margin stored when a takeoff row carries no usable costing at all. */
 const DEFAULT_MARGIN_PCT = 25;
+
+/**
+ * Re-proportion a milestone split across a (possibly new) total. Percentages are normalized to
+ * sum to exactly 100 (or split evenly if the source sums to <= 0), and the last milestone absorbs
+ * the rounding residual so amounts always sum to `total` exactly. The stored percentage is
+ * normalized too, so percentage and amount never disagree.
+ *
+ * Mirrors `recomputeMilestones` in `src/lib/gpt-estimate.ts` (same normalize / last-absorbs-residual
+ * shape, `rmc` in place of that function's `toCents` — both are `Math.round(n * 100) / 100`). Kept
+ * as a small local helper rather than an import so this route doesn't drag in gpt-estimate.ts's
+ * unrelated dependencies.
+ */
+function recomputeMilestoneAmounts(
+    total: number,
+    source: Array<{ name?: string; percentage?: unknown }>,
+): { name: string; percentage: number; amount: number }[] {
+    if (source.length === 0) return [];
+    let pcts = source.map((m) => numOr(m.percentage, 0));
+    const pctSum = rmc(pcts.reduce((s, p) => s + p, 0));
+    if (pctSum <= 0) {
+        const eq = 100 / source.length;
+        pcts = source.map(() => eq);
+    } else if (Math.abs(pctSum - 100) > 0.01) {
+        pcts = pcts.map((p) => (p * 100) / pctSum);
+    }
+    let pctAllocated = 0;
+    let allocated = 0;
+    return source.map((m, idx) => {
+        const isLast = idx === source.length - 1;
+        const percentage = isLast ? rmc(100 - pctAllocated) : rmc(pcts[idx]);
+        pctAllocated = rmc(pctAllocated + percentage);
+        const amount = isLast ? rmc(total - allocated) : rmc((percentage / 100) * total);
+        allocated = rmc(allocated + amount);
+        return { name: m.name || `Payment ${idx + 1}`, percentage, amount };
+    });
+}
 
 /**
  * Translate a takeoff row's costing into the value `EstimateItem.markupPercent` actually holds.
@@ -63,9 +99,58 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ error: "Invalid AI estimate data" }, { status: 400 });
     }
 
-    const items = aiData.items || [];
+    // aiData.items can arrive as something other than an array (malformed/legacy AI output) — a
+    // non-array would still reach the .reduce/.filter calls below and throw a 500 instead of
+    // falling back cleanly.
+    const rawItems: any[] = Array.isArray(aiData.items) ? aiData.items : [];
     const milestones = aiData.paymentMilestones || [];
-    const totalEstimate = aiData.totalEstimate || items.reduce((s: number, i: any) => s + (i.total || 0), 0);
+    // numOr, not `i.total || 0`: a stringy total (`"1000"`) would otherwise string-concatenate
+    // through `+` instead of summing (`"01000500"`), corrupting the legacy fallback total.
+    const totalEstimate = aiData.totalEstimate || rawItems.reduce((s: number, i: any) => s + numOr(i.total, 0), 0);
+
+    // Tax-mode invariant: the AI takeoff prompt writes sales tax as a `99-TAX` LINE ITEM, so
+    // `totalEstimate` above is tax-INCLUSIVE with no `taxRatePercent` set. Every downstream
+    // consumer (portal display, the approval gross-up in actions.ts) reads a null
+    // `taxRatePercent` as "tax-EXCLUSIVE, gross up by the default rate at approval" — left as-is,
+    // that grosses up an already-tax-inclusive total a second time. splitTakeoffTax() strips the
+    // tax row(s) out of the items and derives the rate they imply, so the estimate created below
+    // is stored in the app's canonical shape (pre-tax items + taxRatePercent) instead. When it
+    // can't derive a trustworthy rate, it bails out and returns the items unchanged — legacy
+    // (pre-existing) behavior for that case.
+    const split = splitTakeoffTax(rawItems);
+    const items = split.taxRatePercent != null ? split.items : rawItems;
+
+    let taxRateName: string | null = null;
+    if (split.taxRatePercent != null) {
+        const companySettings = await prisma.companySettings.findUnique({
+            where: { id: "singleton" },
+            select: { salesTaxes: true },
+        });
+        let salesTaxes: Array<{ name?: string; rate?: number }> = [];
+        try {
+            const parsed = companySettings?.salesTaxes ? JSON.parse(companySettings.salesTaxes) : [];
+            // JSON.parse("null") and JSON.parse("{}") both succeed without being an array, and a
+            // subsequent .find/.filter would throw and fail the whole conversion.
+            salesTaxes = Array.isArray(parsed) ? parsed : [];
+        } catch {
+            salesTaxes = [];
+        }
+        // Two configured jurisdictions can share a rate, and the AI takeoff line's own name can
+        // assert a jurisdiction the derived rate contradicts — either way, naming the wrong city on
+        // a client-facing document is worse than a neutral label. Only trust a configured tax's
+        // name when it is the SOLE match; never fall back to the AI line item's name at all.
+        // Tolerance is tight (< 0.0001, not the old < 0.01): naming a jurisdiction on a
+        // client-facing document requires the derived rate to actually BE that jurisdiction's
+        // rate — a 0.01 window let a derived 8.409% match (and inherit the name of) a configured
+        // 8.4% tax it isn't.
+        const matches = salesTaxes.filter(
+            (t) => typeof t?.rate === "number" && Number.isFinite(t.rate) && Math.abs(t.rate - split.taxRatePercent!) < 0.0001,
+        );
+        const soleMatch = matches.length === 1 ? matches[0] : null;
+        taxRateName = soleMatch && typeof soleMatch.name === "string" && soleMatch.name.trim() !== "" ? soleMatch.name : "Sales Tax";
+    }
+
+    const finalTotal = split.taxRatePercent != null ? rmc(split.preTaxSubtotal + split.taxAmount) : totalEstimate;
 
     const code = `EST-${Math.floor(1000 + Math.random() * 9000)}`;
 
@@ -78,9 +163,10 @@ export async function POST(req: NextRequest) {
                 leadId: takeoff.leadId || null,
                 code,
                 status: "Draft",
-                totalAmount: totalEstimate,
-                balanceDue: totalEstimate,
+                totalAmount: finalTotal,
+                balanceDue: finalTotal,
                 privacy: "Shared",
+                ...(split.taxRatePercent != null ? { taxRatePercent: split.taxRatePercent, taxRateName } : {}),
             },
         });
 
@@ -115,15 +201,23 @@ export async function POST(req: NextRequest) {
             });
         }
 
-        // Create payment schedules
+        // Create payment schedules. `milestones` came from `aiData.paymentMilestones`, computed
+        // upstream against `aiData.totalEstimate` — but the estimate above was stored with
+        // `finalTotal`, which differs from `totalEstimate` whenever the tax split applied. Trusting
+        // the stored `m.amount` in that case can leave the schedule not summing to the estimate
+        // total, so recompute from `finalTotal` and the milestone PERCENTAGES instead. When the
+        // split bailed out, `finalTotal === totalEstimate` and the milestones already match it, so
+        // keep reading the stored amounts as-is (legacy behavior, unchanged).
+        const recomputedMilestones = split.taxRatePercent != null ? recomputeMilestoneAmounts(finalTotal, milestones) : null;
         for (let idx = 0; idx < milestones.length; idx++) {
             const m = milestones[idx];
+            const recomputed = recomputedMilestones ? recomputedMilestones[idx] : null;
             await prisma.estimatePaymentSchedule.create({
                 data: {
                     estimateId: estimate.id,
                     name: m.name || `Payment ${idx + 1}`,
-                    percentage: parseFloat(m.percentage) || 0,
-                    amount: parseFloat(m.amount) || 0,
+                    percentage: recomputed ? recomputed.percentage : parseFloat(m.percentage) || 0,
+                    amount: recomputed ? recomputed.amount : parseFloat(m.amount) || 0,
                     dueDate: null,
                     order: idx,
                 },
@@ -147,7 +241,7 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({
             estimateId: estimate.id,
             code: estimate.code,
-            totalAmount: totalEstimate,
+            totalAmount: finalTotal,
             itemCount: items.length,
             redirectUrl,
         });

--- a/src/lib/takeoff-costing.ts
+++ b/src/lib/takeoff-costing.ts
@@ -31,10 +31,21 @@ export function isTaxRow(row: { costCode?: unknown }): boolean {
  * Parse a value that arrived as JSON (or as a form string) into a finite number, or null.
  * Guards the money path against `parseFloat("12junk") === 12` and against stringy numbers
  * silently turning a `+` sum into string concatenation.
+ *
+ * Only `number` and `string` inputs are ever accepted — everything else (including `boolean` and
+ * arrays/objects, which `Number()` coerces to `1`/`0`/`NaN` in ways that have nothing to do with
+ * "is this a usable number") returns null. Strings are trimmed BEFORE the emptiness check, so a
+ * whitespace-only string (`"   "`) is treated as absent rather than coercing through `Number("")`
+ * to a false zero; a numeric string with surrounding whitespace (`" 12.5 "`) still parses normally.
  */
 export function numOrNull(value: unknown): number | null {
-    if (value === null || value === undefined || value === "") return null;
-    const parsed = typeof value === "number" ? value : Number(String(value).trim());
+    if (typeof value === "number") {
+        return Number.isFinite(value) ? value : null;
+    }
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    if (trimmed === "") return null;
+    const parsed = Number(trimmed);
     return Number.isFinite(parsed) ? parsed : null;
 }
 
@@ -45,3 +56,123 @@ export function numOr(value: unknown, fallback: number): number {
 
 /** Round to cents. */
 export const rmc = (n: number) => Math.round(n * 100) / 100;
+
+/**
+ * Result of splitting the AI takeoff's tax pass-through row(s) out of an item list.
+ *
+ * Three distinct outcomes, and the caller must treat them differently:
+ *  - `taxRatePercent: null` — "no usable tax line": either there was no tax row at all, or the
+ *    row(s) present did not imply a sane rate. `items` is returned UNCHANGED so the caller keeps
+ *    today's legacy behavior (tax stays in the line items, no rate is set).
+ *  - `taxRatePercent: 0` — the takeoff is explicitly UNTAXED (a tax row totalling exactly zero).
+ *    This is an answer, not an absence: storing it suppresses the approval-time gross-up that a
+ *    null would let fire. `items` has the tax row(s) removed.
+ *  - `taxRatePercent > 0` — the derived rate. `items` has the tax row(s) removed.
+ */
+export type TakeoffTaxSplit = {
+    items: unknown[]; // input items with the tax pass-through rows removed
+    preTaxSubtotal: number;
+    taxAmount: number;
+    taxRatePercent: number | null; // null => no usable tax line; caller must not set a rate
+};
+
+/**
+ * Separate the AI takeoff's sales-tax pass-through row(s) from the rest of the items, and derive
+ * the tax rate they imply.
+ *
+ * The AI takeoff prompt emits sales tax as a `99-TAX` line item, and `totalEstimate` sums every
+ * item's total — so the takeoff total is TAX-INCLUSIVE while every consumer downstream of the
+ * converted Estimate treats line items as pre-tax and expects `taxRatePercent` to carry the rate.
+ * Left alone, the tax pass-through both sits in the line items AND gets grossed up again by the
+ * portal display and the approval flow's default-rate gross-up — a double tax. This function
+ * un-does the takeoff's shape into the app's canonical one: strip the tax row(s), derive the rate
+ * they imply, and hand back a pre-tax subtotal + tax amount the caller can recombine.
+ *
+ * Bails out (returns `items` UNCHANGED and `taxRatePercent: null`) whenever the tax row(s) don't
+ * imply a rate we can trust: a zero pre-tax subtotal, ANY row (tax or non-tax) whose total isn't a
+ * usable number, a subtotal and tax amount with opposite signs, or a derived rate outside (0, 30].
+ * A nonsense ratio means we cannot prove the line is really a rate-based pass-through — silently
+ * inventing a rate on the money path is worse than leaving the legacy (pre-existing, already
+ * shipped) shape alone. 30 mirrors the taxRatePercent validation bound in gpt-estimate.ts.
+ *
+ * KNOWN LIMIT: the rate is derived as taxAmount / preTaxSubtotal, which assumes the AI taxed the
+ * WHOLE subtotal — which is exactly what the prompt instructs ("the 8.4% tax applies to the ENTIRE
+ * CONTRACT PRICE"). If a takeoff ever taxes only part of the base, the derived rate is a BLENDED
+ * rate: the stored total still ties out to the penny today, but a later edit reprices tax at the
+ * blended rate. That is accepted deliberately — bailing out would restore a guaranteed
+ * full-default-rate overcharge on every such estimate, which is strictly worse than a rate that is
+ * exactly right today and only approximate after an edit.
+ */
+export function splitTakeoffTax<T extends { costCode?: unknown; total?: unknown }>(
+    items: T[],
+): { items: T[]; preTaxSubtotal: number; taxAmount: number; taxRatePercent: number | null } {
+    // Single pass so we don't run isTaxRow twice per item across two .filter calls.
+    const nonTaxRows: T[] = [];
+    const taxRows: T[] = [];
+    for (const item of items) {
+        if (isTaxRow(item)) taxRows.push(item);
+        else nonTaxRows.push(item);
+    }
+
+    const preTaxSubtotal = rmc(nonTaxRows.reduce((sum, item) => sum + numOr(item.total, 0), 0));
+
+    if (taxRows.length === 0) {
+        return { items, preTaxSubtotal, taxAmount: 0, taxRatePercent: null };
+    }
+
+    // EVERY row's total — tax AND non-tax — must be a usable number before we trust anything
+    // derived from them. A non-tax row with a garbage total would otherwise silently shrink
+    // preTaxSubtotal via numOr's 0-fallback (inflating whatever rate a fixed tax amount implies,
+    // and understating the stored total); a tax row with a garbage total tells us nothing about
+    // the rate either, and can't be told apart from a genuine zero-tax answer (see the
+    // `taxAmount === 0` branch below) without this check. One gate covers both directions of the
+    // same failure: a partial base silently reprices tax.
+    const hasUsableTotals =
+        nonTaxRows.every((item) => numOrNull(item.total) !== null) &&
+        taxRows.every((item) => numOrNull(item.total) !== null);
+    const taxAmount = rmc(taxRows.reduce((sum, item) => sum + numOr(item.total, 0), 0));
+
+    // A zero pre-tax subtotal can never imply a rate (division by zero) regardless of sign, and an
+    // unusable total (on either side) tells us nothing either way.
+    if (preTaxSubtotal === 0 || !hasUsableTotals) {
+        return { items, preTaxSubtotal, taxAmount, taxRatePercent: null };
+    }
+
+    // A tax row present with a total of exactly zero is a real, storable answer — the takeoff is
+    // explicitly untaxed, not "unknown" — which suppresses the approval-time default-rate gross-up
+    // instead of leaving it to fire. This is sign-independent: a credit takeoff (negative subtotal)
+    // that is explicitly untaxed is just as real an answer as a positive one, and leaving it to
+    // bail out would let the approval gross-up make the credit MORE negative. (preTaxSubtotal is
+    // already known non-zero here, since the check above returned otherwise.)
+    if (taxAmount === 0) {
+        return { items: nonTaxRows, preTaxSubtotal, taxAmount, taxRatePercent: 0 };
+    }
+
+    // Credit / negative estimates: a negative subtotal with a negative tax row implies the same
+    // rate a positive pair would (dividing two negatives is positive), so derive it the same way.
+    // Mismatched signs (e.g. a positive subtotal with a negative tax row, or vice versa) are not a
+    // rate-based pass-through — bail out rather than guess.
+    const sameSign = (preTaxSubtotal > 0 && taxAmount > 0) || (preTaxSubtotal < 0 && taxAmount < 0);
+    if (!sameSign) {
+        return { items, preTaxSubtotal, taxAmount, taxRatePercent: null };
+    }
+
+    // Round to 4dp for the common case (a clean "8.4" reads better than "8.40000000000001"), but
+    // only keep the rounded value if it actually reproduces the stored tax amount to the penny when
+    // re-applied to the subtotal — e.g. subtotal 100000 / tax 8377.54 has an exact rate of
+    // 8.37754%, which rounds to 8.3775%, but 100000 * 8.3775% = 8377.50, four cents off the real
+    // total. In that case keep the UNROUNDED exact rate instead, so the portal's recomputed
+    // `subtotal * rate/100` always agrees with the persisted total to the penny.
+    // `Estimate.taxRatePercent` is an unbounded Prisma `Decimal?`, so the extra precision persists
+    // fine either way.
+    const exactRate = (taxAmount / preTaxSubtotal) * 100;
+    const rounded4 = Math.round(exactRate * 10000) / 10000;
+    const rounded4ReproducesTax = rmc((preTaxSubtotal * rounded4) / 100) === taxAmount;
+    const derivedRate = rounded4ReproducesTax ? rounded4 : exactRate;
+
+    if (!Number.isFinite(derivedRate) || derivedRate <= 0 || derivedRate > 30) {
+        return { items, preTaxSubtotal, taxAmount, taxRatePercent: null };
+    }
+
+    return { items: nonTaxRows, preTaxSubtotal, taxAmount, taxRatePercent: derivedRate };
+}

--- a/tests/takeoff-convert-tax.test.ts
+++ b/tests/takeoff-convert-tax.test.ts
@@ -1,0 +1,643 @@
+/**
+ * Route-level test for POST /api/takeoffs/convert-to-estimate.
+ *
+ * takeoff-tax-split.test.ts pins the CONTRACT of splitTakeoffTax() in isolation, but the route
+ * itself is where the double-tax fix actually has to hold: it's the route that decides what gets
+ * PERSISTED (the Estimate row, its line items, and its payment schedules). A local mirror of the
+ * math passing tells us nothing about whether the route wired the real values through correctly —
+ * this test drives the actual POST handler against a mocked Prisma and asserts on what was written.
+ *
+ * Requires Node's module-mocking flag: `--experimental-test-module-mocks` (see package.json).
+ *
+ * `@/lib/prisma` is mocked ONCE at module scope (not per-test / not re-imported) because
+ * re-registering `mock.module` for the same specifier across multiple dynamic re-imports of the
+ * route was observed to silently keep serving the FIRST test's mocked prisma object instead of a
+ * fresh one — the route module doesn't seem to actually re-evaluate its `@/lib/prisma` import on a
+ * cache-busted re-import. Instead, the fake Prisma's behavior reads from a single mutable `state`
+ * object that each test overwrites before calling the (single, statically loaded) route handler.
+ */
+
+import { test, mock, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { derivedMarginPct } from "../src/lib/budget-math";
+
+type CreateCall<T> = { data: T };
+
+const calls = {
+    estimateCreates: [] as CreateCall<any>[],
+    estimateItemCreates: [] as CreateCall<any>[],
+    estimatePaymentScheduleCreates: [] as CreateCall<any>[],
+    takeoffUpdates: [] as CreateCall<any>[],
+};
+
+const state: { takeoff: any; companySettings: any } = { takeoff: null, companySettings: null };
+
+function resetFixture() {
+    calls.estimateCreates.length = 0;
+    calls.estimateItemCreates.length = 0;
+    calls.estimatePaymentScheduleCreates.length = 0;
+    calls.takeoffUpdates.length = 0;
+    state.takeoff = null;
+    state.companySettings = null;
+}
+
+let estimateSeq = 0;
+let itemSeq = 0;
+let scheduleSeq = 0;
+
+const fakePrisma = {
+    takeoff: {
+        findUnique: async () => state.takeoff,
+        update: async (args: CreateCall<any>) => {
+            calls.takeoffUpdates.push(args);
+            return { ...state.takeoff, ...args.data };
+        },
+    },
+    companySettings: {
+        findUnique: async () => state.companySettings,
+    },
+    estimate: {
+        create: async (args: CreateCall<any>) => {
+            calls.estimateCreates.push(args);
+            estimateSeq += 1;
+            return { id: `est-${estimateSeq}`, ...args.data };
+        },
+    },
+    estimateItem: {
+        create: async (args: CreateCall<any>) => {
+            calls.estimateItemCreates.push(args);
+            itemSeq += 1;
+            return { id: `item-${itemSeq}`, ...args.data };
+        },
+    },
+    estimatePaymentSchedule: {
+        create: async (args: CreateCall<any>) => {
+            calls.estimatePaymentScheduleCreates.push(args);
+            scheduleSeq += 1;
+            return { id: `sched-${scheduleSeq}`, ...args.data };
+        },
+    },
+};
+
+// Top-level await isn't usable here (tsx transpiles this file to CJS), so the mock registration
+// and the route's dynamic import both happen in `before()` instead; `POST` is populated by the
+// time any test body runs.
+let POST: (req: Request) => Promise<Response>;
+
+before(async () => {
+    mock.module("../src/lib/prisma", { namedExports: { prisma: fakePrisma } });
+    const routeModule = await import("../src/app/api/takeoffs/convert-to-estimate/route");
+    POST = routeModule.POST as any;
+});
+
+beforeEach(() => {
+    resetFixture();
+});
+
+function postRequest(takeoffId: string) {
+    return new Request("http://localhost/api/takeoffs/convert-to-estimate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ takeoffId }),
+    }) as any;
+}
+
+// --- canonical case: tax split applies -------------------------------------------------------
+
+function canonicalTakeoff() {
+    // aiData.totalEstimate deliberately drifts from the raw item sum (108450 vs 108400) — this is
+    // the exact shape that exposes the milestone bug: milestones computed upstream against
+    // totalEstimate, while the route now stores finalTotal (derived from the split), so trusting
+    // the stored milestone amounts would leave the schedule not summing to the persisted total.
+    const items = [
+        { costCode: "01-DEMO", name: "Demo", total: 40000, unitCost: 40000, quantity: 1 },
+        // baseCost + unitCost set deliberately unequal so the derived-margin assertion below can
+        // tell the true-markup -> gross-margin conversion actually ran, rather than the item just
+        // falling through to the 25% default.
+        { costCode: "02-FRAME", name: "Frame", total: 35000, baseCost: 20000, unitCost: 35000, quantity: 2 },
+        { costCode: "03-FINISH", name: "Finish", total: 25000, unitCost: 25000, quantity: 1 },
+        { costCode: "99-TAX", name: "WA Sales Tax", total: 8400, unitCost: 8400, quantity: 1 },
+    ];
+    const aiEstimateData = {
+        items,
+        totalEstimate: 108450,
+        paymentMilestones: [
+            { name: "Deposit", percentage: "30", amount: "32535" },
+            { name: "Progress", percentage: "40", amount: "43380" },
+            { name: "Final", percentage: "30", amount: "32535" },
+        ],
+    };
+    return {
+        id: "takeoff-1",
+        name: "Kitchen Remodel",
+        projectId: "project-1",
+        leadId: null,
+        aiEstimateData: JSON.stringify(aiEstimateData),
+    };
+}
+
+function canonicalCompanySettings() {
+    return { salesTaxes: JSON.stringify([{ name: "Clark County WA", rate: 8.4 }]) };
+}
+
+test("canonical conversion: tax row stripped from line items, rate/name/total persisted correctly, milestones tie to the stored total", async () => {
+    state.takeoff = canonicalTakeoff();
+    state.companySettings = canonicalCompanySettings();
+
+    const res = await POST(postRequest("takeoff-1"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+
+    // No tax row reached EstimateItem.
+    assert.equal(calls.estimateItemCreates.length, 3);
+    for (const call of calls.estimateItemCreates) {
+        assert.notEqual(call.data.name, "WA Sales Tax");
+    }
+
+    // Estimate.taxRatePercent / taxRateName as expected — exactly one configured tax matched 8.4%.
+    assert.equal(calls.estimateCreates.length, 1);
+    const estimateData = calls.estimateCreates[0].data;
+    assert.equal(estimateData.taxRatePercent, 8.4);
+    assert.equal(estimateData.taxRateName, "Clark County WA");
+
+    // Estimate.totalAmount / balanceDue are the tax-INCLUSIVE total: preTaxSubtotal(100000) +
+    // taxAmount(8400) = 108400 — NOT aiData.totalEstimate (108450), which was the AI's own
+    // (drifted) tax-inclusive figure.
+    assert.equal(estimateData.totalAmount, 108400);
+    assert.equal(estimateData.balanceDue, 108400);
+
+    // Payment schedule amounts sum EXACTLY to the persisted total, not to the stale
+    // aiData-totalEstimate-based amounts (32535/43380/32535 -> 108450).
+    assert.equal(calls.estimatePaymentScheduleCreates.length, 3);
+    const amounts = calls.estimatePaymentScheduleCreates.map((c) => c.data.amount);
+    const amountSum = amounts.reduce((s, a) => s + a, 0);
+    assert.equal(Math.round(amountSum * 100) / 100, estimateData.totalAmount);
+    assert.deepEqual(amounts, [32520, 43360, 32520]);
+    const percentages = calls.estimatePaymentScheduleCreates.map((c) => c.data.percentage);
+    assert.deepEqual(percentages, [30, 40, 30]);
+
+    // Item monetary fields, not just count/name: the Frame row carries baseCost/unitCost that
+    // imply a real margin, and must store derivedMarginPct(baseCost, unitCost) — NOT the 25%
+    // default a broken conversion would silently fall back to.
+    const frameCall = calls.estimateItemCreates.find((c) => c.data.name === "Frame");
+    assert.ok(frameCall, "expected a Frame line item");
+    assert.equal(frameCall!.data.quantity, 2);
+    assert.equal(frameCall!.data.baseCost, 20000);
+    assert.equal(frameCall!.data.unitCost, 35000);
+    assert.equal(frameCall!.data.total, 35000);
+    const expectedFrameMargin = derivedMarginPct(20000, 35000);
+    assert.equal(frameCall!.data.markupPercent, expectedFrameMargin);
+    assert.notEqual(expectedFrameMargin, 25); // proves this isn't just the default
+
+    // The takeoff itself must be linked to the new estimate and marked Completed.
+    assert.equal(calls.takeoffUpdates.length, 1);
+    assert.equal(calls.takeoffUpdates[0].data.estimateId, "est-1");
+    assert.equal(calls.takeoffUpdates[0].data.status, "Completed");
+});
+
+// --- bail-out case: no usable rate ------------------------------------------------------------
+
+function bailOutTakeoff() {
+    // Tax row implies a 40% rate — outside the (0, 30] trust bound — so splitTakeoffTax bails out
+    // and the route must fall back to its pre-existing (legacy) behavior verbatim.
+    const items = [
+        { costCode: "01-DEMO", name: "Demo", total: 1000, unitCost: 1000, quantity: 1 },
+        { costCode: "99-TAX", name: "Suspicious Tax Line", total: 400, unitCost: 400, quantity: 1 },
+    ];
+    const aiEstimateData = {
+        items,
+        totalEstimate: 1400,
+        paymentMilestones: [{ name: "Payment in full", percentage: "100", amount: "1400" }],
+    };
+    return {
+        id: "takeoff-2",
+        name: "Small Job",
+        projectId: null,
+        leadId: "lead-1",
+        aiEstimateData: JSON.stringify(aiEstimateData),
+    };
+}
+
+test("bail-out path: tax row persists as a line item, taxRatePercent left unset, legacy milestone amounts kept", async () => {
+    state.takeoff = bailOutTakeoff();
+
+    const res = await POST(postRequest("takeoff-2"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+
+    // The tax row is still a real line item.
+    assert.equal(calls.estimateItemCreates.length, 2);
+    assert.ok(calls.estimateItemCreates.some((c) => c.data.name === "Suspicious Tax Line"));
+
+    // taxRatePercent / taxRateName were never set on the create payload.
+    const estimateData = calls.estimateCreates[0].data;
+    assert.equal("taxRatePercent" in estimateData, false);
+    assert.equal("taxRateName" in estimateData, false);
+    assert.equal(estimateData.totalAmount, 1400);
+
+    // Legacy behavior: milestone amount/percentage read straight off the stored strings.
+    assert.equal(calls.estimatePaymentScheduleCreates.length, 1);
+    assert.equal(calls.estimatePaymentScheduleCreates[0].data.amount, 1400);
+    assert.equal(calls.estimatePaymentScheduleCreates[0].data.percentage, 100);
+});
+
+// --- bail-out with a milestone split that does NOT tie to the total ---------------------------
+
+function bailOutMismatchedMilestonesTakeoff() {
+    // Same 40%-implied-rate bail-out shape as bailOutTakeoff, but the stored milestone
+    // percentage/amount strings deliberately do NOT sum to the total. The bail-out path
+    // deliberately does not recompute milestones (that's legacy, pre-existing behavior) — this
+    // fixture proves it by making a naive recompute change the numbers if it ever ran.
+    const items = [
+        { costCode: "01-DEMO", name: "Demo", total: 1000, unitCost: 1000, quantity: 1 },
+        { costCode: "99-TAX", name: "Suspicious Tax Line", total: 400, unitCost: 400, quantity: 1 },
+    ];
+    const aiEstimateData = {
+        items,
+        totalEstimate: 1400,
+        paymentMilestones: [
+            { name: "Deposit", percentage: "50", amount: "700.55" },
+            { name: "Final", percentage: "50", amount: "800.10" },
+        ],
+    };
+    return {
+        id: "takeoff-3",
+        name: "Mismatched Job",
+        projectId: null,
+        leadId: "lead-1",
+        aiEstimateData: JSON.stringify(aiEstimateData),
+    };
+}
+
+test("bail-out path: mismatched milestone amounts are preserved VERBATIM, not recomputed to tie", async () => {
+    state.takeoff = bailOutMismatchedMilestonesTakeoff();
+
+    const res = await POST(postRequest("takeoff-3"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+
+    assert.equal(calls.estimatePaymentScheduleCreates.length, 2);
+    const amounts = calls.estimatePaymentScheduleCreates.map((c) => c.data.amount);
+    // Verbatim parseFloat of the stored strings — 700.55 + 800.10 = 1500.65, which does NOT equal
+    // the estimate total (1400). That mismatch is the point: the bail-out path is documented to
+    // leave milestones exactly as the legacy data had them.
+    assert.deepEqual(amounts, [700.55, 800.1]);
+    const sum = amounts.reduce((s, a) => s + a, 0);
+    assert.notEqual(Math.round(sum * 100) / 100, calls.estimateCreates[0].data.totalAmount);
+});
+
+// --- zero-total tax row (explicitly untaxed, including on a bail-adjacent shape) ---------------
+
+function zeroTaxTakeoff() {
+    const items = [
+        { costCode: "01-DEMO", name: "Demo", total: 40000, unitCost: 40000, quantity: 1 },
+        { costCode: "99-TAX", name: "WA Sales Tax", total: 0, unitCost: 0, quantity: 1 },
+    ];
+    const aiEstimateData = {
+        items,
+        totalEstimate: 40000,
+        paymentMilestones: [{ name: "Payment in full", percentage: "100", amount: "40000" }],
+    };
+    return {
+        id: "takeoff-zero-tax",
+        name: "Untaxed Job",
+        projectId: "project-1",
+        leadId: null,
+        aiEstimateData: JSON.stringify(aiEstimateData),
+    };
+}
+
+test("zero-total 99-TAX row: taxRatePercent persists as 0 (not absent), no tax line item, total is the pre-tax subtotal", async () => {
+    state.takeoff = zeroTaxTakeoff();
+    state.companySettings = null;
+
+    const res = await POST(postRequest("takeoff-zero-tax"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+
+    // The route's route-level conditions must use `!= null`, not truthiness — a truthy check
+    // would treat a real `taxRatePercent: 0` the same as "no rate", silently reverting to the
+    // legacy (tax-row-kept, no-rate) shape.
+    assert.equal(calls.estimateItemCreates.length, 1);
+    assert.ok(calls.estimateItemCreates.every((c) => c.data.name !== "WA Sales Tax"));
+
+    const estimateData = calls.estimateCreates[calls.estimateCreates.length - 1].data;
+    assert.equal("taxRatePercent" in estimateData, true);
+    assert.equal(estimateData.taxRatePercent, 0);
+    assert.equal(estimateData.totalAmount, 40000);
+    assert.equal(estimateData.balanceDue, 40000);
+});
+
+// --- milestone residual absorption --------------------------------------------------------------
+
+function residualMilestoneTakeoff() {
+    // Three equal thirds of a total that doesn't divide evenly: 33.3333% each. Without the
+    // last-milestone-absorbs-the-residual behavior, 33.33 + 33.33 + 33.33 = 99.99, four cents shy
+    // of the 100 total below.
+    const items = [
+        { costCode: "01-DEMO", name: "Demo", total: 100, unitCost: 100, quantity: 1 },
+        { costCode: "99-TAX", name: "WA Sales Tax", total: 0, unitCost: 0, quantity: 1 },
+    ];
+    const aiEstimateData = {
+        items,
+        totalEstimate: 100,
+        paymentMilestones: [
+            { name: "First", percentage: "33.3333", amount: "33.33" },
+            { name: "Second", percentage: "33.3333", amount: "33.33" },
+            { name: "Third", percentage: "33.3333", amount: "33.33" },
+        ],
+    };
+    return {
+        id: "takeoff-residual",
+        name: "Residual Job",
+        projectId: "project-1",
+        leadId: null,
+        aiEstimateData: JSON.stringify(aiEstimateData),
+    };
+}
+
+test("milestone residual: an uneven three-way split still sums EXACTLY to the total", async () => {
+    state.takeoff = residualMilestoneTakeoff();
+    state.companySettings = null;
+
+    const res = await POST(postRequest("takeoff-residual"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+
+    const estimateData = calls.estimateCreates[calls.estimateCreates.length - 1].data;
+    assert.equal(estimateData.totalAmount, 100);
+
+    const amounts = calls.estimatePaymentScheduleCreates.map((c) => c.data.amount);
+    const sum = amounts.reduce((s, a) => s + a, 0);
+    assert.equal(Math.round(sum * 100) / 100, 100);
+    // The last milestone absorbs the rounding residual, so it is not simply "33.33" like the
+    // other two.
+    assert.deepEqual(amounts, [33.33, 33.33, 33.34]);
+});
+
+// --- percentage normalization -------------------------------------------------------------------
+
+function nonNormalizedPercentageTakeoff() {
+    // Percentages sum to 90, not 100 — must be normalized so both the stored percentages and the
+    // resulting amounts sum correctly.
+    const items = [
+        { costCode: "01-DEMO", name: "Demo", total: 1000, unitCost: 1000, quantity: 1 },
+        { costCode: "99-TAX", name: "WA Sales Tax", total: 0, unitCost: 0, quantity: 1 },
+    ];
+    const aiEstimateData = {
+        items,
+        totalEstimate: 1000,
+        paymentMilestones: [
+            { name: "Deposit", percentage: "20", amount: "200" },
+            { name: "Progress", percentage: "30", amount: "300" },
+            { name: "Final", percentage: "40", amount: "400" },
+        ],
+    };
+    return {
+        id: "takeoff-normalize",
+        name: "Normalize Job",
+        projectId: "project-1",
+        leadId: null,
+        aiEstimateData: JSON.stringify(aiEstimateData),
+    };
+}
+
+test("milestone percentages that sum to 90 are normalized to sum to 100, amounts still sum to the total", async () => {
+    state.takeoff = nonNormalizedPercentageTakeoff();
+    state.companySettings = null;
+
+    const res = await POST(postRequest("takeoff-normalize"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+
+    const estimateData = calls.estimateCreates[calls.estimateCreates.length - 1].data;
+    assert.equal(estimateData.totalAmount, 1000);
+
+    const percentages = calls.estimatePaymentScheduleCreates.map((c) => c.data.percentage);
+    const percentageSum = Math.round(percentages.reduce((s, p) => s + p, 0) * 100) / 100;
+    assert.equal(percentageSum, 100);
+    assert.notDeepEqual(percentages, [20, 30, 40]);
+
+    const amounts = calls.estimatePaymentScheduleCreates.map((c) => c.data.amount);
+    const amountSum = Math.round(amounts.reduce((s, a) => s + a, 0) * 100) / 100;
+    assert.equal(amountSum, 1000);
+    assert.deepEqual(percentages, [22.22, 33.33, 44.45]);
+    assert.deepEqual(amounts, [222.2, 333.3, 444.5]);
+});
+
+// --- zero milestones and a single milestone -----------------------------------------------------
+
+function zeroMilestoneTakeoff() {
+    const items = [
+        { costCode: "01-DEMO", name: "Demo", total: 500, unitCost: 500, quantity: 1 },
+        { costCode: "99-TAX", name: "WA Sales Tax", total: 0, unitCost: 0, quantity: 1 },
+    ];
+    const aiEstimateData = { items, totalEstimate: 500, paymentMilestones: [] };
+    return {
+        id: "takeoff-zero-milestones",
+        name: "No Milestones Job",
+        projectId: "project-1",
+        leadId: null,
+        aiEstimateData: JSON.stringify(aiEstimateData),
+    };
+}
+
+test("zero milestones: no crash, no schedule rows created", async () => {
+    state.takeoff = zeroMilestoneTakeoff();
+    state.companySettings = null;
+
+    const res = await POST(postRequest("takeoff-zero-milestones"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+    assert.equal(calls.estimatePaymentScheduleCreates.length, 0);
+});
+
+function singleMilestoneTakeoff() {
+    const items = [
+        { costCode: "01-DEMO", name: "Demo", total: 500, unitCost: 500, quantity: 1 },
+        { costCode: "99-TAX", name: "WA Sales Tax", total: 0, unitCost: 0, quantity: 1 },
+    ];
+    const aiEstimateData = {
+        items,
+        totalEstimate: 500,
+        paymentMilestones: [{ name: "Payment in full", percentage: "100", amount: "500" }],
+    };
+    return {
+        id: "takeoff-single-milestone",
+        name: "One Milestone Job",
+        projectId: "project-1",
+        leadId: null,
+        aiEstimateData: JSON.stringify(aiEstimateData),
+    };
+}
+
+test("a single milestone gets the full total, no crash", async () => {
+    state.takeoff = singleMilestoneTakeoff();
+    state.companySettings = null;
+
+    const res = await POST(postRequest("takeoff-single-milestone"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+    assert.equal(calls.estimatePaymentScheduleCreates.length, 1);
+    assert.equal(calls.estimatePaymentScheduleCreates[0].data.amount, 500);
+    assert.equal(calls.estimatePaymentScheduleCreates[0].data.percentage, 100);
+});
+
+// --- salesTaxes Array.isArray guard --------------------------------------------------------------
+
+function taxedTakeoffForNaming(id: string) {
+    const items = [
+        { costCode: "01-DEMO", name: "Demo", total: 10000, unitCost: 10000, quantity: 1 },
+        { costCode: "99-TAX", name: "WA Sales Tax", total: 840, unitCost: 840, quantity: 1 },
+    ];
+    const aiEstimateData = {
+        items,
+        totalEstimate: 10840,
+        paymentMilestones: [{ name: "Payment in full", percentage: "100", amount: "10840" }],
+    };
+    return {
+        id,
+        name: "Naming Job",
+        projectId: "project-1",
+        leadId: null,
+        aiEstimateData: JSON.stringify(aiEstimateData),
+    };
+}
+
+test("companySettings.salesTaxes of 'null' does not crash the conversion and names the rate 'Sales Tax'", async () => {
+    state.takeoff = taxedTakeoffForNaming("takeoff-salestax-null");
+    state.companySettings = { salesTaxes: "null" };
+
+    const res = await POST(postRequest("takeoff-salestax-null"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+
+    const estimateData = calls.estimateCreates[calls.estimateCreates.length - 1].data;
+    assert.equal(estimateData.taxRatePercent, 8.4);
+    assert.equal(estimateData.taxRateName, "Sales Tax");
+});
+
+test("companySettings.salesTaxes of '{}' does not crash the conversion and names the rate 'Sales Tax'", async () => {
+    state.takeoff = taxedTakeoffForNaming("takeoff-salestax-object");
+    state.companySettings = { salesTaxes: "{}" };
+
+    const res = await POST(postRequest("takeoff-salestax-object"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+
+    const estimateData = calls.estimateCreates[calls.estimateCreates.length - 1].data;
+    assert.equal(estimateData.taxRatePercent, 8.4);
+    assert.equal(estimateData.taxRateName, "Sales Tax");
+});
+
+// --- tax jurisdiction naming branches --------------------------------------------------------
+
+test("ambiguous match: two configured taxes at the same derived rate names it 'Sales Tax', not either jurisdiction", async () => {
+    state.takeoff = taxedTakeoffForNaming("takeoff-salestax-ambiguous");
+    state.companySettings = {
+        salesTaxes: JSON.stringify([
+            { name: "Clark County WA", rate: 8.4 },
+            { name: "Vancouver WA", rate: 8.4 },
+        ]),
+    };
+
+    const res = await POST(postRequest("takeoff-salestax-ambiguous"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+
+    const estimateData = calls.estimateCreates[calls.estimateCreates.length - 1].data;
+    assert.equal(estimateData.taxRatePercent, 8.4);
+    assert.equal(estimateData.taxRateName, "Sales Tax");
+});
+
+test("a near-miss rate (8.409%) does NOT inherit a configured 8.4% jurisdiction's name (tight tolerance)", async () => {
+    const items = [
+        { costCode: "01-DEMO", name: "Demo", total: 100000, unitCost: 100000, quantity: 1 },
+        { costCode: "99-TAX", name: "WA Sales Tax", total: 8409, unitCost: 8409, quantity: 1 },
+    ];
+    const aiEstimateData = {
+        items,
+        totalEstimate: 108409,
+        paymentMilestones: [{ name: "Payment in full", percentage: "100", amount: "108409" }],
+    };
+    state.takeoff = {
+        id: "takeoff-near-miss-rate",
+        name: "Near Miss Job",
+        projectId: "project-1",
+        leadId: null,
+        aiEstimateData: JSON.stringify(aiEstimateData),
+    };
+    state.companySettings = { salesTaxes: JSON.stringify([{ name: "Clark County WA", rate: 8.4 }]) };
+
+    const res = await POST(postRequest("takeoff-near-miss-rate"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+
+    const estimateData = calls.estimateCreates[calls.estimateCreates.length - 1].data;
+    assert.equal(estimateData.taxRatePercent, 8.409);
+    // Old (0.01) tolerance would have matched Clark County WA here; the tightened (0.0001)
+    // tolerance must not, since 8.409% genuinely is not Clark County's 8.4% rate.
+    assert.equal(estimateData.taxRateName, "Sales Tax");
+});
+
+test("no match: a configured tax list with no matching rate names it 'Sales Tax'", async () => {
+    state.takeoff = taxedTakeoffForNaming("takeoff-salestax-nomatch");
+    state.companySettings = { salesTaxes: JSON.stringify([{ name: "Some Other County", rate: 6.5 }]) };
+
+    const res = await POST(postRequest("takeoff-salestax-nomatch"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+
+    const estimateData = calls.estimateCreates[calls.estimateCreates.length - 1].data;
+    assert.equal(estimateData.taxRatePercent, 8.4);
+    assert.equal(estimateData.taxRateName, "Sales Tax");
+});
+
+// --- aiData.items Array.isArray guard, and the numOr'd legacy total fallback -------------------
+
+test("a non-array aiData.items does not throw a 500 — falls back to zero items", async () => {
+    const aiEstimateData = { items: "not-an-array", totalEstimate: 5000, paymentMilestones: [] };
+    state.takeoff = {
+        id: "takeoff-nonarray-items",
+        name: "Malformed Job",
+        projectId: "project-1",
+        leadId: null,
+        aiEstimateData: JSON.stringify(aiEstimateData),
+    };
+    state.companySettings = null;
+
+    const res = await POST(postRequest("takeoff-nonarray-items"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+    assert.equal(calls.estimateItemCreates.length, 0);
+    assert.equal(calls.estimateCreates[calls.estimateCreates.length - 1].data.totalAmount, 5000);
+});
+
+test("the legacy totalEstimate fallback sums stringy totals numerically, not by string concatenation", async () => {
+    // No aiData.totalEstimate at all, and no tax row (so the split bails and the route falls back
+    // to summing raw item totals itself) — `"0" + "1000"` would concatenate to "01000" under the
+    // old `i.total || 0` reducer; numOr must sum these as 1000 + 500 = 1500.
+    const aiEstimateData = {
+        items: [
+            { costCode: "01-DEMO", name: "Demo", total: "1000", unitCost: "1000", quantity: 1 },
+            { costCode: "02-FRAME", name: "Frame", total: "500", unitCost: "500", quantity: 1 },
+        ],
+        paymentMilestones: [],
+    };
+    state.takeoff = {
+        id: "takeoff-stringy-totals",
+        name: "Stringy Totals Job",
+        projectId: "project-1",
+        leadId: null,
+        aiEstimateData: JSON.stringify(aiEstimateData),
+    };
+    state.companySettings = null;
+
+    const res = await POST(postRequest("takeoff-stringy-totals"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+
+    const estimateData = calls.estimateCreates[calls.estimateCreates.length - 1].data;
+    assert.equal(estimateData.totalAmount, 1500);
+    assert.equal(typeof estimateData.totalAmount, "number");
+});

--- a/tests/takeoff-convert-tax.test.ts
+++ b/tests/takeoff-convert-tax.test.ts
@@ -7,18 +7,52 @@
  * math passing tells us nothing about whether the route wired the real values through correctly —
  * this test drives the actual POST handler against a mocked Prisma and asserts on what was written.
  *
- * Requires Node's module-mocking flag: `--experimental-test-module-mocks` (see package.json).
- *
  * `@/lib/prisma` is mocked ONCE at module scope (not per-test / not re-imported) because
- * re-registering `mock.module` for the same specifier across multiple dynamic re-imports of the
- * route was observed to silently keep serving the FIRST test's mocked prisma object instead of a
- * fresh one — the route module doesn't seem to actually re-evaluate its `@/lib/prisma` import on a
+ * re-registering the mock for the same specifier across multiple dynamic re-imports of the route
+ * was observed to silently keep serving the FIRST test's mocked prisma object instead of a fresh
+ * one — the route module doesn't seem to actually re-evaluate its `@/lib/prisma` import on a
  * cache-busted re-import. Instead, the fake Prisma's behavior reads from a single mutable `state`
  * object that each test overwrites before calling the (single, statically loaded) route handler.
+ *
+ * HOW THE MOCK IS APPLIED — and why this is a manual `Module.prototype.require` patch rather than
+ * `node:test`'s own `mock.module()`, even though `--experimental-test-module-mocks` sounds like
+ * exactly the built-in tool for this job:
+ *
+ * This suite passed locally (this workstation runs Node 24) on every run while failing in CI
+ * (pinned to Node 20 — see .github/workflows/ci.yml) on every run, always with the same symptom:
+ * `TypeError: POST is not a function` across all 15 tests. Reproducing CI's exact Node version
+ * directly (not just "some Linux box" — Node 20.19.0 on a real Linux filesystem) isolated the
+ * cause precisely:
+ *
+ *   - tsx compiles this test file (and the route it dynamically imports) to CommonJS —
+ *     `typeof __dirname === "string"` at runtime here proves it — and route.ts's static
+ *     `import { prisma } from "@/lib/prisma"` transpiles to a literal `require("@/lib/prisma")`
+ *     call, alias text left untouched (tsx defers "@/..." alias resolution to its own require
+ *     hook rather than rewriting the string at transform time). Confirmed by monkey-patching
+ *     `Module.prototype.require` and logging every call made while importing the route.
+ *   - `node:test`'s `mock.module()` does not merely fail to intercept that CJS `require()` call on
+ *     Node 20 — calling it AT ALL (even wrapped in try/catch, even when its own registration call
+ *     doesn't throw) corrupts something in the require chain such that a subsequent, otherwise-
+ *     working manual `require()` patch for the same specifier stops taking effect too. Confirmed
+ *     by an A/B run on Node 20.19.0: identical test file, only the `mock.module()` call present vs
+ *     removed — present: all 15 fail with `POST is not a function`; removed (require-patch only):
+ *     all 15 pass. Node 22+ does not exhibit this — `mock.module()` alone was already sufficient
+ *     there, which is exactly why this was invisible on every local run.
+ *
+ * Given `mock.module()` is actively unsafe here on the Node version this repo's CI actually runs,
+ * this file does not call it at all, and `--experimental-test-module-mocks` has been dropped from
+ * `test:unit` in package.json (no other file in that script uses `mock.module` — verified by grep
+ * across every file `test:unit` runs before making that change). The mock is instead a plain
+ * `Module.prototype.require` override scoped to the exact literal specifier route.ts uses
+ * ("@/lib/prisma"), restored immediately after the route's one-time synchronous load. This is
+ * fully deterministic — it doesn't depend on any module resolver's notion of what "@/lib/prisma"
+ * resolves to, only on Node's own `require()` dispatch, which both Node 20 and Node 22+ interpose
+ * on. See `before()` below.
  */
 
-import { test, mock, before, beforeEach } from "node:test";
+import { test, before, beforeEach } from "node:test";
 import assert from "node:assert/strict";
+import Module from "node:module";
 import { derivedMarginPct } from "../src/lib/budget-math";
 
 type CreateCall<T> = { data: T };
@@ -84,9 +118,57 @@ const fakePrisma = {
 // time any test body runs.
 let POST: (req: Request) => Promise<Response>;
 
+// The literal specifier route.ts uses for its own `import { prisma } from "@/lib/prisma"` — see
+// the file-header comment for why the mock below is keyed on this exact string (route.ts's own
+// unresolved import text, confirmed by intercepting every require() call while loading it) rather
+// than any path the test file itself computes for where it thinks that module lives.
+const PRISMA_SPECIFIER = "@/lib/prisma";
+
 before(async () => {
-    mock.module("../src/lib/prisma", { namedExports: { prisma: fakePrisma } });
-    const routeModule = await import("../src/app/api/takeoffs/convert-to-estimate/route");
+    // A manual CJS require() patch — see the file-header comment for why this replaces
+    // node:test's own `mock.module()` entirely rather than supplementing it. Scoped narrowly to
+    // the literal "@/lib/prisma" string so it can never shadow any other module, and restored in
+    // `finally` immediately after the route's one-time synchronous load — everything the route
+    // needs from prisma is captured into its closures at that moment, so nothing downstream
+    // depends on the patch staying in place.
+    const originalRequire = Module.prototype.require;
+    let requirePatchHit = false;
+    (Module.prototype as unknown as { require: (id: string) => unknown }).require = function (
+        this: NodeModule,
+        id: string,
+    ) {
+        if (id === PRISMA_SPECIFIER) {
+            requirePatchHit = true;
+            return { prisma: fakePrisma };
+        }
+        // eslint-disable-next-line prefer-rest-params
+        return originalRequire.apply(this, arguments as unknown as [string]);
+    } as typeof Module.prototype.require;
+
+    let routeModule: { POST?: unknown };
+    try {
+        routeModule = await import("../src/app/api/takeoffs/convert-to-estimate/route");
+    } finally {
+        Module.prototype.require = originalRequire;
+    }
+
+    // Loud, explicit guard: a mock that silently fails to apply must never again surface as 15
+    // mysterious "POST is not a function" failures scattered across every test body. If the patch
+    // above never actually reached route.ts's "@/lib/prisma" import, fail here, once, with the
+    // exact specifier it was keyed on and whether the patch even fired.
+    if (typeof routeModule.POST !== "function") {
+        throw new Error(
+            `takeoff-convert-tax.test.ts: mock of "${PRISMA_SPECIFIER}" did not apply — ` +
+                `route module's POST export is ${typeof routeModule.POST}, not a function. ` +
+                `The require() patch scoped to "${PRISMA_SPECIFIER}" ` +
+                `${requirePatchHit ? "WAS" : "was NOT"} hit while importing ` +
+                `"../src/app/api/takeoffs/convert-to-estimate/route". ` +
+                `If this fires, the route's "@/lib/prisma" import is resolving to something other ` +
+                `than the literal string "${PRISMA_SPECIFIER}" on this Node/tsx combination — ` +
+                `update PRISMA_SPECIFIER (and the require() patch's match) to whatever it resolves ` +
+                `to here instead of silently letting these tests fail downstream.`,
+        );
+    }
     POST = routeModule.POST as any;
 });
 

--- a/tests/takeoff-tax-split.test.ts
+++ b/tests/takeoff-tax-split.test.ts
@@ -1,0 +1,316 @@
+/**
+ * splitTakeoffTax pulls the AI takeoff's `99-TAX` pass-through row(s) out of the item list and
+ * derives the rate they imply, so a takeoff-converted Estimate lands in the app's canonical tax
+ * shape (pre-tax line items + `taxRatePercent`) instead of the takeoff's own shape (tax baked
+ * into a line item, `taxRatePercent` left null).
+ *
+ * The headline test below is the regression this exists to fix: left in the takeoff's own shape,
+ * a null `taxRatePercent` reads downstream as "tax-exclusive, gross up by the default rate" — both
+ * the portal display and the approval gross-up in actions.ts do this — which double-taxes an
+ * already tax-inclusive total. `approvalGrossUp` and `portalDisplayTotal` below are small local
+ * models of those two call sites, not imports, so this test pins the CONTRACT rather than
+ * reaching into unrelated modules.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { splitTakeoffTax, rmc, numOrNull } from "../src/lib/takeoff-costing";
+
+// Mirrors src/lib/actions.ts's approval-time gross-up (ensureProjectAndDepositInvoiceForEstimate).
+function approvalGrossUp(total: number, taxRatePercent: number | null, taxExempt: boolean, defaultRate: number): number {
+    if (taxExempt || taxRatePercent != null) return total;
+    return rmc(total * (1 + defaultRate / 100));
+}
+
+// Mirrors src/app/portal/estimates/[id]/PortalEstimateClient.tsx's displayed total.
+function portalDisplayTotal(items: Array<{ total: number }>, taxRatePercent: number | null, defaultRate: number): number {
+    const subtotal = items.reduce((s, i) => s + i.total, 0);
+    const rate = taxRatePercent ?? defaultRate;
+    return rmc(subtotal + subtotal * (rate / 100));
+}
+
+test("canonical case: tax row stripped, subtotal/tax/rate derived correctly", () => {
+    const items = [
+        { costCode: "01-DEMO", total: 40000 },
+        { costCode: "02-FRAME", total: 35000 },
+        { costCode: "03-FINISH", total: 25000 },
+        { costCode: "99-TAX", total: 8400 },
+    ];
+    const result = splitTakeoffTax(items);
+    assert.equal(result.items.length, 3);
+    assert.ok(result.items.every((i: any) => i.costCode !== "99-TAX"));
+    assert.equal(result.preTaxSubtotal, 100000);
+    assert.equal(result.taxAmount, 8400);
+    assert.equal(result.taxRatePercent, 8.4);
+    assert.equal(rmc(result.preTaxSubtotal + result.taxAmount), 108400);
+});
+
+test("THE DOUBLE-TAX REGRESSION: old shape double-taxes, new shape does not", () => {
+    const defaultRate = 8.4;
+
+    // OLD SHAPE: tax row left in the items, taxRatePercent left null (today's behavior pre-fix).
+    const oldItems = [
+        { costCode: "01-DEMO", total: 40000 },
+        { costCode: "02-FRAME", total: 35000 },
+        { costCode: "03-FINISH", total: 25000 },
+        { costCode: "99-TAX", total: 8400 },
+    ];
+    const oldTotal = oldItems.reduce((s, i) => s + i.total, 0); // 108400, already tax-inclusive
+    // Approval grosses it up again because taxRatePercent is null.
+    assert.equal(approvalGrossUp(oldTotal, null, false, defaultRate), 117505.6);
+    // Portal display adds default tax on top of a subtotal that already includes the tax row.
+    assert.equal(portalDisplayTotal(oldItems, null, defaultRate), 117505.6);
+
+    // NEW SHAPE: split applied.
+    const split = splitTakeoffTax(oldItems);
+    assert.equal(split.taxRatePercent, 8.4);
+    const newTotal = rmc(split.preTaxSubtotal + split.taxAmount);
+    assert.equal(newTotal, 108400);
+    assert.equal(approvalGrossUp(newTotal, split.taxRatePercent, false, defaultRate), 108400);
+    assert.equal(portalDisplayTotal(split.items as Array<{ total: number }>, split.taxRatePercent, defaultRate), 108400);
+});
+
+test("no tax row: items unchanged, rate null, approval gross-up still fires", () => {
+    const items = [
+        { costCode: "01-DEMO", total: 40000 },
+        { costCode: "02-FRAME", total: 35000 },
+    ];
+    const result = splitTakeoffTax(items);
+    assert.deepEqual(result.items, items);
+    assert.equal(result.taxRatePercent, null);
+    assert.equal(result.preTaxSubtotal, 75000);
+    assert.equal(result.taxAmount, 0);
+    // Must NOT regress: the approval gross-up still needs to apply for a genuinely untaxed takeoff.
+    assert.equal(approvalGrossUp(75000, result.taxRatePercent, false, 8.4), 81300);
+});
+
+test("multiple tax rows (99-TAX and 99-TAX-STATE) sum into one rate", () => {
+    const items = [
+        { costCode: "01-DEMO", total: 50000 },
+        { costCode: "02-FRAME", total: 50000 },
+        { costCode: "99-TAX", total: 5000 },
+        { costCode: "99-TAX-STATE", total: 3400 },
+    ];
+    const result = splitTakeoffTax(items);
+    assert.equal(result.items.length, 2);
+    assert.equal(result.preTaxSubtotal, 100000);
+    assert.equal(result.taxAmount, 8400);
+    assert.equal(result.taxRatePercent, 8.4);
+});
+
+test("99-TAXABLE is not treated as a tax row", () => {
+    const items = [
+        { costCode: "01-DEMO", total: 50000 },
+        { costCode: "99-TAXABLE", total: 25000 },
+    ];
+    const result = splitTakeoffTax(items);
+    assert.deepEqual(result.items, items);
+    assert.equal(result.taxRatePercent, null);
+    assert.equal(result.preTaxSubtotal, 75000);
+});
+
+test("bail-out: zero pre-tax subtotal returns items unchanged and a null rate", () => {
+    const items = [
+        { costCode: "99-TAX", total: 100 },
+    ];
+    const result = splitTakeoffTax(items);
+    assert.deepEqual(result.items, items);
+    assert.equal(result.taxRatePercent, null);
+});
+
+test("bail-out: a tax row implying a rate above 30% returns items unchanged and a null rate", () => {
+    const items = [
+        { costCode: "01-DEMO", total: 1000 },
+        { costCode: "99-TAX", total: 400 }, // implies 40%
+    ];
+    const result = splitTakeoffTax(items);
+    assert.deepEqual(result.items, items);
+    assert.equal(result.taxRatePercent, null);
+});
+
+test("bail-out: a non-numeric/absent total on the tax row returns items unchanged and a null rate", () => {
+    const itemsNonNumeric = [
+        { costCode: "01-DEMO", total: 1000 },
+        { costCode: "99-TAX", total: "not-a-number" as any },
+    ];
+    const resultNonNumeric = splitTakeoffTax(itemsNonNumeric);
+    assert.deepEqual(resultNonNumeric.items, itemsNonNumeric);
+    assert.equal(resultNonNumeric.taxRatePercent, null);
+
+    const itemsAbsent = [
+        { costCode: "01-DEMO", total: 1000 },
+        { costCode: "99-TAX" } as any,
+    ];
+    const resultAbsent = splitTakeoffTax(itemsAbsent);
+    assert.deepEqual(resultAbsent.items, itemsAbsent);
+    assert.equal(resultAbsent.taxRatePercent, null);
+});
+
+test("a non-round rate (8.3775%) round-trips at 4 decimal places", () => {
+    const items = [
+        { costCode: "01-DEMO", total: 100000 },
+        { costCode: "99-TAX", total: 8377.5 },
+    ];
+    const result = splitTakeoffTax(items);
+    assert.equal(result.taxRatePercent, 8.3775);
+});
+
+test("bail-out: a non-numeric/absent total on a NON-tax row also returns items unchanged and a null rate", () => {
+    // A garbage non-tax total must not silently shrink preTaxSubtotal via numOr's 0-fallback,
+    // which would otherwise inflate the rate the (perfectly fine) tax row implies.
+    const itemsNonNumeric = [
+        { costCode: "01-DEMO", total: "garbage" as any },
+        { costCode: "02-FRAME", total: 50000 },
+        { costCode: "99-TAX", total: 4200 },
+    ];
+    const resultNonNumeric = splitTakeoffTax(itemsNonNumeric);
+    assert.deepEqual(resultNonNumeric.items, itemsNonNumeric);
+    assert.equal(resultNonNumeric.taxRatePercent, null);
+
+    const itemsAbsent = [
+        { costCode: "01-DEMO" } as any,
+        { costCode: "02-FRAME", total: 50000 },
+        { costCode: "99-TAX", total: 4200 },
+    ];
+    const resultAbsent = splitTakeoffTax(itemsAbsent);
+    assert.deepEqual(resultAbsent.items, itemsAbsent);
+    assert.equal(resultAbsent.taxRatePercent, null);
+});
+
+test("a rate that doesn't round-trip at 4dp keeps the exact (unrounded) rate so the stored total reconciles", () => {
+    // Exact rate is 8.37754%; rounding to 4dp (8.3775%) reproduces 8377.50, four cents short of the
+    // real 8377.54 tax amount — so the exact rate must be kept instead of the rounded one.
+    const items = [
+        { costCode: "01-DEMO", total: 100000 },
+        { costCode: "99-TAX", total: 8377.54 },
+    ];
+    const result = splitTakeoffTax(items);
+    // Compare against the exact (not the rounded-to-4dp) rate — floating-point division doesn't
+    // land on the clean literal 8.37754, so pin the reconciliation property instead of the exact
+    // float bits.
+    assert.ok(Math.abs(result.taxRatePercent! - 8.37754) < 1e-9);
+    assert.notEqual(result.taxRatePercent, 8.3775); // the rounded-4dp value that would NOT reconcile
+    assert.equal(rmc((result.preTaxSubtotal * result.taxRatePercent!) / 100), result.taxAmount);
+});
+
+test("a zero-total tax row on a positive subtotal is a real answer: rate 0, row stripped", () => {
+    const items = [
+        { costCode: "01-DEMO", total: 40000 },
+        { costCode: "02-FRAME", total: 35000 },
+        { costCode: "99-TAX", total: 0 },
+    ];
+    const result = splitTakeoffTax(items);
+    assert.equal(result.items.length, 2);
+    assert.ok(result.items.every((i: any) => i.costCode !== "99-TAX"));
+    assert.equal(result.preTaxSubtotal, 75000);
+    assert.equal(result.taxAmount, 0);
+    assert.equal(result.taxRatePercent, 0);
+    // A rate of 0 must suppress the approval gross-up, same as any other real rate.
+    assert.equal(approvalGrossUp(75000, result.taxRatePercent, false, 8.4), 75000);
+});
+
+test("a zero-total tax row on a NEGATIVE subtotal is also a real answer: rate 0, row stripped (sign-independent)", () => {
+    const items = [
+        { costCode: "01-DEMO", total: -40000 },
+        { costCode: "99-TAX", total: 0 },
+    ];
+    const result = splitTakeoffTax(items);
+    assert.equal(result.items.length, 1);
+    assert.ok(result.items.every((i: any) => i.costCode !== "99-TAX"));
+    assert.equal(result.preTaxSubtotal, -40000);
+    assert.equal(result.taxAmount, 0);
+    assert.equal(result.taxRatePercent, 0);
+    // A rate of 0 must suppress the approval gross-up here too — otherwise the credit gets MORE
+    // negative, not less.
+    assert.equal(approvalGrossUp(-40000, result.taxRatePercent, false, 8.4), -40000);
+});
+
+test("credit estimate: negative subtotal + negative tax row derives the same rate as the positive pair", () => {
+    const items = [
+        { costCode: "01-DEMO", total: -40000 },
+        { costCode: "02-FRAME", total: -35000 },
+        { costCode: "03-FINISH", total: -25000 },
+        { costCode: "99-TAX", total: -8400 },
+    ];
+    const result = splitTakeoffTax(items);
+    assert.equal(result.items.length, 3);
+    assert.equal(result.preTaxSubtotal, -100000);
+    assert.equal(result.taxAmount, -8400);
+    assert.equal(result.taxRatePercent, 8.4);
+    // The credit total (subtotal + tax, both negative) is more negative, not less.
+    assert.equal(rmc(result.preTaxSubtotal + result.taxAmount), -108400);
+});
+
+test("credit estimate: a derived credit rate above 30% still bails out", () => {
+    const items = [
+        { costCode: "01-DEMO", total: -1000 },
+        { costCode: "99-TAX", total: -400 }, // implies 40%
+    ];
+    const result = splitTakeoffTax(items);
+    assert.deepEqual(result.items, items);
+    assert.equal(result.taxRatePercent, null);
+});
+
+test("mismatched signs (positive subtotal, negative tax row) bail out rather than guess", () => {
+    const items = [
+        { costCode: "01-DEMO", total: 100000 },
+        { costCode: "99-TAX", total: -8400 },
+    ];
+    const result = splitTakeoffTax(items);
+    assert.deepEqual(result.items, items);
+    assert.equal(result.taxRatePercent, null);
+});
+
+test("mismatched signs (negative subtotal, positive tax row) bail out rather than guess", () => {
+    const items = [
+        { costCode: "01-DEMO", total: -100000 },
+        { costCode: "99-TAX", total: 8400 },
+    ];
+    const result = splitTakeoffTax(items);
+    assert.deepEqual(result.items, items);
+    assert.equal(result.taxRatePercent, null);
+});
+
+// --- numOrNull ----------------------------------------------------------------------------------
+
+test("numOrNull: plain numbers pass through, non-finite numbers are null", () => {
+    assert.equal(numOrNull(12.5), 12.5);
+    assert.equal(numOrNull(0), 0);
+    assert.equal(numOrNull(-3), -3);
+    assert.equal(numOrNull(NaN), null);
+    assert.equal(numOrNull(Infinity), null);
+});
+
+test("numOrNull: numeric strings parse, with surrounding whitespace trimmed first", () => {
+    assert.equal(numOrNull("12.5"), 12.5);
+    assert.equal(numOrNull(" 12.5 "), 12.5);
+    assert.equal(numOrNull("\t8400\n"), 8400);
+    assert.equal(numOrNull("-40000"), -40000);
+});
+
+test("numOrNull: empty and whitespace-only strings are null, not a false zero", () => {
+    assert.equal(numOrNull(""), null);
+    assert.equal(numOrNull("   "), null);
+    assert.equal(numOrNull("\t\n"), null);
+});
+
+test("numOrNull: junk strings are null, not parseFloat's partial-parse leniency", () => {
+    assert.equal(numOrNull("12junk"), null);
+    assert.equal(numOrNull("not-a-number"), null);
+});
+
+test("numOrNull: null/undefined are null", () => {
+    assert.equal(numOrNull(null), null);
+    assert.equal(numOrNull(undefined), null);
+});
+
+test("numOrNull: booleans and non-primitive inputs are null, not Number()'s coercion", () => {
+    // Number(true) === 1, Number(false) === 0, Number([]) === 0, Number({}) === NaN — none of
+    // these describe "the caller handed us a usable number", so none should parse.
+    assert.equal(numOrNull(true), null);
+    assert.equal(numOrNull(false), null);
+    assert.equal(numOrNull([]), null);
+    assert.equal(numOrNull([42]), null);
+    assert.equal(numOrNull({}), null);
+    assert.equal(numOrNull({ value: 5 }), null);
+});


### PR DESCRIPTION
## The defect

The AI takeoff prompt emits WA sales tax as its own `99-TAX` **line item** and reports a **tax-INCLUSIVE** `totalEstimate`. `convert-to-estimate` stored that total on the Estimate but never set `taxRatePercent`.

Downstream, a null `taxRatePercent` means *"this total is tax-EXCLUSIVE, gross it up once by the company default rate"*:

- `PortalEstimateClient` sums the line items — **the 99-TAX row included** — then adds tax on top of that subtotal.
- `ensureProjectAndDepositInvoiceForEstimate` multiplies `totalAmount`, `balanceDue` and every Pending milestone by `(1 + defaultRate/100)`.

So the client both **saw** and **signed** a contract taxed twice. At the production default rate of 8.8%, a $108,400 contract presents as **$117,939**.

Surfaced as a documented caveat by the Codex round-2 review on #361 and deliberately not fixed there.

## Production footprint: ZERO

`scripts/audit-takeoff-double-tax.mjs` (read-only, no `--apply`, no write statement in the file) reports **0 affected estimates**. The `Takeoff` table is empty on prod, and no estimate item anywhere carries a `99-TAX` cost code or a sales-tax name.

Control run to prove the zero is real and not a bad connection: 116 estimates, 79 projects, 1,303 estimate items, 85 null-rate estimates. The database is live; the takeoff population is genuinely empty.

**No data repair ships with this PR and none is needed.** The script is kept so the question can be re-asked once the takeoff feature is in real use.

## The fix

`splitTakeoffTax()` normalizes a converted takeoff into the app's canonical tax shape — line items **pre-tax**, `taxRatePercent` carrying the rate the tax row implies, `totalAmount` tax-inclusive. Milestones are re-proportioned against the stored total so they still sum to it exactly.

It refuses to guess. When the tax row(s) don't imply a trustworthy rate — zero pre-tax subtotal, any row whose total isn't a usable number, subtotal and tax with opposite signs, or a derived rate outside `(0, 30]` — it returns the items unchanged and sets no rate, preserving today's behavior rather than inventing a number on the money path. A tax row totalling exactly zero is treated as an **answer** (rate 0, suppressing the gross-up), not an absence.

`marginPercentFor` and the true-markup to gross-margin-on-sell conversion are untouched.

### Known limit, accepted deliberately

The rate is derived as `taxAmount / preTaxSubtotal`, which assumes the AI taxed the whole subtotal — exactly what the prompt instructs. If a takeoff ever taxes only part of the base, the derived rate is a **blended** rate: the stored total still ties out to the penny today, but a later edit reprices tax at the blended rate.

Codex argued for hard-failing instead. Rejected with numbers: on a $50k taxable + $50k exempt job, splitting stores the correct $104,200 today, while bailing out produces $113,369.60 — an immediate **$9,169.60 overcharge**. The post-edit drift is $420. Wrong-now is worse than approximate-later.

## Also fixed (all from the two Codex rounds on this diff)

- `numOrNull("   ")` returned **0** — whitespace read as a genuine zero, so a blank tax total became "explicitly untaxed". Now trims before the emptiness check and accepts only `number`/`string`.
- A garbage total on a **non-tax** row silently shrank the base, inflating the derived rate.
- An untaxed **credit** (negative subtotal, zero tax row) bailed out and was then grossed up, making the credit larger.
- 4dp rate rounding could leave the portal displaying **$108,377.50** against a stored **$108,377.54**. The exact rate is kept whenever the rounded one doesn't reproduce the tax amount.
- `taxRateName` took the **first** configured tax within 0.01 of the derived rate — two cities commonly share a rate, so a signed document could name the wrong jurisdiction. Now requires a unique match within 0.0001, else `"Sales Tax"`. The AI line's own name is no longer trusted at all.
- A non-array `salesTaxes` setting (`"null"`, `"{}"`) crashed the whole conversion.
- The legacy total fallback string-concatenated stringy totals (`"01000500"` instead of `$1,500`).

## Tests

179 unit tests pass; `tsc --noEmit` clean.

- `tests/takeoff-tax-split.test.ts` — the split rules and the double-tax regression itself.
- `tests/takeoff-convert-tax.test.ts` — drives the **real route** against a mocked Prisma and asserts on **persisted** values.

That second file exists because Codex round 2 proved the first round of tests only exercised *local mirrors* of the production logic and would have passed on a fully broken route. Both files were mutation-tested: the production code was actually broken each way, the failure confirmed, then reverted.

## Out of scope, spun off separately

- `convert-to-estimate` is neither atomic nor idempotent (four unwrapped writes; no check that the takeoff was already converted, so a second call orphans the first estimate). Pre-existing, unrelated to tax.
- `marginPercentFor` falls back to the 25% default for negative costing.
- The AI prompt hardcodes **8.4%** (Clark County) while the company default is **8.8%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
