### PR TITLE
fix(estimates): takeoff conversion is now atomic and idempotent

### DIFF
--- a/src/app/api/takeoffs/convert-to-estimate/route.ts
+++ b/src/app/api/takeoffs/convert-to-estimate/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { derivedMarginPct } from "@/lib/budget-math";
 import { isTaxCostCode, numOr, numOrNull, rmc, splitTakeoffTax } from "@/lib/takeoff-costing";
 import { parseSalesTaxes } from "@/lib/sales-tax";
+import { withTxRetry } from "@/lib/tx-retry";
 
 /** The margin stored when a takeoff row carries no usable costing at all. */
 const DEFAULT_MARGIN_PCT = 25;
@@ -69,35 +70,36 @@ function marginPercentFor(item: any, baseCost: number | null, unitCost: number):
     return DEFAULT_MARGIN_PCT;
 }
 
-// POST /api/takeoffs/convert-to-estimate
-// Converts AI-generated takeoff data into a real Estimate with line items
-export async function POST(req: NextRequest) {
-    const body = await req.json();
-    const { takeoffId } = body;
+/**
+ * The conversion's derived values, computed from ONE consistent read of the takeoff row.
+ *
+ * Pure apart from the caller-supplied `salesTaxesJson`, so it is safe to run inside the
+ * transaction — which is where it must run. Everything it derives (line items, milestone amounts,
+ * the tax mode) comes from takeoff fields another request can change, so computing them from a
+ * snapshot taken BEFORE the row lock would let a conversion write an estimate describing a takeoff
+ * that no longer looks like that.
+ */
+type BuiltConversion = {
+    items: any[];
+    milestones: any[];
+    finalTotal: number;
+    taxRatePercent: number | null;
+    taxRateName: string | null;
+    recomputedMilestones: ReturnType<typeof recomputeMilestoneAmounts> | null;
+};
 
-    if (!takeoffId) {
-        return NextResponse.json({ error: "takeoffId is required" }, { status: 400 });
-    }
-
-    const takeoff = await prisma.takeoff.findUnique({
-        where: { id: takeoffId },
-        include: { files: true },
-    });
-
-    if (!takeoff) {
-        return NextResponse.json({ error: "Takeoff not found" }, { status: 404 });
-    }
-
-    if (!takeoff.aiEstimateData) {
-        return NextResponse.json({ error: "No AI estimate data to convert. Generate an AI estimate first." }, { status: 400 });
-    }
-
-    // Parse the AI estimate data
+async function buildConversion(
+    aiEstimateData: string,
+    // Lazy on purpose: the configured sales taxes are only ever consulted to NAME a derived rate,
+    // so a conversion with unparseable AI data or no tax split must not spend a query (or inherit
+    // that query's failure mode) fetching them.
+    loadSalesTaxes: () => Promise<string | null>,
+): Promise<{ error: string } | BuiltConversion> {
     let aiData: any;
     try {
-        aiData = JSON.parse(takeoff.aiEstimateData);
+        aiData = JSON.parse(aiEstimateData);
     } catch {
-        return NextResponse.json({ error: "Invalid AI estimate data" }, { status: 400 });
+        return { error: "Invalid AI estimate data" };
     }
 
     // aiData.items can arrive as something other than an array (malformed/legacy AI output) — a
@@ -140,14 +142,10 @@ export async function POST(req: NextRequest) {
     if (snapshotReconciles) {
         taxRateName = snapshotName ?? "Sales Tax";
     } else if (split.taxRatePercent != null) {
-        const companySettings = await prisma.companySettings.findUnique({
-            where: { id: "singleton" },
-            select: { salesTaxes: true },
-        });
         // parseSalesTaxes swallows unparseable/non-array stored values (JSON.parse("null") and
         // JSON.parse("{}") both succeed without being an array, and the .filter below would throw
         // and fail the whole conversion).
-        const salesTaxes = parseSalesTaxes(companySettings?.salesTaxes);
+        const salesTaxes = parseSalesTaxes(await loadSalesTaxes());
         // Two configured jurisdictions can share a rate, and the AI takeoff line's own name can
         // assert a jurisdiction the derived rate contradicts — either way, naming the wrong city on
         // a client-facing document is worse than a neutral label. Only trust a configured tax's
@@ -170,98 +168,237 @@ export async function POST(req: NextRequest) {
 
     const finalTotal = storedTaxRate != null ? rmc(split.preTaxSubtotal + split.taxAmount) : totalEstimate;
 
-    const code = `EST-${Math.floor(1000 + Math.random() * 9000)}`;
+    // Payment schedule amounts. `milestones` came from `aiData.paymentMilestones`, computed
+    // upstream against `aiData.totalEstimate` — but the estimate is stored with `finalTotal`,
+    // which differs from `totalEstimate` whenever the tax split applied. Trusting the stored
+    // `m.amount` in that case can leave the schedule not summing to the estimate total, so
+    // recompute from `finalTotal` and the milestone PERCENTAGES instead. When the split bailed
+    // out, `finalTotal === totalEstimate` and the milestones already match it, so keep reading the
+    // stored amounts as-is (legacy behavior, unchanged).
+    const recomputedMilestones = split.taxRatePercent != null ? recomputeMilestoneAmounts(finalTotal, milestones) : null;
+
+    // `storedTaxRate`, not the derived `split.taxRatePercent` — when the takeoff's snapshot
+    // reconciles it is the exact configured rate, and that is the one a later edit must reprice at.
+    return { items, milestones, finalTotal, taxRatePercent: storedTaxRate, taxRateName, recomputedMilestones };
+}
+
+// POST /api/takeoffs/convert-to-estimate
+// Converts AI-generated takeoff data into a real Estimate with line items
+export async function POST(req: NextRequest) {
+    const body = await req.json();
+    const { takeoffId } = body;
+
+    if (!takeoffId) {
+        return NextResponse.json({ error: "takeoffId is required" }, { status: 400 });
+    }
 
     try {
-        // Create the Estimate
-        const estimate = await prisma.estimate.create({
-            data: {
-                title: `${takeoff.name} — AI Estimate`,
-                projectId: takeoff.projectId || null,
-                leadId: takeoff.leadId || null,
-                code,
-                status: "Draft",
-                totalAmount: finalTotal,
-                balanceDue: finalTotal,
-                privacy: "Shared",
-                ...(storedTaxRate != null ? { taxRatePercent: storedTaxRate, taxRateName } : {}),
-            },
-        });
+        // ATOMICITY + IDEMPOTENCY. These writes (the Estimate, its line items, its payment
+        // schedules, and the Takeoff link) used to run as four independent statements: a failure
+        // partway through returned a 500 while leaving a complete, findable Estimate carrying real
+        // money with no payment schedules and no takeoff link. They are one transaction now, so
+        // the conversion either lands whole or leaves nothing behind.
+        //
+        // The transaction opens by locking the Takeoff row, and EVERYTHING it goes on to use — the
+        // idempotency check, the takeoff's project/lead ownership, and the AI data the line items
+        // and milestones are built from — is read under that lock. Reading any of it beforehand
+        // would let a concurrent edit (a reassignment to another project, a re-run of the AI
+        // estimate) land between the read and the write, producing an estimate that describes a
+        // takeoff which no longer looks like that.
+        //
+        // The lock is also what makes a second conversion a no-op instead of a duplicate. Note
+        // that `Takeoff.estimateId` being `@unique` does NOT provide this on its own: the unique
+        // index only forbids two takeoffs pointing at one estimate — it happily allows one takeoff
+        // to be REPOINTED at a second estimate, which is exactly the orphaning this prevents.
+        const outcome = await withTxRetry(() =>
+            prisma.$transaction(
+                async (tx) => {
+                    // The lock's own result is the existence check. `FOR UPDATE` locks NOTHING when
+                    // the row is absent, so a read that followed an empty lock would be unlocked:
+                    // under READ COMMITTED a row with this id could be inserted in between, and two
+                    // requests could then each convert it. No row here means no row to convert.
+                    const locked = await tx.$queryRaw<
+                        { id: string }[]
+                    >`SELECT id FROM "Takeoff" WHERE id = ${takeoffId} FOR UPDATE`;
+                    if (locked.length === 0) return { kind: "error" as const, status: 404, message: "Takeoff not found" };
 
-        // Create all estimate line items
-        for (let idx = 0; idx < items.length; idx++) {
-            const item = items[idx];
-            // Tax is a pass-through: never let the default margin land on a tax line. Takeoffs
-            // generated before the AI mapping carried markupPercent have no value stored at all,
-            // so this guard also repairs those.
-            const isTaxItem = isTaxCostCode(item.costCode);
+                    const takeoff = await tx.takeoff.findUnique({
+                        where: { id: takeoffId },
+                        // `files` was included by the previous read here and never used; loading it
+                        // inside the transaction would only lengthen the lock hold.
+                        select: { name: true, projectId: true, leadId: true, aiEstimateData: true, estimateId: true },
+                    });
+                    if (!takeoff) return { kind: "error" as const, status: 404, message: "Takeoff not found" };
 
-            const baseCost = numOrNull(item.baseCost);
-            const unitCost = numOr(item.unitCost, 0);
-            const quantity = numOr(item.quantity, 1);
+                    const redirectTo = (id: string) =>
+                        takeoff.projectId ? `/projects/${takeoff.projectId}/estimates/${id}` : `/leads/${takeoff.leadId}/estimates/${id}`;
 
-            await prisma.estimateItem.create({
-                data: {
-                    estimateId: estimate.id,
-                    name: item.name || "Unnamed Item",
-                    description: item.description || "",
-                    type: item.type || item.costType || "Material",
-                    quantity,
-                    baseCost,
-                    markupPercent: isTaxItem ? 0 : marginPercentFor(item, baseCost, unitCost),
-                    unitCost,
-                    total: numOr(item.total, 0),
-                    order: idx,
-                    parentId: null,
-                    costCodeId: item.costCodeId || null,
-                    costTypeId: item.costTypeId || null,
+                    if (takeoff.estimateId) {
+                        const existing = await tx.estimate.findUnique({
+                            where: { id: takeoff.estimateId },
+                            select: {
+                                id: true,
+                                code: true,
+                                totalAmount: true,
+                                projectId: true,
+                                leadId: true,
+                                _count: { select: { items: true } },
+                            },
+                        });
+                        // Already converted: hand back the estimate that already exists rather
+                        // than minting a second one, matching how re-approval is handled in
+                        // `ensureProjectAndDepositInvoiceForEstimate`.
+                        if (existing) {
+                            return {
+                                kind: "existing" as const,
+                                estimateId: existing.id,
+                                code: existing.code,
+                                // Decimal — send a plain number, never the Prisma Decimal object.
+                                totalAmount: Number(existing.totalAmount),
+                                itemCount: existing._count.items,
+                                // Route by the ESTIMATE's own owner, not the takeoff's. A takeoff
+                                // reassigned after it was converted no longer agrees with the
+                                // estimate it already produced, and the estimate lives where its
+                                // own projectId/leadId says it does.
+                                redirectUrl: existing.projectId
+                                    ? `/projects/${existing.projectId}/estimates/${existing.id}`
+                                    : `/leads/${existing.leadId}/estimates/${existing.id}`,
+                            };
+                        }
+                        // The link outlived its estimate. The FK nulls this column when an estimate
+                        // is deleted, so reaching here means a money document went missing outside
+                        // the app's own delete path — say so loudly. Failing the request would only
+                        // strand the takeoff, so convert and repair the link.
+                        console.error(
+                            `Convert to Estimate: takeoff ${takeoffId} points at missing estimate ${takeoff.estimateId} — reconverting`,
+                        );
+                    }
+
+                    if (!takeoff.aiEstimateData) {
+                        return {
+                            kind: "error" as const,
+                            status: 400,
+                            message: "No AI estimate data to convert. Generate an AI estimate first.",
+                        };
+                    }
+
+                    const built = await buildConversion(takeoff.aiEstimateData, async () => {
+                        const companySettings = await tx.companySettings.findUnique({
+                            where: { id: "singleton" },
+                            select: { salesTaxes: true },
+                        });
+                        return companySettings?.salesTaxes ?? null;
+                    });
+                    if ("error" in built) return { kind: "error" as const, status: 400, message: built.error };
+
+                    const { items, milestones, finalTotal, taxRatePercent, taxRateName, recomputedMilestones } = built;
+                    const code = `EST-${Math.floor(1000 + Math.random() * 9000)}`;
+
+                    // Create the Estimate
+                    const estimate = await tx.estimate.create({
+                        data: {
+                            title: `${takeoff.name} — AI Estimate`,
+                            projectId: takeoff.projectId || null,
+                            leadId: takeoff.leadId || null,
+                            code,
+                            status: "Draft",
+                            totalAmount: finalTotal,
+                            balanceDue: finalTotal,
+                            privacy: "Shared",
+                            ...(taxRatePercent != null ? { taxRatePercent, taxRateName } : {}),
+                        },
+                    });
+
+                    // createMany, not a create-per-row: every round trip here is taken while
+                    // holding the Takeoff lock and spending the transaction's time budget, so a
+                    // large takeoff's line items must not scale the lock hold linearly.
+                    if (items.length > 0) {
+                        await tx.estimateItem.createMany({
+                            data: items.map((item: any, idx: number) => {
+                                // Tax is a pass-through: never let the default margin land on a tax
+                                // line. Takeoffs generated before the AI mapping carried
+                                // markupPercent have no value stored at all, so this guard also
+                                // repairs those.
+                                const isTaxItem = isTaxCostCode(item.costCode);
+
+                                const baseCost = numOrNull(item.baseCost);
+                                const unitCost = numOr(item.unitCost, 0);
+                                const quantity = numOr(item.quantity, 1);
+
+                                return {
+                                    estimateId: estimate.id,
+                                    name: item.name || "Unnamed Item",
+                                    description: item.description || "",
+                                    type: item.type || item.costType || "Material",
+                                    quantity,
+                                    baseCost,
+                                    markupPercent: isTaxItem ? 0 : marginPercentFor(item, baseCost, unitCost),
+                                    unitCost,
+                                    total: numOr(item.total, 0),
+                                    order: idx,
+                                    parentId: null,
+                                    costCodeId: item.costCodeId || null,
+                                    costTypeId: item.costTypeId || null,
+                                };
+                            }),
+                        });
+                    }
+
+                    if (milestones.length > 0) {
+                        await tx.estimatePaymentSchedule.createMany({
+                            data: milestones.map((m: any, idx: number) => {
+                                const recomputed = recomputedMilestones ? recomputedMilestones[idx] : null;
+                                return {
+                                    estimateId: estimate.id,
+                                    name: m.name || `Payment ${idx + 1}`,
+                                    percentage: recomputed ? recomputed.percentage : parseFloat(m.percentage) || 0,
+                                    amount: recomputed ? recomputed.amount : parseFloat(m.amount) || 0,
+                                    dueDate: null,
+                                    order: idx,
+                                };
+                            }),
+                        });
+                    }
+
+                    // Link the takeoff to the new estimate
+                    await tx.takeoff.update({
+                        where: { id: takeoffId },
+                        data: {
+                            estimateId: estimate.id,
+                            status: "Completed",
+                        },
+                    });
+
+                    return {
+                        kind: "created" as const,
+                        estimateId: estimate.id,
+                        code: estimate.code,
+                        totalAmount: finalTotal,
+                        itemCount: items.length,
+                        redirectUrl: redirectTo(estimate.id),
+                    };
                 },
-            });
+                // `timeout` is the budget for the WHOLE transaction — the wait on the `FOR UPDATE`
+                // row lock behind a concurrent conversion, plus every statement after it. `maxWait`
+                // is a different clock: it caps how long Prisma waits to check a pooled connection
+                // OUT before the transaction begins, and does not cover the row-lock wait at all.
+                // The work inside is bounded (bulk inserts, not per-row round trips), so the 30s is
+                // headroom for lock contention rather than for the inserts themselves.
+                { maxWait: 10_000, timeout: 30_000 },
+            ),
+        );
+
+        if (outcome.kind === "error") {
+            return NextResponse.json({ error: outcome.message }, { status: outcome.status });
         }
-
-        // Create payment schedules. `milestones` came from `aiData.paymentMilestones`, computed
-        // upstream against `aiData.totalEstimate` — but the estimate above was stored with
-        // `finalTotal`, which differs from `totalEstimate` whenever the tax split applied. Trusting
-        // the stored `m.amount` in that case can leave the schedule not summing to the estimate
-        // total, so recompute from `finalTotal` and the milestone PERCENTAGES instead. When the
-        // split bailed out, `finalTotal === totalEstimate` and the milestones already match it, so
-        // keep reading the stored amounts as-is (legacy behavior, unchanged).
-        const recomputedMilestones = split.taxRatePercent != null ? recomputeMilestoneAmounts(finalTotal, milestones) : null;
-        for (let idx = 0; idx < milestones.length; idx++) {
-            const m = milestones[idx];
-            const recomputed = recomputedMilestones ? recomputedMilestones[idx] : null;
-            await prisma.estimatePaymentSchedule.create({
-                data: {
-                    estimateId: estimate.id,
-                    name: m.name || `Payment ${idx + 1}`,
-                    percentage: recomputed ? recomputed.percentage : parseFloat(m.percentage) || 0,
-                    amount: recomputed ? recomputed.amount : parseFloat(m.amount) || 0,
-                    dueDate: null,
-                    order: idx,
-                },
-            });
-        }
-
-        // Link the takeoff to the new estimate
-        await prisma.takeoff.update({
-            where: { id: takeoffId },
-            data: {
-                estimateId: estimate.id,
-                status: "Completed",
-            },
-        });
-
-        // Build the redirect URL
-        const redirectUrl = takeoff.projectId
-            ? `/projects/${takeoff.projectId}/estimates/${estimate.id}`
-            : `/leads/${takeoff.leadId}/estimates/${estimate.id}`;
 
         return NextResponse.json({
-            estimateId: estimate.id,
-            code: estimate.code,
-            totalAmount: finalTotal,
-            itemCount: items.length,
-            redirectUrl,
+            estimateId: outcome.estimateId,
+            code: outcome.code,
+            totalAmount: outcome.totalAmount,
+            itemCount: outcome.itemCount,
+            redirectUrl: outcome.redirectUrl,
+            ...(outcome.kind === "existing" ? { alreadyConverted: true } : {}),
         });
     } catch (err: any) {
         console.error("Convert to Estimate error:", err);

--- a/src/app/projects/[id]/takeoffs/TakeoffsClient.tsx
+++ b/src/app/projects/[id]/takeoffs/TakeoffsClient.tsx
@@ -349,7 +349,14 @@ export default function TakeoffsClient({ contextType, contextId, contextName }: 
                 throw new Error(err.error || "Failed to convert");
             }
             const result = await res.json();
-            toast.success(`Estimate ${result.code} created with ${result.itemCount} line items!`);
+            // The conversion is idempotent: a takeoff that was already converted (stale tab, a
+            // double submit, a direct API call) gets its EXISTING estimate back rather than a
+            // second one. Say so instead of claiming a creation that didn't happen.
+            toast.success(
+                result.alreadyConverted
+                    ? `This takeoff was already converted — opening estimate ${result.code}.`
+                    : `Estimate ${result.code} created with ${result.itemCount} line items!`,
+            );
             router.push(result.redirectUrl);
         } catch (err: any) {
             toast.error(err.message || "Failed to convert to estimate");

--- a/tests/takeoff-convert-tax.test.ts
+++ b/tests/takeoff-convert-tax.test.ts
@@ -62,54 +62,148 @@ const calls = {
     estimateItemCreates: [] as CreateCall<any>[],
     estimatePaymentScheduleCreates: [] as CreateCall<any>[],
     takeoffUpdates: [] as CreateCall<any>[],
+    /** How many times the route opened an interactive transaction. */
+    transactions: 0,
+    /** `SELECT ... FOR UPDATE` row locks taken, in order. */
+    rowLocks: [] as string[],
 };
 
-const state: { takeoff: any; companySettings: any } = { takeoff: null, companySettings: null };
+const state: {
+    takeoff: any;
+    /**
+     * What `takeoff.findUnique` returns for the route's RE-READ inside the transaction, when that
+     * must differ from the outer read (concurrent conversion / concurrent delete). `undefined`
+     * means "same as `takeoff`"; `null` means the row is gone.
+     */
+    takeoffInTx: any;
+    companySettings: any;
+    /** Estimates the fake DB already holds, keyed by id — for the already-converted path. */
+    estimates: Record<string, any>;
+    /** When set, `estimateItem.create` throws on the Nth (1-based) call, mid-conversion. */
+    failItemCreateOn: number | null;
+} = { takeoff: null, takeoffInTx: undefined, companySettings: null, estimates: {}, failItemCreateOn: null };
 
 function resetFixture() {
     calls.estimateCreates.length = 0;
     calls.estimateItemCreates.length = 0;
     calls.estimatePaymentScheduleCreates.length = 0;
     calls.takeoffUpdates.length = 0;
+    calls.rowLocks.length = 0;
+    calls.transactions = 0;
+    ops.length = 0;
     state.takeoff = null;
+    state.takeoffInTx = undefined;
     state.companySettings = null;
+    state.estimates = {};
+    state.failItemCreateOn = null;
 }
 
 let estimateSeq = 0;
 let itemSeq = 0;
 let scheduleSeq = 0;
 
+/**
+ * Every operation, in the order it happened, tagged with which client issued it.
+ *
+ * `via: "root"` means the operation went through the top-level `prisma` object; `via: "tx"` means
+ * it went through the client the `$transaction` callback was handed. Those are DISTINCT objects in
+ * this fake (as they are in real Prisma) precisely so that a write which calls `prisma.x.create()`
+ * from inside the callback is caught: it is lexically "inside the transaction" but does NOT run in
+ * it, and would not be rolled back.
+ */
+const ops: { op: string; via: "root" | "tx" }[] = [];
+
+/** Ops issued through the root client — everything here escapes the transaction. */
+function opsOutsideTx() {
+    return ops.filter((o) => o.via === "root");
+}
+
+/**
+ * One set of model methods, bound to a client identity. The root client and the transaction client
+ * are two separate instances so the `via` tag is meaningful.
+ */
+function makeClient(via: "root" | "tx") {
+    const record = (op: string) => ops.push({ op, via });
+    return {
+        takeoff: {
+            findUnique: async () => {
+                record("takeoff.findUnique");
+                return via === "tx" && state.takeoffInTx !== undefined ? state.takeoffInTx : state.takeoff;
+            },
+            update: async (args: CreateCall<any>) => {
+                record("takeoff.update");
+                calls.takeoffUpdates.push(args);
+                return { ...state.takeoff, ...args.data };
+            },
+        },
+        companySettings: {
+            findUnique: async () => {
+                record("companySettings.findUnique");
+                return state.companySettings;
+            },
+        },
+        estimate: {
+            create: async (args: CreateCall<any>) => {
+                record("estimate.create");
+                calls.estimateCreates.push(args);
+                estimateSeq += 1;
+                return { id: `est-${estimateSeq}`, ...args.data };
+            },
+            findUnique: async (args: { where: { id: string } }) => {
+                record("estimate.findUnique");
+                return state.estimates[args.where.id] ?? null;
+            },
+        },
+        estimateItem: {
+            // The route bulk-inserts; the fake fans the rows back out into the same per-row shape
+            // the assertions below have always used.
+            createMany: async (args: { data: any[] }) => {
+                record("estimateItem.createMany");
+                for (const row of args.data) {
+                    calls.estimateItemCreates.push({ data: row });
+                    itemSeq += 1;
+                    if (state.failItemCreateOn != null && calls.estimateItemCreates.length === state.failItemCreateOn) {
+                        throw new Error("simulated mid-conversion failure");
+                    }
+                }
+                return { count: args.data.length };
+            },
+        },
+        estimatePaymentSchedule: {
+            createMany: async (args: { data: any[] }) => {
+                record("estimatePaymentSchedule.createMany");
+                for (const row of args.data) {
+                    calls.estimatePaymentScheduleCreates.push({ data: row });
+                    scheduleSeq += 1;
+                }
+                return { count: args.data.length };
+            },
+        },
+        // Tagged-template call: `tx.$queryRaw`SELECT id FROM "Takeoff" WHERE id = ${id} FOR UPDATE``
+        // arrives as (templateStrings, ...values). Record the joined SQL so a test can assert the
+        // row lock is actually taken, and taken FIRST.
+        // The route reads this result as its existence check, so the fake must answer honestly:
+        // a row when the takeoff exists, nothing when it doesn't. Always returning `[]` (or always
+        // returning a row) would make the missing-row branch untestable.
+        $queryRaw: async (strings: TemplateStringsArray, ...values: unknown[]) => {
+            record("$queryRaw");
+            calls.rowLocks.push(strings.join("?").trim() + ` [${values.join(",")}]`);
+            const row = via === "tx" && state.takeoffInTx !== undefined ? state.takeoffInTx : state.takeoff;
+            return row ? [{ id: values[0] }] : [];
+        },
+    };
+}
+
+const txClient = makeClient("tx");
+
 const fakePrisma = {
-    takeoff: {
-        findUnique: async () => state.takeoff,
-        update: async (args: CreateCall<any>) => {
-            calls.takeoffUpdates.push(args);
-            return { ...state.takeoff, ...args.data };
-        },
-    },
-    companySettings: {
-        findUnique: async () => state.companySettings,
-    },
-    estimate: {
-        create: async (args: CreateCall<any>) => {
-            calls.estimateCreates.push(args);
-            estimateSeq += 1;
-            return { id: `est-${estimateSeq}`, ...args.data };
-        },
-    },
-    estimateItem: {
-        create: async (args: CreateCall<any>) => {
-            calls.estimateItemCreates.push(args);
-            itemSeq += 1;
-            return { id: `item-${itemSeq}`, ...args.data };
-        },
-    },
-    estimatePaymentSchedule: {
-        create: async (args: CreateCall<any>) => {
-            calls.estimatePaymentScheduleCreates.push(args);
-            scheduleSeq += 1;
-            return { id: `sched-${scheduleSeq}`, ...args.data };
-        },
+    ...makeClient("root"),
+    // The fake can't roll anything back, so tests assert on what the route ATTEMPTED: a failure
+    // inside the callback must propagate (no partial commit is possible in the real DB because the
+    // statements share one transaction) and must leave the later steps unexecuted.
+    $transaction: async (fn: (tx: any) => Promise<any>) => {
+        calls.transactions += 1;
+        return await fn(txClient);
     },
 };
 
@@ -722,4 +816,245 @@ test("the legacy totalEstimate fallback sums stringy totals numerically, not by 
     const estimateData = calls.estimateCreates[calls.estimateCreates.length - 1].data;
     assert.equal(estimateData.totalAmount, 1500);
     assert.equal(typeof estimateData.totalAmount, "number");
+});
+
+// --- atomicity ---------------------------------------------------------------------------------
+//
+// Before the fix, the four write groups (Estimate, its items, its schedules, the Takeoff link) ran
+// as four independent statements. A failure partway through returned a 500 while leaving a
+// complete, findable Estimate carrying real money with no payment schedules and no takeoff link.
+
+test("every write happens inside ONE transaction, opened by locking the Takeoff row first", async () => {
+    state.takeoff = canonicalTakeoff();
+    state.companySettings = canonicalCompanySettings();
+
+    const res = await POST(postRequest("takeoff-1"));
+    assert.equal(res.status, 200, JSON.stringify(await res.json()));
+
+    assert.equal(calls.transactions, 1, "expected exactly one interactive transaction");
+    // NOTHING may go through the root prisma client — not the reads either. A read taken outside
+    // the transaction is the stale-snapshot bug: the row it saw can change before the write lands.
+    assert.deepEqual(opsOutsideTx(), [], "every operation must go through the transaction client");
+
+    // The row lock must be the very FIRST operation. Ordering is the whole guarantee: if the
+    // takeoff is read before it is locked, two requests can both read `estimateId = null`, then
+    // serialize on the lock and each create an Estimate. Asserting "a lock happened" would not
+    // catch that, so assert its POSITION.
+    assert.equal(ops[0].op, "$queryRaw", `expected the row lock first, got: ${ops.map((o) => o.op).join(" -> ")}`);
+    assert.equal(ops[1].op, "takeoff.findUnique", "the takeoff must be read only after the lock is held");
+    assert.equal(calls.rowLocks.length, 1);
+    assert.match(calls.rowLocks[0], /SELECT id FROM "Takeoff"[\s\S]*FOR UPDATE/);
+    assert.match(calls.rowLocks[0], /\[takeoff-1\]/);
+
+    // And the writes still all landed.
+    assert.equal(calls.estimateCreates.length, 1);
+    assert.equal(calls.estimateItemCreates.length, 3);
+    assert.equal(calls.estimatePaymentScheduleCreates.length, 3);
+    assert.equal(calls.takeoffUpdates.length, 1);
+});
+
+test("a failure mid-way through the line items aborts the whole conversion: no schedules, no takeoff link", async () => {
+    state.takeoff = canonicalTakeoff();
+    state.companySettings = canonicalCompanySettings();
+    // Blow up on the 2nd of 3 line items — after the Estimate row was created, which is exactly
+    // the window that used to leave an orphaned money document behind.
+    state.failItemCreateOn = 2;
+
+    const res = await POST(postRequest("takeoff-1"));
+    const body = await res.json();
+    assert.equal(res.status, 500);
+    assert.equal(body.error, "simulated mid-conversion failure");
+
+    // Everything after the failure point must be unreached — in the real DB the transaction rolls
+    // back, so the Estimate row attempted above never becomes visible either.
+    assert.equal(calls.estimateItemCreates.length, 2);
+    assert.equal(calls.estimatePaymentScheduleCreates.length, 0, "schedules must not be written after a failed item");
+    assert.equal(calls.takeoffUpdates.length, 0, "takeoff must not be linked/Completed by a failed conversion");
+    assert.deepEqual(opsOutsideTx(), []);
+});
+
+test("the estimate is built from the takeoff as it exists UNDER THE LOCK, not from an earlier read", async () => {
+    // `state.takeoff` is what an un-locked read would have seen; `state.takeoffInTx` is the row as
+    // it actually is once the lock is held — a concurrent request reassigned the takeoff to another
+    // project and re-ran its AI estimate. Reading any conversion input before the lock would create
+    // an estimate for project-1 with the old $108,400 of items and then link the project-2 takeoff
+    // to it.
+    state.takeoff = canonicalTakeoff();
+    state.takeoffInTx = {
+        name: "Reassigned Job",
+        projectId: "project-2",
+        leadId: null,
+        estimateId: null,
+        aiEstimateData: JSON.stringify({
+            items: [{ costCode: "01-DEMO", name: "Fresh Demo", total: 7000, unitCost: 7000, quantity: 1 }],
+            totalEstimate: 7000,
+            paymentMilestones: [{ name: "Payment in full", percentage: "100", amount: "7000" }],
+        }),
+    };
+    state.companySettings = canonicalCompanySettings();
+
+    const res = await POST(postRequest("takeoff-1"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+
+    const estimateData = calls.estimateCreates[0].data;
+    assert.equal(estimateData.projectId, "project-2", "ownership must come from the locked read");
+    assert.equal(estimateData.title, "Reassigned Job — AI Estimate");
+    assert.equal(estimateData.totalAmount, 7000);
+    assert.equal(calls.estimateItemCreates.length, 1);
+    assert.equal(calls.estimateItemCreates[0].data.name, "Fresh Demo");
+    // The redirect follows the same locked read, so the client is not sent to the old project.
+    assert.equal(body.redirectUrl, `/projects/project-2/estimates/${body.estimateId}`);
+});
+
+// --- idempotency -------------------------------------------------------------------------------
+//
+// Before the fix the route never checked `takeoff.estimateId`, so a second POST minted a SECOND
+// Estimate and relinked the takeoff to it, orphaning the first with its real money and milestones.
+// `Takeoff.estimateId` being @unique does not prevent that: the unique index forbids two takeoffs
+// pointing at one estimate, but happily allows one takeoff to be repointed at a second estimate.
+
+function alreadyConvertedTakeoff() {
+    const t = canonicalTakeoff();
+    return { ...t, id: "takeoff-converted", estimateId: "est-existing", status: "Completed" };
+}
+
+test("converting an already-converted takeoff returns the EXISTING estimate and writes nothing", async () => {
+    state.takeoff = alreadyConvertedTakeoff();
+    state.companySettings = canonicalCompanySettings();
+    state.estimates = {
+        "est-existing": {
+            id: "est-existing",
+            code: "EST-1234",
+            totalAmount: 108400,
+            projectId: "project-1",
+            leadId: null,
+            _count: { items: 3 },
+        },
+    };
+
+    const res = await POST(postRequest("takeoff-converted"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+    assert.deepEqual(opsOutsideTx(), [], "the existing-estimate lookup must also run in the transaction");
+
+    // The pre-existing estimate is handed back, flagged so the caller can tell it wasn't new.
+    assert.equal(body.estimateId, "est-existing");
+    assert.equal(body.code, "EST-1234");
+    assert.equal(body.totalAmount, 108400);
+    assert.equal(typeof body.totalAmount, "number");
+    assert.equal(body.itemCount, 3);
+    assert.equal(body.alreadyConverted, true);
+    assert.equal(body.redirectUrl, "/projects/project-1/estimates/est-existing");
+
+    // NOTHING was written — no second estimate, no duplicate items or milestones, and the takeoff
+    // was not relinked.
+    assert.equal(calls.estimateCreates.length, 0);
+    assert.equal(calls.estimateItemCreates.length, 0);
+    assert.equal(calls.estimatePaymentScheduleCreates.length, 0);
+    assert.equal(calls.takeoffUpdates.length, 0);
+});
+
+test("a takeoff converted by a concurrent request that commits first does not get a second estimate", async () => {
+    // A concurrent conversion commits while this one waits on the row lock, so the state visible
+    // once the lock is finally held already carries an estimateId. Reading `estimateId` anywhere
+    // but under the lock is precisely the interleaving that creates the orphan.
+    state.takeoff = canonicalTakeoff();
+    state.takeoffInTx = { estimateId: "est-raced" };
+    state.companySettings = canonicalCompanySettings();
+    state.estimates = {
+        "est-raced": {
+            id: "est-raced",
+            code: "EST-9999",
+            totalAmount: 108400,
+            projectId: "project-1",
+            leadId: null,
+            _count: { items: 3 },
+        },
+    };
+
+    const res = await POST(postRequest("takeoff-1"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+
+    assert.equal(body.estimateId, "est-raced");
+    assert.equal(body.alreadyConverted, true);
+    assert.equal(calls.estimateCreates.length, 0);
+    assert.equal(calls.takeoffUpdates.length, 0);
+    assert.deepEqual(opsOutsideTx(), []);
+});
+
+test("the already-converted redirect follows the ESTIMATE's owner, not the takeoff's current one", async () => {
+    // The takeoff was reassigned to project-2 after it produced this estimate. The estimate still
+    // lives under project-1, which is where the client has to be sent — routing by the takeoff
+    // would build a URL for a project that does not hold this estimate.
+    state.takeoff = { ...alreadyConvertedTakeoff(), projectId: "project-2" };
+    state.companySettings = canonicalCompanySettings();
+    state.estimates = {
+        "est-existing": {
+            id: "est-existing",
+            code: "EST-1234",
+            totalAmount: 108400,
+            projectId: "project-1",
+            leadId: null,
+            _count: { items: 3 },
+        },
+    };
+
+    const res = await POST(postRequest("takeoff-converted"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+    assert.equal(body.redirectUrl, "/projects/project-1/estimates/est-existing");
+});
+
+test("a takeoff deleted before the lock is acquired returns 404, decided by the lock's own result", async () => {
+    state.takeoff = canonicalTakeoff();
+    state.takeoffInTx = null;
+    state.companySettings = canonicalCompanySettings();
+
+    const res = await POST(postRequest("takeoff-1"));
+    const body = await res.json();
+    assert.equal(res.status, 404);
+    assert.equal(body.error, "Takeoff not found");
+    assert.equal(calls.estimateCreates.length, 0);
+    // `FOR UPDATE` locks nothing when the row is absent, so the route must stop on the EMPTY LOCK
+    // rather than proceeding to an unlocked read. Proving that means proving it never read at all.
+    assert.deepEqual(
+        ops.map((o) => o.op),
+        ["$queryRaw"],
+    );
+});
+
+test("a takeoff whose estimateId points at a missing estimate self-heals: it converts again", async () => {
+    // Not reachable through the app (the FK nulls the link when an estimate is deleted), but if a
+    // dangling link ever exists, failing forever would strand the takeoff. Convert and relink.
+    state.takeoff = alreadyConvertedTakeoff();
+    state.companySettings = canonicalCompanySettings();
+    state.estimates = {}; // est-existing is gone
+
+    const res = await POST(postRequest("takeoff-converted"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+
+    assert.equal(body.alreadyConverted, undefined);
+    assert.equal(calls.estimateCreates.length, 1);
+    assert.equal(calls.estimateItemCreates.length, 3);
+    assert.equal(calls.takeoffUpdates.length, 1);
+    assert.equal(calls.takeoffUpdates[0].data.estimateId, body.estimateId);
+    assert.deepEqual(opsOutsideTx(), []);
+});
+
+test("companySettings is not queried when there is no tax split to name", async () => {
+    // The configured sales taxes exist only to NAME a derived rate. A conversion with no tax row
+    // must not spend a query — or inherit that query's failure mode — inside the lock.
+    state.takeoff = bailOutTakeoff();
+    state.companySettings = canonicalCompanySettings();
+
+    const res = await POST(postRequest("takeoff-2"));
+    assert.equal(res.status, 200, JSON.stringify(await res.json()));
+    assert.equal(
+        ops.filter((o) => o.op === "companySettings.findUnique").length,
+        0,
+        "the bail-out path derives no rate, so there is nothing to name",
+    );
 });


### PR DESCRIPTION
Two pre-existing money-document lifecycle defects in `POST /api/takeoffs/convert-to-estimate`, both flagged by the Codex review during #372 and deliberately left out of scope there because they are unrelated to tax.

## 1. Not atomic

Four independent writes, no transaction: `estimate.create`, a loop of `estimateItem.create`, a loop of `estimatePaymentSchedule.create`, and the `takeoff.update` that links them. A failure partway through returned a 500 while leaving a complete, findable Estimate carrying real money with **no payment schedules** and a Takeoff still unlinked.

Now one transaction, wrapped in `withTxRetry`. It lands whole or leaves nothing.

## 2. Not idempotent

The route never checked `takeoff.estimateId`, so a second call created a **second** Estimate and relinked the takeoff to it, orphaning the first with its real money and milestones.

`Takeoff.estimateId` being `@unique` does not prevent this — the unique index forbids two takeoffs pointing at one estimate, but happily allows one takeoff to be *repointed* at a second estimate, which is exactly the orphaning.

The transaction now takes `SELECT ... FOR UPDATE` on the Takeoff as its **first** statement and reads `estimateId` under that lock. An already-converted takeoff gets its existing estimate back with `alreadyConverted: true`, matching how `ensureProjectAndDepositInvoiceForEstimate` handles re-approval. The UI's success toast honors the flag instead of claiming a creation that didn't happen.

## Also, from the review

- **Everything** the conversion uses is read under the lock, not just `estimateId` — ownership, and the AI data the items and milestones are built from. A snapshot taken before the lock lets a concurrent reassignment or AI re-run land in between, producing an estimate that describes a takeoff which no longer looks like that. The tax/milestone math moved verbatim into a pure `buildConversion()` called inside the transaction.
- Its sales-tax lookup is **lazy**, so an unparseable-AI-data 400 and every no-tax conversion cost no extra query inside the lock.
- Items and schedules are **bulk-inserted**, so a large takeoff doesn't scale the lock hold linearly.
- The **empty result of the lock is the existence check**. `FOR UPDATE` locks nothing when the row is absent, so reading after an empty lock would be reading unlocked.
- The already-converted redirect routes by the **estimate's own** `projectId`/`leadId`, not the takeoff's current one — a takeoff reassigned after conversion no longer agrees with the estimate it produced.

## Not changed

The tax-splitting behavior from #372. It was relocated, not modified — confirmed line by line, and by the 15 pre-existing tax tests still passing untouched.

## Tests

`tests/takeoff-convert-tax.test.ts`, 15 -> 24, extending the existing harness.

The fake Prisma now builds **two distinct clients** (root vs transaction) and records every operation into one ordered, client-tagged log. That is what gives the new assertions teeth, and it was verified by mutation rather than assumed:

| mutation | result |
|---|---|
| move the `FOR UPDATE` below the takeoff read | 1 test fails |
| swap `tx.estimate.create` for `prisma.estimate.create` | 2 tests fail |

New cases: single-transaction + lock-ordering, mid-conversion failure writes nothing downstream, conversion built from the locked read, already-converted returns the existing estimate and writes nothing, concurrent-conversion loser doesn't duplicate, redirect follows the estimate's owner, empty lock stops before any read, dangling link self-heals, no settings query when there's no rate to name.

## Verification

- `npm run build` (typecheck + next build) — clean
- `npm run test:unit` — 186/186
- `e2e/money-pipeline.spec.ts` — runs in PR CI (needs the throwaway Postgres container; not run locally)
- Not exercised in a browser: the route only fires from the takeoff screen against real AI data and writes real money documents, so a click-through would have to create a live estimate in prod.

## Review

Codex gpt-5.6-sol xhigh, two rounds.

- **Round 1** found the stale-snapshot hole (only `estimateId` was re-read under the lock) and that the first cut of the tests could not detect either mutation in the table above. Both fixed.
- **Round 2** found the ignored lock result and the wrong-owner redirect, plus two low findings (unconditional settings query, missing tx-client assertions on the existing-estimate branches). All four fixed. No high-severity findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
