### PR TITLE
fix(portal): SSR crash on contract and estimate pages — DOMPurify has no DOM on the server

### DIFF
--- a/src/app/portal/contracts/[id]/PortalContractClient.tsx
+++ b/src/app/portal/contracts/[id]/PortalContractClient.tsx
@@ -63,10 +63,20 @@ export default function PortalContractClient({
         markContractViewed(initialContract.id, accessToken || undefined).catch(console.error);
     }, [initialContract.id, accessToken]);
 
+    // DOMPurify requires a browser DOM and is undefined in the Node SSR environment
+    // that renders this "use client" component's first HTML. Gate on a mounted flag
+    // (false on both the server render and the initial client render, so no hydration
+    // mismatch) rather than `typeof window`, which would flip true on the very first
+    // client render and diverge from the server-sent markup.
+    const [mounted, setMounted] = useState(false);
+    useEffect(() => {
+        setMounted(true);
+    }, []);
+
     // Parse and Inject HTML Buttons — returns derived block counts alongside HTML
     const { parsedBody, totalRequiredBlocks, totalSigBlocks } = React.useMemo(() => {
         // Sanitize DB content before rendering; our own placeholder injections below are safe
-        let html = DOMPurify.sanitize(initialContract.body || "", { USE_PROFILES: { html: true } });
+        let html = mounted ? DOMPurify.sanitize(initialContract.body || "", { USE_PROFILES: { html: true } }) : "";
         const escapeHtml = (s: string) => s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");
 
         let sigCount = 0;
@@ -144,7 +154,7 @@ export default function PortalContractClient({
         }
 
         return { parsedBody: html, totalRequiredBlocks: sigCount + initCount, totalSigBlocks: sigCount };
-    }, [initialContract.body, isSigned, initialContract.approvedAt, initialContract.contractorSignedAt, initialContract.contractorSignatureUrl, initialContract.contractorSignedBy, signatures, initials]);
+    }, [mounted, initialContract.body, isSigned, initialContract.approvedAt, initialContract.contractorSignedAt, initialContract.contractorSignatureUrl, initialContract.contractorSignedBy, signatures, initials]);
 
     // Attach Delegated Listeners
     useEffect(() => {

--- a/src/app/portal/estimates/[id]/PortalEstimateClient.tsx
+++ b/src/app/portal/estimates/[id]/PortalEstimateClient.tsx
@@ -748,6 +748,15 @@ function formatFileSize(bytes: number): string {
 function TermsAndConditions({ html }: { html: string }) {
     const ref = useRef<HTMLDivElement>(null);
 
+    // DOMPurify needs a browser DOM; in the Node SSR pass `DOMPurify.sanitize` is
+    // undefined and calling it throws. Same mounted-gate as PortalContractClient:
+    // false on the server render AND the first client render (no hydration
+    // mismatch), then flips true and the content sanitizes client-side.
+    const [mounted, setMounted] = useState(false);
+    useEffect(() => {
+        setMounted(true);
+    }, []);
+
     // Detect rich HTML by whether the content starts with a block-level tag.
     // Legacy plain-text snapshots never start with "<p" or "<h"; editor-produced
     // HTML always does. Anchoring to trimStart() avoids false-positives from
@@ -760,7 +769,7 @@ function TermsAndConditions({ html }: { html: string }) {
         trimmed.startsWith("<ol") ||
         trimmed.startsWith("<div");
 
-    const sanitized = isRichHtml ? DOMPurify.sanitize(html) : "";
+    const sanitized = mounted && isRichHtml ? DOMPurify.sanitize(html) : "";
 
     // After mount, wrap each top-level block element in a data-pdf-row wrapper
     // so the PDF paginator can break between paragraphs/sections instead of
@@ -819,6 +828,12 @@ function TermsAndConditions({ html }: { html: string }) {
 function PortalRichSection({ title, html, variant }: { title: string; html: string; variant: "overview" | "notes" }) {
     const ref = useRef<HTMLDivElement>(null);
 
+    // Same SSR guard as TermsAndConditions above — see that comment.
+    const [mounted, setMounted] = useState(false);
+    useEffect(() => {
+        setMounted(true);
+    }, []);
+
     const trimmed = (html || "").trimStart();
     const isRichHtml =
         trimmed.startsWith("<p") ||
@@ -827,7 +842,7 @@ function PortalRichSection({ title, html, variant }: { title: string; html: stri
         trimmed.startsWith("<ol") ||
         trimmed.startsWith("<div");
 
-    const sanitized = isRichHtml ? DOMPurify.sanitize(html) : "";
+    const sanitized = mounted && isRichHtml ? DOMPurify.sanitize(html) : "";
 
     useEffect(() => {
         if (!ref.current || !isRichHtml) return;


### PR DESCRIPTION
## What

The client portal's contract page crashed during server rendering, and the estimate page carried the identical latent crash for rich-HTML content.

`DOMPurify.sanitize` was called in the render body of `"use client"` components. Next.js still executes those bodies on the server for the initial HTML, where `dompurify` has no DOM and `sanitize` is `undefined` — reproduced directly:

```
node -e "require('dompurify').sanitize('<b>hi</b>')"
// TypeError: DOMPurify.sanitize is not a function
```

- `portal/contracts/[id]/PortalContractClient.tsx` — unconditional sanitize in a `useMemo`; crashed the page on first server render.
- `portal/estimates/[id]/PortalEstimateClient.tsx` — `TermsAndConditions` and `PortalRichSection` sanitize inline; crashes for any estimate whose terms/overview/notes are editor-produced rich HTML (block-tag detection gates it, which is why plain-text legacy content survived).

## How

The codebase's existing safe pattern (cf. `EntityContractsClient.tsx`, which only sanitizes behind client-only state): a `mounted` flag that is `false` on both the server render and the first client render (no hydration mismatch), flipping `true` post-mount, at which point content sanitizes client-side. Same three-line pattern in all three components.

## Verification

`npm run build` green (typecheck + next build). Premise verified with the Node repro above before fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
