### PR TITLE
Fix CO PDF: add space between letterhead and CHANGE ORDER title

### DIFF
--- a/src/app/portal/change-orders/[id]/PortalChangeOrderClient.tsx
+++ b/src/app/portal/change-orders/[id]/PortalChangeOrderClient.tsx
@@ -44,6 +44,11 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
 
     const isApproved = initialData.status === "Approved";
     const isSent = initialData.status === "Sent";
+    const isDeclined = initialData.status === "Declined";
+    // Draft covers "never sent yet" and "pulled back for edits after being sent" — the
+    // client-facing copy already calls this state "Under Revision" in the skipped panel
+    // below; the badge reuses that same label so a Draft/superseded CO never reads as
+    // approvable on the printed PDF.
     const companyName = companySettings?.companyName || "Golden Touch Remodeling";
     const companyPhone = companySettings?.phone || "";
     const companyEmail = companySettings?.email || "";
@@ -56,9 +61,18 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
         setIsDownloading(true);
         const prevShadow = element.style.boxShadow;
         const prevBorder = element.style.border;
+        // buildPdf measures element.offsetHeight BEFORE the html-to-image capture step,
+        // which filters out [data-pdf-skip] nodes. The two terminal panels below (Ready
+        // to Approve? / Change Order Under Revision) are data-pdf-skip, so if they're
+        // still visible during measurement, totalHeight is inflated relative to what's
+        // actually captured — which can add a blank trailing page. Hide them for
+        // measurement too so both steps see the identical layout.
+        const skipEls = Array.from(element.querySelectorAll<HTMLElement>("[data-pdf-skip]"));
+        const prevDisplays = skipEls.map(el => el.style.display);
         try {
             element.style.boxShadow = "none";
             element.style.border = "none";
+            skipEls.forEach(el => { el.style.display = "none"; });
             const pdf = await buildPdf(element, { bannerText: changeOrderBannerText });
             pdf.save(`ChangeOrder_${initialData.code || initialData.id}.pdf`);
         } catch (err) {
@@ -66,9 +80,10 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
             toast.error("Couldn't generate the PDF. Please try again.");
         } finally {
             // Restore even on failure — a thrown buildPdf() must not leave the
-            // card visually altered (no shadow/border) for the rest of the visit.
+            // card visually altered (no shadow/border, hidden panels) for the rest of the visit.
             element.style.boxShadow = prevShadow;
             element.style.border = prevBorder;
+            skipEls.forEach((el, i) => { el.style.display = prevDisplays[i]; });
             setIsDownloading(false);
         }
     }
@@ -84,6 +99,15 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
     const taxLabel = coTaxLabel(initialData.estimate);
     const isCostPlus = initialData.pricingType === "COST_PLUS";
     const schedules = initialData.paymentSchedules || [];
+
+    // Split on blank lines so each paragraph can be its own top-level data-pdf-row —
+    // build-pdf.ts hard-slices any row taller than one page, which can cut through a
+    // text line if the whole description is one atomic row. Sibling rows give the
+    // paginator safe break points between paragraphs (mirrors PortalInvoiceClient's
+    // Notes section).
+    const descriptionParagraphs = initialData.description
+        ? String(initialData.description).split(/\n\s*\n/).map((p: string) => p.trim()).filter(Boolean)
+        : [];
 
     return (
         <div className="min-h-screen bg-slate-100 font-sans">
@@ -153,9 +177,17 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
                                             <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" /></svg>
                                             Approved
                                         </span>
-                                    ) : (
+                                    ) : isSent ? (
                                         <span className="inline-flex items-center px-3 py-1 rounded-md text-xs font-bold bg-amber-50 text-amber-700 border border-amber-200 uppercase tracking-wider">
-                                            Pending Approval
+                                            Sent - Awaiting Approval
+                                        </span>
+                                    ) : isDeclined ? (
+                                        <span className="inline-flex items-center px-3 py-1 rounded-md text-xs font-bold bg-red-50 text-red-700 border border-red-200 uppercase tracking-wider">
+                                            Declined
+                                        </span>
+                                    ) : (
+                                        <span className="inline-flex items-center px-3 py-1 rounded-md text-xs font-bold bg-slate-100 text-slate-600 border border-slate-300 uppercase tracking-wider">
+                                            Under Revision
                                         </span>
                                     )}
                                 </div>
@@ -179,11 +211,24 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
                         </div>
                     </div>
 
-                    {/* Memo / Description */}
-                    {initialData.description && (
-                        <div data-pdf-row="true" className="px-5 sm:px-10 py-8 border-b border-slate-100">
-                            <h2 className="text-sm font-semibold text-slate-800 uppercase tracking-wider mb-3">Reason for Change</h2>
-                            <p className="text-sm text-slate-600 leading-relaxed whitespace-pre-wrap">{initialData.description}</p>
+                    {/* Memo / Description — heading and each paragraph are sibling data-pdf-row
+                        blocks (not nested inside a parent that itself carries data-pdf-row, which
+                        build-pdf.ts would ignore) so a long description gets safe per-paragraph
+                        page breaks instead of one atomic block that can hard-slice through text. */}
+                    {descriptionParagraphs.length > 0 && (
+                        <div className="border-b border-slate-100">
+                            <div data-pdf-row="true" className="px-5 sm:px-10 pt-8 pb-3">
+                                <h2 className="text-sm font-semibold text-slate-800 uppercase tracking-wider">Reason for Change</h2>
+                            </div>
+                            {descriptionParagraphs.map((para: string, i: number) => (
+                                <div
+                                    key={i}
+                                    data-pdf-row="true"
+                                    className={`px-5 sm:px-10 text-sm text-slate-600 leading-relaxed whitespace-pre-wrap ${i === descriptionParagraphs.length - 1 ? "pb-8" : "pb-3"}`}
+                                >
+                                    {para}
+                                </div>
+                            ))}
                         </div>
                     )}
 

--- a/src/app/portal/change-orders/[id]/PortalChangeOrderClient.tsx
+++ b/src/app/portal/change-orders/[id]/PortalChangeOrderClient.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { toast } from "sonner";
 import { formatCurrency } from "@/lib/utils";
 import { coTaxRate, coTaxLabel, coLineCents, coItemsSubtotal, billableCoItems } from "@/lib/co-tax";
+import { buildPdf } from "@/lib/build-pdf";
 
 export default function PortalChangeOrderClient({ initialData, companySettings }: { initialData: any, companySettings?: any }) {
     const [isApproving, setIsApproving] = useState(false);
@@ -14,6 +15,7 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
     const [signatureDataUrl, setSignatureDataUrl] = useState<string | null>(null);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [error, setError] = useState("");
+    const [isDownloading, setIsDownloading] = useState(false);
 
     const handleApprove = async () => {
         if (!signature.trim()) {
@@ -46,6 +48,30 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
     const companyPhone = companySettings?.phone || "";
     const companyEmail = companySettings?.email || "";
     const companyAddress = companySettings?.address || "";
+    const changeOrderBannerText = `${companyName} • Change Order ${initialData.code} (continued)`;
+
+    async function handleDownload() {
+        const element = document.getElementById("change-order-document-wrapper");
+        if (!element) return;
+        setIsDownloading(true);
+        const prevShadow = element.style.boxShadow;
+        const prevBorder = element.style.border;
+        try {
+            element.style.boxShadow = "none";
+            element.style.border = "none";
+            const pdf = await buildPdf(element, { bannerText: changeOrderBannerText });
+            pdf.save(`ChangeOrder_${initialData.code || initialData.id}.pdf`);
+        } catch (err) {
+            console.error("Download failed:", err);
+            toast.error("Couldn't generate the PDF. Please try again.");
+        } finally {
+            // Restore even on failure — a thrown buildPdf() must not leave the
+            // card visually altered (no shadow/border) for the rest of the visit.
+            element.style.boxShadow = prevShadow;
+            element.style.border = prevBorder;
+            setIsDownloading(false);
+        }
+    }
 
     const items = initialData.items || [];
     // Same integer-cents math as the editor, updateChangeOrder's item sync, and
@@ -72,7 +98,20 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
                     <span className="text-sm text-slate-500">Change Order Portal</span>
                 </div>
                 <div className="flex items-center gap-4">
-                    <Link href={`/portal/projects/${initialData.projectId}`} className="text-sm text-blue-600 hover:underline">
+                    <button
+                        data-pdf-skip="true"
+                        onClick={handleDownload}
+                        disabled={isDownloading}
+                        className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-slate-600 hover:text-slate-800 hover:bg-slate-100 rounded-lg transition disabled:opacity-50"
+                    >
+                        {isDownloading ? (
+                            <svg className="animate-spin w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" /><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" /></svg>
+                        ) : (
+                            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg>
+                        )}
+                        {isDownloading ? "Generating..." : "Download PDF"}
+                    </button>
+                    <Link data-pdf-skip="true" href={`/portal/projects/${initialData.projectId}`} className="text-sm text-blue-600 hover:underline">
                         Back to Portal
                     </Link>
                     {isApproved && (
@@ -83,10 +122,10 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
 
             {/* Document Container */}
             <div className="max-w-4xl mx-auto py-8 px-4 print:py-0 print:px-0">
-                <div className="bg-white rounded-lg shadow-sm border border-slate-200 overflow-hidden print:shadow-none print:border-none print:rounded-none">
+                <div id="change-order-document-wrapper" className="bg-white rounded-lg shadow-sm border border-slate-200 overflow-hidden print:shadow-none print:border-none print:rounded-none">
 
                     {/* Document Header */}
-                    <div className="px-5 sm:px-10 pt-10 pb-8 border-b border-slate-200">
+                    <div data-pdf-row="true" className="px-5 sm:px-10 pt-10 pb-8 border-b border-slate-200">
                         <div className="flex flex-col gap-6 sm:flex-row sm:justify-between items-start">
                             <div>
                                 {companySettings?.logoUrl ? (
@@ -142,14 +181,14 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
 
                     {/* Memo / Description */}
                     {initialData.description && (
-                        <div className="px-5 sm:px-10 py-8 border-b border-slate-100">
+                        <div data-pdf-row="true" className="px-5 sm:px-10 py-8 border-b border-slate-100">
                             <h2 className="text-sm font-semibold text-slate-800 uppercase tracking-wider mb-3">Reason for Change</h2>
                             <p className="text-sm text-slate-600 leading-relaxed whitespace-pre-wrap">{initialData.description}</p>
                         </div>
                     )}
 
                     {isCostPlus && (
-                        <div className="mx-5 sm:mx-10 mt-6 p-5 bg-amber-50 border border-amber-200 rounded-lg">
+                        <div data-pdf-row="true" className="mx-5 sm:mx-10 mt-6 p-5 bg-amber-50 border border-amber-200 rounded-lg">
                             <p className="text-xs font-semibold text-amber-700 uppercase tracking-wider">Cost-plus terms</p>
                             <p className="text-xl font-bold text-slate-900 mt-1">Cost + {initialData.markupPercent ?? 10}% + tax</p>
                             <p className="text-sm text-slate-600 mt-2">This approval covers the scope and markup terms. Work is billed from actual time and materials; scope-line prices are non-binding estimates.</p>
@@ -158,7 +197,7 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
 
                     {/* Signed Badge */}
                     {isApproved && initialData.approvedBy && (
-                        <div className="mx-5 sm:mx-10 mt-6 p-5 bg-green-50 border border-green-200 rounded-lg">
+                        <div data-pdf-row="true" className="mx-5 sm:mx-10 mt-6 p-5 bg-green-50 border border-green-200 rounded-lg">
                             <div className="flex items-start gap-3">
                                 <div className="w-8 h-8 bg-green-100 rounded-full flex items-center justify-center shrink-0">
                                     <svg className="h-4 w-4 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M5 13l4 4L19 7" /></svg>
@@ -180,7 +219,7 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
 
                     {/* Company Countersignature */}
                     {initialData.companySignedBy && (
-                        <div className="mx-5 sm:mx-10 mt-4 p-5 bg-slate-50 border border-slate-200 rounded-lg">
+                        <div data-pdf-row="true" className="mx-5 sm:mx-10 mt-4 p-5 bg-slate-50 border border-slate-200 rounded-lg">
                             <div className="flex items-start gap-3">
                                 <div className="w-8 h-8 bg-amber-100 rounded-full flex items-center justify-center shrink-0">
                                     <svg className="h-4 w-4 text-amber-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M5 13l4 4L19 7" /></svg>
@@ -219,7 +258,7 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
                                 {billableCoItems(items).map((item: any) => {
                                     const itemTotal = coLineCents(Number(item.quantity || 0), Number(item.unitCost || 0)) / 100;
                                     return (
-                                        <tr key={item.id}>
+                                        <tr data-pdf-row="true" key={item.id}>
                                             <td className="py-3 align-top">
                                                 <div className="font-medium text-slate-800">{item.name}</div>
                                                 {item.description && (
@@ -233,13 +272,13 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
                                     );
                                 })}
                                 {items.length === 0 && (
-                                    <tr><td colSpan={4} className="py-6 text-center text-slate-400">No items specified for this Change Order.</td></tr>
+                                    <tr data-pdf-row="true"><td colSpan={4} className="py-6 text-center text-slate-400">No items specified for this Change Order.</td></tr>
                                 )}
                             </tbody>
                         </table>
 
                         {/* Totals */}
-                        {!isCostPlus ? <div className="flex justify-end mt-6">
+                        {!isCostPlus ? <div data-pdf-row="true" className="flex justify-end mt-6">
                             <div className="w-full sm:w-72">
                                 <div className="flex justify-between py-2 text-sm text-slate-600">
                                     <span>Subtotal</span>
@@ -254,13 +293,13 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
                                     <span>{formatCurrency(total)}</span>
                                 </div>
                             </div>
-                        </div> : <div className="flex justify-end mt-6"><div className="w-full sm:w-72 border-t-2 border-slate-800 pt-3 text-right"><p className="text-xs text-slate-500 uppercase">Approved terms</p><p className="text-lg font-bold text-amber-600">Cost + {initialData.markupPercent ?? 10}% + tax</p></div></div>}
+                        </div> : <div data-pdf-row="true" className="flex justify-end mt-6"><div className="w-full sm:w-72 border-t-2 border-slate-800 pt-3 text-right"><p className="text-xs text-slate-500 uppercase">Approved terms</p><p className="text-lg font-bold text-amber-600">Cost + {initialData.markupPercent ?? 10}% + tax</p></div></div>}
 
                         {!isCostPlus && schedules.length > 0 && (
                             <div className="mt-8 border-t border-slate-200 pt-6">
                                 <h3 className="text-sm font-semibold text-slate-800 uppercase tracking-wider mb-3">Payment schedule</h3>
                                 <div className="space-y-2">
-                                    {schedules.map((row: any) => <div key={row.id} className="flex justify-between text-sm"><span>{row.name}{row.dueDate ? ` · ${new Date(row.dueDate).toLocaleDateString()}` : ""}</span><strong>{formatCurrency(row.amount)}</strong></div>)}
+                                    {schedules.map((row: any) => <div data-pdf-row="true" key={row.id} className="flex justify-between text-sm"><span>{row.name}{row.dueDate ? ` · ${new Date(row.dueDate).toLocaleDateString()}` : ""}</span><strong>{formatCurrency(row.amount)}</strong></div>)}
                                 </div>
                             </div>
                         )}
@@ -268,7 +307,7 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
 
                     {/* Signature / Approval Area */}
                     {isSent && (
-                        <div className="px-5 sm:px-10 pb-10 print:hidden">
+                        <div data-pdf-skip="true" className="px-5 sm:px-10 pb-10 print:hidden">
                             <div className="border-t-2 border-slate-200 pt-8">
                                 <div className="text-center max-w-lg mx-auto">
                                     <h3 className="text-lg font-bold text-slate-800 mb-2">Ready to Approve?</h3>
@@ -338,7 +377,7 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
                         </div>
                     )}
                     {!isApproved && !isSent && (
-                        <div className="px-5 sm:px-10 pb-10 print:hidden">
+                        <div data-pdf-skip="true" className="px-5 sm:px-10 pb-10 print:hidden">
                             <div className="border-t-2 border-slate-200 pt-8 text-center">
                                 <h3 className="text-lg font-bold text-slate-800 mb-2">Change Order Under Revision</h3>
                                 <p className="text-sm text-slate-500">This change order is not currently available for approval. Please use the newest link from your contractor.</p>

--- a/src/app/portal/change-orders/[id]/PortalChangeOrderClient.tsx
+++ b/src/app/portal/change-orders/[id]/PortalChangeOrderClient.tsx
@@ -105,9 +105,46 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
     // text line if the whole description is one atomic row. Sibling rows give the
     // paginator safe break points between paragraphs (mirrors PortalInvoiceClient's
     // Notes section).
+    //
+    // A single paragraph with no blank lines (the real Mesplay Foundation CO has one)
+    // can still be taller than a page, so any paragraph over ~700 chars is further
+    // chunked at sentence boundaries (". ", "! ", "? ", punctuation kept with the
+    // preceding chunk) — accumulating sentences until the next one would cross the
+    // limit, then starting a new chunk. A single sentence longer than 700 chars is
+    // never split mid-sentence; it becomes its own chunk, and 700+ chars is still far
+    // below a page. Each chunk becomes its own sibling data-pdf-row too.
+    const DESCRIPTION_CHUNK_MAX_LEN = 700;
+    function chunkParagraph(paragraph: string): string[] {
+        if (paragraph.length <= DESCRIPTION_CHUNK_MAX_LEN) return [paragraph];
+        const sentences = paragraph.split(/(?<=[.!?])\s+/).filter(Boolean);
+        const chunks: string[] = [];
+        let current = "";
+        for (const sentence of sentences) {
+            if (current && current.length + 1 + sentence.length > DESCRIPTION_CHUNK_MAX_LEN) {
+                chunks.push(current);
+                current = sentence;
+            } else {
+                current = current ? `${current} ${sentence}` : sentence;
+            }
+        }
+        if (current) chunks.push(current);
+        return chunks;
+    }
     const descriptionParagraphs = initialData.description
         ? String(initialData.description).split(/\n\s*\n/).map((p: string) => p.trim()).filter(Boolean)
         : [];
+    const descriptionChunks = descriptionParagraphs.flatMap((para: string, paraIdx: number) =>
+        chunkParagraph(para).map((text: string, chunkIdx: number) => ({ text, paraIdx, chunkIdx }))
+    );
+    // Gap below a chunk: pb-8 for the final row, pb-3 between paragraphs (existing
+    // rhythm), or a tighter pb-1 when the next row is another chunk of the SAME
+    // paragraph — these rows only ever use bottom padding (no row has top padding),
+    // so "space above the next chunk" is expressed as this row's own bottom padding.
+    function descriptionRowPadding(i: number): string {
+        if (i === descriptionChunks.length - 1) return "pb-8";
+        const next = descriptionChunks[i + 1];
+        return next.paraIdx === descriptionChunks[i].paraIdx ? "pb-1" : "pb-3";
+    }
 
     return (
         <div className="min-h-screen bg-slate-100 font-sans">
@@ -211,24 +248,33 @@ export default function PortalChangeOrderClient({ initialData, companySettings }
                         </div>
                     </div>
 
-                    {/* Memo / Description — heading and each paragraph are sibling data-pdf-row
-                        blocks (not nested inside a parent that itself carries data-pdf-row, which
-                        build-pdf.ts would ignore) so a long description gets safe per-paragraph
-                        page breaks instead of one atomic block that can hard-slice through text. */}
-                    {descriptionParagraphs.length > 0 && (
+                    {/* Memo / Description — heading and the FIRST description chunk share one
+                        data-pdf-row (anti-orphan: keeps the heading from stranding alone at the
+                        bottom of a page with no text under it). Remaining chunks are sibling
+                        data-pdf-row blocks (not nested inside a parent that itself carries
+                        data-pdf-row, which build-pdf.ts would ignore) so a long description gets
+                        safe page breaks between paragraphs, and between chunks of an over-length
+                        paragraph, instead of one atomic block that can hard-slice through text. */}
+                    {descriptionChunks.length > 0 && (
                         <div className="border-b border-slate-100">
-                            <div data-pdf-row="true" className="px-5 sm:px-10 pt-8 pb-3">
+                            <div data-pdf-row="true" className={`px-5 sm:px-10 pt-8 ${descriptionRowPadding(0)}`}>
                                 <h2 className="text-sm font-semibold text-slate-800 uppercase tracking-wider">Reason for Change</h2>
+                                <p className="mt-3 text-sm text-slate-600 leading-relaxed whitespace-pre-wrap">
+                                    {descriptionChunks[0].text}
+                                </p>
                             </div>
-                            {descriptionParagraphs.map((para: string, i: number) => (
-                                <div
-                                    key={i}
-                                    data-pdf-row="true"
-                                    className={`px-5 sm:px-10 text-sm text-slate-600 leading-relaxed whitespace-pre-wrap ${i === descriptionParagraphs.length - 1 ? "pb-8" : "pb-3"}`}
-                                >
-                                    {para}
-                                </div>
-                            ))}
+                            {descriptionChunks.slice(1).map((chunk, sliceIdx: number) => {
+                                const i = sliceIdx + 1;
+                                return (
+                                    <div
+                                        key={`${chunk.paraIdx}-${chunk.chunkIdx}`}
+                                        data-pdf-row="true"
+                                        className={`px-5 sm:px-10 text-sm text-slate-600 leading-relaxed whitespace-pre-wrap ${descriptionRowPadding(i)}`}
+                                    >
+                                        {chunk.text}
+                                    </div>
+                                );
+                            })}
                         </div>
                     )}
 

--- a/src/lib/pdf.ts
+++ b/src/lib/pdf.ts
@@ -1242,6 +1242,7 @@ export async function generateChangeOrderPdf(coId: string): Promise<Buffer> {
 
     // Header mirrors the invoice PDF: 26pt title, BILL TO block (name + email),
     // right-aligned meta column, then a divider clear of both columns.
+    y -= 24;
     page.drawText('CHANGE ORDER', { x: margin, y, size: 26, font: helveticaBold, color: colors.textMain });
 
     if (co.title) {


### PR DESCRIPTION
﻿Richard flagged the cramped gap between the letterhead and the CHANGE ORDER title on the Foundation CO PDF (CC-00061, Mesplay Kitchen). The title baseline was drawn at the exact y drawLetterhead returned, leaving about 2 points of visual space. This drops the cursor 24pt before drawing the title.

Scope: change order PDF only. The invoice and PO headers share the same crowding but were not flagged; noting here rather than changing them in this PR.

Note: merging ships to prod (git auto-deploy is ON). After merge, re-download the Mesplay Foundation CO PDF to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
