### PR TITLE
fix(security): delete the two caller-less contract server actions

### DIFF
--- a/AGENT_CONTEXT.md
+++ b/AGENT_CONTEXT.md
@@ -43,7 +43,7 @@ Colors: `text-hui-textMain` (#222), `text-hui-textMuted` (#666), `border-hui-bor
 `createInvoiceFromEstimate` · `getInvoice` · `getProjectInvoices` · `getAllInvoices` · `issueInvoice` · `deleteInvoice` · `updateInvoiceNotes` · `sendInvoiceToClient` · `getInvoiceForPortal` · `markInvoiceViewed` · `recordPayment`
 
 ### Contracts
-`getContracts` · `getContract` · `createContractFromTemplate` · `createContractBlank` · `updateContract` · `deleteContract` · `sendContractToClient` · `approveContract` · `getContractSigningHistory` · `markContractViewed`
+`getContract` · `createContractFromTemplate` · `createContractBlank` · `updateContract` · `deleteContract` · `sendContractToClient` · `approveContract` · `getContractSigningHistory` · `markContractViewed`
 
 ### Schedule
 `getScheduleTasks` · `getAllScheduleTasks` · `createScheduleTask` · `updateScheduleTask` · `deleteScheduleTask` · `linkTasks` · `unlinkTasks` · `importEstimateToSchedule` · `clearAllTasks` · `aiGenerateSchedule`

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -81,8 +81,9 @@ Blast radius of removing them was effectively nil: both were only ever called fr
 Components (server-render calls), never imported into a Client Component or bound to a
 `<form action>`, so no shipped browser bundle carries their action ids and no stale tab can
 call them. Deleting an action that *had* been serialized to clients is a different matter — stale
-tabs get "Failed to find Server Action" unless Vercel Skew Protection is on, which is a project
-setting and is not configured in `next.config.ts`.
+tabs get "Failed to find Server Action" unless Vercel Skew Protection is on. That is a Vercel
+project setting rather than repo config, so `next.config.ts` says nothing either way about it —
+its dashboard state has not been checked.
 
 `e2e/financial-action-auth.spec.ts` keeps both deleted, reading the export list off the
 TypeScript AST rather than by regex.

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -1,6 +1,6 @@
 # Contracts — System Status
 
-_Last updated: 2026-06-23. Snapshot of the whole contract system: what works, where it lives, what's deployed, and what's still open._
+_Last updated: 2026-08-13 (auth/dead-surface pass — #360, #367 and the caller-less-export deletion below). The capability, verification and deployment sections further down are still the 2026-06-23 snapshot and have NOT been re-verified since._
 
 ## TL;DR
 
@@ -53,7 +53,8 @@ Draft ──send──▶ Sent ──client opens──▶ Viewed ──client s
 
 | File | Role |
 |---|---|
-| `src/lib/actions.ts` | `createContract*`, `updateContract`, `sendContractToClient`, `getContractSendDefaults`, `signContractAsContractor`, `approveContract`, **`countersignContractAsCompany`**, `getExecutedContractPdf` |
+| `src/lib/actions.ts` | `createContract*`, `updateContract`, `sendContractToClient`, `getContractSendDefaults`, `signContractAsContractor`, `approveContract`, **`countersignContractAsCompany`** |
+| `src/lib/contract-files-core.ts` | `executedContractPdfFor` — session-free executed-PDF lookup, called directly by the client portal and by `countersignContractAsCompany`. The staff `getExecutedContractPdf` wrapper was deleted as caller-less dead surface (see note below) |
 | `src/lib/contract-finalize.ts` | shared `archiveExecutedContractPdf` + `sendExecutedContractEmails` (one writer for archive/email) |
 | `src/lib/pdf.ts` | `appendContractCountersignaturePage` (pdf-lib cert page), `embedSignatureImage` |
 | `src/lib/signature-storage.ts` | `persistSignature` (data-URL → Storage URL, graceful fallback) |
@@ -61,6 +62,30 @@ Draft ──send──▶ Sent ──client opens──▶ Viewed ──client s
 | `src/components/EntityContractsClient.tsx` | internal UI (shared by leads + projects) |
 | `src/app/portal/contracts/[id]/PortalContractClient.tsx` | customer signing UI + awaiting-countersign state |
 | `prisma/schema.prisma` | `Contract` (+ `requiresCountersign`, `companySigned*`, `signedPdfPath`), `ContractSigningRecord`, `CompanySettings.requireContractCountersign` |
+
+## Caller-less server actions are still endpoints (2026-08-13)
+
+`getContracts` and `getExecutedContractPdf` were gated by #367 and then deleted, because a
+caller survey found neither had a single call site — no static import, no `await import(...)`,
+nothing in the MCP route, `e2e/`, `scripts/`, or the mobile app.
+
+That does not make such an export inert. Next.js documents that unused actions *may* be
+eliminated, so this is stated as **measured ProBuild behaviour, not a universal rule**: on
+Next 16.2.11, `.next/server/server-reference-manifest.json` from a clean `npm run build`
+registered **360** server-action endpoints from `src/lib/actions.ts`, including 37 exports with
+no reference anywhere in `src/`. `getContracts` appears in that manifest before the deletion and
+is absent after it. A caller-less export is therefore live POST surface whose auth gate nothing
+exercises — worse than dead code, because it looks covered.
+
+Blast radius of removing them was effectively nil: both were only ever called from Server
+Components (server-render calls), never imported into a Client Component or bound to a
+`<form action>`, so no shipped browser bundle carries their action ids and no stale tab can
+call them. Deleting an action that *had* been serialized to clients is a different matter — stale
+tabs get "Failed to find Server Action" unless Vercel Skew Protection is on, which is a project
+setting and is not configured in `next.config.ts`.
+
+`e2e/financial-action-auth.spec.ts` keeps both deleted, reading the export list off the
+TypeScript AST rather than by regex.
 
 ## Related: Change Orders (dual-signature)
 

--- a/e2e/contract-auth-runtime.spec.ts
+++ b/e2e/contract-auth-runtime.spec.ts
@@ -21,7 +21,10 @@ import { signClientPortalToken } from "../src/lib/client-portal-auth";
  */
 
 const PROJECT_ID = "cmml6vt3y000lpwrh0p9p3k12";
-const OOS_PROJECT_ID = "e2e-scope-oos-project";
+// (The out-of-scope PROJECT id is referenced only in prose now — its last
+// runtime use went with the forged-descriptor test. The seeded project itself
+// is still required, both by the converted-contract fixture below and by
+// estimate-scope-labels.spec.ts, so only the unused constant is dropped here.)
 const OOS_LEAD_ID = "e2e-scope-oos-lead";
 const TEST_CLIENT_ID = "test-client-do-not-delete";
 const TEST_CLIENT_EMAIL = "test-client@goldentouchremodeling.com";
@@ -76,10 +79,14 @@ test.describe("the dispatcher's own gate", () => {
         test(`${label} gets a bare 404, not an action result`, async ({ request }) => {
             const res = await request.post("/api/test-only/contract-actions", {
                 headers: { "content-type": "application/json", ...headers },
-                // An ALLOWLISTED action, deliberately: if this named something
-                // unknown, the 404 could come from the allowlist rather than
-                // from the credential gate, and the test would pass even if the
-                // gate were removed.
+                // An ALLOWLISTED action, deliberately. This used to name
+                // `getContracts`, which the deletion turned into an unknown
+                // action. That would not have made the test vacuous — unknown
+                // actions answer 400, not 404, so an removed credential gate
+                // would still have failed the expected-404 assertion (Codex
+                // corrected my first reading of this). Naming a live action is
+                // simply more direct: the credential gate becomes the only
+                // thing in the request that can produce a 404.
                 data: { action: "getContract", args: [CONTRACT_INSCOPE_ID] },
             });
             expect(res.status()).toBe(404);
@@ -218,9 +225,15 @@ test.describe("staff with `contracts` + `leadAccess` but no access to the conver
     // a caller-supplied {projectId, leadId} descriptor — the hole #367 closed.
     // It could only be written against `getExecutedContractPdf`, because that
     // was the sole action in the family taking a descriptor rather than a bare
-    // id. That action has been deleted, so no remaining action in this
-    // dispatcher accepts caller-supplied ownership at all and the attack it
-    // guarded against has no entry point left. The session-free core it wrapped,
+    // id. That action has been deleted, so no surviving action in this
+    // dispatcher takes ownership as an AUTHORIZATION input: each authorizes by
+    // bare contract id and reloads current ownership from the row, leaving the
+    // read bypass no entry point. (Narrower than "accepts no caller-supplied
+    // ownership at all", which Codex showed is false: updateContract's payload
+    // still reaches Prisma by spread, so ownership keys can ride along in the
+    // UPDATE even though they cannot influence the access decision. That is a
+    // pre-existing mass-assignment gap, tracked separately, not something this
+    // branch introduced or removed coverage for.) The core it wrapped,
     // executedContractPdfFor, still takes a descriptor, but only from callers
     // that already hold the loaded row (the portal, after getContractForPortal
     // proves ownership; countersignContractAsCompany, after its own gate) — so

--- a/e2e/contract-auth-runtime.spec.ts
+++ b/e2e/contract-auth-runtime.spec.ts
@@ -76,7 +76,11 @@ test.describe("the dispatcher's own gate", () => {
         test(`${label} gets a bare 404, not an action result`, async ({ request }) => {
             const res = await request.post("/api/test-only/contract-actions", {
                 headers: { "content-type": "application/json", ...headers },
-                data: { action: "getContracts", args: [] },
+                // An ALLOWLISTED action, deliberately: if this named something
+                // unknown, the 404 could come from the allowlist rather than
+                // from the credential gate, and the test would pass even if the
+                // gate were removed.
+                data: { action: "getContract", args: [CONTRACT_INSCOPE_ID] },
             });
             expect(res.status()).toBe(404);
             const body = await res.text();
@@ -109,14 +113,9 @@ test.describe("unauthenticated caller", () => {
     );
 
     for (const [action, args] of [
-        ["getContracts", []],
         ["getContract", [CONTRACT_INSCOPE_ID]],
         ["updateContract", [CONTRACT_INSCOPE_ID, { title: "hacked" }]],
         ["deleteContract", [CONTRACT_INSCOPE_ID]],
-        [
-            "getExecutedContractPdf",
-            [{ id: CONTRACT_LEADONLY_ID, title: CONTRACT_LEADONLY_TITLE, projectId: null, leadId: OOS_LEAD_ID }],
-        ],
         ["getContractSigningHistory", [CONTRACT_INSCOPE_ID]],
         ["getContractSendDefaults", [CONTRACT_INSCOPE_ID]],
     ] as const) {
@@ -177,20 +176,14 @@ test.describe("staff with project access but no `contracts` permission (FINANCE)
         await expect(page.getByText("No contracts yet")).toBeVisible();
     });
 
-    // getContracts REFUSES rather than returning []. Its gate is
-    // assertStaffPermission("contracts"), which throws before
-    // contractScopeWhere is ever consulted — so the action and the pages answer
-    // "no contracts" by two different mechanisms, and only the pages (which
-    // query Prisma directly through contractScopeWhere, never through this
-    // action) degrade to an empty list. Asserting `ok: true, data: []` here
-    // fails against the real system; that is what the first live run showed.
-    test("getContracts refuses outright — it never degrades to an empty list", async ({ request }) => {
-        const result = await callAction(request, "getContracts", []);
-        expect(result.ok).toBe(false);
-        expect(result.error).toBe("Forbidden");
-        expect(result.raw).not.toContain(CONTRACT_INSCOPE_TOKEN);
-        expect(result.raw).not.toContain(CONTRACT_INSCOPE_BODY);
-    });
+    // A `getContracts` case sat here: it asserted the LIST action refuses this
+    // caller outright rather than degrading to an empty list, because its gate
+    // (assertStaffPermission) threw before contractScopeWhere was consulted.
+    // That action has since been deleted as caller-less dead surface, and the
+    // behaviour it described no longer has a subject — the two page tests just
+    // above are now the whole of the list story, and they are the mechanism the
+    // product actually uses (direct Prisma + contractScopeWhere, never the
+    // action). See docs/CONTRACTS.md.
 
     // Project access is not the contract permission — this is the exact
     // over-grant contractScopeWhere's vertical check exists to stop. Every
@@ -200,10 +193,6 @@ test.describe("staff with project access but no `contracts` permission (FINANCE)
         ["getContract", [CONTRACT_INSCOPE_ID]],
         ["updateContract", [CONTRACT_INSCOPE_ID, { title: "hacked" }]],
         ["deleteContract", [CONTRACT_INSCOPE_ID]],
-        [
-            "getExecutedContractPdf",
-            [{ id: CONTRACT_INSCOPE_ID, title: "irrelevant", projectId: PROJECT_ID, leadId: null }],
-        ],
         ["getContractSigningHistory", [CONTRACT_INSCOPE_ID]],
         ["getContractSendDefaults", [CONTRACT_INSCOPE_ID]],
     ] as const) {
@@ -224,31 +213,28 @@ test.describe("staff with `contracts` + `leadAccess` but no access to the conver
         expect(result.data.id).toBe(CONTRACT_LEADONLY_ID);
     });
 
-    // contractOwnerOrThrow exists specifically so ownership is read from the DB
-    // by contract id, NOT from the caller-supplied descriptor — but nothing
-    // else in this file pins that, because every other call passes truthful
-    // ownership. Here the descriptor LIES: it claims CONTRACT_CONVERTED_ID
-    // (which actually lives on OOS_PROJECT_ID, unreachable to this user) is
-    // lead-only on OOS_LEAD_ID, which this user CAN reach via leadAccess. If
-    // getExecutedContractPdf ever regressed to trusting the supplied
-    // projectId/leadId instead of re-reading them from the DB row, this is the
-    // only test in the file that would catch it — every other test here passes
-    // truthful descriptors and would keep passing under that regression.
-    test("forged descriptor cannot smuggle access to a contract this user cannot reach", async ({ request }) => {
-        const result = await callAction(request, "getExecutedContractPdf", [
-            { id: CONTRACT_CONVERTED_ID, title: "irrelevant", projectId: null, leadId: OOS_LEAD_ID },
-        ]);
-        expect(result.ok).toBe(false);
-        expect(result.error).toBe("Forbidden");
-    });
+    // A forged-descriptor test sat here. It was the only test pinning that
+    // ownership is re-read from the DB by contract id rather than trusted from
+    // a caller-supplied {projectId, leadId} descriptor — the hole #367 closed.
+    // It could only be written against `getExecutedContractPdf`, because that
+    // was the sole action in the family taking a descriptor rather than a bare
+    // id. That action has been deleted, so no remaining action in this
+    // dispatcher accepts caller-supplied ownership at all and the attack it
+    // guarded against has no entry point left. The session-free core it wrapped,
+    // executedContractPdfFor, still takes a descriptor, but only from callers
+    // that already hold the loaded row (the portal, after getContractForPortal
+    // proves ownership; countersignContractAsCompany, after its own gate) — so
+    // there is no untrusted descriptor anywhere on that path to forge.
 
-    test("positive control: getContracts lists the lead-only contract", async ({ request }) => {
-        const result = await callAction(request, "getContracts", []);
-        expect(result.ok).toBe(true);
-        expect((result.data as any[]).some((c) => c.id === CONTRACT_LEADONLY_ID)).toBe(true);
-    });
+    // A `getContracts` positive control sat here too, for the same deleted
+    // action. Its subject is covered by the page-level positive controls below,
+    // which exercise the real list mechanism (direct Prisma + contractScopeWhere).
 
-    test("positive control: signing history / send defaults / executed PDF succeed on the lead-only contract", async ({
+    // The executed-PDF leg of this control went with getExecutedContractPdf.
+    // The seeded ProjectFile it asserted on is still exercised end-to-end by
+    // the portal tests at the bottom of this file, which render the real
+    // executed-PDF link through the session-free core.
+    test("positive control: signing history / send defaults succeed on the lead-only contract", async ({
         request,
     }) => {
         const history = await callAction(request, "getContractSigningHistory", [CONTRACT_LEADONLY_ID]);
@@ -256,17 +242,6 @@ test.describe("staff with `contracts` + `leadAccess` but no access to the conver
 
         const sendDefaults = await callAction(request, "getContractSendDefaults", [CONTRACT_LEADONLY_ID]);
         expect(sendDefaults.ok).toBe(true);
-
-        const pdf = await callAction(request, "getExecutedContractPdf", [
-            { id: CONTRACT_LEADONLY_ID, title: CONTRACT_LEADONLY_TITLE, projectId: null, leadId: OOS_LEAD_ID },
-        ]);
-        expect(pdf.ok).toBe(true);
-        // A guard that denies everyone would ALSO fail this assertion — but a
-        // lookup that resolves to `null` on every call (never actually reading
-        // the seeded ProjectFile) would still pass `ok: true`. Assert the real
-        // file came back, not just that the call didn't throw.
-        expect(pdf.data).not.toBeNull();
-        expect(pdf.raw).toContain("example.test/e2e/executed-contract.pdf");
     });
 
     // It carries BOTH ids and canAccessJobScope lets projectId win, so
@@ -275,10 +250,6 @@ test.describe("staff with `contracts` + `leadAccess` but no access to the conver
         ["getContract", [CONTRACT_CONVERTED_ID]],
         ["updateContract", [CONTRACT_CONVERTED_ID, { title: "hacked" }]],
         ["deleteContract", [CONTRACT_CONVERTED_ID]],
-        [
-            "getExecutedContractPdf",
-            [{ id: CONTRACT_CONVERTED_ID, title: "irrelevant", projectId: OOS_PROJECT_ID, leadId: OOS_LEAD_ID }],
-        ],
         ["getContractSigningHistory", [CONTRACT_CONVERTED_ID]],
         ["getContractSendDefaults", [CONTRACT_CONVERTED_ID]],
     ] as const) {
@@ -289,23 +260,15 @@ test.describe("staff with `contracts` + `leadAccess` but no access to the conver
         });
     }
 
-    // The list must agree with the detail action, in BOTH directions — a filter
-    // that simply returned nothing would satisfy an exclusion-only assertion.
-    // This user reaches PROJECT_ID, so the in-scope contract is legitimately
-    // theirs and MUST appear; the converted one is on a project they cannot
-    // reach and must not, even though its leadId would otherwise admit it.
-    test("getContracts list admits what the by-id action admits and excludes the converted contract", async ({
-        request,
-    }) => {
-        const result = await callAction(request, "getContracts", []);
-        expect(result.ok).toBe(true);
-        const ids = (result.data as any[]).map((c) => c.id);
-        expect(ids).toContain(CONTRACT_LEADONLY_ID);
-        expect(ids).toContain(CONTRACT_INSCOPE_ID);
-        expect(ids).not.toContain(CONTRACT_CONVERTED_ID);
-        expect(result.raw).not.toContain(CONTRACT_CONVERTED_TOKEN);
-        expect(result.raw).not.toContain(CONTRACT_CONVERTED_BODY);
-    });
+    // A bidirectional list-vs-detail agreement test sat here, against
+    // getContracts. That action is deleted, and it was never how the product
+    // listed contracts anyway — the staff pages query Prisma directly through
+    // contractScopeWhere. The same both-directions property is asserted at page
+    // level further down: "project contracts page shows the in-scope contract,
+    // not the empty state" (must-appear) and "lead contracts page ... hides the
+    // converted contract" (must-not-appear), against the real mechanism rather
+    // than a parallel one. The must-appear half matters most — a filter that
+    // simply returned nothing would satisfy an exclusion-only assertion.
 
     // Without this, the unauthenticated block's "getLead never throws, but its
     // embedded contracts relation stays empty" assertion is vacuous — an empty

--- a/e2e/financial-action-auth.spec.ts
+++ b/e2e/financial-action-auth.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import ts from "typescript";
 import { canWriteDocumentTemplateType, canCreateContractFor, canAccessJobScope, canAccessContract, contractScopeWhere } from "../src/lib/access-rules";
 
 function exportSource(source: string, name: string): string {
@@ -559,11 +560,10 @@ test("contract creation is gated for staff and session-free for the shared-secre
 test("every exported contract action authorizes and scopes by contract id", () => {
   const source = stripComments(readFileSync(join(process.cwd(), "src/lib/actions.ts"), "utf8"));
 
-  // getContracts is the list, so it takes the where-fragment form of the same
-  // rule rather than the single-row assertion; everything else is by id.
+  // getContracts and getExecutedContractPdf used to be in this sweep. Both are
+  // now DELETED rather than gated — see the dead-surface test below.
   const byId = [
     "getContract",
-    "getExecutedContractPdf",
     "updateContract",
     "deleteContract",
     "getContractSigningHistory",
@@ -605,30 +605,8 @@ test("every exported contract action authorizes and scopes by contract id", () =
     expect(afterGuard.trimStart(), `${name} must still do its work after authorizing`)
       .not.toMatch(/^return\s+(null|undefined|\{\}|\[\])/);
     expect(afterGuard, `${name} must still reach the data layer`)
-      .toMatch(/prisma\.|executedContractPdfFor\(/);
+      .toMatch(/prisma\./);
   }
-
-  // The list must be filtered by the scope rule, not merely authenticated — an
-  // argument-less call previously returned EVERY contract in the database.
-  const list = exportSource(source, "getContracts");
-  const permissionIndex = list.indexOf('await assertStaffPermission("contracts")');
-  const filterIndex = list.indexOf("contractScopeWhere(user)");
-  expect(permissionIndex, "getContracts must require the contracts permission").toBeGreaterThanOrEqual(0);
-  expect(filterIndex, "getContracts must apply the contract scope filter").toBeGreaterThanOrEqual(0);
-  expect(permissionIndex, "getContracts must authenticate before querying")
-    .toBeLessThan(list.indexOf("prisma."));
-  expect(list.slice(0, permissionIndex), "getContracts must not return before authorizing")
-    .not.toMatch(/\breturn\b/);
-
-  // getExecutedContractPdf used to trust a caller-supplied {projectId, leadId,
-  // title} descriptor, so naming another job's ids returned that job's file.
-  // Only the id may be read off the argument now; the rest comes from the row.
-  const pdf = exportSource(source, "getExecutedContractPdf");
-  for (const trusted of ["contract.projectId", "contract.leadId", "contract.title"]) {
-    expect(pdf, `getExecutedContractPdf must not trust the caller's ${trusted}`).not.toContain(trusted);
-  }
-  expect(pdf, "getExecutedContractPdf must delegate the lookup to the core")
-    .toContain("executedContractPdfFor(");
 
   // Gating the by-id actions is not enough while a differently named action
   // returns the same rows. getLead embeds the lead's contracts and resolves its
@@ -641,6 +619,111 @@ test("every exported contract action authorizes and scopes by contract id", () =
   expect(lead, "getLead must scope the contracts it embeds")
     .toMatch(/contracts: \{ where: contractScopeWhere\(user\) \}/);
   expect(lead, "getLead must not embed contracts unscoped").not.toMatch(/contracts: true/);
+});
+
+// #367 GATED `getContracts` and `getExecutedContractPdf`. A caller survey then
+// found neither had a single call site — not in src/, e2e/, scripts/, not via
+// `await import(...)`, not from the MCP route, not from the mobile app. In a
+// "use server" module that does not make an export inert: Next.js registers
+// every export as an individually invokable POST endpoint whether or not any
+// component imports it, so a caller-less export is live attack surface whose
+// gate nothing exercises. Both were deleted; this test keeps them deleted.
+//
+// Asserting on the source text, not on behaviour, for the same reason the
+// tests around it do: there is no request-level harness here.
+//
+// This one resolves the export list through the TypeScript AST rather than by
+// regex. Every regex form was defeatable (Codex round 1): `stripComments` treats
+// a `//` inside a string literal as a comment opener, so
+//   const marker = "//"; export async function getContracts() { return [] }
+// blanked the real export out of the text and passed. `export let`,
+// `export const { getContracts } = holder` (destructuring) and `export * from`
+// all slipped past the pattern too, and `export { getContracts as other }`
+// false-POSITIVED. The AST has no such gaps: it reports what the module
+// actually exports, under every syntax, with comments and strings already
+// handled by the parser.
+function exportedNames(filePath: string): Set<string> {
+  const file = ts.createSourceFile(
+    filePath,
+    readFileSync(filePath, "utf8"),
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS,
+  );
+
+  const names = new Set<string>();
+  const isExported = (node: ts.Node) =>
+    ts.canHaveModifiers(node) &&
+    (ts.getModifiers(node) ?? []).some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+
+  // Destructuring and array patterns can export several names at once
+  // (`export const { getContracts } = holder`), so bindings are walked
+  // recursively rather than assumed to be plain identifiers.
+  const addBinding = (name: ts.BindingName) => {
+    if (ts.isIdentifier(name)) return void names.add(name.text);
+    for (const element of name.elements) {
+      if (ts.isBindingElement(element)) addBinding(element.name);
+    }
+  };
+
+  for (const statement of file.statements) {
+    if (ts.isFunctionDeclaration(statement) && isExported(statement) && statement.name) {
+      names.add(statement.name.text);
+    } else if (ts.isVariableStatement(statement) && isExported(statement)) {
+      // Covers `export const`, `export let` and `export var` alike.
+      for (const declaration of statement.declarationList.declarations) addBinding(declaration.name);
+    } else if (ts.isExportDeclaration(statement)) {
+      if (!statement.exportClause) {
+        // `export * from "./elsewhere"` re-exports an unknown set of names, so
+        // it could reinstate either endpoint invisibly. Fail loudly instead of
+        // silently passing — actions.ts has none today.
+        throw new Error(
+          `src/lib/actions.ts uses 'export *', which can re-export a deleted action invisibly: ${statement.getText(file)}`,
+        );
+      }
+      if (ts.isNamedExports(statement.exportClause)) {
+        // The EXPORTED name is what registers the endpoint, so read the alias
+        // (`export { foo as getContracts }` exports getContracts), not the local.
+        for (const element of statement.exportClause.elements) names.add(element.name.text);
+      } else {
+        names.add(statement.exportClause.name.text);
+      }
+    }
+  }
+  return names;
+}
+
+test("the caller-less contract exports stay deleted", () => {
+  const actionsPath = join(process.cwd(), "src/lib/actions.ts");
+  const exported = exportedNames(actionsPath);
+
+  // Sanity check the extractor itself before trusting its negatives: a parser
+  // that silently returned an empty set would pass every assertion below while
+  // proving nothing (the same "prove the control works before trusting a zero"
+  // reasoning the estimate audits use).
+  expect(exported.size, "the AST export extractor must actually find exports").toBeGreaterThan(100);
+  expect(exported, "the extractor must see a known-live action").toContain("getContract");
+
+  for (const name of ["getContracts", "getExecutedContractPdf"]) {
+    expect(exported, `${name} must not be exported from the server-action module`).not.toContain(name);
+  }
+
+  // Deleting them must not have orphaned the scope rule: contractScopeWhere is
+  // still what getLead's embedded contracts relation uses, and what both staff
+  // contract pages use (asserted in the test below). Scoped to getLead, not
+  // searched module-wide, or the rule could move out of getLead entirely and
+  // this would still pass (Codex round 1).
+  const source = stripComments(readFileSync(actionsPath, "utf8"));
+  expect(exportSource(source, "getLead"), "contractScopeWhere must still scope getLead's contracts")
+    .toContain("contracts: { where: contractScopeWhere(user) }");
+
+  // And the core the deleted PDF action wrapped must still exist and still be
+  // reached directly by its real caller — deleting the wrapper must not have
+  // taken the countersign path's file lookup with it. Also scoped, for the same
+  // reason: a module-wide match would pass on any other use of the core.
+  expect(exportSource(source, "countersignContractAsCompany"),
+    "countersign must still resolve the executed PDF through the core")
+    .toContain("executedContractPdfFor(");
 });
 
 // The live staff contract screens do NOT go through getContracts — they query
@@ -716,7 +799,10 @@ test("the contract gate pairs the contracts permission with the job-scope rule",
   expect(portal, "the portal must prove ownership first").toContain("getContractForPortal(");
   expect(portal, "the portal must use the session-free core")
     .toContain('from "@/lib/contract-files-core"');
-  expect(portal, "the portal must not call the staff-gated action")
+  // The staff wrapper this once guarded against is now deleted outright, so
+  // this assertion is belt-and-braces: it stops the portal reaching for a
+  // resurrected staff action instead of the core it is supposed to use.
+  expect(portal, "the portal must not call a staff-gated wrapper")
     .not.toMatch(/\bgetExecutedContractPdf\(/);
 });
 

--- a/e2e/financial-action-auth.spec.ts
+++ b/e2e/financial-action-auth.spec.ts
@@ -623,11 +623,14 @@ test("every exported contract action authorizes and scopes by contract id", () =
 
 // #367 GATED `getContracts` and `getExecutedContractPdf`. A caller survey then
 // found neither had a single call site — not in src/, e2e/, scripts/, not via
-// `await import(...)`, not from the MCP route, not from the mobile app. In a
-// "use server" module that does not make an export inert: Next.js registers
-// every export as an individually invokable POST endpoint whether or not any
-// component imports it, so a caller-less export is live attack surface whose
-// gate nothing exercises. Both were deleted; this test keeps them deleted.
+// `await import(...)`, not from the MCP route, not from the mobile app. That
+// did not make them inert. Measured on this build (Next 16.2.11), not assumed:
+// .next/server/server-reference-manifest.json registers all 360 exports of
+// actions.ts as individually invokable POST endpoints, 37 of them unreferenced
+// anywhere in src/. Next documents that unused actions MAY be eliminated, so
+// this is a property of how ProBuild actually builds rather than a universal
+// rule — and while it holds, a caller-less export here is live attack surface
+// whose gate nothing exercises. Both were deleted; this test keeps them so.
 //
 // Asserting on the source text, not on behaviour, for the same reason the
 // tests around it do: there is no request-level harness here.
@@ -639,9 +642,16 @@ test("every exported contract action authorizes and scopes by contract id", () =
 // blanked the real export out of the text and passed. `export let`,
 // `export const { getContracts } = holder` (destructuring) and `export * from`
 // all slipped past the pattern too, and `export { getContracts as other }`
-// false-POSITIVED. The AST has no such gaps: it reports what the module
-// actually exports, under every syntax, with comments and strings already
-// handled by the parser.
+// false-POSITIVED. The AST closes every one of those, with comments and string
+// literals already handled by the parser.
+//
+// Scope, stated precisely (Codex round 2): this collects top-level NAMED
+// exports, which is what can reinstate an endpoint under either forbidden name.
+// It deliberately does not model `export default` / `export =` — a default
+// export's exported name is "default", not `getContracts`, so it cannot
+// reinstate either name — and `export *` throws rather than passing silently.
+// Type-only exports are skipped: they erase at compile time and register no
+// endpoint, so counting them would be a false positive.
 function exportedNames(filePath: string): Set<string> {
   const file = ts.createSourceFile(
     filePath,
@@ -673,6 +683,7 @@ function exportedNames(filePath: string): Set<string> {
       // Covers `export const`, `export let` and `export var` alike.
       for (const declaration of statement.declarationList.declarations) addBinding(declaration.name);
     } else if (ts.isExportDeclaration(statement)) {
+      if (statement.isTypeOnly) continue;
       if (!statement.exportClause) {
         // `export * from "./elsewhere"` re-exports an unknown set of names, so
         // it could reinstate either endpoint invisibly. Fail loudly instead of
@@ -684,7 +695,10 @@ function exportedNames(filePath: string): Set<string> {
       if (ts.isNamedExports(statement.exportClause)) {
         // The EXPORTED name is what registers the endpoint, so read the alias
         // (`export { foo as getContracts }` exports getContracts), not the local.
-        for (const element of statement.exportClause.elements) names.add(element.name.text);
+        for (const element of statement.exportClause.elements) {
+          if (element.isTypeOnly) continue;
+          names.add(element.name.text);
+        }
       } else {
         names.add(statement.exportClause.name.text);
       }

--- a/src/app/api/test-only/contract-actions/route.ts
+++ b/src/app/api/test-only/contract-actions/route.ts
@@ -1,11 +1,9 @@
 import { NextResponse } from "next/server";
 import { timingSafeEqual } from "node:crypto";
 import {
-    getContracts,
     getContract,
     updateContract,
     deleteContract,
-    getExecutedContractPdf,
     getContractSigningHistory,
     getContractSendDefaults,
     getLead,
@@ -76,12 +74,21 @@ export const dynamic = "force-dynamic";
 // relation was the Codex round-1 blocker (an anonymous caller holding a lead id
 // received every contract field, including the signing accessToken, through an
 // action that is not itself part of the contract family).
+//
+// `getContracts` and `getExecutedContractPdf` were in this allowlist until they
+// were DELETED from actions.ts as caller-less dead surface. They had no product
+// caller — this dispatcher was the only thing importing them — and a "use
+// server" export is a live POST endpoint regardless, so keeping them alive
+// purely so this suite could prove their gates behave was backwards. The scope
+// rule and the by-id gate they exercised are both still covered here: the list
+// side by getLead's embedded contracts relation and the two staff contract
+// pages (which query Prisma directly and never went through getContracts), and
+// the executed-PDF lookup by the portal page's use of the session-free core.
+// See docs/CONTRACTS.md.
 const ACTIONS: Record<string, (...args: any[]) => Promise<any>> = {
-    getContracts,
     getContract,
     updateContract,
     deleteContract,
-    getExecutedContractPdf,
     getContractSigningHistory,
     getContractSendDefaults,
     // Projected down to the id and the contracts relation. getLead otherwise

--- a/src/app/api/test-only/contract-actions/route.ts
+++ b/src/app/api/test-only/contract-actions/route.ts
@@ -40,25 +40,34 @@ import {
  * "Forbidden" vs "Unauthorized" vs data — and the actions already surface both
  * strings to any caller who triggers them through the UI.
  *
- * THREE INDEPENDENT ENVIRONMENT/CREDENTIAL GATES, plus an allowlist:
+ * FOUR INDEPENDENT ENVIRONMENT/CREDENTIAL GATES, plus an allowlist:
  *  1. E2E_TEST_ROUTES must be exactly "1" — an explicit, positive opt-in whose
  *     ONLY purpose is enabling test routes. Codex's point: deriving "test
  *     routes are on" from an auth secret makes the route a side effect of a
  *     credential rather than a decision, so a secret that leaked into an
- *     environment would silently switch it on. This flag is set nowhere but
- *     the CI Playwright job.
+ *     environment would silently switch it on. Nothing in the app sets this;
+ *     the Playwright harness sets it for the server it starts (see the
+ *     `env` block in playwright.config.ts), so it is on for a local Playwright
+ *     run as well as in CI — but never for a server started any other way.
  *  2. PLAYWRIGHT_TEST_SECRET must be set. Production does not set it (it is
  *     also what registers the test-only CredentialsProvider in lib/auth.ts —
  *     see CLAUDE.md).
- *  3. VERCEL_ENV must not be "production". Note this one FAILS OPEN when
+ *  3. NODE_ENV must not be "production" UNLESS CI is "true". This is the
+ *     positive clause: the CI job runs `npm run start`, i.e. a production
+ *     NODE_ENV, so it needs the CI escape hatch; a real production server has
+ *     neither.
+ *  4. VERCEL_ENV must not be "production". Note this one FAILS OPEN when
  *     VERCEL_ENV is undefined (self-hosted, or a promoted artifact), which is
  *     exactly why it is the belt and gate 1 is the braces — never rely on it
  *     alone.
- *  4. Then: the request must present that secret in `x-e2e-secret`, compared in
- *     constant time, and name one of the eight allowlisted actions.
+ *  5. Then: the request must present that secret in `x-e2e-secret`, compared in
+ *     constant time, and name one of the six allowlisted actions.
  *
- * Every rejection is a bare 404, not a 401/403: an enabled-but-unauthorized
- * caller learns nothing about whether the route exists. Thrown errors are
+ * Every ENVIRONMENT or CREDENTIAL rejection is a bare 404, not a 401/403: an
+ * enabled-but-unauthorized caller learns nothing about whether the route
+ * exists. (A caller who has already cleared those gates and merely names an
+ * unknown action gets a 400 — at that point it is a malformed request from an
+ * authorized test, not a probe, and the distinction leaks nothing.) Thrown errors are
  * mapped through a known-message allowlist rather than returned raw, so a
  * malformed argument cannot surface Prisma model names or source paths the way
  * an unsanitized `Error.message` would.
@@ -77,9 +86,10 @@ export const dynamic = "force-dynamic";
 //
 // `getContracts` and `getExecutedContractPdf` were in this allowlist until they
 // were DELETED from actions.ts as caller-less dead surface. They had no product
-// caller — this dispatcher was the only thing importing them — and a "use
-// server" export is a live POST endpoint regardless, so keeping them alive
-// purely so this suite could prove their gates behave was backwards. The scope
+// caller — this dispatcher was the only thing importing them — and in this
+// build every export of that module is registered as a live POST endpoint
+// anyway (measured, see docs/CONTRACTS.md), so keeping them alive purely so
+// this suite could prove their gates behave was backwards. The scope
 // rule and the by-id gate they exercised are both still covered here: the list
 // side by getLead's embedded contracts relation and the two staff contract
 // pages (which query Prisma directly and never went through getContracts), and

--- a/src/app/portal/contracts/[id]/page.tsx
+++ b/src/app/portal/contracts/[id]/page.tsx
@@ -1,6 +1,8 @@
 import { getContractForPortal, getPublicCompanySettings, getPortalVisibility } from "@/lib/actions";
-// The session-free core, NOT the getExecutedContractPdf server action: this page
-// has no staff session. Access was already proven above by getContractForPortal,
+// The session-free core, NOT a staff-gated server action: this page has no
+// staff session. (The staff wrapper `getExecutedContractPdf` that used to sit
+// beside this core in actions.ts has since been deleted as caller-less dead
+// surface.) Access was already proven above by getContractForPortal,
 // which matches the emailed accessToken or a portal session resolving to the
 // owning Client, and the descriptor below comes from the row it returned.
 import { executedContractPdfFor } from "@/lib/contract-files-core";

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -5956,30 +5956,13 @@ export async function getResolvedMergePreview(
     return buildContractMergeData(projectId, leadId);
 }
 
-export async function getContracts(projectId?: string, leadId?: string) {
-    // Called with no arguments this returned EVERY contract with all scalar
-    // fields — legal body, approval IP/user-agent, signature paths and the
-    // portal accessToken that authorizes signing — to any anonymous caller.
-    // The scope filter is the list form of the same rule assertContractAccess
-    // applies to one row, so the list and the detail page cannot disagree.
-    const user = await assertStaffPermission("contracts");
-    return prisma.contract.findMany({
-        where: {
-            AND: [
-                contractScopeWhere(user),
-                {
-                    ...(projectId ? { projectId } : {}),
-                    ...(leadId ? { leadId } : {}),
-                },
-            ],
-        },
-        orderBy: { createdAt: "desc" },
-        include: {
-            project: { select: { name: true, client: { select: { name: true } } } },
-            lead: { select: { name: true, client: { select: { name: true } } } },
-        }
-    });
-}
+// `getContracts` was deleted here. It had no callers anywhere — the live staff
+// screens (projects/[id]/contracts, leads/[id]/contracts) query prisma.contract
+// directly with contractScopeWhere(viewer) — but in a "use server" module every
+// export is an individually invokable POST endpoint regardless, so a caller-less
+// export is live attack surface rather than inert code. #367 gated it; this
+// removes it. The scope rule it used, contractScopeWhere, is NOT orphaned: the
+// two pages above and getLead's contracts relation are its consumers.
 
 export async function getContract(id: string) {
     // Staff-only, scoped to the owning job. The docstring on getContractForPortal
@@ -6051,22 +6034,12 @@ export async function getContractForPortal(id: string, token?: string | null) {
     return contract;
 }
 
-/**
- * Staff-facing executed-contract file lookup. The lookup itself lives in
- * src/lib/contract-files-core.ts (session-free, shared with the client portal,
- * which proves access by accessToken or portal session instead).
- *
- * ONLY the contract `id` in the argument is trusted. The owning project/lead
- * and the title are re-read from the database, because the whole descriptor
- * used to be caller-supplied: naming another job's projectId returned that
- * job's executed PDF, and a crafted `title` steered the legacy prefix match.
- * The parameter keeps its old shape so existing callers are unchanged; the
- * extra fields are now ignored.
- */
-export async function getExecutedContractPdf(contract: { id: string; title: string; projectId: string | null; leadId: string | null }) {
-    const { projectId, leadId, title } = await assertContractAccess(contract.id);
-    return executedContractPdfFor({ id: contract.id, title, projectId, leadId });
-}
+// `getExecutedContractPdf` was deleted here, for the same reason as
+// `getContracts` above: no callers, but a "use server" export is a POST
+// endpoint whether or not anything imports it. Every real caller already uses
+// the session-free core `executedContractPdfFor` in contract-files-core.ts —
+// the client portal proves access by accessToken/portal session, and
+// countersignContractAsCompany calls it after its own gate.
 
 export async function createContractFromTemplate(
     templateId: string,

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -5958,11 +5958,15 @@ export async function getResolvedMergePreview(
 
 // `getContracts` was deleted here. It had no callers anywhere — the live staff
 // screens (projects/[id]/contracts, leads/[id]/contracts) query prisma.contract
-// directly with contractScopeWhere(viewer) — but in a "use server" module every
-// export is an individually invokable POST endpoint regardless, so a caller-less
-// export is live attack surface rather than inert code. #367 gated it; this
-// removes it. The scope rule it used, contractScopeWhere, is NOT orphaned: the
-// two pages above and getLead's contracts relation are its consumers.
+// directly with contractScopeWhere(viewer). Having no callers did NOT make it
+// inert: as this module actually builds (Next 16.2.11), the server-reference
+// manifest registers all 360 of its exports as individually invokable POST
+// endpoints, 37 of them unreferenced anywhere in src/ — so a caller-less export
+// here is live attack surface whose gate nothing exercises. Next documents that
+// unused actions MAY be eliminated, so that is a measurement of this build, not
+// a universal rule; see docs/CONTRACTS.md. #367 gated it; this removes it. The
+// scope rule it used, contractScopeWhere, is NOT orphaned: the two pages above
+// and getLead's contracts relation are its consumers.
 
 export async function getContract(id: string) {
     // Staff-only, scoped to the owning job. The docstring on getContractForPortal
@@ -6035,8 +6039,8 @@ export async function getContractForPortal(id: string, token?: string | null) {
 }
 
 // `getExecutedContractPdf` was deleted here, for the same reason as
-// `getContracts` above: no callers, but a "use server" export is a POST
-// endpoint whether or not anything imports it. Every real caller already uses
+// `getContracts` above: no callers, but on this build every export of this
+// module is registered as a POST endpoint anyway. Every real caller already uses
 // the session-free core `executedContractPdfFor` in contract-files-core.ts —
 // the client portal proves access by accessToken/portal session, and
 // countersignContractAsCompany calls it after its own gate.

--- a/src/lib/contract-files-core.ts
+++ b/src/lib/contract-files-core.ts
@@ -1,11 +1,14 @@
 import { prisma } from "@/lib/prisma";
 
-// Session-free core of the executed-contract file lookup, shared by the
-// permission-gated `getExecutedContractPdf` server action in actions.ts and by
-// the client portal page (src/app/portal/contracts/[id]/page.tsx), which has no
-// staff session at all — it proves access with the contract's `accessToken`
-// magic link or a portal session resolving to the owning Client, upstream via
-// getContractForPortal.
+// Session-free core of the executed-contract file lookup, shared by
+// `countersignContractAsCompany` in actions.ts (which runs its own staff gate
+// first) and by the client portal page (src/app/portal/contracts/[id]/page.tsx),
+// which has no staff session at all — it proves access with the contract's
+// `accessToken` magic link or a portal session resolving to the owning Client,
+// upstream via getContractForPortal.
+//
+// There was also a thin staff wrapper here, `getExecutedContractPdf`. It was
+// deleted once a survey found it had no callers at all; see docs/CONTRACTS.md.
 //
 // actions.ts is a server-action module, so every export there is an
 // individually invokable POST endpoint. Auth-free logic must live HERE, not
@@ -14,12 +17,10 @@ import { prisma } from "@/lib/prisma";
 // and src/lib/lead-conversion-core.ts. (This file deliberately carries no
 // server-action directive.)
 //
-// The body below is moved verbatim from actions.ts. The one behavioural change
-// lives at the CALLER: the exported action now resolves the owner and title
-// from the database by contract id instead of trusting the descriptor it was
-// handed, so a caller can no longer name another job's scope. This core still
-// takes a descriptor because its two callers have each already established, by
-// different means, which contract they are allowed to be looking at.
+// The body below is moved verbatim from actions.ts. This core takes a
+// descriptor rather than an id because both of its callers have already
+// established, by different means, which contract they are allowed to be
+// looking at, and each already holds the loaded row.
 
 /** What the lookup needs to know about a contract. */
 export type ExecutedContractDescriptor = {

--- a/src/lib/contract-finalize.ts
+++ b/src/lib/contract-finalize.ts
@@ -12,7 +12,7 @@ import { uploadSecureDoc, removeSecureDoc } from "./secure-storage";
 const esc = (s: string) =>
   s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 
-/** Canonical DB `name` of the executed-contract ProjectFile (matched exactly by getExecutedContractPdf). */
+/** Canonical DB `name` of the executed-contract ProjectFile (matched exactly by executedContractPdfFor). */
 export function executedContractFileName(contractId: string): string {
   return `Executed_Contract_${contractId}.pdf`;
 }


### PR DESCRIPTION
## What

Deletes two contract server actions that #367 had just gated, because a caller survey found neither had a real call site:

- **`getContracts`** — the live staff screens (`projects/[id]/contracts`, `leads/[id]/contracts`) query `prisma.contract` directly with `contractScopeWhere(viewer)`.
- **`getExecutedContractPdf`** — the client portal and `countersignContractAsCompany` both call the session-free core `executedContractPdfFor` directly.

## Why deleting, not keeping the gate

`src/lib/actions.ts` is a `"use server"` module, so an export with no importers is still an individually invokable POST endpoint — live attack surface whose auth gate nothing exercises, which is *worse* than dead code because it reads as covered. Repo precedent (#345) favours deleting dead surface over merely scoping it.

**Measured, not assumed.** Next documents that unused actions *may* be eliminated, so this was checked against the real build. On Next 16.2.11, `.next/server/server-reference-manifest.json` registers **360** endpoints from `actions.ts`, including **37 exports with no reference anywhere in `src/`**. `getContracts` is present in that manifest before this change and absent after it. Every comment and doc line states it in those terms rather than as a universal rule.

## Blast radius: nil

Both were only ever called from Server Components — never imported into a Client Component or bound to a `<form action>` — so no shipped browser bundle carries their action ids and no stale tab can call them.

## ⚠️ #376 landed mid-flight — the harness was trimmed, not the deletion abandoned

[#376](https://github.com/Clarion1631/probuild/pull/376) merged after this branch was cut, adding a triple-gated **test-only** dispatcher plus a behavioural request-level suite that covered both of these actions. The rebase was textually clean but the premise went stale: the dispatcher imported both, and the build broke.

In production they still have no caller — the dispatcher needs `E2E_TEST_ROUTES=1` + `PLAYWRIGHT_TEST_SECRET` + non-production `NODE_ENV`/`VERCEL_ENV`, and is only on under Playwright. Keeping two live POST endpoints alive purely so a suite could prove their gates behave is backwards, so the harness shrank to match.

Codex verified **no security property was silently dropped**. Each removal names where its subject now lives:

| Removed | Still covered by |
|---|---|
| `getContracts` refuse + positive control + list-vs-detail agreement | The two page-level tests, which exercise the **real** mechanism (direct Prisma + `contractScopeWhere`) and assert **both** directions — must-appear and must-not-appear |
| Forged-descriptor smuggling test | Moot: `getExecutedContractPdf` was the only action in the family taking a caller-supplied `{projectId, leadId}` descriptor. Every survivor authorizes by bare id and reloads ownership from the row |
| Executed-PDF leg of the lead-only positive control | The portal tests, which assert the exact seeded PDF URL in a visible anchor — not merely that the page renders |
| Loop entries in the anonymous / FINANCE / converted-contract sweeps | The same loops still run for the 5 surviving actions; nothing was unique to the removed entries |

Also hardened one test in passing: the bad-secret 404 case now names an allowlisted action, so the credential gate is the only thing that can produce its 404.

## `contractScopeWhere` is not orphaned

Still consumed by `getLead`'s contracts relation and both staff contract pages. The test asserts this, so the rule cannot lose its last consumer silently.

## The e2e guard reads the AST, not a regex

Codex round 1 defeated **every** regex form I tried:

| Bypass | Why the regex missed it |
|---|---|
| `const marker = "//"; export async function getContracts() {}` | `stripComments` treats `//` in a string literal as a comment opener and blanked the real export out |
| `export let getContracts = ...` | pattern only matched `async function`/`const` |
| `export const { getContracts } = holder` | destructuring |
| `export * from "./x"` | invisible re-export |
| `export { getContracts as other }` | **false positive** — flagged a harmless rename |

The AST version catches all five (mutation-tested individually, plus a control), and `export *` throws rather than passing silently. A self-check asserts the extractor finds >100 exports and sees a known-live action, so a parser returning an empty set cannot pass as "secure".

## Verification

- `npm run build` — clean, 0 errors
- `e2e/financial-action-auth.spec.ts` — 17/17 passing locally; `contract-auth-runtime.spec.ts` parses and lists, and runs in CI (it needs the throwaway Postgres + test-route env, never the live DB)
- Mutation-tested the new guard 5 ways + control; all caught
- Server-reference manifest re-checked post-build: both names absent
- Contract routes verified to compile and execute cleanly against a local dev server, no server errors
- Codex peer review (`gpt-5.6-sol`, `xhigh`) — 3 passes. Round 1 raised the regex blocker → AST rewrite. Round 2 confirmed resolved, flagged the "endpoint regardless" claim as too universal and `exportedNames` as over-claiming its coverage → both narrowed. Round 3 reviewed the harness trim, confirmed no lost coverage, and corrected three claims of mine (my bad-secret reasoning was wrong — unknown actions answer 400, not 404; "no surviving action accepts caller-supplied ownership" was too strong; the dispatcher docstring was stale in four ways). All fixed. **No open blockers.**

## Spun off, not fixed here

Codex found a **pre-existing** mass-assignment gap in `updateContract`: it spreads the caller's payload into Prisma, so an already-authorized editor can also write `accessToken`, `projectId`/`leadId` and approval/signature columns. It is not an access-control bypass (authorization still reloads ownership by id) and this branch neither introduced it nor removed coverage for it, so it is tracked separately rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
