### PR TITLE
test(security): behavioural request-level auth tests for the contract action family

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,15 @@ jobs:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_ORG: golden-touch-remodeling
       PLAYWRIGHT_TEST_SECRET: ${{ secrets.PLAYWRIGHT_TEST_SECRET }}
+      # Explicit opt-in for src/app/api/test-only/contract-actions (and the
+      # src/proxy.ts bypass it needs): the dispatcher e2e/contract-auth-runtime.spec.ts
+      # calls to exercise the contract guards behaviorally. Deliberately set ONLY
+      # in this job — a secret leaking into an environment must not silently turn
+      # the route on, so "test routes are enabled" is its own positive decision,
+      # not a side effect of PLAYWRIGHT_TEST_SECRET being present. Without it the
+      # dispatcher 404s and the spec fails loudly instead of silently passing
+      # against a route that never ran.
+      E2E_TEST_ROUTES: "1"
       CI: true
 
     steps:

--- a/e2e/auth-contract.setup.ts
+++ b/e2e/auth-contract.setup.ts
@@ -1,0 +1,48 @@
+import { test as setup, expect } from "@playwright/test";
+
+/**
+ * Fourth storage state: an EMPLOYEE staff reader holding `contracts` +
+ * `leadAccess`, scoped to a single project.
+ *
+ * ADMIN and MANAGER short-circuit hasPermission() to true and
+ * accessibleProjectIds() to "ALL" (ADMIN_ROLES in access-rules.ts), so an
+ * ADMIN-only suite can never reach the branch where a caller genuinely holds
+ * the `contracts` permission but is still refused on horizontal scope — the
+ * case where a converted contract carries both a projectId the caller cannot
+ * reach and a leadId that would otherwise rescue it. This session IS the test
+ * for that branch — see e2e/contract-auth-runtime.spec.ts, Block C.
+ *
+ * The fixture (user, permissions, single ProjectAccess row) is seeded by
+ * data.setup.ts, which this project depends on.
+ */
+setup("authenticate contract staff", async ({ page }) => {
+  const baseURL = "http://localhost:3000";
+  const email = "contract-staff@test.local";
+
+  const csrfRes = await page.request.get(`${baseURL}/api/auth/csrf`);
+  const { csrfToken } = await csrfRes.json();
+
+  const authRes = await page.request.post(`${baseURL}/api/auth/callback/credentials`, {
+    form: {
+      csrfToken,
+      email,
+      secret: process.env.PLAYWRIGHT_TEST_SECRET || "",
+    },
+  });
+  expect(authRes.ok(), `Credentials callback failed at ${authRes.url()}`).toBeTruthy();
+
+  // In development the app falls back to a known ADMIN when there is no
+  // session. That fallback would make every assertion in the contract spec pass
+  // for the wrong reason, so prove the session is this user and NOT an admin
+  // before saving the state.
+  const sessionRes = await page.request.get(`${baseURL}/api/auth/session`);
+  expect(sessionRes.ok()).toBeTruthy();
+  const session = await sessionRes.json();
+  expect(session.user).toMatchObject({ email, role: "EMPLOYEE" });
+  expect(session.user.id).toBeTruthy();
+
+  await page.goto("/projects", { waitUntil: "networkidle", timeout: 15_000 });
+  await expect(page).not.toHaveURL(/.*login.*/);
+
+  await page.context().storageState({ path: "e2e/.auth/contract-user.json" });
+});

--- a/e2e/auth-finance.setup.ts
+++ b/e2e/auth-finance.setup.ts
@@ -1,0 +1,46 @@
+import { test as setup, expect } from "@playwright/test";
+
+/**
+ * Third storage state: a FINANCE staff reader with project access but NOT the
+ * `contracts` permission.
+ *
+ * ADMIN and MANAGER short-circuit hasPermission() to true unconditionally
+ * (ADMIN_ROLES in access-rules.ts), so an ADMIN-only suite can never reach the
+ * branch where a caller has project scope but is refused on the vertical
+ * `contracts` check. This session IS the test for that branch — see
+ * e2e/contract-auth-runtime.spec.ts, Block B.
+ *
+ * The fixture (user, permissions, single ProjectAccess row) is seeded by
+ * data.setup.ts, which this project depends on.
+ */
+setup("authenticate finance staff", async ({ page }) => {
+  const baseURL = "http://localhost:3000";
+  const email = "finance-staff@test.local";
+
+  const csrfRes = await page.request.get(`${baseURL}/api/auth/csrf`);
+  const { csrfToken } = await csrfRes.json();
+
+  const authRes = await page.request.post(`${baseURL}/api/auth/callback/credentials`, {
+    form: {
+      csrfToken,
+      email,
+      secret: process.env.PLAYWRIGHT_TEST_SECRET || "",
+    },
+  });
+  expect(authRes.ok(), `Credentials callback failed at ${authRes.url()}`).toBeTruthy();
+
+  // In development the app falls back to a known ADMIN when there is no
+  // session. That fallback would make every assertion in the finance spec pass
+  // for the wrong reason, so prove the session is this user and NOT an admin
+  // before saving the state.
+  const sessionRes = await page.request.get(`${baseURL}/api/auth/session`);
+  expect(sessionRes.ok()).toBeTruthy();
+  const session = await sessionRes.json();
+  expect(session.user).toMatchObject({ email, role: "FINANCE" });
+  expect(session.user.id).toBeTruthy();
+
+  await page.goto("/projects", { waitUntil: "networkidle", timeout: 15_000 });
+  await expect(page).not.toHaveURL(/.*login.*/);
+
+  await page.context().storageState({ path: "e2e/.auth/finance-user.json" });
+});

--- a/e2e/contract-auth-runtime.spec.ts
+++ b/e2e/contract-auth-runtime.spec.ts
@@ -53,11 +53,53 @@ async function callAction(
     });
     expect(
         res.status(),
-        `dispatcher returned ${res.status()} for action "${action}" — a 404 here means PLAYWRIGHT_TEST_SECRET/VERCEL_ENV gate is off and every downstream assertion in this file is vacuous`
+        `dispatcher returned ${res.status()} for action "${action}". A 404 means the route's gate is off — most likely E2E_TEST_ROUTES=1 is missing from the SERVER's environment (playwright.config.ts sets it on the webServer it starts, but reuseExistingServer will happily attach to a hand-started dev server that lacks it). Every downstream assertion in this file would be vacuous, so this fails loudly instead.`
     ).toBe(200);
     const raw = await res.text();
     return { ...JSON.parse(raw), raw };
 }
+
+// The dispatcher's own gate. Codex's round-2 point: nothing in this file failed
+// if a gate clause were deleted, so the route's protection was itself untested.
+// The three ENVIRONMENT clauses cannot be exercised from here — they are read by
+// the already-running server and a test cannot change them mid-run — but the
+// credential clause can, and it is the one an outside caller would actually
+// have to defeat. A bare 404 (not 401/403) is the contract: an unauthorized
+// caller must not even learn the route exists.
+test.describe("the dispatcher's own gate", () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    for (const [label, headers] of [
+        ["a wrong secret", { "x-e2e-secret": "not-the-secret" }],
+        ["no secret at all", {}],
+    ] as const) {
+        test(`${label} gets a bare 404, not an action result`, async ({ request }) => {
+            const res = await request.post("/api/test-only/contract-actions", {
+                headers: { "content-type": "application/json", ...headers },
+                data: { action: "getContracts", args: [] },
+            });
+            expect(res.status()).toBe(404);
+            const body = await res.text();
+            expect(body).not.toContain(CONTRACT_INSCOPE_TOKEN);
+            expect(body).not.toContain(CONTRACT_LEADONLY_TOKEN);
+            expect(body).not.toContain(CONTRACT_CONVERTED_TOKEN);
+        });
+    }
+
+    test("an unknown action name never dispatches", async ({ request }) => {
+        const res = await request.post("/api/test-only/contract-actions", {
+            headers: {
+                "content-type": "application/json",
+                "x-e2e-secret": process.env.PLAYWRIGHT_TEST_SECRET || "",
+            },
+            // `constructor` would resolve on a plain object without the
+            // hasOwnProperty check the route uses.
+            data: { action: "constructor", args: [] },
+        });
+        expect(res.status()).toBe(400);
+        expect(await res.text()).toContain("Unknown action");
+    });
+});
 
 test.describe("unauthenticated caller", () => {
     test.use({ storageState: { cookies: [], origins: [] } });

--- a/e2e/contract-auth-runtime.spec.ts
+++ b/e2e/contract-auth-runtime.spec.ts
@@ -134,10 +134,19 @@ test.describe("staff with project access but no `contracts` permission (FINANCE)
         await expect(page.getByText("No contracts yet")).toBeVisible();
     });
 
-    test("getContracts returns an empty list", async ({ request }) => {
+    // getContracts REFUSES rather than returning []. Its gate is
+    // assertStaffPermission("contracts"), which throws before
+    // contractScopeWhere is ever consulted — so the action and the pages answer
+    // "no contracts" by two different mechanisms, and only the pages (which
+    // query Prisma directly through contractScopeWhere, never through this
+    // action) degrade to an empty list. Asserting `ok: true, data: []` here
+    // fails against the real system; that is what the first live run showed.
+    test("getContracts refuses outright — it never degrades to an empty list", async ({ request }) => {
         const result = await callAction(request, "getContracts", []);
-        expect(result.ok).toBe(true);
-        expect(result.data.length).toBe(0);
+        expect(result.ok).toBe(false);
+        expect(result.error).toBe("Forbidden");
+        expect(result.raw).not.toContain(CONTRACT_INSCOPE_TOKEN);
+        expect(result.raw).not.toContain(CONTRACT_INSCOPE_BODY);
     });
 
     // Project access is not the contract permission — this is the exact
@@ -213,14 +222,22 @@ test.describe("staff with `contracts` + `leadAccess` but no access to the conver
         });
     }
 
-    test("getContracts list excludes the converted and in-scope contracts", async ({ request }) => {
+    // The list must agree with the detail action, in BOTH directions — a filter
+    // that simply returned nothing would satisfy an exclusion-only assertion.
+    // This user reaches PROJECT_ID, so the in-scope contract is legitimately
+    // theirs and MUST appear; the converted one is on a project they cannot
+    // reach and must not, even though its leadId would otherwise admit it.
+    test("getContracts list admits what the by-id action admits and excludes the converted contract", async ({
+        request,
+    }) => {
         const result = await callAction(request, "getContracts", []);
         expect(result.ok).toBe(true);
         const ids = (result.data as any[]).map((c) => c.id);
+        expect(ids).toContain(CONTRACT_LEADONLY_ID);
+        expect(ids).toContain(CONTRACT_INSCOPE_ID);
         expect(ids).not.toContain(CONTRACT_CONVERTED_ID);
-        expect(ids).not.toContain(CONTRACT_INSCOPE_ID);
         expect(result.raw).not.toContain(CONTRACT_CONVERTED_TOKEN);
-        expect(result.raw).not.toContain(CONTRACT_INSCOPE_TOKEN);
+        expect(result.raw).not.toContain(CONTRACT_CONVERTED_BODY);
     });
 
     test.describe.serial("scratch contract write control", () => {

--- a/e2e/contract-auth-runtime.spec.ts
+++ b/e2e/contract-auth-runtime.spec.ts
@@ -40,6 +40,7 @@ const CONTRACT_LEADONLY_TOKEN = "e2e-contract-token-leadonly";
 const CONTRACT_LEADONLY_BODY = "E2E LEAD-ONLY CONTRACT BODY — DO NOT DELETE";
 
 const SCRATCH_CONTRACT_ID = "e2e-contract-scratch";
+const SCRATCH_CONTRACT_DEL_ID = "e2e-contract-scratch-del";
 
 async function callAction(
     request: APIRequestContext,
@@ -181,6 +182,24 @@ test.describe("staff with `contracts` + `leadAccess` but no access to the conver
         expect(result.data.id).toBe(CONTRACT_LEADONLY_ID);
     });
 
+    // contractOwnerOrThrow exists specifically so ownership is read from the DB
+    // by contract id, NOT from the caller-supplied descriptor — but nothing
+    // else in this file pins that, because every other call passes truthful
+    // ownership. Here the descriptor LIES: it claims CONTRACT_CONVERTED_ID
+    // (which actually lives on OOS_PROJECT_ID, unreachable to this user) is
+    // lead-only on OOS_LEAD_ID, which this user CAN reach via leadAccess. If
+    // getExecutedContractPdf ever regressed to trusting the supplied
+    // projectId/leadId instead of re-reading them from the DB row, this is the
+    // only test in the file that would catch it — every other test here passes
+    // truthful descriptors and would keep passing under that regression.
+    test("forged descriptor cannot smuggle access to a contract this user cannot reach", async ({ request }) => {
+        const result = await callAction(request, "getExecutedContractPdf", [
+            { id: CONTRACT_CONVERTED_ID, title: "irrelevant", projectId: null, leadId: OOS_LEAD_ID },
+        ]);
+        expect(result.ok).toBe(false);
+        expect(result.error).toBe("Forbidden");
+    });
+
     test("positive control: getContracts lists the lead-only contract", async ({ request }) => {
         const result = await callAction(request, "getContracts", []);
         expect(result.ok).toBe(true);
@@ -200,6 +219,12 @@ test.describe("staff with `contracts` + `leadAccess` but no access to the conver
             { id: CONTRACT_LEADONLY_ID, title: CONTRACT_LEADONLY_TITLE, projectId: null, leadId: OOS_LEAD_ID },
         ]);
         expect(pdf.ok).toBe(true);
+        // A guard that denies everyone would ALSO fail this assertion — but a
+        // lookup that resolves to `null` on every call (never actually reading
+        // the seeded ProjectFile) would still pass `ok: true`. Assert the real
+        // file came back, not just that the call didn't throw.
+        expect(pdf.data).not.toBeNull();
+        expect(pdf.raw).toContain("example.test/e2e/executed-contract.pdf");
     });
 
     // It carries BOTH ids and canAccessJobScope lets projectId win, so
@@ -240,6 +265,41 @@ test.describe("staff with `contracts` + `leadAccess` but no access to the conver
         expect(result.raw).not.toContain(CONTRACT_CONVERTED_BODY);
     });
 
+    // Without this, the unauthenticated block's "getLead never throws, but its
+    // embedded contracts relation stays empty" assertion is vacuous — an empty
+    // array is exactly what a `contracts: []` relation that NEVER resolves
+    // would also return. This user holds leadAccess + the `contracts`
+    // permission and reaches OOS_LEAD_ID, so the relation must actually
+    // populate for them, which is what makes the anonymous-caller empty-array
+    // assertion mean something.
+    test("positive control: getLead's contracts relation resolves for an authorized reader", async ({ request }) => {
+        const result = await callAction(request, "getLead", [OOS_LEAD_ID]);
+        expect(result.ok).toBe(true);
+        const ids = (result.data.contracts as any[]).map((c) => c.id);
+        expect(ids).toContain(CONTRACT_LEADONLY_ID);
+    });
+
+    test("project contracts page shows the in-scope contract, not the empty state", async ({ page }) => {
+        const response = await page.goto(`/projects/${PROJECT_ID}/contracts`);
+        expect(response?.ok()).toBeTruthy();
+        await expect(page).not.toHaveURL(/.*login.*/);
+        await expect(page.getByText("E2E In-Scope Contract", { exact: false })).toBeVisible();
+        await expect(page.getByText("No contracts yet")).not.toBeVisible();
+    });
+
+    test("lead contracts page shows the lead-only contract, not the empty state, and hides the converted contract", async ({ page }) => {
+        const response = await page.goto(`/leads/${OOS_LEAD_ID}/contracts`);
+        expect(response?.ok()).toBeTruthy();
+        await expect(page).not.toHaveURL(/.*login.*/);
+        await expect(page.getByText(CONTRACT_LEADONLY_TITLE)).toBeVisible();
+        await expect(page.getByText("No contracts yet")).not.toBeVisible();
+        // The converted contract carries this same leadId, but canAccessJobScope
+        // lets its projectId (OOS_PROJECT_ID, unreachable to this user) win —
+        // the lead page's union is bidirectional, so without this assertion a
+        // regression that let leadId alone admit it would go unnoticed.
+        await expect(page.getByText("E2E Converted Contract")).not.toBeVisible();
+    });
+
     test.describe.serial("scratch contract write control", () => {
         const prisma = new PrismaClient();
 
@@ -264,11 +324,35 @@ test.describe("staff with `contracts` + `leadAccess` but no access to the conver
                     accessToken: "e2e-contract-token-scratch",
                 },
             });
+            // A SEPARATE row for the delete control, so the two write tests never
+            // interfere with each other's fixture.
+            await prisma.contract.upsert({
+                where: { id: SCRATCH_CONTRACT_DEL_ID },
+                update: {
+                    leadId: OOS_LEAD_ID,
+                    projectId: null,
+                    title: "E2E Scratch Contract (delete control)",
+                    body: "scratch body",
+                    status: "Draft",
+                    accessToken: "e2e-contract-token-scratch-del",
+                },
+                create: {
+                    id: SCRATCH_CONTRACT_DEL_ID,
+                    leadId: OOS_LEAD_ID,
+                    projectId: null,
+                    title: "E2E Scratch Contract (delete control)",
+                    body: "scratch body",
+                    status: "Draft",
+                    accessToken: "e2e-contract-token-scratch-del",
+                },
+            });
         });
 
         test.afterAll(async () => {
             try {
-                await prisma.contract.deleteMany({ where: { id: SCRATCH_CONTRACT_ID } });
+                // Idempotent regardless of whether the delete test already removed
+                // SCRATCH_CONTRACT_DEL_ID — deleteMany on a missing id is a no-op.
+                await prisma.contract.deleteMany({ where: { id: { in: [SCRATCH_CONTRACT_ID, SCRATCH_CONTRACT_DEL_ID] } } });
             } finally {
                 await prisma.$disconnect();
             }
@@ -286,6 +370,22 @@ test.describe("staff with `contracts` + `leadAccess` but no access to the conver
                 select: { title: true },
             });
             expect(row?.title).toBe("updated by e2e");
+        });
+
+        // Runs after the update test above, on a SEPARATE id, so the two write
+        // controls never interfere. A guard that denies every delete would fail
+        // this test's `ok: true` assertion, and a guard that reports success
+        // without actually deleting would fail the follow-up findUnique check —
+        // without this, no test in the file proves an AUTHORIZED delete actually
+        // removes the row.
+        test("deleteContract actually removes the row, not just returns ok", async ({ request }) => {
+            const result = await callAction(request, "deleteContract", [SCRATCH_CONTRACT_DEL_ID]);
+            expect(result.ok).toBe(true);
+
+            const row = await prisma.contract.findUnique({
+                where: { id: SCRATCH_CONTRACT_DEL_ID },
+            });
+            expect(row).toBeNull();
         });
     });
 });

--- a/e2e/contract-auth-runtime.spec.ts
+++ b/e2e/contract-auth-runtime.spec.ts
@@ -1,0 +1,320 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import { PrismaClient } from "@prisma/client";
+import { signClientPortalToken } from "../src/lib/client-portal-auth";
+
+/**
+ * Behavioral (request-level) coverage for the contract server-action auth
+ * family: assertContractAccess / canAccessContract / contractScopeWhere
+ * (PR #367). e2e/financial-action-auth.spec.ts proves the guard TOKENS appear
+ * in the right order by reading actions.ts as text — that passes just as
+ * happily against a refactor that keeps the token shapes while changing the
+ * semantics. This spec proves the guards actually BEHAVE: it invokes the real
+ * exported actions, as a specific caller, through the test-only dispatcher
+ * route (src/app/api/test-only/contract-actions/route.ts), and asserts on the
+ * outcome.
+ *
+ * Fixtures (users, permissions, contracts, the executed-PDF file) are seeded
+ * by e2e/data.setup.ts — see its "Contract-auth fixtures" section. IDs are
+ * re-declared here as literals (matching e2e/estimate-scope-labels.spec.ts's
+ * convention for OOS_PROJECT_ID/OOS_LEAD_ID) rather than imported, because
+ * data.setup.ts is a Playwright setup file, not a module other specs import.
+ */
+
+const PROJECT_ID = "cmml6vt3y000lpwrh0p9p3k12";
+const OOS_PROJECT_ID = "e2e-scope-oos-project";
+const OOS_LEAD_ID = "e2e-scope-oos-lead";
+const TEST_CLIENT_ID = "test-client-do-not-delete";
+const TEST_CLIENT_EMAIL = "test-client@goldentouchremodeling.com";
+
+const CONTRACT_INSCOPE_ID = "e2e-contract-inscope";
+const CONTRACT_INSCOPE_TOKEN = "e2e-contract-token-inscope";
+const CONTRACT_INSCOPE_BODY = "E2E IN-SCOPE CONTRACT BODY — DO NOT DELETE";
+
+const CONTRACT_CONVERTED_ID = "e2e-contract-converted";
+const CONTRACT_CONVERTED_TOKEN = "e2e-contract-token-converted";
+const CONTRACT_CONVERTED_BODY = "E2E CONVERTED CONTRACT BODY — DO NOT DELETE";
+
+const CONTRACT_LEADONLY_ID = "e2e-contract-leadonly";
+const CONTRACT_LEADONLY_TITLE = "E2E Lead-Only Contract — DO NOT DELETE";
+const CONTRACT_LEADONLY_TOKEN = "e2e-contract-token-leadonly";
+const CONTRACT_LEADONLY_BODY = "E2E LEAD-ONLY CONTRACT BODY — DO NOT DELETE";
+
+const SCRATCH_CONTRACT_ID = "e2e-contract-scratch";
+
+async function callAction(
+    request: APIRequestContext,
+    action: string,
+    args: any[]
+): Promise<{ ok: boolean; data?: any; error?: string; raw: string }> {
+    const res = await request.post("/api/test-only/contract-actions", {
+        headers: { "content-type": "application/json", "x-e2e-secret": process.env.PLAYWRIGHT_TEST_SECRET || "" },
+        data: { action, args },
+    });
+    expect(
+        res.status(),
+        `dispatcher returned ${res.status()} for action "${action}" — a 404 here means PLAYWRIGHT_TEST_SECRET/VERCEL_ENV gate is off and every downstream assertion in this file is vacuous`
+    ).toBe(200);
+    const raw = await res.text();
+    return { ...JSON.parse(raw), raw };
+}
+
+test.describe("unauthenticated caller", () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+    test.skip(
+        !process.env.CI,
+        "src/proxy.ts returns NextResponse.next() for everything in development, and currentStaffUserOrNull falls back to a known ADMIN (canUseDevAuthFallback) — so an anonymous caller looks like an admin locally. Only the CI production build (npm run start) is a real anonymous caller."
+    );
+
+    for (const [action, args] of [
+        ["getContracts", []],
+        ["getContract", [CONTRACT_INSCOPE_ID]],
+        ["updateContract", [CONTRACT_INSCOPE_ID, { title: "hacked" }]],
+        ["deleteContract", [CONTRACT_INSCOPE_ID]],
+        [
+            "getExecutedContractPdf",
+            [{ id: CONTRACT_LEADONLY_ID, title: CONTRACT_LEADONLY_TITLE, projectId: null, leadId: OOS_LEAD_ID }],
+        ],
+        ["getContractSigningHistory", [CONTRACT_INSCOPE_ID]],
+        ["getContractSendDefaults", [CONTRACT_INSCOPE_ID]],
+    ] as const) {
+        test(`${action} refuses an anonymous caller`, async ({ request }) => {
+            const result = await callAction(request, action, args as any[]);
+            expect(result.ok).toBe(false);
+            expect(result.error).toBe("Unauthorized");
+            expect(result.raw).not.toContain(CONTRACT_INSCOPE_TOKEN);
+            expect(result.raw).not.toContain(CONTRACT_CONVERTED_TOKEN);
+            expect(result.raw).not.toContain(CONTRACT_LEADONLY_TOKEN);
+            expect(result.raw).not.toContain(CONTRACT_INSCOPE_BODY);
+            expect(result.raw).not.toContain(CONTRACT_CONVERTED_BODY);
+            expect(result.raw).not.toContain(CONTRACT_LEADONLY_BODY);
+        });
+    }
+
+    // getLead is not part of the assertContractAccess family — it never throws
+    // for anonymous callers — but its embedded `contracts` relation was the
+    // Codex round-1 blocker that motivated this whole spec: an anonymous caller
+    // handed a lead id used to receive every contract field on that lead,
+    // accessToken included, through an action with no permission gate at all.
+    // contractScopeWhere(null) must resolve that relation to an empty list.
+    test("getLead never throws, but its embedded contracts relation stays empty", async ({ request }) => {
+        const result = await callAction(request, "getLead", [OOS_LEAD_ID]);
+        expect(result.ok).toBe(true);
+        expect(result.data.contracts).toEqual([]);
+        expect(result.raw).not.toContain(CONTRACT_CONVERTED_TOKEN);
+        expect(result.raw).not.toContain(CONTRACT_LEADONLY_TOKEN);
+        expect(result.raw).not.toContain(CONTRACT_CONVERTED_BODY);
+        expect(result.raw).not.toContain(CONTRACT_LEADONLY_BODY);
+    });
+});
+
+// Runs in CI AND locally — a real session cookie means the dev ADMIN fallback
+// does not apply.
+test.describe("staff with project access but no `contracts` permission (FINANCE)", () => {
+    test.use({ storageState: "e2e/.auth/finance-user.json" });
+
+    test("project contracts page renders the empty state, not the in-scope contract", async ({ page }) => {
+        const response = await page.goto(`/projects/${PROJECT_ID}/contracts`);
+        expect(response?.ok()).toBeTruthy();
+        await expect(page).not.toHaveURL(/.*login.*/);
+        const body = await page.textContent("body");
+        expect(body).not.toContain("E2E In-Scope Contract");
+        expect(body).not.toContain(CONTRACT_INSCOPE_BODY);
+        expect(body).not.toContain(CONTRACT_INSCOPE_TOKEN);
+        await expect(page.getByText("No contracts yet")).toBeVisible();
+    });
+
+    test("lead contracts page renders the empty state too", async ({ page }) => {
+        const response = await page.goto(`/leads/${OOS_LEAD_ID}/contracts`);
+        expect(response?.ok()).toBeTruthy();
+        await expect(page).not.toHaveURL(/.*login.*/);
+        const body = await page.textContent("body");
+        expect(body).not.toContain(CONTRACT_LEADONLY_TITLE);
+        expect(body).not.toContain(CONTRACT_LEADONLY_BODY);
+        expect(body).not.toContain(CONTRACT_LEADONLY_TOKEN);
+        await expect(page.getByText("No contracts yet")).toBeVisible();
+    });
+
+    test("getContracts returns an empty list", async ({ request }) => {
+        const result = await callAction(request, "getContracts", []);
+        expect(result.ok).toBe(true);
+        expect(result.data.length).toBe(0);
+    });
+
+    // Project access is not the contract permission — this is the exact
+    // over-grant contractScopeWhere's vertical check exists to stop. Every
+    // by-id action must refuse this user on CONTRACT_INSCOPE_ID even though
+    // they can otherwise read and write PROJECT_ID.
+    for (const [action, args] of [
+        ["getContract", [CONTRACT_INSCOPE_ID]],
+        ["updateContract", [CONTRACT_INSCOPE_ID, { title: "hacked" }]],
+        ["deleteContract", [CONTRACT_INSCOPE_ID]],
+        [
+            "getExecutedContractPdf",
+            [{ id: CONTRACT_INSCOPE_ID, title: "irrelevant", projectId: PROJECT_ID, leadId: null }],
+        ],
+        ["getContractSigningHistory", [CONTRACT_INSCOPE_ID]],
+        ["getContractSendDefaults", [CONTRACT_INSCOPE_ID]],
+    ] as const) {
+        test(`${action} refuses FINANCE on an in-scope project's contract`, async ({ request }) => {
+            const result = await callAction(request, action, args as any[]);
+            expect(result.ok).toBe(false);
+            expect(result.error).toBe("Forbidden");
+        });
+    }
+});
+
+test.describe("staff with `contracts` + `leadAccess` but no access to the converted contract's project", () => {
+    test.use({ storageState: "e2e/.auth/contract-user.json" });
+
+    test("positive control: getContract on the lead-only contract succeeds", async ({ request }) => {
+        const result = await callAction(request, "getContract", [CONTRACT_LEADONLY_ID]);
+        expect(result.ok).toBe(true);
+        expect(result.data.id).toBe(CONTRACT_LEADONLY_ID);
+    });
+
+    test("positive control: getContracts lists the lead-only contract", async ({ request }) => {
+        const result = await callAction(request, "getContracts", []);
+        expect(result.ok).toBe(true);
+        expect((result.data as any[]).some((c) => c.id === CONTRACT_LEADONLY_ID)).toBe(true);
+    });
+
+    test("positive control: signing history / send defaults / executed PDF succeed on the lead-only contract", async ({
+        request,
+    }) => {
+        const history = await callAction(request, "getContractSigningHistory", [CONTRACT_LEADONLY_ID]);
+        expect(history.ok).toBe(true);
+
+        const sendDefaults = await callAction(request, "getContractSendDefaults", [CONTRACT_LEADONLY_ID]);
+        expect(sendDefaults.ok).toBe(true);
+
+        const pdf = await callAction(request, "getExecutedContractPdf", [
+            { id: CONTRACT_LEADONLY_ID, title: CONTRACT_LEADONLY_TITLE, projectId: null, leadId: OOS_LEAD_ID },
+        ]);
+        expect(pdf.ok).toBe(true);
+    });
+
+    // It carries BOTH ids and canAccessJobScope lets projectId win, so
+    // leadAccess must NOT rescue it.
+    for (const [action, args] of [
+        ["getContract", [CONTRACT_CONVERTED_ID]],
+        ["updateContract", [CONTRACT_CONVERTED_ID, { title: "hacked" }]],
+        ["deleteContract", [CONTRACT_CONVERTED_ID]],
+        [
+            "getExecutedContractPdf",
+            [{ id: CONTRACT_CONVERTED_ID, title: "irrelevant", projectId: OOS_PROJECT_ID, leadId: OOS_LEAD_ID }],
+        ],
+        ["getContractSigningHistory", [CONTRACT_CONVERTED_ID]],
+        ["getContractSendDefaults", [CONTRACT_CONVERTED_ID]],
+    ] as const) {
+        test(`${action} refuses on the converted (project-wins) contract`, async ({ request }) => {
+            const result = await callAction(request, action, args as any[]);
+            expect(result.ok).toBe(false);
+            expect(result.error).toBe("Forbidden");
+        });
+    }
+
+    test("getContracts list excludes the converted and in-scope contracts", async ({ request }) => {
+        const result = await callAction(request, "getContracts", []);
+        expect(result.ok).toBe(true);
+        const ids = (result.data as any[]).map((c) => c.id);
+        expect(ids).not.toContain(CONTRACT_CONVERTED_ID);
+        expect(ids).not.toContain(CONTRACT_INSCOPE_ID);
+        expect(result.raw).not.toContain(CONTRACT_CONVERTED_TOKEN);
+        expect(result.raw).not.toContain(CONTRACT_INSCOPE_TOKEN);
+    });
+
+    test.describe.serial("scratch contract write control", () => {
+        const prisma = new PrismaClient();
+
+        test.beforeAll(async () => {
+            await prisma.contract.upsert({
+                where: { id: SCRATCH_CONTRACT_ID },
+                update: {
+                    leadId: OOS_LEAD_ID,
+                    projectId: null,
+                    title: "E2E Scratch Contract",
+                    body: "scratch body",
+                    status: "Draft",
+                    accessToken: "e2e-contract-token-scratch",
+                },
+                create: {
+                    id: SCRATCH_CONTRACT_ID,
+                    leadId: OOS_LEAD_ID,
+                    projectId: null,
+                    title: "E2E Scratch Contract",
+                    body: "scratch body",
+                    status: "Draft",
+                    accessToken: "e2e-contract-token-scratch",
+                },
+            });
+        });
+
+        test.afterAll(async () => {
+            try {
+                await prisma.contract.deleteMany({ where: { id: SCRATCH_CONTRACT_ID } });
+            } finally {
+                await prisma.$disconnect();
+            }
+        });
+
+        test("updateContract actually persists the write, not just returns ok", async ({ request }) => {
+            const result = await callAction(request, "updateContract", [
+                SCRATCH_CONTRACT_ID,
+                { title: "updated by e2e" },
+            ]);
+            expect(result.ok).toBe(true);
+
+            const row = await prisma.contract.findUnique({
+                where: { id: SCRATCH_CONTRACT_ID },
+                select: { title: true },
+            });
+            expect(row?.title).toBe("updated by e2e");
+        });
+    });
+});
+
+test.describe("client portal path still works", () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    test("accessToken path renders the lead-only contract and its executed-PDF link", async ({ page }) => {
+        const response = await page.goto(`/portal/contracts/${CONTRACT_LEADONLY_ID}?token=${CONTRACT_LEADONLY_TOKEN}`);
+        expect(response?.status()).not.toBe(404);
+        await expect(page).not.toHaveURL(/.*login.*/);
+        await expect(page.getByText(CONTRACT_LEADONLY_TITLE)).toBeVisible();
+        await expect(page.getByText(CONTRACT_LEADONLY_BODY)).toBeVisible();
+        await expect(page.locator('a[href*="example.test/e2e/executed-contract.pdf"]')).toBeVisible();
+    });
+
+    test("portal-session path (no token) renders the same contract", async ({ page }) => {
+        const token = await signClientPortalToken(TEST_CLIENT_ID, TEST_CLIENT_EMAIL);
+        // page.request shares the page's own browser context, so the Set-Cookie
+        // response from /api/portal/verify lands where page.goto can use it —
+        // an APIRequestContext obtained a different way would not share cookies
+        // with this page.
+        const verifyRes = await page.request.get(`/api/portal/verify?token=${encodeURIComponent(token)}&next=/portal`);
+        expect(verifyRes.ok()).toBeTruthy();
+
+        const response = await page.goto(`/portal/contracts/${CONTRACT_LEADONLY_ID}`);
+        expect(response?.status()).not.toBe(404);
+        await expect(page).not.toHaveURL(/.*login.*/);
+        await expect(page.getByText(CONTRACT_LEADONLY_TITLE)).toBeVisible();
+        await expect(page.getByText(CONTRACT_LEADONLY_BODY)).toBeVisible();
+        await expect(page.locator('a[href*="example.test/e2e/executed-contract.pdf"]')).toBeVisible();
+    });
+
+    test("negative control: a wrong token with no portal session 404s", async ({ browser }) => {
+        // A fresh, isolated context: no portal cookie, no shared state with the
+        // tests above.
+        const context = await browser.newContext();
+        const page = await context.newPage();
+        try {
+            const response = await page.goto(`/portal/contracts/${CONTRACT_LEADONLY_ID}?token=not-a-real-token`);
+            // No custom not-found.tsx exists under src/app/portal, so Next's
+            // default not-found page renders — asserting on the HTTP status is
+            // more robust than matching that page's copy.
+            expect(response?.status()).toBe(404);
+        } finally {
+            await context.close();
+        }
+    });
+});

--- a/e2e/data.setup.ts
+++ b/e2e/data.setup.ts
@@ -654,8 +654,11 @@ setup("guard prod DB + seed test data + probe anthropic", async () => {
         // The POSITIVE control, reachable by contract-staff via leadAccess. Also
         // the contract the portal tests use (lead-owned, so /portal/contracts/[id]
         // skips the getPortalVisibility(projectId) branch). Signed + approvedBy/At
-        // set (and requiresCountersign left at its default false) so the portal
-        // treats it as executed and renders the archived-PDF banner.
+        // set, with requiresCountersign explicitly false, so the portal treats it
+        // as executed (isExecuted = isSigned && !awaitingCountersign) and renders
+        // the archived-PDF banner. A default only applies on `create` — restated
+        // here in `update` too, or a pre-existing `true` on a reused database
+        // would survive and silently flip the portal's executed/awaiting state.
         await prisma.contract.upsert({
             where: { id: CONTRACT_LEADONLY_ID },
             update: {
@@ -667,6 +670,7 @@ setup("guard prod DB + seed test data + probe anthropic", async () => {
                 accessToken: "e2e-contract-token-leadonly",
                 approvedBy: "Test Client",
                 approvedAt: new Date(),
+                requiresCountersign: false,
             },
             create: {
                 id: CONTRACT_LEADONLY_ID,
@@ -678,6 +682,7 @@ setup("guard prod DB + seed test data + probe anthropic", async () => {
                 accessToken: "e2e-contract-token-leadonly",
                 approvedBy: "Test Client",
                 approvedAt: new Date(),
+                requiresCountersign: false,
             },
         });
         console.log("[data.setup] contracts upserted:", {

--- a/e2e/data.setup.ts
+++ b/e2e/data.setup.ts
@@ -42,6 +42,22 @@ const OOS_ESTIMATE_ID = "e2e-scope-oos-estimate";
 const OOS_LEAD_ID = "e2e-scope-oos-lead";
 const OOS_LEAD_ESTIMATE_ID = "e2e-scope-oos-lead-estimate";
 
+// --- Contract-auth fixtures (prefix e2e-contract-) ---
+// Two more staff users, distinct from SCOPED_STAFF above, because the contract
+// guard (canAccessContract) is BOTH a vertical check (the `contracts`
+// permission) and the horizontal one (project/lead scope) — proving it needs a
+// user that has scope but lacks the permission, and a separate user that has
+// the permission but lacks scope on a specific job. See
+// e2e/contract-auth-runtime.spec.ts, which exercises PR #367's
+// assertContractAccess/canAccessContract/contractScopeWhere through the
+// test-only dispatcher.
+const FINANCE_STAFF_EMAIL = "finance-staff@test.local";
+const CONTRACT_STAFF_EMAIL = "contract-staff@test.local";
+const CONTRACT_INSCOPE_ID = "e2e-contract-inscope";
+const CONTRACT_CONVERTED_ID = "e2e-contract-converted";
+const CONTRACT_LEADONLY_ID = "e2e-contract-leadonly";
+const CONTRACT_EXECUTED_PDF_ID = "e2e-contract-executed-pdf";
+
 // Substrings that identify the LIVE database. The e2e suite creates leads,
 // estimates, and invoices — it must never do that against production data.
 // See docs/TESTING.md (the Henderson-lead incident, June 2026).
@@ -495,6 +511,218 @@ setup("guard prod DB + seed test data + probe anthropic", async () => {
         console.log("[data.setup] partial-scope fixtures upserted:", {
             project: OOS_PROJECT_ID, lead: OOS_LEAD_ID, estimates: [OOS_ESTIMATE_ID, OOS_LEAD_ESTIMATE_ID],
         });
+
+        // --- Contract-auth fixtures ---
+        // FINANCE: holds project access (PROJECT_ID) but NOT `contracts` — FINANCE's
+        // role default is `estimates` (getDefaultPermission in access-rules.ts), never
+        // `contracts`. This is the user who must get an EMPTY contract list from the
+        // pages and "Forbidden" from every by-id contract action, proving project
+        // access alone is not the contract permission.
+        const financeStaff = await prisma.user.upsert({
+            where: { email: FINANCE_STAFF_EMAIL },
+            update: { role: "FINANCE", status: "ACTIVATED" },
+            create: {
+                email: FINANCE_STAFF_EMAIL,
+                name: "E2E Finance Staff",
+                role: "FINANCE",
+                status: "ACTIVATED",
+            },
+        });
+        const financePermissions = {
+            estimates: true,
+            leadAccess: true,
+            contracts: false,
+            autoGrantNewProjects: false,
+        };
+        await prisma.userPermission.upsert({
+            where: { userId: financeStaff.id },
+            update: financePermissions,
+            create: { userId: financeStaff.id, ...financePermissions },
+        });
+        await prisma.projectAccess.upsert({
+            where: { userId_projectId: { userId: financeStaff.id, projectId: PROJECT_ID } },
+            update: {},
+            create: { userId: financeStaff.id, projectId: PROJECT_ID },
+        });
+        await prisma.projectAccess.deleteMany({
+            where: { userId: financeStaff.id, projectId: { not: PROJECT_ID } },
+        });
+        const financeCrewProjects = await prisma.project.findMany({
+            where: { id: { not: PROJECT_ID }, crew: { some: { id: financeStaff.id } } },
+            select: { id: true },
+        });
+        for (const p of financeCrewProjects) {
+            await prisma.project.update({
+                where: { id: p.id },
+                data: { crew: { disconnect: { id: financeStaff.id } } },
+            });
+        }
+        console.log("[data.setup] finance staff user upserted:", { id: financeStaff.id, email: financeStaff.email });
+
+        // CONTRACT_STAFF: holds `contracts` + `leadAccess`, but scope reaches only
+        // PROJECT_ID — proves canAccessJobScope lets projectId win when a converted
+        // contract carries BOTH ids (CONTRACT_CONVERTED_ID below): leadAccess must
+        // not rescue a contract on a project this user cannot otherwise reach.
+        const contractStaff = await prisma.user.upsert({
+            where: { email: CONTRACT_STAFF_EMAIL },
+            update: { role: "EMPLOYEE", status: "ACTIVATED" },
+            create: {
+                email: CONTRACT_STAFF_EMAIL,
+                name: "E2E Contract Staff",
+                role: "EMPLOYEE",
+                status: "ACTIVATED",
+            },
+        });
+        const contractPermissions = {
+            estimates: true,
+            leadAccess: true,
+            contracts: true,
+            autoGrantNewProjects: false,
+        };
+        await prisma.userPermission.upsert({
+            where: { userId: contractStaff.id },
+            update: contractPermissions,
+            create: { userId: contractStaff.id, ...contractPermissions },
+        });
+        await prisma.projectAccess.upsert({
+            where: { userId_projectId: { userId: contractStaff.id, projectId: PROJECT_ID } },
+            update: {},
+            create: { userId: contractStaff.id, projectId: PROJECT_ID },
+        });
+        await prisma.projectAccess.deleteMany({
+            where: { userId: contractStaff.id, projectId: { not: PROJECT_ID } },
+        });
+        const contractCrewProjects = await prisma.project.findMany({
+            where: { id: { not: PROJECT_ID }, crew: { some: { id: contractStaff.id } } },
+            select: { id: true },
+        });
+        for (const p of contractCrewProjects) {
+            await prisma.project.update({
+                where: { id: p.id },
+                data: { crew: { disconnect: { id: contractStaff.id } } },
+            });
+        }
+        console.log("[data.setup] contract staff user upserted:", { id: contractStaff.id, email: contractStaff.email });
+
+        // Three contracts covering the three scope shapes canAccessContract cares
+        // about. Every field is restated in `update:` — an empty update adopts
+        // whatever drift an earlier run left behind.
+        await prisma.contract.upsert({
+            where: { id: CONTRACT_INSCOPE_ID },
+            update: {
+                projectId: PROJECT_ID,
+                leadId: null,
+                title: "E2E In-Scope Contract — DO NOT DELETE",
+                body: "E2E IN-SCOPE CONTRACT BODY — DO NOT DELETE",
+                status: "Draft",
+                accessToken: "e2e-contract-token-inscope",
+            },
+            create: {
+                id: CONTRACT_INSCOPE_ID,
+                projectId: PROJECT_ID,
+                leadId: null,
+                title: "E2E In-Scope Contract — DO NOT DELETE",
+                body: "E2E IN-SCOPE CONTRACT BODY — DO NOT DELETE",
+                status: "Draft",
+                accessToken: "e2e-contract-token-inscope",
+            },
+        });
+        // THIS IS THE CRITICAL ONE — carries BOTH projectId and leadId, like a
+        // converted lead. leadAccess alone would admit it via the lead, but
+        // canAccessJobScope lets the project id win, and contract-staff cannot
+        // reach OOS_PROJECT_ID, so it must be refused.
+        await prisma.contract.upsert({
+            where: { id: CONTRACT_CONVERTED_ID },
+            update: {
+                projectId: OOS_PROJECT_ID,
+                leadId: OOS_LEAD_ID,
+                title: "E2E Converted Contract — DO NOT DELETE",
+                body: "E2E CONVERTED CONTRACT BODY — DO NOT DELETE",
+                status: "Draft",
+                accessToken: "e2e-contract-token-converted",
+            },
+            create: {
+                id: CONTRACT_CONVERTED_ID,
+                projectId: OOS_PROJECT_ID,
+                leadId: OOS_LEAD_ID,
+                title: "E2E Converted Contract — DO NOT DELETE",
+                body: "E2E CONVERTED CONTRACT BODY — DO NOT DELETE",
+                status: "Draft",
+                accessToken: "e2e-contract-token-converted",
+            },
+        });
+        // The POSITIVE control, reachable by contract-staff via leadAccess. Also
+        // the contract the portal tests use (lead-owned, so /portal/contracts/[id]
+        // skips the getPortalVisibility(projectId) branch). Signed + approvedBy/At
+        // set (and requiresCountersign left at its default false) so the portal
+        // treats it as executed and renders the archived-PDF banner.
+        await prisma.contract.upsert({
+            where: { id: CONTRACT_LEADONLY_ID },
+            update: {
+                projectId: null,
+                leadId: OOS_LEAD_ID,
+                title: "E2E Lead-Only Contract — DO NOT DELETE",
+                body: "E2E LEAD-ONLY CONTRACT BODY — DO NOT DELETE",
+                status: "Signed",
+                accessToken: "e2e-contract-token-leadonly",
+                approvedBy: "Test Client",
+                approvedAt: new Date(),
+            },
+            create: {
+                id: CONTRACT_LEADONLY_ID,
+                projectId: null,
+                leadId: OOS_LEAD_ID,
+                title: "E2E Lead-Only Contract — DO NOT DELETE",
+                body: "E2E LEAD-ONLY CONTRACT BODY — DO NOT DELETE",
+                status: "Signed",
+                accessToken: "e2e-contract-token-leadonly",
+                approvedBy: "Test Client",
+                approvedAt: new Date(),
+            },
+        });
+        console.log("[data.setup] contracts upserted:", {
+            inscope: CONTRACT_INSCOPE_ID, converted: CONTRACT_CONVERTED_ID, leadonly: CONTRACT_LEADONLY_ID,
+        });
+
+        // Executed-PDF file for CONTRACT_LEADONLY_ID. Name must be the EXACT string
+        // executedContractPdfFor() matches on (src/lib/contract-files-core.ts).
+        await prisma.projectFile.upsert({
+            where: { id: CONTRACT_EXECUTED_PDF_ID },
+            update: {
+                leadId: OOS_LEAD_ID,
+                projectId: null,
+                mimeType: "application/pdf",
+                name: `Executed_Contract_${CONTRACT_LEADONLY_ID}.pdf`,
+                url: "https://example.test/e2e/executed-contract.pdf",
+            },
+            create: {
+                id: CONTRACT_EXECUTED_PDF_ID,
+                leadId: OOS_LEAD_ID,
+                projectId: null,
+                mimeType: "application/pdf",
+                name: `Executed_Contract_${CONTRACT_LEADONLY_ID}.pdf`,
+                url: "https://example.test/e2e/executed-contract.pdf",
+            },
+        });
+        console.log("[data.setup] executed contract PDF file upserted:", { id: CONTRACT_EXECUTED_PDF_ID });
+
+        // Portal sanity check: resolveSessionClientId (src/lib/portal-auth.ts)
+        // collapses to `null` — silently — if this email matches zero OR more than
+        // one Client row, which would make the portal-session contract test pass
+        // for the wrong reason (a null session falls through to the accessToken-only
+        // path, never exercising the session branch at all).
+        const portalClientMatches = await prisma.client.findMany({
+            where: { email: "test-client@goldentouchremodeling.com" },
+            select: { id: true },
+        });
+        console.log("[data.setup] portal client sanity check:", portalClientMatches);
+        if (portalClientMatches.length !== 1) {
+            throw new Error(
+                `[data.setup] expected exactly one Client with email test-client@goldentouchremodeling.com, ` +
+                    `found ${portalClientMatches.length}. resolveSessionClientId() would silently return null, ` +
+                    `and the portal-session contract test would pass for the wrong reason.`
+            );
+        }
 
         const verify = await prisma.project.findUnique({ where: { id: PROJECT_ID }, select: { id: true, name: true } });
         console.log("[data.setup] verify project exists:", verify);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -70,5 +70,16 @@ export default defineConfig({
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
+    env: {
+      // The test harness turning on its own test routes, which is the only
+      // context that should ever enable them. Without this a LOCAL run 404s on
+      // src/app/api/test-only/contract-actions and every dispatcher assertion
+      // in e2e/contract-auth-runtime.spec.ts fails — that spec's FINANCE and
+      // contract-staff blocks are meant to run locally, not only in CI.
+      // ci.yml sets the same variable at job level; a server started by hand
+      // (reuseExistingServer picks it up) will not have it, and the spec says
+      // so in its failure message rather than passing vacuously.
+      E2E_TEST_ROUTES: "1",
+    },
   },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,6 +37,22 @@ export default defineConfig({
       dependencies: ["data"],
     },
     {
+      // A THIRD session: FINANCE staff with project access but no `contracts`
+      // permission. See auth-finance.setup.ts and
+      // e2e/contract-auth-runtime.spec.ts.
+      name: "setup-finance",
+      testMatch: /(^|[\\/])auth-finance\.setup\.ts$/,
+      dependencies: ["data"],
+    },
+    {
+      // A FOURTH session: EMPLOYEE staff with `contracts` + `leadAccess` but
+      // scope reaching only one project. See auth-contract.setup.ts and
+      // e2e/contract-auth-runtime.spec.ts.
+      name: "setup-contract",
+      testMatch: /(^|[\\/])auth-contract\.setup\.ts$/,
+      dependencies: ["data"],
+    },
+    {
       name: "chromium",
       // The setup files are run by the setup projects above. Without this they
       // would ALSO run here as ordinary tests and rewrite the storage-state
@@ -46,7 +62,7 @@ export default defineConfig({
         ...devices["Desktop Chrome"],
         storageState: "e2e/.auth/user.json",
       },
-      dependencies: ["data", "setup", "setup-scoped"],
+      dependencies: ["data", "setup", "setup-scoped", "setup-finance", "setup-contract"],
     },
   ],
   webServer: {

--- a/src/app/api/test-only/contract-actions/route.ts
+++ b/src/app/api/test-only/contract-actions/route.ts
@@ -42,25 +42,32 @@ import {
  * "Forbidden" vs "Unauthorized" vs data — and the actions already surface both
  * strings to any caller who triggers them through the UI.
  *
- * FOUR INDEPENDENT GATES, so a single mistake does not expose it:
- *  1. PLAYWRIGHT_TEST_SECRET must be set. Production does not set it (it is
+ * THREE INDEPENDENT ENVIRONMENT/CREDENTIAL GATES, plus an allowlist:
+ *  1. E2E_TEST_ROUTES must be exactly "1" — an explicit, positive opt-in whose
+ *     ONLY purpose is enabling test routes. Codex's point: deriving "test
+ *     routes are on" from an auth secret makes the route a side effect of a
+ *     credential rather than a decision, so a secret that leaked into an
+ *     environment would silently switch it on. This flag is set nowhere but
+ *     the CI Playwright job.
+ *  2. PLAYWRIGHT_TEST_SECRET must be set. Production does not set it (it is
  *     also what registers the test-only CredentialsProvider in lib/auth.ts —
- *     see CLAUDE.md), so in production this module answers 404 and nothing
- *     below it ever runs.
- *  2. VERCEL_ENV must not be "production", belt-and-braces against the secret
- *     ever being added to the prod environment by accident.
- *  3. The request must present that same secret in `x-e2e-secret`, compared in
- *     constant time.
- *  4. Only the eight allowlisted action names dispatch at all.
+ *     see CLAUDE.md).
+ *  3. VERCEL_ENV must not be "production". Note this one FAILS OPEN when
+ *     VERCEL_ENV is undefined (self-hosted, or a promoted artifact), which is
+ *     exactly why it is the belt and gate 1 is the braces — never rely on it
+ *     alone.
+ *  4. Then: the request must present that secret in `x-e2e-secret`, compared in
+ *     constant time, and name one of the eight allowlisted actions.
  *
  * Every rejection is a bare 404, not a 401/403: an enabled-but-unauthorized
- * caller learns nothing about whether the route exists.
+ * caller learns nothing about whether the route exists. Thrown errors are
+ * mapped through a known-message allowlist rather than returned raw, so a
+ * malformed argument cannot surface Prisma model names or source paths the way
+ * an unsanitized `Error.message` would.
  *
- * The proxy bypass this route needs (src/proxy.ts) is gated on the SAME
- * PLAYWRIGHT_TEST_SECRET, so it too is dead code in production. The bypass is
- * required only so an UNAUTHENTICATED request reaches the action and is
- * refused by the action's own gate, rather than being bounced to /login by the
- * proxy — the proxy redirect would prove nothing about assertContractAccess.
+ * The proxy bypass this route needs (src/proxy.ts) repeats gates 1–3 verbatim
+ * and additionally refuses anything carrying a `next-action` header, so
+ * bypassing the proxy can never also mean bypassing the Server Action boundary.
  */
 
 export const dynamic = "force-dynamic";
@@ -77,8 +84,32 @@ const ACTIONS: Record<string, (...args: any[]) => Promise<any>> = {
     getExecutedContractPdf,
     getContractSigningHistory,
     getContractSendDefaults,
-    getLead,
+    // Projected down to the id and the contracts relation. getLead otherwise
+    // returns the client record, tasks, manager, room designs and the linked
+    // project — none of which this route is here to expose, and all of which
+    // would make the dispatcher a strictly wider door than the assertion it
+    // supports. The test only ever reads `.contracts`.
+    getLead: async (id: string) => {
+        const lead: any = await getLead(id);
+        if (!lead) return null;
+        return { id: lead.id, contracts: lead.contracts ?? [] };
+    },
 };
+
+/**
+ * Errors are reported by an allowlist of the messages the guards themselves
+ * raise — the ones a caller can already read off the UI, and the only ones the
+ * tests distinguish. Anything else collapses to a generic string rather than
+ * echoing a raw `Error.message`, which on a malformed argument can carry Prisma
+ * model names, column names and absolute source paths.
+ */
+const REPORTABLE_ERRORS = new Set([
+    "Unauthorized",
+    "Forbidden",
+    "Contract not found",
+    "Lead not found",
+    "This contract is not attached to a project or lead, so access cannot be checked",
+]);
 
 function secretMatches(provided: string | null): boolean {
     const expected = process.env.PLAYWRIGHT_TEST_SECRET;
@@ -92,14 +123,24 @@ function secretMatches(provided: string | null): boolean {
     return timingSafeEqual(a, b);
 }
 
-function enabled(): boolean {
-    return !!process.env.PLAYWRIGHT_TEST_SECRET && process.env.VERCEL_ENV !== "production";
+/**
+ * Keep IDENTICAL to the matching condition in src/proxy.ts. Two gates that are
+ * meant to agree and quietly don't is the exact defect Codex found in the first
+ * version of this pair.
+ */
+// NOT exported: a route module may only export the framework's own names.
+function testOnlyRoutesEnabled(): boolean {
+    return (
+        process.env.E2E_TEST_ROUTES === "1"
+        && !!process.env.PLAYWRIGHT_TEST_SECRET
+        && process.env.VERCEL_ENV !== "production"
+    );
 }
 
 const NOT_FOUND = () => new NextResponse("Not Found", { status: 404 });
 
 export async function POST(req: Request) {
-    if (!enabled()) return NOT_FOUND();
+    if (!testOnlyRoutesEnabled()) return NOT_FOUND();
     if (!secretMatches(req.headers.get("x-e2e-secret"))) return NOT_FOUND();
 
     const body = await req.json().catch(() => null);
@@ -118,6 +159,10 @@ export async function POST(req: Request) {
         // 200 with ok:false, deliberately: the test asserts on WHICH error the
         // action threw, and an HTTP error status would be indistinguishable
         // from the proxy or the framework rejecting the request first.
-        return NextResponse.json({ ok: false, error: (e as Error).message });
+        const message = (e as Error)?.message ?? "";
+        return NextResponse.json({
+            ok: false,
+            error: REPORTABLE_ERRORS.has(message) ? message : "Internal error",
+        });
     }
 }

--- a/src/app/api/test-only/contract-actions/route.ts
+++ b/src/app/api/test-only/contract-actions/route.ts
@@ -106,10 +106,14 @@ const ACTIONS: Record<string, (...args: any[]) => Promise<any>> = {
 const REPORTABLE_ERRORS = new Set([
     "Unauthorized",
     "Forbidden",
-    "Contract not found",
-    "Lead not found",
-    "This contract is not attached to a project or lead, so access cannot be checked",
 ]);
+// Deliberately just those two. An earlier version also passed through "Contract
+// not found" and the ownerless-contract message; Codex pointed out that
+// "not found" vs "Forbidden" is an existence oracle for a staff caller who
+// holds the `contracts` permission but not the scope — precisely the caller
+// assertContractAccess orders its checks to deny that distinction to. Every
+// other failure is still fully detectable as `ok: false`; only its wording is
+// withheld, and no test needs the wording.
 
 function secretMatches(provided: string | null): boolean {
     const expected = process.env.PLAYWRIGHT_TEST_SECRET;
@@ -133,6 +137,14 @@ function testOnlyRoutesEnabled(): boolean {
     return (
         process.env.E2E_TEST_ROUTES === "1"
         && !!process.env.PLAYWRIGHT_TEST_SECRET
+        // The POSITIVE condition. Every other clause here is a negative — an
+        // absent variable satisfies it — so on a self-hosted production server
+        // with no VERCEL_ENV at all, the earlier version enabled itself. This
+        // one has to be affirmatively true: either we are not a production
+        // build, or we are the CI Playwright job (which runs `npm run start`,
+        // i.e. NODE_ENV=production, with CI=true). A real production server is
+        // neither.
+        && (process.env.NODE_ENV !== "production" || process.env.CI === "true")
         && process.env.VERCEL_ENV !== "production"
     );
 }

--- a/src/app/api/test-only/contract-actions/route.ts
+++ b/src/app/api/test-only/contract-actions/route.ts
@@ -1,0 +1,123 @@
+import { NextResponse } from "next/server";
+import { timingSafeEqual } from "node:crypto";
+import {
+    getContracts,
+    getContract,
+    updateContract,
+    deleteContract,
+    getExecutedContractPdf,
+    getContractSigningHistory,
+    getContractSendDefaults,
+    getLead,
+} from "@/lib/actions";
+
+/**
+ * TEST-ONLY dispatcher for the contract server-action family.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The contract guards (assertContractAccess / canAccessContract /
+ * contractScopeWhere, PR #367) were covered only by source-pattern assertions
+ * in e2e/financial-action-auth.spec.ts: read actions.ts as text, check the
+ * guard tokens appear in the right order. Codex flagged that twice as only
+ * partially sufficient — any refactor that keeps the token shapes while
+ * changing the semantics passes. Proving the guards BEHAVE requires actually
+ * invoking the actions as a specific caller and asserting the outcome.
+ *
+ * Server Actions are addressed over the wire by a build-hash `Next-Action` id,
+ * and the actions under test are called from server components, so they have
+ * no stable client reference a test could POST to. This route is the smallest
+ * thing that closes that gap: a dispatcher that calls the SAME exported
+ * functions the app calls, inside a real request, with the caller's own
+ * cookies.
+ *
+ * WHY IT IS NOT A PRIVILEGE ESCALATION
+ * ------------------------------------
+ * It grants nothing. It does not construct a session, does not impersonate,
+ * and does not bypass a single guard — it forwards the request's own identity
+ * into the action and reports what the action decided. A caller can already
+ * invoke every one of these actions through the app; this route only makes the
+ * invocation addressable by name so a test can assert on the answer. The error
+ * message is returned verbatim precisely BECAUSE the meaningful assertion is
+ * "Forbidden" vs "Unauthorized" vs data — and the actions already surface both
+ * strings to any caller who triggers them through the UI.
+ *
+ * FOUR INDEPENDENT GATES, so a single mistake does not expose it:
+ *  1. PLAYWRIGHT_TEST_SECRET must be set. Production does not set it (it is
+ *     also what registers the test-only CredentialsProvider in lib/auth.ts —
+ *     see CLAUDE.md), so in production this module answers 404 and nothing
+ *     below it ever runs.
+ *  2. VERCEL_ENV must not be "production", belt-and-braces against the secret
+ *     ever being added to the prod environment by accident.
+ *  3. The request must present that same secret in `x-e2e-secret`, compared in
+ *     constant time.
+ *  4. Only the eight allowlisted action names dispatch at all.
+ *
+ * Every rejection is a bare 404, not a 401/403: an enabled-but-unauthorized
+ * caller learns nothing about whether the route exists.
+ *
+ * The proxy bypass this route needs (src/proxy.ts) is gated on the SAME
+ * PLAYWRIGHT_TEST_SECRET, so it too is dead code in production. The bypass is
+ * required only so an UNAUTHENTICATED request reaches the action and is
+ * refused by the action's own gate, rather than being bounced to /login by the
+ * proxy — the proxy redirect would prove nothing about assertContractAccess.
+ */
+
+export const dynamic = "force-dynamic";
+
+// Exactly the family under test, plus getLead — whose embedded `contracts`
+// relation was the Codex round-1 blocker (an anonymous caller holding a lead id
+// received every contract field, including the signing accessToken, through an
+// action that is not itself part of the contract family).
+const ACTIONS: Record<string, (...args: any[]) => Promise<any>> = {
+    getContracts,
+    getContract,
+    updateContract,
+    deleteContract,
+    getExecutedContractPdf,
+    getContractSigningHistory,
+    getContractSendDefaults,
+    getLead,
+};
+
+function secretMatches(provided: string | null): boolean {
+    const expected = process.env.PLAYWRIGHT_TEST_SECRET;
+    if (!expected || !provided) return false;
+    const a = Buffer.from(provided);
+    const b = Buffer.from(expected);
+    // timingSafeEqual throws on a length mismatch, which would itself be a
+    // length oracle if it escaped as a 500. Compare lengths first, and keep the
+    // comparison constant time for equal-length candidates.
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(a, b);
+}
+
+function enabled(): boolean {
+    return !!process.env.PLAYWRIGHT_TEST_SECRET && process.env.VERCEL_ENV !== "production";
+}
+
+const NOT_FOUND = () => new NextResponse("Not Found", { status: 404 });
+
+export async function POST(req: Request) {
+    if (!enabled()) return NOT_FOUND();
+    if (!secretMatches(req.headers.get("x-e2e-secret"))) return NOT_FOUND();
+
+    const body = await req.json().catch(() => null);
+    const name = typeof body?.action === "string" ? body.action : "";
+    const args = Array.isArray(body?.args) ? body.args : [];
+
+    const action = Object.prototype.hasOwnProperty.call(ACTIONS, name) ? ACTIONS[name] : undefined;
+    if (!action) return NextResponse.json({ ok: false, error: "Unknown action" }, { status: 400 });
+
+    try {
+        const data = await action(...args);
+        // Prisma Decimal / Date do not survive NextResponse.json on their own
+        // in a shape a test can compare; normalize through JSON first.
+        return NextResponse.json({ ok: true, data: JSON.parse(JSON.stringify(data ?? null)) });
+    } catch (e) {
+        // 200 with ok:false, deliberately: the test asserts on WHICH error the
+        // action threw, and an HTTP error status would be indistinguishable
+        // from the proxy or the framework rejecting the request first.
+        return NextResponse.json({ ok: false, error: (e as Error).message });
+    }
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -90,6 +90,22 @@ export default async function proxy(req: any, event: any) {
         }
     }
 
+    // Test-only contract-action dispatcher (src/app/api/test-only/contract-actions).
+    // Gated on the SAME env var that enables the route itself and the test-only
+    // CredentialsProvider, so in production PLAYWRIGHT_TEST_SECRET is unset and
+    // this branch never runs. It exists so an UNAUTHENTICATED request reaches
+    // the action and is refused by assertContractAccess — a proxy redirect to
+    // /login would prove nothing about the action's own gate, which is exactly
+    // what e2e/contract-auth-runtime.spec.ts has to pin. The route still
+    // demands the secret in a header and answers 404 without it.
+    if (
+        process.env.PLAYWRIGHT_TEST_SECRET
+        && typeof pathname === "string"
+        && pathname === "/api/test-only/contract-actions"
+    ) {
+        return NextResponse.next();
+    }
+
     // Legal pages are readable by anyone but are not an action endpoint.
     if (isServerAction && typeof pathname === "string" && LEGAL_PAGE_PATTERN.test(pathname)) {
         return new NextResponse("Forbidden", { status: 403 });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -109,6 +109,10 @@ export default async function proxy(req: any, event: any) {
         !isServerAction
         && process.env.E2E_TEST_ROUTES === "1"
         && !!process.env.PLAYWRIGHT_TEST_SECRET
+        // Affirmative, not merely "not production" — see the same clause in the
+        // route. Every other condition is satisfied by an ABSENT variable, so a
+        // self-hosted production server (no VERCEL_ENV) passed them all.
+        && (process.env.NODE_ENV !== "production" || process.env.CI === "true")
         && process.env.VERCEL_ENV !== "production"
         && typeof pathname === "string"
         && pathname === "/api/test-only/contract-actions"

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -91,15 +91,25 @@ export default async function proxy(req: any, event: any) {
     }
 
     // Test-only contract-action dispatcher (src/app/api/test-only/contract-actions).
-    // Gated on the SAME env var that enables the route itself and the test-only
-    // CredentialsProvider, so in production PLAYWRIGHT_TEST_SECRET is unset and
-    // this branch never runs. It exists so an UNAUTHENTICATED request reaches
-    // the action and is refused by assertContractAccess — a proxy redirect to
-    // /login would prove nothing about the action's own gate, which is exactly
-    // what e2e/contract-auth-runtime.spec.ts has to pin. The route still
-    // demands the secret in a header and answers 404 without it.
+    // It exists so an UNAUTHENTICATED request reaches the action and is refused
+    // by assertContractAccess — a proxy redirect to /login would prove nothing
+    // about the action's own gate, which is exactly what
+    // e2e/contract-auth-runtime.spec.ts has to pin.
+    //
+    // The conditions here MUST stay identical to testOnlyRoutesEnabled() in that
+    // route, and `!isServerAction` is load-bearing on top of them. Codex flagged
+    // the earlier version: it checked only PLAYWRIGHT_TEST_SECRET while the
+    // route also checked VERCEL_ENV, so the two supposedly-matching gates did
+    // not match, and it waved through a request carrying a `next-action` header
+    // that the checks above had deliberately just scrutinised. An anonymous
+    // caller has no session cookie, so the stale-cookie check above does not
+    // cover them. Bypassing the proxy is never allowed to also mean bypassing
+    // the Server Action boundary.
     if (
-        process.env.PLAYWRIGHT_TEST_SECRET
+        !isServerAction
+        && process.env.E2E_TEST_ROUTES === "1"
+        && !!process.env.PLAYWRIGHT_TEST_SECRET
+        && process.env.VERCEL_ENV !== "production"
         && typeof pathname === "string"
         && pathname === "/api/test-only/contract-actions"
     ) {


### PR DESCRIPTION
## Why

PR #367 gated the contract server-action family behind `assertContractAccess` / `canAccessContract` / `contractScopeWhere`. The only coverage was **source-pattern based**: `e2e/financial-action-auth.spec.ts` reads `actions.ts` as text and asserts the guard tokens appear in the right order. Codex flagged that twice as only partially sufficient — any refactor that keeps the token shapes while changing the semantics passes.

These tests **invoke the real actions as a specific caller and assert the outcome**, against the throwaway CI Postgres. The `data.setup.ts` prod-DB guard is untouched.

## What is covered

- an anonymous caller is refused (`"Unauthorized"`) by `getContracts`, `getContract`, `updateContract`, `deleteContract`, `getExecutedContractPdf`, `getContractSigningHistory`, `getContractSendDefaults` — and no `accessToken` or contract body appears in any response
- `getLead` returns **no contract rows** to an anonymous caller. This was the Codex round-1 blocker: an ungated relation handed every contract field, `accessToken` included, to anyone holding a lead id, through an action outside the contract family
- a **FINANCE** user with project access but no `contracts` permission gets an empty list from `/projects/[id]/contracts` and `/leads/[id]/contracts`, and `"Forbidden"` from every by-id action. Note the action and the pages answer "no contracts" by **two different mechanisms** — `getContracts` throws at its permission gate before `contractScopeWhere` is consulted; only the pages degrade to an empty list
- a user with `contracts` + `leadAccess` but no access to a converted contract's project **cannot reach it** — it carries both ids and `canAccessJobScope` lets `projectId` win
- the client portal still works, by `accessToken` and by portal session, still surfaces the executed PDF, and 404s on a wrong token

Every block carries **positive controls**, so none of it can pass by denying everything. Including the one that matters most: `getExecutedContractPdf` is called with a **forged descriptor** — the converted contract, claimed to be lead-only. `contractOwnerOrThrow` exists precisely so ownership comes from the database rather than the caller, and nothing pinned that before.

## How the actions are invoked

Server Actions are addressed by a build-hash `Next-Action` id, and these are called from server components, so they have no stable client reference a test can POST to. `src/app/api/test-only/contract-actions/route.ts` is a dispatcher that calls the **same exported functions** with the caller's own cookies.

**It grants nothing.** No session is constructed, no guard is bypassed; it forwards the request's own identity into the action and reports what the action decided. Gates:

1. `E2E_TEST_ROUTES === "1"` — an explicit positive opt-in, set by `playwright.config.ts`'s webServer and the CI job, nowhere else
2. `PLAYWRIGHT_TEST_SECRET` set — production does not set it
3. `NODE_ENV !== "production" || CI === "true"` — the **affirmative** clause; every other condition is satisfied by an absent variable, so without this a self-hosted production server enabled itself
4. `VERCEL_ENV !== "production"`
5. the request must present that secret in `x-e2e-secret`, compared in constant time, naming one of eight allowlisted actions

Every rejection is a bare 404. Thrown errors pass through an allowlist of `"Unauthorized"` / `"Forbidden"` only — `"Contract not found"` vs `"Forbidden"` would be an existence oracle for a caller with the permission but not the scope. The gate has its own tests: wrong secret, missing secret, unknown action name.

The `src/proxy.ts` bypass repeats gates 1–4 verbatim and additionally refuses anything carrying a `next-action` header, so bypassing the proxy can never mean bypassing the Server Action boundary. It exists only so an anonymous request reaches the action's own gate instead of a login redirect — a redirect would prove nothing about `assertContractAccess`.

## Two new storage states

An ADMIN-only suite can never reach a non-admin branch: `accessibleProjectIds` returns `"ALL"` and `hasPermission` short-circuits for ADMIN/MANAGER. The extra sessions **are** the test — same lesson as the scope-label work.

## Verification

- `npm run build` clean
- new spec: **44 passed** against a throwaway Postgres, in a production build (`npm run start`, `CI=true`) so the anonymous cases face the real proxy rather than the dev auth fallback
- full suite: **464 passed**, 1 flaky (unrelated reports-page test, passed on retry), 0 failed

Running it for real falsified two of my own expectations that a source grep never could have. Both were wrong tests, not product bugs, and both are recorded in the commit history rather than quietly amended away.

## Reviews

Codex `gpt-5.6-sol` at `xhigh`, two rounds. Round 1 found a genuine gate asymmetry (the proxy and route conditions were meant to match and did not) plus five mutation-test gaps. Round 2 found the gate still failed open on a self-hosted production server. All addressed. Two nits accepted without change and named in the commit message.

## Unrelated finding, not fixed here

`src/app/portal/contracts/[id]/PortalContractClient.tsx` throws `TypeError: d.default.sanitize is not a function` during SSR on **every** load — it imports the browser-only `dompurify` build in a component Next still renders on the server. Pre-existing on `main`; clients still see the page because the browser re-renders it. Spun off separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
