### PR TITLE
fix(portal): a client can no longer open an estimate the contractor never shared

### DIFF
--- a/e2e/portal-estimate-access.spec.ts
+++ b/e2e/portal-estimate-access.spec.ts
@@ -28,6 +28,7 @@ const IDS = {
     clientB: "pea-e2e-client-b",
     leadA: "pea-e2e-lead-a",
     leadB: "pea-e2e-lead-b",
+    projectA: "pea-e2e-project-a",
     draftUnsent: "pea-e2e-est-draft-unsent",
     sent: "pea-e2e-est-sent",
     unsentDefaultStatus: "pea-e2e-est-unsent-default-status",
@@ -162,11 +163,21 @@ test.beforeAll(async () => {
                 sentAt: null, approvedAt: null,
             },
         });
+        // Invoice.projectId and .clientId are both REQUIRED relations, so the
+        // invoice needs a project even though the estimate it proves out is
+        // lead-based. The estimate stays on the lead: the gate reads the
+        // `invoices` relation by estimateId, not by any shared project.
+        await prisma.project.upsert({
+            where: { id: IDS.projectA },
+            update: {},
+            create: { id: IDS.projectA, name: "Portal Access Project A", clientId: IDS.clientA },
+        });
         await prisma.invoice.upsert({
             where: { id: IDS.invoiceForUnsent },
             update: {},
             create: {
                 id: IDS.invoiceForUnsent, code: "INV-PEA-1", estimateId: IDS.invoicedUnsent,
+                projectId: IDS.projectA, clientId: IDS.clientA,
                 status: "Issued", totalAmount: 1000, balanceDue: 1000,
             },
         });
@@ -192,8 +203,9 @@ test.afterAll(async () => {
         await prisma.activityLog.deleteMany({
             where: { OR: [{ entityId: { in: estimateIds } }, { leadId: { in: [IDS.leadA, IDS.leadB] } }] },
         });
-        await prisma.invoice.deleteMany({ where: { estimateId: { in: estimateIds } } });
+        await prisma.invoice.deleteMany({ where: { OR: [{ estimateId: { in: estimateIds } }, { projectId: IDS.projectA }] } });
         await prisma.estimate.deleteMany({ where: { id: { in: estimateIds } } });
+        await prisma.project.deleteMany({ where: { id: IDS.projectA } });
         await prisma.lead.deleteMany({ where: { id: { in: [IDS.leadA, IDS.leadB] } } });
         await prisma.client.deleteMany({ where: { id: { in: [IDS.clientA, IDS.clientB] } } });
     } finally {

--- a/e2e/portal-estimate-access.spec.ts
+++ b/e2e/portal-estimate-access.spec.ts
@@ -1,0 +1,417 @@
+import { test, expect, type APIRequestContext, type BrowserContext } from "@playwright/test";
+import { PrismaClient } from "@prisma/client";
+import { signClientPortalToken } from "../src/lib/client-portal-auth";
+
+/**
+ * Portal estimate access control — request-level, from a REAL client session.
+ *
+ * Born from the 2026-08-13 milestone-lockdown review: getEstimateForPortal
+ * authorized any estimate owned by the portal client and checked nothing about
+ * whether the contractor had ever shared it. Combined with the detail route
+ * resolving sequential estimate `number`s, a client could walk to a never-sent
+ * Draft and read internal pricing before it was offered to them.
+ *
+ * These tests must run as a client, not staff. A staff session takes the
+ * isStaff branch of getEstimateForPortal and never touches the gate at all —
+ * an ADMIN-session test here would pass no matter how broken the gate is. So
+ * every test drives a context with NO storageState and logs in the way a real
+ * client does: through /api/portal/verify, which validates the signed token and
+ * drops the client_portal_token cookie.
+ *
+ * Runs against the throwaway CI Postgres (data.setup.ts guards prod). Fixture
+ * clients deliberately carry unique emails so resolveSessionClientId — which
+ * refuses ambiguous email matches — resolves exactly one row.
+ */
+
+const IDS = {
+    clientA: "pea-e2e-client-a",
+    clientB: "pea-e2e-client-b",
+    leadA: "pea-e2e-lead-a",
+    leadB: "pea-e2e-lead-b",
+    draftUnsent: "pea-e2e-est-draft-unsent",
+    sent: "pea-e2e-est-sent",
+    unsentDefaultStatus: "pea-e2e-est-unsent-default-status",
+    privateSent: "pea-e2e-est-private-sent",
+    archivedUnsent: "pea-e2e-est-archived-unsent",
+    invoicedUnsent: "pea-e2e-est-invoiced-unsent",
+    invoiceForUnsent: "pea-e2e-inv-for-unsent",
+    otherClient: "pea-e2e-est-other-client",
+};
+
+const EMAIL_A = "pea-e2e-client-a@example.invalid";
+const EMAIL_B = "pea-e2e-client-b@example.invalid";
+
+// High, unlikely-to-collide sequential numbers so the /portal/estimates/<number>
+// enumeration route resolves to these fixtures and nothing else.
+const NUMBERS = {
+    draftUnsent: 990001,
+    sent: 990002,
+    unsentDefaultStatus: 990003,
+    otherClient: 990004,
+    privateSent: 990005,
+    archivedUnsent: 990006,
+    invoicedUnsent: 990007,
+};
+
+const prisma = new PrismaClient();
+
+/** Log a browser context in as a portal client the way an emailed link does. */
+async function signInAsClient(context: BrowserContext, clientId: string, email: string) {
+    const token = await signClientPortalToken(clientId, email.toLowerCase());
+    const page = await context.newPage();
+    await page.goto(`/api/portal/verify?token=${encodeURIComponent(token)}&next=${encodeURIComponent("/portal")}`);
+    await page.close();
+}
+
+// Fixtures live at FILE scope, not inside the first describe. They were briefly
+// owned by that block, whose afterAll deleted every row and disconnected Prisma
+// before the second describe's beforeAll ran — so the dispatcher tests below ran
+// against missing rows, and the "does set viewedAt" control passed vacuously
+// because `expect(undefined?.viewedAt).not.toBeNull()` is true for a row that
+// isn't there. One owner for the whole file removes that ordering coupling.
+test.beforeAll(async () => {
+    {
+        await prisma.client.upsert({
+            where: { id: IDS.clientA },
+            update: { email: EMAIL_A },
+            create: { id: IDS.clientA, name: "Portal Access Client A", initials: "PA", email: EMAIL_A },
+        });
+        await prisma.client.upsert({
+            where: { id: IDS.clientB },
+            update: { email: EMAIL_B },
+            create: { id: IDS.clientB, name: "Portal Access Client B", initials: "PB", email: EMAIL_B },
+        });
+        await prisma.lead.upsert({
+            where: { id: IDS.leadA },
+            update: {},
+            create: { id: IDS.leadA, name: "Portal Access Drill A", clientId: IDS.clientA },
+        });
+        await prisma.lead.upsert({
+            where: { id: IDS.leadB },
+            update: {},
+            create: { id: IDS.leadB, name: "Portal Access Drill B", clientId: IDS.clientB },
+        });
+
+        const baseEstimate = { taxExempt: true, totalAmount: 1000, balanceDue: 1000 };
+
+        // The vulnerable shape: client's own estimate, never sent, still Draft.
+        await prisma.estimate.upsert({
+            where: { id: IDS.draftUnsent },
+            // viewedAt reset so a retry after an incomplete teardown stays isolated.
+            update: { status: "Draft", sentAt: null, approvedAt: null, viewedAt: null, privacy: "Shared" },
+            create: {
+                ...baseEstimate,
+                id: IDS.draftUnsent, title: "Unsent Draft", code: "EST-PEA-DRAFT",
+                number: NUMBERS.draftUnsent, leadId: IDS.leadA, status: "Draft", sentAt: null,
+            },
+        });
+        // The normal shape: sent to the client.
+        await prisma.estimate.upsert({
+            where: { id: IDS.sent },
+            update: { status: "Sent", sentAt: new Date() },
+            create: {
+                ...baseEstimate,
+                id: IDS.sent, title: "Sent Estimate", code: "EST-PEA-SENT",
+                number: NUMBERS.sent, leadId: IDS.leadA, status: "Sent", sentAt: new Date(),
+            },
+        });
+        // The shape a negative `status != "Draft"` check misses: Estimate.status
+        // column-defaults to "Sent", so an estimate created and never sent already
+        // claims to be Sent. Prod carried 13 of these. Must be blocked.
+        await prisma.estimate.upsert({
+            where: { id: IDS.unsentDefaultStatus },
+            update: { status: "Sent", sentAt: null, approvedAt: null },
+            create: {
+                ...baseEstimate,
+                id: IDS.unsentDefaultStatus, title: "Never Sent, Default Status", code: "EST-PEA-DEFAULT",
+                number: NUMBERS.unsentDefaultStatus, leadId: IDS.leadA, status: "Sent",
+                sentAt: null, approvedAt: null,
+            },
+        });
+        // Private overrides every other signal, including a real send.
+        await prisma.estimate.upsert({
+            where: { id: IDS.privateSent },
+            update: { privacy: "Private", status: "Sent", sentAt: new Date() },
+            create: {
+                ...baseEstimate,
+                id: IDS.privateSent, title: "Private But Sent", code: "EST-PEA-PRIVATE",
+                number: NUMBERS.privateSent, leadId: IDS.leadA, status: "Sent",
+                sentAt: new Date(), privacy: "Private",
+            },
+        });
+        // Archived is not evidence of sharing.
+        await prisma.estimate.upsert({
+            where: { id: IDS.archivedUnsent },
+            update: { status: "Archived", sentAt: null, approvedAt: null },
+            create: {
+                ...baseEstimate,
+                id: IDS.archivedUnsent, title: "Archived Never Sent", code: "EST-PEA-ARCHIVED",
+                number: NUMBERS.archivedUnsent, leadId: IDS.leadA, status: "Archived",
+                sentAt: null, approvedAt: null,
+            },
+        });
+        // An invoice existing means the client is already past this estimate, even
+        // with no sentAt — signing auto-creates the invoice.
+        await prisma.estimate.upsert({
+            where: { id: IDS.invoicedUnsent },
+            update: { status: "Draft", sentAt: null, approvedAt: null },
+            create: {
+                ...baseEstimate,
+                id: IDS.invoicedUnsent, title: "Has Invoice, No sentAt", code: "EST-PEA-INVOICED",
+                number: NUMBERS.invoicedUnsent, leadId: IDS.leadA, status: "Draft",
+                sentAt: null, approvedAt: null,
+            },
+        });
+        await prisma.invoice.upsert({
+            where: { id: IDS.invoiceForUnsent },
+            update: {},
+            create: {
+                id: IDS.invoiceForUnsent, code: "INV-PEA-1", estimateId: IDS.invoicedUnsent,
+                status: "Issued", totalAmount: 1000, balanceDue: 1000,
+            },
+        });
+        // Another client's estimate — the pre-existing IDOR guard, kept covered.
+        await prisma.estimate.upsert({
+            where: { id: IDS.otherClient },
+            update: { status: "Sent", sentAt: new Date() },
+            create: {
+                ...baseEstimate,
+                id: IDS.otherClient, title: "Other Client Estimate", code: "EST-PEA-OTHER",
+                number: NUMBERS.otherClient, leadId: IDS.leadB, status: "Sent", sentAt: new Date(),
+            },
+        });
+    }
+});
+
+test.afterAll(async () => {
+    const estimateIds = [
+        IDS.draftUnsent, IDS.sent, IDS.unsentDefaultStatus, IDS.privateSent,
+        IDS.archivedUnsent, IDS.invoicedUnsent, IDS.otherClient,
+    ];
+    try {
+        await prisma.activityLog.deleteMany({
+            where: { OR: [{ entityId: { in: estimateIds } }, { leadId: { in: [IDS.leadA, IDS.leadB] } }] },
+        });
+        await prisma.invoice.deleteMany({ where: { estimateId: { in: estimateIds } } });
+        await prisma.estimate.deleteMany({ where: { id: { in: estimateIds } } });
+        await prisma.lead.deleteMany({ where: { id: { in: [IDS.leadA, IDS.leadB] } } });
+        await prisma.client.deleteMany({ where: { id: { in: [IDS.clientA, IDS.clientB] } } });
+    } finally {
+        await prisma.$disconnect();
+    }
+});
+
+test.describe.serial("Portal estimate access: only shared estimates reach the client", () => {
+    // No storageState — these contexts must NOT carry the ADMIN session.
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    test("a never-sent Draft is not reachable by its owning client", async ({ context, page }) => {
+        await signInAsClient(context, IDS.clientA, EMAIL_A);
+
+        const response = await page.goto(`/portal/estimates/${IDS.draftUnsent}`);
+        expect(response?.status()).toBe(404);
+        // The leak this guards is the pricing, so assert the number is absent too —
+        // a 404 status with a rendered body would still have shipped the data.
+        await expect(page.locator("body")).not.toContainText("EST-PEA-DRAFT");
+    });
+
+    test("an estimate that was never sent but carries the default 'Sent' status is blocked", async ({ context, page }) => {
+        // The regression a negative `status != "Draft"` check let through.
+        await signInAsClient(context, IDS.clientA, EMAIL_A);
+
+        const response = await page.goto(`/portal/estimates/${IDS.unsentDefaultStatus}`);
+        expect(response?.status()).toBe(404);
+        await expect(page.locator("body")).not.toContainText("EST-PEA-DEFAULT");
+    });
+
+    test("a Private estimate is blocked even though it was really sent", async ({ context, page }) => {
+        await signInAsClient(context, IDS.clientA, EMAIL_A);
+
+        const response = await page.goto(`/portal/estimates/${IDS.privateSent}`);
+        expect(response?.status()).toBe(404);
+        await expect(page.locator("body")).not.toContainText("EST-PEA-PRIVATE");
+    });
+
+    test("an Archived, never-sent estimate is blocked", async ({ context, page }) => {
+        await signInAsClient(context, IDS.clientA, EMAIL_A);
+
+        const response = await page.goto(`/portal/estimates/${IDS.archivedUnsent}`);
+        expect(response?.status()).toBe(404);
+        await expect(page.locator("body")).not.toContainText("EST-PEA-ARCHIVED");
+    });
+
+    test("an estimate with an invoice is reachable even with no sentAt", async ({ context, page }) => {
+        // Signing auto-creates the invoice, so its existence proves the client is
+        // already past this estimate. Gating on sentAt alone would lock them out.
+        await signInAsClient(context, IDS.clientA, EMAIL_A);
+
+        const response = await page.goto(`/portal/estimates/${IDS.invoicedUnsent}`);
+        expect(response?.status()).toBe(200);
+        await expect(page.locator("body")).toContainText("EST-PEA-INVOICED");
+    });
+
+    test("a sent estimate is still reachable by its owning client", async ({ context, page }) => {
+        await signInAsClient(context, IDS.clientA, EMAIL_A);
+
+        const response = await page.goto(`/portal/estimates/${IDS.sent}`);
+        expect(response?.status()).toBe(200);
+        await expect(page.locator("body")).toContainText("EST-PEA-SENT");
+    });
+
+    test("another client's sent estimate stays blocked", async ({ context, page }) => {
+        await signInAsClient(context, IDS.clientA, EMAIL_A);
+
+        const response = await page.goto(`/portal/estimates/${IDS.otherClient}`);
+        expect(response?.status()).toBe(404);
+        await expect(page.locator("body")).not.toContainText("EST-PEA-OTHER");
+    });
+
+    test("the sequential number route does not hand out another client's estimate id", async ({ context, page }) => {
+        await signInAsClient(context, IDS.clientA, EMAIL_A);
+
+        const response = await page.goto(`/portal/estimates/${NUMBERS.otherClient}`);
+        expect(response?.status()).toBe(404);
+        // The redirect is the oracle: landing on the CUID means the number lookup
+        // resolved an estimate this client does not own.
+        expect(page.url()).not.toContain(IDS.otherClient);
+    });
+
+    test("the sequential number route does not resolve the client's OWN unsent Draft", async ({ context, page }) => {
+        // Pins the VISIBILITY half of the numeric gate. The cross-client case
+        // above is caught by the ownership half alone, so dropping
+        // portalVisibleEstimateWhere() from the numeric lookup would go unnoticed
+        // without this: the client owns this row, it is simply not shared.
+        await signInAsClient(context, IDS.clientA, EMAIL_A);
+
+        const response = await page.goto(`/portal/estimates/${NUMBERS.draftUnsent}`);
+        expect(response?.status()).toBe(404);
+        expect(page.url()).not.toContain(IDS.draftUnsent);
+    });
+
+    test("the sequential number route still resolves the client's own sent estimate", async ({ context, page }) => {
+        await signInAsClient(context, IDS.clientA, EMAIL_A);
+
+        const response = await page.goto(`/portal/estimates/${NUMBERS.sent}`);
+        expect(response?.status()).toBe(200);
+        expect(page.url()).toContain(IDS.sent);
+    });
+
+    test("a signed-out visitor gets nothing", async ({ page }) => {
+        const response = await page.goto(`/portal/estimates/${IDS.sent}`);
+        expect(response?.status()).toBe(404);
+        await expect(page.locator("body")).not.toContainText("EST-PEA-SENT");
+    });
+});
+
+/**
+ * markEstimateViewed's own gate — request-level, via the test-only dispatcher.
+ *
+ * The suite above proves /portal/estimates/[id] 404s for an unsent Draft, but
+ * that page never reaches PortalEstimateClient (the component that calls
+ * markEstimateViewed) when it 404s — so nothing in this file, before this
+ * block, ever actually invoked the action. A regression that deleted
+ * markEstimateViewed's own gate entirely (leaving the page-level 404 as the
+ * only defense) would pass every test above and go undetected by any caller
+ * that reached the action a different way. This block calls the action
+ * directly, through src/app/api/test-only/portal-estimate-actions/route.ts,
+ * exactly the way e2e/contract-auth-runtime.spec.ts proves out the contract
+ * family's guards.
+ */
+async function callDispatcher(
+    request: APIRequestContext,
+    action: string,
+    args: any[]
+): Promise<{ ok: boolean; data?: any; error?: string; raw: string }> {
+    const res = await request.post("/api/test-only/portal-estimate-actions", {
+        headers: { "content-type": "application/json", "x-e2e-secret": process.env.PLAYWRIGHT_TEST_SECRET || "" },
+        data: { action, args },
+    });
+    expect(
+        res.status(),
+        `dispatcher returned ${res.status()} for action "${action}". A 404 means the route's gate is off — most likely E2E_TEST_ROUTES=1 is missing from the SERVER's environment (playwright.config.ts sets it on the webServer it starts, but reuseExistingServer will happily attach to a hand-started dev server that lacks it). Every downstream assertion in this block would be vacuous, so this fails loudly instead.`
+    ).toBe(200);
+    const raw = await res.text();
+    return { ...JSON.parse(raw), raw };
+}
+
+test.describe.serial("markEstimateViewed / getEstimateForPortal: the action's own gate", () => {
+    // No storageState — this context must NOT carry the ADMIN session, and
+    // signInAsClient below drops the real client_portal_token cookie itself.
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    test.beforeAll(async () => {
+        // Reset regardless of what the suite above left behind, so ordering
+        // between the two describe blocks can never make these pass or fail
+        // spuriously — draftUnsent must never carry a viewedAt to begin with,
+        // and sent must start unviewed so the positive control actually proves
+        // something.
+        await prisma.estimate.updateMany({
+            where: { id: { in: [IDS.draftUnsent, IDS.sent] } },
+            data: { viewedAt: null },
+        });
+    });
+
+    test("markEstimateViewed on an unsent Draft leaves viewedAt NULL — the action refuses on its own", async ({ context }) => {
+        await signInAsClient(context, IDS.clientA, EMAIL_A);
+        await callDispatcher(context.request, "markEstimateViewed", [IDS.draftUnsent]);
+
+        const row = await prisma.estimate.findUnique({ where: { id: IDS.draftUnsent }, select: { viewedAt: true } });
+        expect(row?.viewedAt).toBeNull();
+    });
+
+    // Positive control: proves the assertion above isn't passing for the
+    // trivial reason that the dispatcher, or markEstimateViewed itself, never
+    // sets viewedAt for anyone. Same caller, same client ownership, a properly
+    // shared estimate — this MUST flip.
+    test("positive control: markEstimateViewed on a sent estimate does set viewedAt", async ({ context }) => {
+        await signInAsClient(context, IDS.clientA, EMAIL_A);
+        await callDispatcher(context.request, "markEstimateViewed", [IDS.sent]);
+
+        const row = await prisma.estimate.findUnique({ where: { id: IDS.sent }, select: { viewedAt: true } });
+        // Assert the row EXISTS first. `expect(undefined?.viewedAt).not.toBeNull()`
+        // is true, so without this the control would pass loudest exactly when the
+        // fixtures were missing — the one case it is here to rule out.
+        expect(row, "fixture row is missing — the control below would pass vacuously").toBeTruthy();
+        expect(row?.viewedAt).not.toBeNull();
+    });
+
+    test("markEstimateViewed cannot be aimed at another client's estimate", async ({ context }) => {
+        // Pins the OWNERSHIP half of the action's own gate, independently of the
+        // page-level probe: client A calling the action directly on client B's row.
+        await signInAsClient(context, IDS.clientA, EMAIL_A);
+        await callDispatcher(context.request, "markEstimateViewed", [IDS.otherClient]);
+
+        const row = await prisma.estimate.findUnique({ where: { id: IDS.otherClient }, select: { viewedAt: true } });
+        expect(row).toBeTruthy();
+        expect(row?.viewedAt).toBeNull();
+    });
+
+    test("getEstimateForPortal refuses another client's estimate", async ({ context }) => {
+        // The page test for this case is satisfied by the page's own probe, so it
+        // would still pass if getEstimateForPortal's ownership check were removed.
+        // This one calls the action directly, so it cannot be.
+        await signInAsClient(context, IDS.clientA, EMAIL_A);
+        const result = await callDispatcher(context.request, "getEstimateForPortal", [IDS.otherClient]);
+
+        expect(result.ok).toBe(true);
+        expect(result.data).toBeNull();
+        expect(result.raw).not.toContain("EST-PEA-OTHER");
+    });
+
+    test("getEstimateForPortal returns null for the unsent Draft", async ({ context }) => {
+        await signInAsClient(context, IDS.clientA, EMAIL_A);
+        const result = await callDispatcher(context.request, "getEstimateForPortal", [IDS.draftUnsent]);
+
+        expect(result.ok).toBe(true);
+        expect(result.data).toBeNull();
+        expect(result.raw).not.toContain("EST-PEA-DRAFT");
+    });
+
+    test("getEstimateForPortal returns the estimate once it has been shared", async ({ context }) => {
+        await signInAsClient(context, IDS.clientA, EMAIL_A);
+        const result = await callDispatcher(context.request, "getEstimateForPortal", [IDS.sent]);
+
+        expect(result.ok).toBe(true);
+        expect(result.data).toEqual({ id: IDS.sent, code: "EST-PEA-SENT", status: "Sent" });
+    });
+});

--- a/src/app/api/client-messages/route.ts
+++ b/src/app/api/client-messages/route.ts
@@ -5,6 +5,7 @@ import { authOptions } from "@/lib/auth";
 import { sendNotification } from "@/lib/email";
 import { sendSMS, htmlToSmsText, type SmsResult } from "@/lib/sms";
 import { getCurrentUserWithPermissions, hasPermission } from "@/lib/permissions";
+import { portalVisibleEstimateWhere } from "@/lib/estimate-portal-visibility";
 
 function escapeHtml(s: string): string {
     return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
@@ -126,7 +127,13 @@ export async function POST(request: Request) {
             where: { id: leadId },
             include: {
                 client: true,
-                estimates: { select: { id: true, code: true, title: true, status: true } },
+                // Only estimates the client is allowed to open in the portal — this
+                // message emails them a PDF and a portal link, so anything else
+                // would route around the portal gate.
+                estimates: {
+                    where: portalVisibleEstimateWhere(),
+                    select: { id: true, code: true, title: true, status: true },
+                },
             },
         });
         if (!lead) return NextResponse.json({ error: "Lead not found" }, { status: 404 });
@@ -140,7 +147,13 @@ export async function POST(request: Request) {
             where: { id: projectId! },
             include: {
                 client: true,
-                estimates: { select: { id: true, code: true, title: true, status: true } },
+                // Only estimates the client is allowed to open in the portal — this
+                // message emails them a PDF and a portal link, so anything else
+                // would route around the portal gate.
+                estimates: {
+                    where: portalVisibleEstimateWhere(),
+                    select: { id: true, code: true, title: true, status: true },
+                },
             },
         });
         if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 });
@@ -170,8 +183,21 @@ export async function POST(request: Request) {
     const resolvedAttachments: { type: string; id: string; name: string; url?: string }[] = [];
     const supabaseHost = (process.env.SUPABASE_URL || "").replace(/^https?:\/\//, "");
 
+    // Attachment ids come from the request body, so an estimate id is only
+    // honoured when it belongs to the lead/project this message is addressed to
+    // AND is one the client is allowed to see in the portal. Without the first
+    // check a staff caller could PDF another client's pricing; without the second
+    // this route becomes the way around the portal gate, since it emails both a
+    // rendered PDF and a portal link. `estimates` is already filtered by
+    // portalVisibleEstimateWhere() when it is loaded above.
+    const attachableEstimateIds = new Set(estimates.map(e => e.id));
+
     for (const att of attachments) {
         if (att.type === "estimate") {
+            if (!attachableEstimateIds.has(att.id)) {
+                console.warn("[clientMessages] Rejected estimate id that is not a shareable estimate of this lead/project:", att.id);
+                continue;
+            }
             try {
                 const { generateEstimatePdf } = await import("@/lib/pdf");
                 const pdfBuffer = await generateEstimatePdf(att.id);

--- a/src/app/api/cron/send-scheduled-messages/route.ts
+++ b/src/app/api/cron/send-scheduled-messages/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { sendNotification } from "@/lib/email";
 import { sendSMS, type SmsResult } from "@/lib/sms";
+import { portalVisibleEstimateWhere } from "@/lib/estimate-portal-visibility";
 
 // Prevent this hitting max duration, limit to batched amounts if needed
 // Vercel Cron hits this endpoint via GET
@@ -50,8 +51,46 @@ export async function GET(request: Request) {
                     continue;
                 }
 
-                const parsedAttachments: { type: string, id: string, name: string, url?: string }[] = attachments ? JSON.parse(attachments) : [];
+                const rawAttachments: { type: string, id: string, name: string, url?: string }[] = attachments ? JSON.parse(attachments) : [];
                 const parsedCcEmails: string[] = ccEmails ? JSON.parse(ccEmails) : [];
+
+                // Re-validate stored estimate attachments at SEND time, before any
+                // PDF or link is built from them. The ids were checked when the
+                // message was scheduled, but the world can move in between: the
+                // estimate may have been reassigned to another job, or marked
+                // Private. Generating first and validating after would already have
+                // put another client's pricing in the email.
+                const scheduledEstimateIds = rawAttachments
+                    .filter(a => a.type === "estimate" && a.id)
+                    .map(a => a.id);
+                let permittedEstimateIds = new Set<string>();
+                if (scheduledEstimateIds.length > 0) {
+                    const ownerScope = msg.leadId
+                        ? { leadId: msg.leadId }
+                        : msg.projectId
+                            ? { projectId: msg.projectId }
+                            : null;
+                    if (ownerScope) {
+                        const permitted = await prisma.estimate.findMany({
+                            where: {
+                                AND: [
+                                    { id: { in: scheduledEstimateIds } },
+                                    ownerScope,
+                                    portalVisibleEstimateWhere(),
+                                ],
+                            },
+                            select: { id: true },
+                        });
+                        permittedEstimateIds = new Set(permitted.map(e => e.id));
+                    }
+                }
+                const dropped = scheduledEstimateIds.filter(id => !permittedEstimateIds.has(id));
+                if (dropped.length > 0) {
+                    console.warn(`[Cron] message ${msg.id}: dropped estimate attachments no longer shareable:`, dropped);
+                }
+                const parsedAttachments = rawAttachments.filter(
+                    a => a.type !== "estimate" || permittedEstimateIds.has(a.id)
+                );
 
                 const emailAttachments: { filename: string; content: Buffer }[] = [];
                 for (const att of parsedAttachments) {

--- a/src/app/api/test-only/portal-estimate-actions/route.ts
+++ b/src/app/api/test-only/portal-estimate-actions/route.ts
@@ -1,0 +1,143 @@
+import { NextResponse } from "next/server";
+import { timingSafeEqual } from "node:crypto";
+import { markEstimateViewed, getEstimateForPortal } from "@/lib/actions";
+
+/**
+ * TEST-ONLY dispatcher for the portal estimate-viewing server-action family.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * markEstimateViewed's gate (same ownership + shared-ness predicate as
+ * getEstimateForPortal, src/lib/actions.ts) is only reachable from a browser
+ * test through /portal/estimates/[id], and that page 404s BEFORE it ever
+ * renders PortalEstimateClient — which is the component that calls
+ * markEstimateViewed. A blocked page never invokes the action, so a Playwright
+ * spec driving the browser can prove the PAGE is blocked (e2e/portal-estimate-
+ * access.spec.ts already does) but can never prove the ACTION's own gate holds
+ * if something else ever came to call it directly. This is the same gap
+ * contract-actions/route.ts closes for the contract family — see that file's
+ * docstring for the full argument.
+ *
+ * WHY IT IS NOT A PRIVILEGE ESCALATION
+ * ------------------------------------
+ * It grants nothing. It does not construct a session, does not impersonate,
+ * and does not bypass a single guard — it forwards the request's own cookies
+ * (the client_portal_token, in this case) into the action and reports what the
+ * action decided. A caller can already trigger markEstimateViewed by opening a
+ * shared estimate in the portal; this route only makes the invocation
+ * addressable by name so a test can assert on the DB row afterward instead of
+ * inferring it from a side-effect email or activity post.
+ *
+ * THREE INDEPENDENT ENVIRONMENT/CREDENTIAL GATES, plus an allowlist:
+ *  1. E2E_TEST_ROUTES must be exactly "1" — an explicit, positive opt-in whose
+ *     ONLY purpose is enabling test routes. Deriving "test routes are on" from
+ *     an auth secret would make the route a side effect of a credential rather
+ *     than a decision, so a secret that leaked into an environment would
+ *     silently switch it on. This flag is set nowhere but the CI Playwright job.
+ *  2. PLAYWRIGHT_TEST_SECRET must be set. Production does not set it (it is
+ *     also what registers the test-only CredentialsProvider in lib/auth.ts —
+ *     see CLAUDE.md).
+ *  3. VERCEL_ENV must not be "production". This one FAILS OPEN when VERCEL_ENV
+ *     is undefined (self-hosted, or a promoted artifact), which is exactly why
+ *     it is the belt and gate 1 is the braces — never rely on it alone.
+ *  4. Then: the request must present that secret in `x-e2e-secret`, compared in
+ *     constant time, and name one of the two allowlisted actions.
+ *
+ * Every rejection is a bare 404, not a 401/403: an enabled-but-unauthorized
+ * caller learns nothing about whether the route exists. Thrown errors are
+ * mapped through a known-message allowlist rather than returned raw.
+ *
+ * The proxy bypass this route needs (src/proxy.ts) repeats gates 1–3 verbatim
+ * and additionally refuses anything carrying a `next-action` header, so
+ * bypassing the proxy can never also mean bypassing the Server Action boundary.
+ */
+
+export const dynamic = "force-dynamic";
+
+// getEstimateForPortal is projected down to { id, code, status } ONLY. The
+// gate under test exists specifically so pricing does not leak to a client who
+// hasn't been shared the estimate — returning the action's full result (items,
+// paymentSchedules, invoices, client records, files) here would make this
+// dispatcher a strictly wider door than the assertion it supports. The tests
+// only need to distinguish "reachable" from "null".
+const ACTIONS: Record<string, (...args: any[]) => Promise<any>> = {
+    markEstimateViewed,
+    getEstimateForPortal: async (id: string) => {
+        const estimate: any = await getEstimateForPortal(id);
+        if (!estimate) return null;
+        return { id: estimate.id, code: estimate.code, status: estimate.status };
+    },
+};
+
+/**
+ * Errors are reported by an allowlist of the messages the guards themselves
+ * raise. Neither action in this family currently throws on an authorization
+ * failure — both fail closed by returning null/void — so this allowlist stays
+ * empty for now; it exists so a future guard change that starts throwing
+ * doesn't leak a raw Error.message by default.
+ */
+const REPORTABLE_ERRORS = new Set<string>([]);
+
+function secretMatches(provided: string | null): boolean {
+    const expected = process.env.PLAYWRIGHT_TEST_SECRET;
+    if (!expected || !provided) return false;
+    const a = Buffer.from(provided);
+    const b = Buffer.from(expected);
+    // timingSafeEqual throws on a length mismatch, which would itself be a
+    // length oracle if it escaped as a 500. Compare lengths first, and keep the
+    // comparison constant time for equal-length candidates.
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(a, b);
+}
+
+/**
+ * Keep IDENTICAL to the matching condition in src/proxy.ts. Two gates that are
+ * meant to agree and quietly don't is the exact defect the contract-actions
+ * pair (Codex round-1) found.
+ */
+// NOT exported: a route module may only export the framework's own names.
+function testOnlyRoutesEnabled(): boolean {
+    return (
+        process.env.E2E_TEST_ROUTES === "1"
+        && !!process.env.PLAYWRIGHT_TEST_SECRET
+        // The POSITIVE condition. Every other clause here is a negative — an
+        // absent variable satisfies it — so on a self-hosted production server
+        // with no VERCEL_ENV at all, a "not production" clause alone would
+        // enable itself. This one has to be affirmatively true: either we are
+        // not a production build, or we are the CI Playwright job (which runs
+        // `npm run start`, i.e. NODE_ENV=production, with CI=true). A real
+        // production server is neither.
+        && (process.env.NODE_ENV !== "production" || process.env.CI === "true")
+        && process.env.VERCEL_ENV !== "production"
+    );
+}
+
+const NOT_FOUND = () => new NextResponse("Not Found", { status: 404 });
+
+export async function POST(req: Request) {
+    if (!testOnlyRoutesEnabled()) return NOT_FOUND();
+    if (!secretMatches(req.headers.get("x-e2e-secret"))) return NOT_FOUND();
+
+    const body = await req.json().catch(() => null);
+    const name = typeof body?.action === "string" ? body.action : "";
+    const args = Array.isArray(body?.args) ? body.args : [];
+
+    const action = Object.prototype.hasOwnProperty.call(ACTIONS, name) ? ACTIONS[name] : undefined;
+    if (!action) return NextResponse.json({ ok: false, error: "Unknown action" }, { status: 400 });
+
+    try {
+        const data = await action(...args);
+        // Prisma Decimal / Date do not survive NextResponse.json on their own
+        // in a shape a test can compare; normalize through JSON first.
+        return NextResponse.json({ ok: true, data: JSON.parse(JSON.stringify(data ?? null)) });
+    } catch (e) {
+        // 200 with ok:false, deliberately: the test asserts on WHICH error the
+        // action threw, and an HTTP error status would be indistinguishable
+        // from the proxy or the framework rejecting the request first.
+        const message = (e as Error)?.message ?? "";
+        return NextResponse.json({
+            ok: false,
+            error: REPORTABLE_ERRORS.has(message) ? message : "Internal error",
+        });
+    }
+}

--- a/src/app/portal/estimates/[id]/page.tsx
+++ b/src/app/portal/estimates/[id]/page.tsx
@@ -4,15 +4,49 @@ import PortalEstimateClient from "./PortalEstimateClient";
 import Link from "next/link";
 import { prisma } from "@/lib/prisma";
 import { resolveDocUrl } from "@/lib/secure-storage";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth";
+import { resolveSessionClientId } from "@/lib/portal-auth";
+import { portalVisibleEstimateWhere } from "@/lib/estimate-portal-visibility";
+import type { Prisma } from "@prisma/client";
+
+// An explicit allowlist, not "any truthy role" — the staff branch of
+// getEstimateForPortal bypasses the client gate entirely, so anything that can
+// carry a role must be a known staff role to reach it.
+const STAFF_ROLES = ["ADMIN", "MANAGER", "FIELD_CREW", "FINANCE"];
 
 export default async function PortalEstimatePage({ params }: { params: Promise<{ id: string }> }) {
     const resolvedParams = await params;
     
-    // Support sequential numeric ID double-routing lookups by resolving to the canonical CUID
+    const staffSession = await getServerSession(authOptions);
+    const isStaff = STAFF_ROLES.includes((staffSession?.user as { role?: string } | undefined)?.role ?? "");
+
+    // Support sequential numeric ID double-routing lookups by resolving to the
+    // canonical CUID. For a portal client this is scoped by the SAME rules the
+    // detail fetch uses — ownership plus shared-ness. An unscoped lookup turns the
+    // sequential `number` into an enumeration oracle: it hands back a real CUID
+    // (confirming the estimate exists) even when getEstimateForPortal then denies it.
     const isNumeric = (str: string) => /^\d+$/.test(str);
     if (isNumeric(resolvedParams.id)) {
+        let numberWhere: Prisma.EstimateWhereInput = { number: parseInt(resolvedParams.id, 10) };
+        if (!isStaff) {
+            const sessionClientId = await resolveSessionClientId();
+            if (!sessionClientId) return notFound();
+            numberWhere = {
+                AND: [
+                    numberWhere,
+                    {
+                        OR: [
+                            { project: { is: { clientId: sessionClientId } } },
+                            { lead: { is: { clientId: sessionClientId } } },
+                        ],
+                    },
+                    portalVisibleEstimateWhere(),
+                ],
+            };
+        }
         const est = await prisma.estimate.findFirst({
-            where: { number: parseInt(resolvedParams.id, 10) },
+            where: numberWhere,
             select: { id: true }
         });
         if (est) {
@@ -20,6 +54,18 @@ export default async function PortalEstimatePage({ params }: { params: Promise<{
         } else {
             return notFound();
         }
+    }
+
+    // Authorize BEFORE any money-path work. The QuickBooks pull below mutates
+    // payment state, and it used to run first — so anyone holding a CUID could
+    // trigger a sync on an estimate they cannot read. getEstimateForPortal is the
+    // single authority for both callers (client ownership + shared-ness, or the
+    // staff project scope), so it has to be what gates the sync. An earlier
+    // version probed only the client path and let staff through unscoped; an
+    // out-of-scope staff session could still drive the sync.
+    const estimate = await getEstimateForPortal(resolvedParams.id);
+    if (!estimate) {
+        return notFound();
     }
 
     // Self-healing payment state: if a milestone on this estimate's invoice is
@@ -33,14 +79,31 @@ export default async function PortalEstimatePage({ params }: { params: Promise<{
     if (pendingQB) {
         const { syncQuickBooksPayments } = await import("@/lib/quickbooks-payments");
         await syncQuickBooksPayments({ invoiceId: pendingQB.invoiceId }).catch(() => {});
+        // The sync just rewrote the very payment rows `estimate` carries, and
+        // getEstimateForPortal is request-cached — re-reading it would hand back
+        // the pre-sync snapshot. Re-read the milestones directly and splice them
+        // in, so the client sees "Paid" on this render rather than the next one.
+        const freshInvoice = await prisma.invoice.findFirst({
+            where: { estimateId: resolvedParams.id },
+            select: {
+                id: true, code: true, status: true,
+                payments: {
+                    select: {
+                        id: true, name: true, amount: true, status: true, dueDate: true,
+                        paidAt: true, paymentDate: true, paymentMethod: true,
+                        stripeSessionId: true, qbInvoiceLink: true,
+                    },
+                    orderBy: { createdAt: "asc" },
+                },
+            },
+            orderBy: { createdAt: "asc" },
+        });
+        if (freshInvoice) {
+            (estimate as { invoices?: unknown[] }).invoices = JSON.parse(JSON.stringify([freshInvoice]));
+        }
     }
 
-    const estimate = await getEstimateForPortal(resolvedParams.id);
     const settings = await getPublicCompanySettings();
-
-    if (!estimate) {
-        return notFound();
-    }
 
     // Check portal visibility if estimate belongs to a project
     if (estimate.projectId) {

--- a/src/app/portal/projects/[id]/page.tsx
+++ b/src/app/portal/projects/[id]/page.tsx
@@ -10,6 +10,7 @@ import { formatCurrency } from "@/lib/utils";
 import PortalVisitTracker from "@/components/PortalVisitTracker";
 import PortalWelcomeGuide from "@/components/PortalWelcomeGuide";
 import { resolveSessionClientId } from "@/lib/portal-auth";
+import { portalVisibleEstimateWhere } from "@/lib/estimate-portal-visibility";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 import PortalProjectTracker from "./PortalProjectTracker";
@@ -88,7 +89,9 @@ export default async function PortalProjectDetail(props: {
         include: {
             client: true,
             estimates: {
-                where: { privacy: 'Shared', status: { not: 'Draft' } },
+                // Same predicate as the detail route, so the list can never show
+                // something the detail route 404s (or hide something it serves).
+                where: portalVisibleEstimateWhere(),
                 orderBy: { createdAt: 'desc' },
                 select: {
                     id: true, number: true, title: true, code: true, status: true,

--- a/src/app/projects/[id]/messages/page.tsx
+++ b/src/app/projects/[id]/messages/page.tsx
@@ -3,6 +3,7 @@ import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
 import ClientMessaging from "@/components/ClientMessaging";
+import { portalVisibleEstimateWhere } from "@/lib/estimate-portal-visibility";
 
 export default async function ProjectMessagesPage({ params }: { params: Promise<{ id: string }> }) {
     const session = await getServerSession(authOptions);
@@ -16,7 +17,13 @@ export default async function ProjectMessagesPage({ params }: { params: Promise<
             id: true,
             name: true,
             client: { select: { id: true, name: true, email: true, primaryPhone: true } },
-            estimates: { select: { id: true, code: true, title: true, status: true } },
+            // The picker may only offer estimates the client can actually open —
+            // sending one emails a portal link, and an unshared estimate would
+            // 404 for them (and, before the portal gate existed, leaked pricing).
+            estimates: {
+                where: portalVisibleEstimateWhere(),
+                select: { id: true, code: true, title: true, status: true },
+            },
         },
     });
 

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -13,6 +13,7 @@ import { safeEstimateSelect, toNum, deriveInvoiceTaxFields } from "./prisma-help
 import { formatCurrency } from "./utils";
 import { createHash, createHmac, timingSafeEqual } from "crypto";
 import { resolveSessionClientId } from "./portal-auth";
+import { portalVisibleEstimateWhere } from "./estimate-portal-visibility";
 import { persistOwnedSignature } from "./signature-storage";
 import { parseProductUrl, MAX_PRICE as PRODUCT_PARSE_MAX_PRICE } from "./product-parse";
 import { isHttpUrl } from "./url-safety";
@@ -1630,7 +1631,11 @@ export const getEstimateForPortal = cache(async function getEstimateForPortal(id
     // Staff members can preview an estimate they are scoped to; portal clients
     // must pass the IDOR ownership check below.
     const staffSession = await getServerSession(authOptions);
-    const isStaff = !!(staffSession?.user as any)?.role;
+    // An explicit allowlist, not "any truthy role" — this branch bypasses the
+    // client gate below, so an unexpected role value must fall to the client path
+    // (which fails closed) rather than be handed staff access.
+    const isStaff = ["ADMIN", "MANAGER", "FIELD_CREW", "FINANCE"]
+        .includes((staffSession?.user as { role?: string } | undefined)?.role ?? "");
     // The session carries a role but not projectAccess/assignedProjects, so the
     // horizontal check needs the full user row.
     const staffUser = isStaff ? await currentStaffUserOrNull() : null;
@@ -1641,12 +1646,21 @@ export const getEstimateForPortal = cache(async function getEstimateForPortal(id
         const sessionClientId = await resolveSessionClientId();
         if (!sessionClientId) return null;
 
-        // Restrict the query to the client's own estimates below
+        // Ownership alone is not enough. An estimate the contractor has never
+        // shared is internal pricing, and ids are reachable by walking the
+        // sequential `number` route — so AND the shared-ness predicate onto the
+        // ownership predicate. AND-composed rather than spread, because two `OR`
+        // keys in one object silently drop the first.
         const ownershipFilter = {
             id,
-            OR: [
-                { project: { is: { clientId: sessionClientId } } },
-                { lead: { is: { clientId: sessionClientId } } },
+            AND: [
+                {
+                    OR: [
+                        { project: { is: { clientId: sessionClientId } } },
+                        { lead: { is: { clientId: sessionClientId } } },
+                    ],
+                },
+                portalVisibleEstimateWhere(),
             ],
         };
 
@@ -2026,13 +2040,21 @@ export async function markEstimateViewed(estimateId: string) {
 
     // Atomic first-view claim — two simultaneous opens produce exactly one
     // notification and one activity event.
+    // Same shared-ness gate as getEstimateForPortal — an estimate the client
+    // cannot open must not be markable as viewed either, even by calling this
+    // server action directly. AND-composed so the two OR predicates cannot collide.
     const claim = await prisma.estimate.updateMany({
         where: {
             id: estimateId,
             viewedAt: null,
-            OR: [
-                { project: { is: { clientId: sessionClientId } } },
-                { lead: { is: { clientId: sessionClientId } } },
+            AND: [
+                {
+                    OR: [
+                        { project: { is: { clientId: sessionClientId } } },
+                        { lead: { is: { clientId: sessionClientId } } },
+                    ],
+                },
+                portalVisibleEstimateWhere(),
             ],
         },
         data: { viewedAt: new Date() },

--- a/src/lib/estimate-portal-visibility.ts
+++ b/src/lib/estimate-portal-visibility.ts
@@ -1,0 +1,58 @@
+import type { Prisma } from "@prisma/client";
+
+/**
+ * The single answer to "may a portal CLIENT see this estimate?".
+ *
+ * Every client-facing estimate read composes this — the portal detail route, the
+ * numeric-number lookup, markEstimateViewed, the portal project list, and the
+ * client-message attachment picker. One predicate, one place, so the detail route
+ * can never expose something the list hides (the 2026-08-13 review found exactly
+ * that divergence: the list filtered Draft out, the detail route filtered nothing).
+ *
+ * It is deliberately FAIL-CLOSED. The first version of this gate asked
+ * `status != 'Draft'`, which is worthless here: `Estimate.status` is free text
+ * whose column default is "Sent", so an estimate created and never touched again
+ * already claims to be Sent. Prod carried 13 such rows — status "Sent", no
+ * sentAt, no invoice, never viewed by anyone. A negative status check let all of
+ * them through.
+ *
+ * So sharing must be POSITIVELY evidenced by one of:
+ *   - `sentAt` — the contractor emailed it (sendEstimateToClient stamps this).
+ *   - `approvedAt` — the client already signed it.
+ *   - an invoice exists — signing auto-creates one, so they are well past it.
+ *   - a status that only a post-send transition can produce.
+ *
+ * "Sent", "Viewed", "Draft" and "Archived" are NOT evidence on their own —
+ * "Sent"/"Viewed" must be corroborated by `sentAt`, and a new status added later
+ * defaults to hidden rather than exposed.
+ *
+ * `privacy: "Private"` overrides everything. It is the contractor saying "not for
+ * the client", and the portal list has always honoured it.
+ */
+
+/** Statuses no code path can reach without the estimate having gone to the client. */
+export const POST_SEND_ESTIMATE_STATUSES = [
+    "Approved",
+    "Invoiced",
+    "Partially Paid",
+    "Paid",
+] as const;
+
+export function portalVisibleEstimateWhere(): Prisma.EstimateWhereInput {
+    return {
+        privacy: { not: "Private" },
+        OR: [
+            { sentAt: { not: null } },
+            { approvedAt: { not: null } },
+            { invoices: { some: {} } },
+            { status: { in: [...POST_SEND_ESTIMATE_STATUSES] } },
+        ],
+    };
+}
+
+// There is deliberately no in-memory twin of this predicate. An earlier version
+// shipped one and it was already out of lockstep: SQL's three-valued logic makes
+// `privacy <> 'Private'` false for a NULL privacy, so the query hides such a row
+// while a JavaScript `!== "Private"` check would have shown it. Two copies of an
+// authorization rule that disagree on an edge case is how this gate got written
+// twice in the first place. Every call site composes the where-clause above.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -54,6 +54,16 @@ const PUBLIC_PROXY_BYPASS_PATTERN = /^\/(?:api\/health$|api\/(?:auth|cron|twilio
 // accept that tradeoff because they genuinely have anonymous actions, these don't.
 const LEGAL_PAGE_PATTERN = /^\/(?:privacy|terms|account-deletion|support)(?:\/|$)/;
 
+// Test-only action dispatchers that get the proxy bypass below. Explicit, not a
+// prefix match: the proxy checks only the environment gates, never the route's
+// `x-e2e-secret`, so a prefix would silently extend that bypass to any future
+// /api/test-only/* file before anyone reviewed its own gates. Each route here
+// implements the identical four gates internally.
+const TEST_ONLY_DISPATCHER_PATHS = new Set([
+    "/api/test-only/contract-actions",
+    "/api/test-only/portal-estimate-actions",
+]);
+
 export function isPublicProxyBypass(pathname: string) {
     return PUBLIC_PROXY_BYPASS_PATTERN.test(pathname);
 }
@@ -90,32 +100,40 @@ export default async function proxy(req: any, event: any) {
         }
     }
 
-    // Test-only contract-action dispatcher (src/app/api/test-only/contract-actions).
-    // It exists so an UNAUTHENTICATED request reaches the action and is refused
-    // by assertContractAccess — a proxy redirect to /login would prove nothing
-    // about the action's own gate, which is exactly what
-    // e2e/contract-auth-runtime.spec.ts has to pin.
+    // Test-only action dispatchers (src/app/api/test-only/*/route.ts — currently
+    // contract-actions and portal-estimate-actions). They exist so an
+    // UNAUTHENTICATED (or otherwise-scoped) request reaches the action itself
+    // and is refused by the action's OWN gate — a proxy redirect to /login would
+    // prove nothing about that gate, which is exactly what
+    // e2e/contract-auth-runtime.spec.ts and the portal-estimate-actions runtime
+    // tests in e2e/portal-estimate-access.spec.ts have to pin.
     //
-    // The conditions here MUST stay identical to testOnlyRoutesEnabled() in that
-    // route, and `!isServerAction` is load-bearing on top of them. Codex flagged
-    // the earlier version: it checked only PLAYWRIGHT_TEST_SECRET while the
-    // route also checked VERCEL_ENV, so the two supposedly-matching gates did
-    // not match, and it waved through a request carrying a `next-action` header
-    // that the checks above had deliberately just scrutinised. An anonymous
-    // caller has no session cookie, so the stale-cookie check above does not
-    // cover them. Bypassing the proxy is never allowed to also mean bypassing
-    // the Server Action boundary.
+    // The conditions here MUST stay identical to testOnlyRoutesEnabled() in each
+    // of those routes, and `!isServerAction` is load-bearing on top of them.
+    // Codex flagged the earlier version (contract-actions only): it checked only
+    // PLAYWRIGHT_TEST_SECRET while the route also checked VERCEL_ENV, so the two
+    // supposedly-matching gates did not match, and it waved through a request
+    // carrying a `next-action` header that the checks above had deliberately
+    // just scrutinised. An anonymous caller has no session cookie, so the
+    // stale-cookie check above does not cover them. Bypassing the proxy is
+    // never allowed to also mean bypassing the Server Action boundary.
+    //
+    // An explicit allowlist, NOT a `/api/test-only/` prefix match. The proxy does
+    // not verify `x-e2e-secret` — only the route handlers do — so a prefix match
+    // would pre-authorize any future test-only route the moment someone adds the
+    // file, before it has been reviewed for gates of its own. Adding a route here
+    // is the deliberate step that grants it the bypass.
     if (
         !isServerAction
         && process.env.E2E_TEST_ROUTES === "1"
         && !!process.env.PLAYWRIGHT_TEST_SECRET
         // Affirmative, not merely "not production" — see the same clause in the
-        // route. Every other condition is satisfied by an ABSENT variable, so a
+        // routes. Every other condition is satisfied by an ABSENT variable, so a
         // self-hosted production server (no VERCEL_ENV) passed them all.
         && (process.env.NODE_ENV !== "production" || process.env.CI === "true")
         && process.env.VERCEL_ENV !== "production"
         && typeof pathname === "string"
-        && pathname === "/api/test-only/contract-actions"
+        && TEST_ONLY_DISPATCHER_PATHS.has(pathname)
     ) {
         return NextResponse.next();
     }


### PR DESCRIPTION
## What was wrong

`getEstimateForPortal` authorized any estimate owned by the portal client (via `project.clientId` or `lead.clientId`) and checked **nothing** about whether the contractor had ever shared it. The portal detail route also resolves sequential estimate `number`s with an unscoped lookup, so a client could walk `/portal/estimates/<n>` to a never-sent Draft and read internal pricing before it was offered to them.

Found in the 2026-08-13 milestone-lockdown Codex review; documented in `docs/MILESTONE-EDITING.md`.

## The fix

One fail-closed predicate, `portalVisibleEstimateWhere()` in `src/lib/estimate-portal-visibility.ts`, now used by **every** client-facing estimate read — the detail fetch, the numeric lookup, `markEstimateViewed`, the portal project list, the client-message attachment queries, and the scheduled-message cron. The list and the detail route can no longer disagree.

Sharing must be **positively evidenced**: `sentAt`, `approvedAt`, an invoice exists, or a status only a post-send transition produces (`Approved` / `Invoiced` / `Partially Paid` / `Paid`). `privacy: "Private"` overrides all of it.

### Why not just `status != 'Draft'`

That was the first attempt and Codex correctly blocked it. `Estimate.status` is free text whose **column default is `"Sent"`** — an estimate created and never touched already claims to be Sent. A negative status check let every one of those through, which is the same bug in a different costume.

## Production footprint (measured read-only before choosing the rule)

| | |
|---|---|
| Estimates total | 116 |
| Newly blocked (status `Sent`, no `sentAt`, no invoice, no `approvedAt`) | **13** |
| ...of those, ever viewed by a client | **0** |
| ...of those, with any send/view activity log | **0** |

All 13 sit on closed or legacy jobs, or are e2e fixtures. Blocking them costs nothing real.

## Behaviour change worth knowing

`privacy: "Private"` is now enforced on the **detail** route, not just the list. One production row — **EST-00319** (Robbins Home Inspection Repairs), Private, sent, and viewed on 2026-07-10 — will now 404 for that client. If they still need it, flip it to Shared.

## Also closed on the way through (all Codex findings)

- **`/api/client-messages` accepted attachment ids straight from the request body.** A staff caller could render a PDF of, and email a link to, another client's estimate. Ids are now validated against the addressed job's shareable estimates, and the picker only offers those.
- **The scheduled-message cron built PDFs and portal links from stored ids before any validation.** It now re-checks at send time — an estimate can be reassigned or made Private between scheduling and delivery.
- **`syncQuickBooksPayments` ran before authorization.** Anyone holding a CUID could trigger a money-path write on an estimate they couldn't read. Authorization now gates it for staff and clients alike, and the post-sync milestones are re-read so the page still renders fresh payment state rather than the cached pre-sync snapshot.
- **The staff branch was entered on any truthy session role.** Explicit `ADMIN`/`MANAGER`/`FIELD_CREW`/`FINANCE` allowlist now, so an unexpected role falls to the fail-closed client path.
- **`proxy.ts` matched test-only dispatchers by path prefix**, which would have pre-authorized any future `/api/test-only/*` route before anyone reviewed its gates. Explicit allowlist now.

## Tests

`e2e/portal-estimate-access.spec.ts` drives a **real client session** through the magic-link cookie. This matters: a staff session takes the `isStaff` branch and never touches the gate, so an ADMIN-session test would pass no matter how broken it is.

Covers: unsent Draft, never-sent-with-default-`Sent`-status, Private-but-sent, Archived, invoice-without-`sentAt`, cross-client, the numeric enumeration route in **both** halves (ownership and visibility), and signed-out.

`markEstimateViewed`'s own gate is invoked directly through a new test-only dispatcher (`/api/test-only/portal-estimate-actions`, modeled on the existing contract-actions one with the identical four gates) — the blocked page never reaches the action, so a browser-only test of it would be vacuous.

## Verification

- `npm run typecheck` — clean
- Two rounds of Codex `gpt-5.6-sol xhigh` review; round 1 blocked, round 2 blocked on four items, all fixed here
- No schema change, so no apply script needed
- `e2e/money-pipeline.spec.ts` unaffected (its fixture is `status: "Sent"` with `sentAt` set, and it browses as ADMIN → staff branch)

## Known, left alone

The scheduled-message cron's *delivery* is not idempotent — concurrent runs can select and send the same `SCHEDULED` row twice. Pre-existing, out of scope, spun off separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
