### PR TITLE
fix(po): opening an itemless PO no longer destroys its stored total on save

### DIFF
--- a/src/app/projects/[id]/purchase-orders/[poId]/PurchaseOrderEditor.tsx
+++ b/src/app/projects/[id]/purchase-orders/[poId]/PurchaseOrderEditor.tsx
@@ -53,7 +53,16 @@ export default function PurchaseOrderEditor({ context, initialData }: { context:
     const isSavingRef = useRef(false); // sync guard against double-tap Save
 
     // Dynamic calculations
-    const totalAmount = items.reduce((acc, curr) => acc + (Number(curr.total) || 0), 0);
+    const itemsTotal = items.reduce((acc, curr) => acc + (Number(curr.total) || 0), 0);
+    // Quick-created / imported POs can legitimately carry a total with zero line items
+    // (see quickCreatePOAndLink in src/lib/actions.ts). This editor always seeds a blank
+    // placeholder row when there are none, so a bare items-sum would show — and on Save,
+    // persist — $0, silently destroying that stored total. Fall back to the stored total
+    // only while the itemized sum is still $0; as soon as a real priced item is entered,
+    // the computed sum takes over as normal.
+    const totalAmount = (!initialData?.items || initialData.items.length === 0) && itemsTotal === 0
+        ? (Number(initialData?.totalAmount) || 0)
+        : itemsTotal;
 
     const handleItemChange = (index: number, field: string, value: any) => {
         const newItems = [...items];

--- a/src/app/projects/[id]/purchase-orders/[poId]/PurchaseOrderEditor.tsx
+++ b/src/app/projects/[id]/purchase-orders/[poId]/PurchaseOrderEditor.tsx
@@ -26,12 +26,19 @@ export default function PurchaseOrderEditor({ context, initialData }: { context:
     const [terms, setTerms] = useState(initialData?.terms || "");
     const [memos, setMemos] = useState(initialData?.memos || "");
     
-    // Line items
-    const [items, setItems] = useState<any[]>(
-        initialData?.items?.length > 0 
-            ? initialData.items 
-            : [{ id: "temp-1", description: "", quantity: 1, unitCost: 0, total: 0, costCodeId: null, order: 0 }]
-    );
+    // Line items. Quick-created / imported POs legitimately carry a totalAmount with zero
+    // item rows (quickCreatePOAndLink in src/lib/actions.ts). Seed the placeholder row
+    // CARRYING that stored total: the displayed total (a plain items-sum below) is correct
+    // on load, and the first save persists the amount as a real, consistent line item
+    // instead of a $0 row silently overwriting the stored total server-side
+    // (updatePurchaseOrder persists whatever total the client sends). A user who really
+    // wants to zero the PO can still edit the row to $0 — the seed only sets the starting
+    // value. New POs (no initialData) seed $0 exactly as before.
+    const [items, setItems] = useState<any[]>(() => {
+        if (initialData?.items?.length > 0) return initialData.items;
+        const carried = Number(initialData?.totalAmount) || 0;
+        return [{ id: "temp-1", description: "", quantity: 1, unitCost: carried, total: carried, costCodeId: null, order: 0 }];
+    });
 
     const [isSaving, setIsSaving] = useState(false);
     const [isDeleting, setIsDeleting] = useState(false);
@@ -52,17 +59,9 @@ export default function PurchaseOrderEditor({ context, initialData }: { context:
     const fileInputRef = useRef<HTMLInputElement>(null);
     const isSavingRef = useRef(false); // sync guard against double-tap Save
 
-    // Dynamic calculations
-    const itemsTotal = items.reduce((acc, curr) => acc + (Number(curr.total) || 0), 0);
-    // Quick-created / imported POs can legitimately carry a total with zero line items
-    // (see quickCreatePOAndLink in src/lib/actions.ts). This editor always seeds a blank
-    // placeholder row when there are none, so a bare items-sum would show — and on Save,
-    // persist — $0, silently destroying that stored total. Fall back to the stored total
-    // only while the itemized sum is still $0; as soon as a real priced item is entered,
-    // the computed sum takes over as normal.
-    const totalAmount = (!initialData?.items || initialData.items.length === 0) && itemsTotal === 0
-        ? (Number(initialData?.totalAmount) || 0)
-        : itemsTotal;
+    // Dynamic calculations — always the plain items-sum. The itemless-PO case is handled
+    // at state seeding above, so display, payload, and persisted rows can never disagree.
+    const totalAmount = items.reduce((acc, curr) => acc + (Number(curr.total) || 0), 0);
 
     const handleItemChange = (index: number, field: string, value: any) => {
         const newItems = [...items];


### PR DESCRIPTION
## What

Opening an itemless purchase order silently destroyed its stored total. `quickCreatePOAndLink` legitimately creates POs with a `totalAmount` but zero item rows; the editor seeded a blank $0 placeholder, displayed $0, and — because the save guards force the user to fill that placeholder before saving *anything* (status, vendor, notes) — the first save persisted `totalAmount: 0` over the real total. `updatePurchaseOrder` trusts whatever total the client sends.

## How

Seed the placeholder row **carrying the stored total** (quantity 1, unit cost = total). The displayed total is a plain items-sum again, correct on load; the first save persists the amount as a real, consistent line item; deliberate zeroing still works by editing the row. New POs seed $0 exactly as before.

## Review

Codex peer review, two rounds. Round 1 **blocked** the first approach (a display-time fallback that disarmed after one save and lost the total on the next) and recommended this shape instead. Round 2 on the rework: no blockers, no real issues — verified the destruction sequence is resolved, legitimate zeros aren't masked, behavior no longer depends on save history, and the float `=== 0` branch is gone. Remaining nit (pre-existing UX): metadata-only edits to an itemless PO still require naming the synthesized row.

Known pre-existing gaps deliberately not addressed here (candidates for a server-side follow-up): `updatePurchaseOrder` accepts client-sent totals without recompute, and the parent/item rewrite is non-transactional.

## Verification

`npm run build` green (typecheck + next build). Premise verified against `quickCreatePOAndLink` and `updatePurchaseOrder` source; Codex independently re-read both server actions to confirm the claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
