### PR TITLE
fix(money): make the payment calendar-day sentinel timezone-independent

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -647,7 +647,10 @@ model PaymentSchedule {
   taxAmount             Decimal?
   status                String    @default("Pending") // Pending, Paid, Canceled
   dueDate               DateTime?
-  paymentDate           DateTime?
+  // Mirrored to EstimatePaymentSchedule.paymentDate, which is Timestamptz(6) — the two
+  // sides must match or every settle copy crosses timestamp semantics. Carries DUAL
+  // SEMANTICS (calendar day vs instant); see lib/payment-date.ts before touching it.
+  paymentDate           DateTime? @db.Timestamptz(6)
   stripeSessionId       String?
   stripePaymentIntentId String?
   paymentMethod         String? // Stripe: "card"/"ach"; manual: "check"/"cash"; "quickbooks" via QB Payments
@@ -655,7 +658,8 @@ model PaymentSchedule {
   notes                 String? // free-form memo
   receiptSentAt         DateTime? // last time admin sent the receipt email
   lastReminderAt        DateTime? @db.Timestamptz(6) // last time the automated payment-reminder cron emailed the client for this milestone
-  paidAt                DateTime?
+  // Mirrored to EstimatePaymentSchedule.paidAt (Timestamptz(6)) — keep the types equal.
+  paidAt                DateTime? @db.Timestamptz(6)
   createdAt             DateTime  @default(now())
 
   // QuickBooks Payments rail: each milestone maps to one QBO invoice with its own pay link.

--- a/scripts/apply-payment-timestamp-alignment.mjs
+++ b/scripts/apply-payment-timestamp-alignment.mjs
@@ -1,0 +1,147 @@
+// Aligns the mirrored milestone timestamp columns across the two sides of the money path.
+//
+// EstimatePaymentSchedule.paymentDate/.paidAt are timestamptz(6), while their mirrored twins
+// PaymentSchedule.paymentDate/.paidAt were zone-LESS timestamp(3). Settle/unsettle paths copy
+// values between the pairs, so every copy crossed timestamp semantics. Nothing has drifted yet
+// only because the Postgres session TimeZone is UTC, which makes the implicit conversion a
+// no-op — a latent dependency on a session setting, not a property of the schema.
+//
+// This converts the invoice side UP to timestamptz(6) so both sides match.
+//
+// SAFETY
+//  - Value-preserving: the USING clause pins the interpretation to UTC explicitly rather than
+//    inheriting the session TimeZone, so each stored wall clock is reinterpreted as the UTC
+//    instant it already effectively was. Every existing value round-trips to the identical
+//    rendered timestamp, and the midnight-UTC calendar-day sentinel (lib/payment-date.ts) is
+//    preserved. Precision widens 3 -> 6, which cannot lose data.
+//  - Idempotent: each ALTER is skipped when the column is already timestamptz.
+//  - No column is dropped, renamed, or nulled.
+//  - Safe to run while the OLD build is live: the old Prisma client reads and writes these
+//    columns as DateTime either way, and both types round-trip identically under a UTC session.
+//    PaymentSchedule is small (56 rows in prod as of 2026-08-14), so the table rewrite each
+//    ALTER TYPE performs holds its ACCESS EXCLUSIVE lock only momentarily.
+//
+// Run BEFORE deploying the build that ships the matching schema.prisma.
+// Usage: node scripts/apply-payment-timestamp-alignment.mjs
+import { PrismaClient } from "@prisma/client";
+import fs from "node:fs";
+
+// Same resolution the sibling apply-*.mjs scripts use: env first, then the checked-out .env
+// files, since these are run by hand rather than by Next.
+function resolveDatabaseUrl() {
+    if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+    for (const file of [".env", ".env.local", ".env.production.local"]) {
+        if (!fs.existsSync(file)) continue;
+        const match = fs.readFileSync(file, "utf8").match(/^DATABASE_URL\s*=\s*"?([^"\n]+)"?/m);
+        if (match) return match[1];
+    }
+    throw new Error("DATABASE_URL not found in env or .env files");
+}
+
+const url = resolveDatabaseUrl();
+const prisma = new PrismaClient({ datasources: { db: { url } } });
+
+// Both columns are mirrored between the estimate and invoice sides.
+const TARGETS = [
+    { table: "PaymentSchedule", column: "paymentDate" },
+    { table: "PaymentSchedule", column: "paidAt" },
+];
+
+async function columnType(table, column) {
+    const rows = await prisma.$queryRawUnsafe(
+        `SELECT data_type FROM information_schema.columns
+          WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2;`,
+        table,
+        column,
+    );
+    return rows.length ? rows[0].data_type : null;
+}
+
+async function main() {
+    console.log(`Applying to ${url.replace(/:[^:@]*@/, ":****@")}`);
+
+    // Deliberately no `SET TIME ZONE`. DATABASE_URL points at the pgbouncer TRANSACTION
+    // pooler, where session state does not reliably carry to the next statement — so a
+    // SET here would be silent-fail fragility. It is also unnecessary: `x AT TIME ZONE
+    // 'UTC'` names its zone inline and does not consult the session TimeZone. Only the
+    // DISPLAY of a timestamptz depends on the session, never what gets stored.
+
+    for (const { table, column } of TARGETS) {
+        const type = await columnType(table, column);
+        if (type === null) {
+            console.log(`  SKIP "${table}"."${column}" — column does not exist`);
+            continue;
+        }
+        if (type === "timestamp with time zone") {
+            console.log(`  SKIP "${table}"."${column}" — already timestamptz`);
+            continue;
+        }
+        // ALTER COLUMN TYPE takes ACCESS EXCLUSIVE and rewrites the table. Postgres
+        // defaults lock_timeout to 0 (wait forever): if a long transaction is holding
+        // PaymentSchedule, we would block indefinitely AND queue every application query
+        // behind our pending lock request. Fail fast instead and retry in a quiet moment.
+        const alterSql =
+            `ALTER TABLE "${table}" ALTER COLUMN "${column}" TYPE timestamptz(6) ` +
+            `USING "${column}" AT TIME ZONE 'UTC'`;
+        console.log(`  ${alterSql}`);
+        // Two separate statements inside ONE interactive transaction, NOT a single
+        // multi-statement string: Prisma sends raw SQL over the extended protocol, which
+        // rejects several top-level commands in one call, so `SET ...; ALTER ...` would
+        // error out before the ALTER ever ran. The transaction also pins both statements
+        // to the same backend, which a bare SET could not guarantee through pgbouncer.
+        // SET LOCAL (not SET) so the timeout dies with the transaction instead of leaking
+        // to whoever gets this pooled connection next.
+        await prisma.$transaction(
+            async t => {
+                await t.$executeRawUnsafe(`SET LOCAL lock_timeout = '5s'`);
+                await t.$executeRawUnsafe(alterSql);
+            },
+            { timeout: 15_000 },
+        );
+        console.log(`  OK   "${table}"."${column}" ${type} -> timestamptz(6)`);
+    }
+
+    // Verify BOTH mirrored sides now agree — the whole point of the change.
+    const final = await prisma.$queryRawUnsafe(
+        `SELECT table_name, column_name, data_type, datetime_precision
+           FROM information_schema.columns
+          WHERE table_schema = 'public'
+            AND column_name IN ('paymentDate', 'paidAt')
+            AND table_name IN ('PaymentSchedule', 'EstimatePaymentSchedule')
+          ORDER BY table_name, column_name;`,
+    );
+    console.log("\nFinal state:");
+    for (const r of final) {
+        console.log(`  ${r.table_name}.${r.column_name} = ${r.data_type}(${r.datetime_precision})`);
+    }
+    // Assert every EXPECTED (table, column) is present AND timestamptz(6). Checking only
+    // the set of data_type values would pass with a column missing entirely, or with all
+    // four at the wrong precision — both of which leave the mirror misaligned.
+    const EXPECTED = [
+        ["EstimatePaymentSchedule", "paidAt"],
+        ["EstimatePaymentSchedule", "paymentDate"],
+        ["PaymentSchedule", "paidAt"],
+        ["PaymentSchedule", "paymentDate"],
+    ];
+    for (const [table, column] of EXPECTED) {
+        const row = final.find(r => r.table_name === table && r.column_name === column);
+        if (!row) throw new Error(`Verification failed: "${table}"."${column}" is missing`);
+        if (row.data_type !== "timestamp with time zone") {
+            throw new Error(`Verification failed: "${table}"."${column}" is ${row.data_type}, expected timestamptz`);
+        }
+        if (Number(row.datetime_precision) !== 6) {
+            throw new Error(`Verification failed: "${table}"."${column}" has precision ${row.datetime_precision}, expected 6`);
+        }
+    }
+    if (final.length !== EXPECTED.length) {
+        throw new Error(`Verification failed: expected ${EXPECTED.length} mirrored columns, found ${final.length}`);
+    }
+    console.log("\nAll 4 mirrored columns are timestamptz(6). Done.");
+}
+
+main()
+    .catch(error => {
+        console.error(error);
+        process.exitCode = 1;
+    })
+    .finally(() => prisma.$disconnect());

--- a/src/app/api/payments/deposit-ingest/route.ts
+++ b/src/app/api/payments/deposit-ingest/route.ts
@@ -6,6 +6,7 @@ import { revalidatePath } from "next/cache";
 import { findBestProjectNameMatches, normalizeWords } from "@/lib/project-match";
 import { toNum } from "@/lib/prisma-helpers";
 import { recordPaymentCore } from "@/lib/payment-record-core";
+import { parsePaymentDateInput } from "@/lib/payment-date";
 import { getFreshQBTokens, settleMilestoneFromQBPayment } from "@/lib/quickbooks-payments";
 import { buildQBPaymentRequest, sendQBPaymentCreateRequest, type QBTokens } from "@/lib/quickbooks";
 
@@ -412,7 +413,14 @@ async function applyNonQbo(row: DepositIngest, schedule: MatchedSchedule, payloa
     if (!row.settleStartedAt) {
         await prisma.depositIngest.update({ where: { id: row.id }, data: { settleStartedAt: new Date() } });
     }
-    const paymentDate = parseCheckDateLocalMidnight(payload.checkDate!);
+    // checkDate is already validated as strict YYYY-MM-DD by isValidCheckDate before
+    // we get here, so the canonical parser's calendar-day branch always takes it.
+    const paymentDate = parsePaymentDateInput(payload.checkDate!);
+    if (!paymentDate) {
+        // Unreachable given isValidCheckDate upstream; belt-and-braces so a future
+        // change to that gate can never silently store a wrong day.
+        return await finalizeUnmatched(row, `check date could not be parsed: ${payload.checkDate}`);
+    }
     const result = await recordPaymentCore(schedule.id, schedule.invoiceId, {
         paymentDate, method: "check", referenceNumber: payload.checkNumber, notes: payload.memo,
     });
@@ -529,7 +537,7 @@ async function settleAndFinalize(
     schedule: MatchedSchedule,
     ctx: { checkDate: string; checkNumber: string; qbPaymentId: string },
 ): Promise<NextResponse> {
-    const paidAt = new Date(`${ctx.checkDate}T12:00:00`);
+    const paidAt = new Date(`${ctx.checkDate}T12:00:00Z`);
     const settled = await settleMilestoneFromQBPayment({
         paymentScheduleId: schedule.id,
         invoiceId: schedule.invoiceId,
@@ -668,9 +676,7 @@ function isValidCheckDate(value: string | null): value is string {
     return Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
 }
 
-/** Strict YYYY-MM-DD → LOCAL midnight, matching actions.ts's parsePaymentDateInput
- *  (the value is already validated by isValidCheckDate before this is called). */
-function parseCheckDateLocalMidnight(value: string): Date {
-    const [y, mo, d] = value.split("-").map(Number);
-    return new Date(y, mo - 1, d);
-}
+// A local copy of this parser used to live here, building LOCAL midnight. That made
+// this route a SECOND writer of the calendar-day sentinel, disagreeing with
+// lib/payment-date.ts's isDateOnly under any non-UTC runtime. It now shares the one
+// canonical writer, parsePaymentDateInput, so there is genuinely only one.

--- a/src/app/api/webhook/stripe/route.ts
+++ b/src/app/api/webhook/stripe/route.ts
@@ -80,14 +80,18 @@ async function processEvent(eventId: string) {
                         // link is read non-locking first so the order can never invert.
                         const invLink = await t.invoice.findUnique({ where: { id: invoiceId }, select: { estimateId: true } });
                         await lockMoneyParents(t, { estimateId: invLink?.estimateId, invoiceId });
+                        // One settle instant, taken AFTER the locks — see payment-record-core.ts.
+                        const settledAt = new Date();
                         const claim = await t.paymentSchedule.updateMany({
                             where: { id: scheduleId, status: { not: "Paid" } },
                             data: {
                                 status: "Paid",
                                 stripePaymentIntentId: session.payment_intent as string | null,
                                 paymentMethod,
-                                paymentDate: new Date(),
-                                paidAt: new Date(),
+                                // Stripe-sourced: a real INSTANT, not a calendar day (see
+                                // lib/payment-date.ts). Same instant in both columns.
+                                paymentDate: settledAt,
+                                paidAt: settledAt,
                             },
                         });
                         const alreadyPaid = claim.count === 0;

--- a/src/app/portal/invoices/[id]/page.tsx
+++ b/src/app/portal/invoices/[id]/page.tsx
@@ -52,6 +52,8 @@ async function verifyStripeSession(sessionId: string, invoiceId: string): Promis
             // non-locking first so the order can never invert against another flow.
             const invLink = await t.invoice.findUnique({ where: { id: invoiceId }, select: { estimateId: true } });
             await lockMoneyParents(t, { estimateId: invLink?.estimateId, invoiceId });
+            // One settle instant, taken AFTER the locks — see payment-record-core.ts.
+            const settledAt = new Date();
             const claim = await t.paymentSchedule.updateMany({
                 where: { id: scheduleId, invoiceId, status: { not: "Paid" } },
                 data: {
@@ -59,8 +61,10 @@ async function verifyStripeSession(sessionId: string, invoiceId: string): Promis
                     stripeSessionId: sessionId,
                     stripePaymentIntentId: session.payment_intent as string | null,
                     paymentMethod,
-                    paymentDate: new Date(),
-                    paidAt: new Date(),
+                    // Stripe-sourced: a real INSTANT, not a calendar day (see lib/payment-date.ts).
+                    // Both columns take the same instant so they can never disagree.
+                    paymentDate: settledAt,
+                    paidAt: settledAt,
                 },
             });
             const won = claim.count > 0;

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -16,6 +16,7 @@ import { resolveSessionClientId } from "./portal-auth";
 import { persistOwnedSignature } from "./signature-storage";
 import { parseProductUrl, MAX_PRICE as PRODUCT_PARSE_MAX_PRICE } from "./product-parse";
 import { isHttpUrl } from "./url-safety";
+import { parsePaymentDateInput } from "./payment-date";
 // normalizeEstimateItemForSave is no longer imported here — the item projection moved into
 // estimate-item-upsert.ts, which is now its only caller on the save path.
 import { selectedBillableRows } from "./estimate-item-payload";
@@ -3624,35 +3625,8 @@ export async function getInvoice(id: string) {
     return invoice;
 }
 
-/** Parse a payment-date input into a Date.
- *  Accepts:
- *   - `YYYY-MM-DD` (strict — end-anchored, rejects overflow) → interpreted as LOCAL midnight
- *     so the stored value matches the calendar day the user typed.
- *   - A positive epoch-ms number → treated as an absolute instant.
- *   - An ISO-8601 datetime with a time component → `new Date()` (UTC semantics).
- *  Rejects: empty strings, 0/negative numbers, non-strict YYYY-M-D-ish shapes. */
-function parsePaymentDateInput(input: number | string): Date | null {
-    if (typeof input === "number") {
-        if (!Number.isFinite(input) || input <= 0) return null;
-        const d = new Date(input);
-        return isNaN(d.getTime()) ? null : d;
-    }
-    if (typeof input !== "string" || input.trim() === "") return null;
-    // Strict YYYY-MM-DD → local midnight (primary path from the date picker).
-    const ymd = /^(\d{4})-(\d{2})-(\d{2})$/.exec(input);
-    if (ymd) {
-        const y = Number(ymd[1]);
-        const mo = Number(ymd[2]);
-        const d = Number(ymd[3]);
-        if (mo < 1 || mo > 12 || d < 1 || d > 31) return null;
-        const dt = new Date(y, mo - 1, d);
-        if (dt.getFullYear() !== y || dt.getMonth() !== mo - 1 || dt.getDate() !== d) return null;
-        return dt;
-    }
-    // Accept full ISO datetimes (e.g. "2026-04-20T14:30:00Z") for API callers that pass them.
-    const dt = new Date(input);
-    return isNaN(dt.getTime()) ? null : dt;
-}
+// parsePaymentDateInput lives in lib/payment-date.ts, next to isDateOnly — the
+// calendar-day sentinel's writer and reader have to agree, so they are unit-tested together.
 
 export async function recordPayment(
     paymentId: string,
@@ -3871,6 +3845,11 @@ export async function recordEstimatePayment(
         });
         if (lockInv) await lockMoneyParents(t, { invoiceId: lockInv.id });
 
+        // One settle instant for BOTH sides of the mirrored pair, taken AFTER the parent
+        // locks so a contended settle records when it settled, not when it started
+        // queueing — see the fuller note in payment-record-core.ts.
+        const settledAt = new Date();
+
         const payment = await t.estimatePaymentSchedule.findUnique({ where: { id: paymentId } });
         if (!payment) return { success: false as const, error: "Milestone not found" as const };
         if (payment.status === "Paid") return { success: false as const, error: "Milestone already paid" as const };
@@ -3902,7 +3881,7 @@ export async function recordEstimatePayment(
                 const mirrorClaim = await t.paymentSchedule.updateMany({
                     where: { id: copy.id, status: { not: "Paid" } },
                     data: {
-                        status: "Paid", paymentDate, paidAt: new Date(), paymentMethod: method, referenceNumber, notes,
+                        status: "Paid", paymentDate, paidAt: settledAt, paymentMethod: method, referenceNumber, notes,
                         // Keep both sides agreeing on what was actually paid when the
                         // recorded amount overrides the milestone amount.
                         ...(input.amount != null && { amount: input.amount }),
@@ -3928,7 +3907,7 @@ export async function recordEstimatePayment(
             data: {
                 status: "Paid",
                 paymentDate,
-                paidAt: new Date(),
+                paidAt: settledAt,
                 paymentMethod: method,
                 referenceNumber,
                 notes,

--- a/src/lib/payment-date.ts
+++ b/src/lib/payment-date.ts
@@ -1,7 +1,25 @@
 /**
- * Back-dated payment classification, shared by the server-side notifier
+ * Money-record date semantics, shared by the server-side notifier
  * (payment-notifications.ts) and the client-side RecordPaymentModal. Must stay
  * free of Prisma/server-only imports — it is bundled into client components.
+ *
+ * ## The one invariant this file owns
+ *
+ * `paymentDate` carries DUAL SEMANTICS in a single column: a calendar DAY for
+ * manually entered payments, and a real INSTANT for Stripe/QuickBooks-sourced
+ * ones. The discriminator is a sentinel — a calendar day is stored as exactly
+ * midnight UTC — with `parsePaymentDateInput` as the sole writer and
+ * `isDateOnly` as the sole reader. They must agree or a picked day renders as
+ * the day before to a Pacific viewer.
+ *
+ * The sentinel is anchored to **UTC, not the server's timezone**, so it holds
+ * identically on Vercel (UTC), in local dev (US/Pacific), and in CI. Producing
+ * it with a local-midnight `new Date(y, m, d)` made the discriminator
+ * environment-dependent: correct on Vercel by luck, silently reclassifying every
+ * manual payment as an instant anywhere else.
+ *
+ * Both mirrored sides store this column as `timestamptz(6)`, so copying an
+ * estimate milestone to its invoice twin (and back) is lossless.
  */
 
 /** Receipts stop auto-sending when the payment date is older than this many calendar days. */
@@ -62,10 +80,55 @@ export function isBackdatedPayment(
 const DEFAULT_DAY_OPTS: Intl.DateTimeFormatOptions = { year: "numeric", month: "short", day: "numeric" };
 
 /**
+ * Parse a payment-date input into the value to store. The SOLE writer of the
+ * calendar-day sentinel — `isDateOnly` is its only reader, and the two must agree.
+ *
+ * - `"YYYY-MM-DD"` (the date picker's value) → **midnight UTC** on that day, which
+ *   is what marks it a calendar day. Anchored to UTC rather than the server's zone
+ *   so the classification is identical on Vercel, in dev, and in CI.
+ * - A full ISO datetime **carrying an explicit `Z` or ±HH:MM offset** (API/Stripe/
+ *   QuickBooks callers) → that exact instant, preserved verbatim.
+ *
+ * An offset-LESS datetime like `"2026-08-04T14:30:00"` is REJECTED, not guessed.
+ * ECMAScript parses that form in the host's local zone, so it would store 14:30Z on
+ * Vercel and 21:30Z in Pacific dev — the same environment-dependence this module
+ * exists to eliminate, but silent. Callers must say which zone they mean.
+ *
+ * Returns null for anything unparseable, ambiguous, or out of range, so callers can
+ * reject rather than silently store a wrong day.
+ */
+export function parsePaymentDateInput(input: number | string): Date | null {
+    if (typeof input === "number") {
+        if (!Number.isFinite(input) || input <= 0) return null;
+        const d = new Date(input);
+        return isNaN(d.getTime()) ? null : d;
+    }
+    if (typeof input !== "string" || input.trim() === "") return null;
+    // Strict YYYY-MM-DD → midnight UTC (primary path from the date picker).
+    const ymd = /^(\d{4})-(\d{2})-(\d{2})$/.exec(input);
+    if (ymd) {
+        const y = Number(ymd[1]);
+        const mo = Number(ymd[2]);
+        const d = Number(ymd[3]);
+        if (mo < 1 || mo > 12 || d < 1 || d > 31) return null;
+        const dt = new Date(Date.UTC(y, mo - 1, d));
+        // Rejects overflow like 2026-02-31, which Date.UTC would roll into March.
+        if (dt.getUTCFullYear() !== y || dt.getUTCMonth() !== mo - 1 || dt.getUTCDate() !== d) return null;
+        return dt;
+    }
+    // Accept full ISO datetimes for API callers, but ONLY with an explicit zone —
+    // a trailing Z, or a ±HH:MM / ±HHMM offset. Without one the instant is
+    // host-zone-dependent (see the doc comment), so reject instead of guessing.
+    if (!/^\d{4}-\d{2}-\d{2}[Tt].+([Zz]|[+-]\d{2}:?\d{2})$/.test(input.trim())) return null;
+    const dt = new Date(input);
+    return isNaN(dt.getTime()) ? null : dt;
+}
+
+/**
  * True when the value carries no time-of-day (exactly 00:00:00.000 UTC) — i.e. it is a
- * stored calendar day, not an instant. Manual payments (parsePaymentDateInput → local
- * midnight, UTC on Vercel) land here; Stripe/QuickBooks writes, which store real
- * instants in the same column, do not.
+ * stored calendar day, not an instant. Manual payments (parsePaymentDateInput → midnight
+ * UTC) land here; Stripe/QuickBooks writes, which store real instants in the same
+ * column, do not.
  */
 export function isDateOnly(d: Date): boolean {
     return d.getUTCHours() === 0 && d.getUTCMinutes() === 0

--- a/src/lib/payment-record-core.ts
+++ b/src/lib/payment-record-core.ts
@@ -43,6 +43,14 @@ export async function recordPaymentCore(
         const invLink = await t.invoice.findUnique({ where: { id: invoiceId }, select: { estimateId: true } });
         await lockMoneyParents(t, { estimateId: invLink?.estimateId, invoiceId });
 
+        // ONE settle instant for BOTH sides of the mirrored pair. Calling new Date()
+        // separately per side stamped them ~0.5s apart, so the invoice and estimate copies
+        // of the same payment disagreed on paidAt (11 such pairs in prod as of 2026-08-14).
+        // Taken AFTER the parent locks: a contended settle can wait on the lock, and a
+        // stamp captured before that wait would record when we started queueing rather
+        // than when we settled — landing in the previous day or month near a boundary.
+        const settledAt = new Date();
+
         const payment = await t.paymentSchedule.findUnique({ where: { id: paymentId } });
         if (!payment) return { success: false as const, error: "Milestone not found" };
         if (payment.status === "Paid") return { success: false as const, error: "Milestone already paid" };
@@ -53,7 +61,7 @@ export async function recordPaymentCore(
             data: {
                 status: "Paid",
                 paymentDate,
-                paidAt: new Date(),
+                paidAt: settledAt,
                 paymentMethod: method,
                 referenceNumber,
                 notes,
@@ -101,7 +109,7 @@ export async function recordPaymentCore(
             if (estCopy) {
                 const mirrorClaim = await t.estimatePaymentSchedule.updateMany({
                     where: { id: estCopy.id, status: { not: "Paid" } },
-                    data: { status: "Paid", paymentDate, paidAt: new Date(), paymentMethod: method, referenceNumber },
+                    data: { status: "Paid", paymentDate, paidAt: settledAt, paymentMethod: method, referenceNumber },
                 });
                 if (mirrorClaim.count > 0) {
                     const estimate = await t.estimate.findUnique({ where: { id: invoice.estimateId } });

--- a/src/lib/quickbooks-payments.ts
+++ b/src/lib/quickbooks-payments.ts
@@ -747,7 +747,7 @@ export async function syncQuickBooksPayments(scope?: { invoiceId?: string; proje
                 let referenceNumber: string | null = null;
                 if (paymentId) {
                     const p = await getQBPayment(tokens, paymentId);
-                    if (p?.txnDate) paidAt = new Date(`${p.txnDate}T12:00:00`);
+                    if (p?.txnDate) paidAt = new Date(`${p.txnDate}T12:00:00Z`);
                     referenceNumber = p?.referenceNumber || null;
                 }
                 const recorded = await settleMilestoneFromQBPayment({
@@ -791,7 +791,7 @@ export async function syncQuickBooksPayments(scope?: { invoiceId?: string; proje
                 let referenceNumber: string | null = null;
                 if (paymentId) {
                     const p = await getQBPayment(tokens, paymentId);
-                    if (p?.txnDate) paidAt = new Date(`${p.txnDate}T12:00:00`);
+                    if (p?.txnDate) paidAt = new Date(`${p.txnDate}T12:00:00Z`);
                     referenceNumber = p?.referenceNumber || null;
                 }
                 const settled = await settleProgressBillingPaidCore(billing.id, { paidAt, referenceNumber, qbPaymentId: paymentId });

--- a/tests/payment-date-display.test.ts
+++ b/tests/payment-date-display.test.ts
@@ -6,6 +6,7 @@ import {
     formatMoneyMonth,
     formatMoneyMonthKey,
     formatMoneyDateISO,
+    parsePaymentDateInput,
 } from "../src/lib/payment-date";
 
 // These tests only mean something in a west-of-UTC zone — that is where a stored
@@ -13,7 +14,7 @@ import {
 const PT = process.env.TZ === "America/Los_Angeles";
 
 // Real shapes observed in prod:
-//   manual entry (parsePaymentDateInput -> local midnight, UTC on Vercel)
+//   manual entry (parsePaymentDateInput -> midnight UTC, in every environment)
 const MANUAL_JUL_28 = "2026-07-28T00:00:00.000Z";
 //   QuickBooks import (paidAt copied into paymentDate) — noon UTC, a real instant
 const QBO_JUL_20 = "2026-07-20T12:00:00.000Z";
@@ -79,4 +80,103 @@ test("a first-of-month calendar day does not fall into the previous month", () =
 test("CSV export writes the picked calendar day", () => {
     assert.equal(formatMoneyDateISO(new Date(MANUAL_JUL_28)), "2026-07-28");
     assert.equal(formatMoneyDateISO(new Date("2026-07-22T00:00:00.000Z")), "2026-07-22");
+});
+
+// ---------------------------------------------------------------------------
+// parsePaymentDateInput — the WRITER of the calendar-day sentinel that isDateOnly
+// reads. These two must agree, or a picked day is silently reclassified as an
+// instant and renders as the day before to a Pacific viewer.
+// ---------------------------------------------------------------------------
+
+test("the writer's calendar day satisfies the reader's predicate (round-trip)", () => {
+    // Regression: parsePaymentDateInput used to build LOCAL midnight, so in any
+    // non-UTC zone this produced e.g. 07:00Z and isDateOnly returned FALSE. The
+    // sentinel was correct on Vercel (UTC) purely by accident of deployment zone.
+    for (const day of ["2026-07-28", "2026-01-01", "2026-12-31", "2026-08-04"]) {
+        const stored = parsePaymentDateInput(day);
+        assert.ok(stored, `${day} should parse`);
+        assert.equal(isDateOnly(stored), true, `${day} must be classified as a calendar day`);
+        assert.equal(formatMoneyDateISO(stored), day, `${day} must round-trip unchanged`);
+    }
+});
+
+test("a picked day renders as that same day, not the day before", () => {
+    const stored = parsePaymentDateInput("2026-08-04");
+    assert.ok(stored);
+    assert.equal(stored.toISOString(), "2026-08-04T00:00:00.000Z");
+    assert.equal(formatMoneyDate(stored), "Aug 4, 2026");
+    if (PT) {
+        // The whole point: under Pacific rendering it is still Aug 4.
+        assert.equal(formatMoneyDateISO(stored), "2026-08-04");
+    }
+});
+
+test("real instants are preserved verbatim and stay classified as instants", () => {
+    // ISO datetime (API callers) and epoch millis (Stripe/QBO) are NOT calendar days.
+    const iso = parsePaymentDateInput("2026-04-20T14:30:00Z");
+    assert.ok(iso);
+    assert.equal(iso.toISOString(), "2026-04-20T14:30:00.000Z");
+    assert.equal(isDateOnly(iso), false);
+
+    const ms = parsePaymentDateInput(Date.UTC(2026, 6, 20, 12, 0, 0));
+    assert.ok(ms);
+    assert.equal(ms.toISOString(), "2026-07-20T12:00:00.000Z");
+    assert.equal(isDateOnly(ms), false);
+});
+
+test("an ISO datetime that happens to land on UTC midnight is left alone", () => {
+    // Deliberate: the sentinel is lossy by design — an instant exactly at UTC midnight
+    // is indistinguishable from a calendar day. Documented so the ambiguity is a known
+    // property rather than a surprise. It renders as that day either way.
+    const midnightInstant = parsePaymentDateInput("2026-05-21T00:00:00Z");
+    assert.ok(midnightInstant);
+    assert.equal(isDateOnly(midnightInstant), true);
+    assert.equal(formatMoneyDateISO(midnightInstant), "2026-05-21");
+});
+
+test("invalid and out-of-range input is rejected, never coerced to a wrong day", () => {
+    for (const bad of ["", "   ", "not-a-date", "2026-13-01", "2026-00-10", "2026-07-32"]) {
+        assert.equal(parsePaymentDateInput(bad), null, `${JSON.stringify(bad)} must be rejected`);
+    }
+    // Overflow must not silently roll forward into the next month.
+    assert.equal(parsePaymentDateInput("2026-02-31"), null);
+    assert.equal(parsePaymentDateInput(0), null);
+    assert.equal(parsePaymentDateInput(-1), null);
+    assert.equal(parsePaymentDateInput(NaN), null);
+});
+
+test("a leap day is accepted in a leap year and rejected otherwise", () => {
+    const leap = parsePaymentDateInput("2028-02-29");
+    assert.ok(leap);
+    assert.equal(formatMoneyDateISO(leap), "2028-02-29");
+    assert.equal(parsePaymentDateInput("2026-02-29"), null);
+});
+
+test("an offset-less ISO datetime is rejected, not silently read in the host zone", () => {
+    // Regression (Codex round 1): ECMAScript parses a date-TIME string without a zone
+    // designator in the HOST's local zone, so "2026-08-04T14:30:00" stored 14:30Z on
+    // Vercel and 21:30Z in Pacific dev. Ambiguous input must fail loudly.
+    for (const ambiguous of [
+        "2026-08-04T14:30:00",
+        "2026-08-04T14:30",
+        "2026-08-04T14:30:00.500",
+        "Aug 4, 2026 2:30 PM",
+    ]) {
+        assert.equal(parsePaymentDateInput(ambiguous), null, `${ambiguous} must be rejected`);
+    }
+});
+
+test("an ISO datetime WITH an explicit zone is accepted and exact", () => {
+    const cases = [
+        ["2026-08-04T14:30:00Z", "2026-08-04T14:30:00.000Z"],
+        ["2026-08-04T14:30:00z", "2026-08-04T14:30:00.000Z"],
+        ["2026-08-04T14:30:00.250Z", "2026-08-04T14:30:00.250Z"],
+        ["2026-08-04T07:30:00-07:00", "2026-08-04T14:30:00.000Z"], // Pacific daylight
+        ["2026-08-04T14:30:00+0000", "2026-08-04T14:30:00.000Z"],
+    ];
+    for (const [input, expected] of cases) {
+        const got = parsePaymentDateInput(input);
+        assert.ok(got, `${input} should parse`);
+        assert.equal(got.toISOString(), expected, `${input} must be exact`);
+    }
 });


### PR DESCRIPTION
Surfaced (not caused) by #370, which made `schema.prisma` describe production's real column types for the first time.

## The problem

Estimate and invoice milestones are mirrored pairs linked by `PaymentSchedule.sourceScheduleId`, and settle/unsettle paths copy values between them. But the two sides stored the same logical field in different Postgres types:

| Column | Type before |
|---|---|
| `EstimatePaymentSchedule.paymentDate` / `.paidAt` | `timestamptz(6)` — zone-aware instant |
| `PaymentSchedule.paymentDate` / `.paidAt` | `timestamp(3)` — zone-LESS wall clock |

Every mirror copy therefore crossed timestamp semantics. Nothing had drifted only because the Postgres session TimeZone is UTC — a latent dependency on a session setting, not a property of the schema.

## Production audit first (read-only)

Before changing anything:

- **Mirrored `paymentDate`: 22 non-null pairs, ZERO disagreements.** No corruption.
- **Mirrored `paidAt`: 11 pairs differ — but every delta is sub-second (0.36s–0.75s).** That is two separate `new Date()` calls per settle, not a timezone shift.
- 12 `PaymentSchedule` + 11 `EstimatePaymentSchedule` manual dates sit at midnight UTC. They would render as the previous day in Pacific, but every render site goes through `formatMoneyDate`, so they display correctly today. (Verified: no raw `toLocaleDateString`/`toLocaleString` on these columns anywhere in `src/`.)

**So this is a prevent-future fix, not a repair. No backfill is needed.**

## The actual defect

It is upstream of the column types. `paymentDate` carries dual semantics in one column — a calendar DAY for manual entries, a real INSTANT for Stripe/QBO — with a midnight-UTC sentinel as the discriminator (#318). But `parsePaymentDateInput` built that sentinel with `new Date(y, mo-1, d)`: **midnight in the *server's* timezone.**

On Vercel (UTC) that is midnight UTC and the sentinel works — by accident of deployment zone. Anywhere non-UTC it yields e.g. `07:00Z`, `isDateOnly` returns false, the value is reclassified as an instant, and the day shifts.

## Changes

- `parsePaymentDateInput` moves into `lib/payment-date.ts` beside its reader `isDateOnly` — writer and reader must agree, so they are now unit-tested together — and anchors calendar days to `Date.UTC`, identically in every environment.
- It now **rejects** offset-less ISO datetimes (`2026-08-04T14:30:00`) rather than silently parsing them in the host zone.
- `deposit-ingest` had its **own** local-midnight copy of the parser, which made the "sole writer" invariant false. It now calls the canonical one.
- Three QBO/check-date constructions used `` `T12:00:00` `` with no zone designator; now `Z`.
- Each settle captures **one** `settledAt`, **after** the parent locks, and writes it to both sides of the mirrored pair.
- `scripts/apply-payment-timestamp-alignment.mjs` converts the invoice side to `timestamptz(6)` with an explicit `USING ... AT TIME ZONE 'UTC'`, so both mirrored sides agree. Additive, idempotent, `lock_timeout`-guarded, and it verifies all four columns are `timestamptz(6)` before declaring success.

## Design decision

Kept the single column plus the midnight-UTC sentinel rather than splitting into a separate date-only column. Zero data corruption exists, #318 already committed to the sentinel, and a split would touch ~30 files across the money path. The sentinel's one real ambiguity — an instant landing exactly on UTC midnight is indistinguishable from a calendar day — is now documented in place rather than implicit. Codex independently agreed this is defensible for this scope.

`Expense.qbSyncedAt` (timestamptz) remains inconsistent with the other `qbSyncedAt` columns (timestamp(6)). It is not mirrored or copied through these paths, so it is deliberately left for a separate change.

## Verification

- `npm run build` (typecheck + Next build) green.
- 187 unit tests pass.
- New regression tests were **mutation-tested**: reverting the `Date.UTC` fix fails exactly the two tests that should fail under `TZ=America/Los_Angeles`, and they pass with the fix.
- Codex `gpt-5.6-sol` at `xhigh`, two rounds. All in-scope findings fixed, including one it caught that I had missed (the second local-midnight writer in deposit-ingest) and one where it was right that Prisma rejects multi-statement raw SQL.

## Deliberately deferred

Codex surfaced two pre-existing refund defects, both independent of timestamp semantics and each needing its own diff and review:

1. A blind `async_payment_failed` unwind can flip a milestone to Pending even when a *different* successful payment settled it.
2. A stale `stripePaymentIntentId` surviving unrecord/re-record lets an old refund erase a newer manual payment.

Neither is made worse by this PR (Codex confirmed). Both are spun off as separate tasks.

## Deploy order

The apply script **must** run against production **before** this merges — the new Prisma client describes the columns as `timestamptz(6)` immediately.

```
node scripts/apply-payment-timestamp-alignment.mjs
```
