### PR TITLE
fix(refunds): give refunds a real row identity — unwind the whole charge group

### DIFF
--- a/e2e/money-pipeline.spec.ts
+++ b/e2e/money-pipeline.spec.ts
@@ -1135,6 +1135,21 @@ const S = {
   estGroup: "mp3-e2e-eps-group",
   invGroupA: "mp3-e2e-ps-group-a",
   invGroupB: "mp3-e2e-ps-group-b",
+  // S9: a one-to-many group where the second clone was paid by CHEQUE. It has
+  // no PaymentIntent (the mirror could not claim the already-Paid estimate
+  // row), so it looks like a mirror but is a separate payment.
+  estimate4: "mp3-e2e-estimate-4",
+  invoice4a: "mp3-e2e-invoice-4a",
+  invoice4b: "mp3-e2e-invoice-4b",
+  estMixed: "mp3-e2e-eps-mixed",
+  invMixedStripe: "mp3-e2e-ps-mixed-stripe",
+  invMixedManual: "mp3-e2e-ps-mixed-manual",
+  // S10: a genuine 1:1 mirror whose estimate original predates the intent
+  // being written to both sides.
+  estimate5: "mp3-e2e-estimate-5",
+  invoice5: "mp3-e2e-invoice-5",
+  estLegacy: "mp3-e2e-eps-legacy",
+  invLegacy: "mp3-e2e-ps-legacy",
 };
 const S_NAME = "Stripe Mirror Drill - MP3TEST";
 const sPrisma = new PrismaClient();
@@ -1144,6 +1159,8 @@ const INTENT = "pi_mp3_e2e_intent";
 const PAIR2_INTENT = "pi_mp3_e2e_pair2_intent";
 const OTHER_INTENT = "pi_mp3_e2e_other_intent";
 const GROUP_INTENT = "pi_mp3_e2e_group_intent";
+const MIXED_INTENT = "pi_mp3_e2e_mixed_intent";
+const LEGACY_INTENT = "pi_mp3_e2e_legacy_intent";
 
 test.describe.serial("Money pipeline: Stripe rails mirror both sides", () => {
   test.beforeAll(async () => {
@@ -1284,12 +1301,89 @@ test.describe.serial("Money pipeline: Stripe rails mirror both sides", () => {
         },
       });
     }
+
+    // Fourth fixture: same one-to-many shape, but clone B was paid by cheque.
+    await sPrisma.estimate.upsert({
+      where: { id: S.estimate4 },
+      update: { status: "Paid", totalAmount: 300, balanceDue: 0, statusBeforePayment: "Invoiced" },
+      create: {
+        id: S.estimate4, title: `${S_NAME} 4`, code: "EST-MP3TEST-4", projectId: S.project,
+        status: "Paid", taxExempt: true, totalAmount: 300, balanceDue: 0, statusBeforePayment: "Invoiced",
+      },
+    });
+    for (const [id, code] of [[S.invoice4a, "4A"], [S.invoice4b, "4B"]] as const) {
+      await sPrisma.invoice.upsert({
+        where: { id },
+        update: { status: "Paid", totalAmount: 300, balanceDue: 0 },
+        create: {
+          id, code: `INV-MP3TEST-${code}`, projectId: S.project, clientId: S.client,
+          estimateId: S.estimate4, status: "Paid", totalAmount: 300, balanceDue: 0, issueDate: new Date(),
+        },
+      });
+    }
+    await sPrisma.estimatePaymentSchedule.upsert({
+      where: { id: S.estMixed },
+      update: { status: "Paid", stripePaymentIntentId: MIXED_INTENT, paidAt: new Date(), paymentDate: new Date() },
+      create: {
+        id: S.estMixed, estimateId: S.estimate4, name: "MP3 Mixed", amount: 300,
+        status: "Paid", order: 1, stripePaymentIntentId: MIXED_INTENT,
+      },
+    });
+    await sPrisma.paymentSchedule.upsert({
+      where: { id: S.invMixedStripe },
+      update: { status: "Paid", stripePaymentIntentId: MIXED_INTENT, paidAt: new Date(), paymentDate: new Date() },
+      create: {
+        id: S.invMixedStripe, invoiceId: S.invoice4a, name: "MP3 Mixed", amount: 300,
+        status: "Paid", sourceScheduleId: S.estMixed, stripePaymentIntentId: MIXED_INTENT,
+      },
+    });
+    await sPrisma.paymentSchedule.upsert({
+      where: { id: S.invMixedManual },
+      update: { status: "Paid", stripePaymentIntentId: null, paymentMethod: "check", paidAt: new Date(), paymentDate: new Date() },
+      create: {
+        id: S.invMixedManual, invoiceId: S.invoice4b, name: "MP3 Mixed", amount: 300,
+        status: "Paid", sourceScheduleId: S.estMixed, paymentMethod: "check", referenceNumber: "1042",
+      },
+    });
+
+    // Fifth fixture: a true 1:1 mirror whose ESTIMATE side carries no intent.
+    await sPrisma.estimate.upsert({
+      where: { id: S.estimate5 },
+      update: { status: "Paid", totalAmount: 400, balanceDue: 0, statusBeforePayment: "Invoiced" },
+      create: {
+        id: S.estimate5, title: `${S_NAME} 5`, code: "EST-MP3TEST-5", projectId: S.project,
+        status: "Paid", taxExempt: true, totalAmount: 400, balanceDue: 0, statusBeforePayment: "Invoiced",
+      },
+    });
+    await sPrisma.invoice.upsert({
+      where: { id: S.invoice5 },
+      update: { status: "Paid", totalAmount: 400, balanceDue: 0 },
+      create: {
+        id: S.invoice5, code: "INV-MP3TEST-5", projectId: S.project, clientId: S.client,
+        estimateId: S.estimate5, status: "Paid", totalAmount: 400, balanceDue: 0, issueDate: new Date(),
+      },
+    });
+    await sPrisma.estimatePaymentSchedule.upsert({
+      where: { id: S.estLegacy },
+      update: { status: "Paid", stripePaymentIntentId: null, paidAt: new Date(), paymentDate: new Date() },
+      create: {
+        id: S.estLegacy, estimateId: S.estimate5, name: "MP3 Legacy", amount: 400, status: "Paid", order: 1,
+      },
+    });
+    await sPrisma.paymentSchedule.upsert({
+      where: { id: S.invLegacy },
+      update: { status: "Paid", stripePaymentIntentId: LEGACY_INTENT, paidAt: new Date(), paymentDate: new Date() },
+      create: {
+        id: S.invLegacy, invoiceId: S.invoice5, name: "MP3 Legacy", amount: 400,
+        status: "Paid", sourceScheduleId: S.estLegacy, stripePaymentIntentId: LEGACY_INTENT,
+      },
+    });
   });
 
   test.afterAll(async () => {
     try {
-      const invoiceIds = [S.invoice, S.invoice2, S.invoice3a, S.invoice3b];
-      const estimateIds = [S.estimate, S.estimate2, S.estimate3];
+      const invoiceIds = [S.invoice, S.invoice2, S.invoice3a, S.invoice3b, S.invoice4a, S.invoice4b, S.invoice5];
+      const estimateIds = [S.estimate, S.estimate2, S.estimate3, S.estimate4, S.estimate5];
       await sPrisma.paymentSchedule.deleteMany({ where: { invoiceId: { in: invoiceIds } } });
       await sPrisma.invoice.deleteMany({ where: { id: { in: invoiceIds } } });
       await sPrisma.estimatePaymentSchedule.deleteMany({ where: { estimateId: { in: estimateIds } } });
@@ -1479,5 +1573,49 @@ test.describe.serial("Money pipeline: Stripe rails mirror both sides", () => {
     });
     expect(after.map((i) => Number(i.balanceDue))).toEqual(before.map((i) => Number(i.balanceDue)));
     expect(after.map((i) => i.status)).toEqual(before.map((i) => i.status));
+  });
+
+  test("S9: a cheque-paid clone is NOT released just because it mirrors the charge", async () => {
+    // Codex round 1 blocker. Once the estimate milestone is Paid, a mirror claim
+    // on it fails, so a SECOND invoice clone settled by cheque ends up Paid with
+    // a null PaymentIntent — indistinguishable by shape from a Stripe mirror.
+    // Releasing it on this refund would raise a balance the client already paid.
+    const group = await resolveChargeGroup(sPrisma, MIXED_INTENT);
+    expect(group.invoiceSchedules.map((r) => r.id), "only the clone that carries the charge")
+      .toEqual([S.invMixedStripe]);
+    expect(group.unattributable.map((r) => r.id), "the cheque-paid clone is handed to a human")
+      .toEqual([S.invMixedManual]);
+
+    const unwound = await unwindRefundedCharge(sPrisma, MIXED_INTENT);
+    expect(unwound.unattributable.map((r) => r.id)).toEqual([S.invMixedManual]);
+
+    const manual = await sPrisma.paymentSchedule.findUniqueOrThrow({ where: { id: S.invMixedManual } });
+    expect(manual.status, "the cheque payment is untouched").toBe("Paid");
+    const untouched = await sPrisma.invoice.findUniqueOrThrow({ where: { id: S.invoice4b } });
+    expect(Number(untouched.balanceDue), "and its invoice is not re-opened").toBe(0);
+
+    // The Stripe side still unwinds normally.
+    const stripeClone = await sPrisma.paymentSchedule.findUniqueOrThrow({ where: { id: S.invMixedStripe } });
+    expect(stripeClone.status).toBe("Pending");
+    const refunded = await sPrisma.invoice.findUniqueOrThrow({ where: { id: S.invoice4a } });
+    expect(Number(refunded.balanceDue)).toBe(300);
+  });
+
+  test("S10: a genuine 1:1 mirror with no intent on the estimate side IS released", async () => {
+    // The counterweight to S9: with exactly one Paid clone there is no second
+    // payment to confuse it with, so the legacy null-intent original is safe to
+    // adopt. Dropping this would leave the estimate claiming refunded money.
+    const group = await resolveChargeGroup(sPrisma, LEGACY_INTENT);
+    expect(group.estimateSchedules.map((r) => r.id), "the sole mirror is adopted").toEqual([S.estLegacy]);
+    expect(group.unattributable).toEqual([]);
+
+    await unwindRefundedCharge(sPrisma, LEGACY_INTENT);
+
+    const est = await sPrisma.estimatePaymentSchedule.findUniqueOrThrow({ where: { id: S.estLegacy } });
+    expect(est.status).toBe("Pending");
+    const estimate = await sPrisma.estimate.findUniqueOrThrow({ where: { id: S.estimate5 } });
+    expect(Number(estimate.balanceDue), "estimate balance restored").toBe(400);
+    const invoice = await sPrisma.invoice.findUniqueOrThrow({ where: { id: S.invoice5 } });
+    expect(Number(invoice.balanceDue), "invoice balance restored").toBe(400);
   });
 });

--- a/e2e/money-pipeline.spec.ts
+++ b/e2e/money-pipeline.spec.ts
@@ -1150,6 +1150,13 @@ const S = {
   invoice5: "mp3-e2e-invoice-5",
   estLegacy: "mp3-e2e-eps-legacy",
   invLegacy: "mp3-e2e-ps-legacy",
+  // S11: a pre-link invoice row (no sourceScheduleId) with two identical
+  // estimate candidates — attribution is impossible, silence is not acceptable.
+  estimate6: "mp3-e2e-estimate-6",
+  invoice6: "mp3-e2e-invoice-6",
+  estPrelinkA: "mp3-e2e-eps-prelink-a",
+  estPrelinkB: "mp3-e2e-eps-prelink-b",
+  invPrelink: "mp3-e2e-ps-prelink",
 };
 const S_NAME = "Stripe Mirror Drill - MP3TEST";
 const sPrisma = new PrismaClient();
@@ -1161,6 +1168,7 @@ const OTHER_INTENT = "pi_mp3_e2e_other_intent";
 const GROUP_INTENT = "pi_mp3_e2e_group_intent";
 const MIXED_INTENT = "pi_mp3_e2e_mixed_intent";
 const LEGACY_INTENT = "pi_mp3_e2e_legacy_intent";
+const PRELINK_INTENT = "pi_mp3_e2e_prelink_intent";
 
 test.describe.serial("Money pipeline: Stripe rails mirror both sides", () => {
   test.beforeAll(async () => {
@@ -1378,12 +1386,48 @@ test.describe.serial("Money pipeline: Stripe rails mirror both sides", () => {
         status: "Paid", sourceScheduleId: S.estLegacy, stripePaymentIntentId: LEGACY_INTENT,
       },
     });
+
+    // Sixth fixture: pre-link invoice row, two indistinguishable candidates.
+    await sPrisma.estimate.upsert({
+      where: { id: S.estimate6 },
+      update: { status: "Paid", totalAmount: 1000, balanceDue: 0, statusBeforePayment: "Invoiced" },
+      create: {
+        id: S.estimate6, title: `${S_NAME} 6`, code: "EST-MP3TEST-6", projectId: S.project,
+        status: "Paid", taxExempt: true, totalAmount: 1000, balanceDue: 0, statusBeforePayment: "Invoiced",
+      },
+    });
+    await sPrisma.invoice.upsert({
+      where: { id: S.invoice6 },
+      update: { status: "Paid", totalAmount: 500, balanceDue: 0 },
+      create: {
+        id: S.invoice6, code: "INV-MP3TEST-6", projectId: S.project, clientId: S.client,
+        estimateId: S.estimate6, status: "Paid", totalAmount: 500, balanceDue: 0, issueDate: new Date(),
+      },
+    });
+    for (const [id, order] of [[S.estPrelinkA, 1], [S.estPrelinkB, 2]] as const) {
+      await sPrisma.estimatePaymentSchedule.upsert({
+        where: { id },
+        update: { status: "Paid", stripePaymentIntentId: null, paidAt: new Date(), paymentDate: new Date() },
+        create: {
+          id, estimateId: S.estimate6, name: "MP3 Prelink", amount: 500, status: "Paid", order,
+        },
+      });
+    }
+    await sPrisma.paymentSchedule.upsert({
+      where: { id: S.invPrelink },
+      update: { status: "Paid", stripePaymentIntentId: PRELINK_INTENT, paidAt: new Date(), paymentDate: new Date() },
+      create: {
+        // No sourceScheduleId: this is the pre-link shape.
+        id: S.invPrelink, invoiceId: S.invoice6, name: "MP3 Prelink", amount: 500,
+        status: "Paid", stripePaymentIntentId: PRELINK_INTENT,
+      },
+    });
   });
 
   test.afterAll(async () => {
     try {
-      const invoiceIds = [S.invoice, S.invoice2, S.invoice3a, S.invoice3b, S.invoice4a, S.invoice4b, S.invoice5];
-      const estimateIds = [S.estimate, S.estimate2, S.estimate3, S.estimate4, S.estimate5];
+      const invoiceIds = [S.invoice, S.invoice2, S.invoice3a, S.invoice3b, S.invoice4a, S.invoice4b, S.invoice5, S.invoice6];
+      const estimateIds = [S.estimate, S.estimate2, S.estimate3, S.estimate4, S.estimate5, S.estimate6];
       await sPrisma.paymentSchedule.deleteMany({ where: { invoiceId: { in: invoiceIds } } });
       await sPrisma.invoice.deleteMany({ where: { id: { in: invoiceIds } } });
       await sPrisma.estimatePaymentSchedule.deleteMany({ where: { estimateId: { in: estimateIds } } });
@@ -1601,21 +1645,43 @@ test.describe.serial("Money pipeline: Stripe rails mirror both sides", () => {
     expect(Number(refunded.balanceDue)).toBe(300);
   });
 
-  test("S10: a genuine 1:1 mirror with no intent on the estimate side IS released", async () => {
-    // The counterweight to S9: with exactly one Paid clone there is no second
-    // payment to confuse it with, so the legacy null-intent original is safe to
-    // adopt. Dropping this would leave the estimate claiming refunded money.
+  test("S10: a lone null-intent mirror is REPORTED, not released", async () => {
+    // The counterweight to S9. A single Paid clone was briefly treated as proof
+    // that a null-intent partner recorded this charge — but a lone cheque-paid
+    // mirror looks exactly like a lone legacy Stripe mirror, and nothing on the
+    // row says which it is (Codex round 2). So it is named for a human instead
+    // of being moved on a guess.
     const group = await resolveChargeGroup(sPrisma, LEGACY_INTENT);
-    expect(group.estimateSchedules.map((r) => r.id), "the sole mirror is adopted").toEqual([S.estLegacy]);
-    expect(group.unattributable).toEqual([]);
+    expect(group.estimateSchedules, "the estimate side carries no charge reference").toEqual([]);
+    expect(group.invoiceSchedules.map((r) => r.id)).toEqual([S.invLegacy]);
+    expect(group.unattributable.map((r) => r.id), "and is handed to a human by name")
+      .toEqual([S.estLegacy]);
 
-    await unwindRefundedCharge(sPrisma, LEGACY_INTENT);
+    const unwound = await unwindRefundedCharge(sPrisma, LEGACY_INTENT);
+    expect(unwound.unattributable.map((r) => r.id)).toEqual([S.estLegacy]);
 
     const est = await sPrisma.estimatePaymentSchedule.findUniqueOrThrow({ where: { id: S.estLegacy } });
-    expect(est.status).toBe("Pending");
-    const estimate = await sPrisma.estimate.findUniqueOrThrow({ where: { id: S.estimate5 } });
-    expect(Number(estimate.balanceDue), "estimate balance restored").toBe(400);
+    expect(est.status, "left alone rather than guessed at").toBe("Paid");
+    // The row that does carry the charge still unwinds.
+    const inv = await sPrisma.paymentSchedule.findUniqueOrThrow({ where: { id: S.invLegacy } });
+    expect(inv.status).toBe("Pending");
     const invoice = await sPrisma.invoice.findUniqueOrThrow({ where: { id: S.invoice5 } });
     expect(Number(invoice.balanceDue), "invoice balance restored").toBe(400);
+  });
+
+  test("S11: an ambiguous pre-link candidate set is reported, never silently dropped", async () => {
+    // A legacy invoice row with no sourceScheduleId and TWO identical estimate
+    // candidates. Neither can be attributed — but the invoice side still resets,
+    // so staying silent would leave the estimate quietly holding the money.
+    const group = await resolveChargeGroup(sPrisma, PRELINK_INTENT);
+    expect(group.invoiceSchedules.map((r) => r.id)).toEqual([S.invPrelink]);
+    expect(group.unattributable.map((r) => r.id).sort(), "both candidates surface")
+      .toEqual([S.estPrelinkA, S.estPrelinkB].sort());
+
+    await unwindRefundedCharge(sPrisma, PRELINK_INTENT);
+    const rows = await sPrisma.estimatePaymentSchedule.findMany({
+      where: { id: { in: [S.estPrelinkA, S.estPrelinkB] } },
+    });
+    expect(rows.every((r) => r.status === "Paid"), "neither candidate was touched").toBe(true);
   });
 });

--- a/e2e/money-pipeline.spec.ts
+++ b/e2e/money-pipeline.spec.ts
@@ -1157,6 +1157,14 @@ const S = {
   estPrelinkA: "mp3-e2e-eps-prelink-a",
   estPrelinkB: "mp3-e2e-eps-prelink-b",
   invPrelink: "mp3-e2e-ps-prelink",
+  // S12: the shape reachable only by walking BOTH links — a null-intent estimate
+  // original whose OTHER clone is also null-intent.
+  estimate7: "mp3-e2e-estimate-7",
+  invoice7a: "mp3-e2e-invoice-7a",
+  invoice7b: "mp3-e2e-invoice-7b",
+  estSib: "mp3-e2e-eps-sib",
+  invSibCharge: "mp3-e2e-ps-sib-charge",
+  invSibNull: "mp3-e2e-ps-sib-null",
 };
 const S_NAME = "Stripe Mirror Drill - MP3TEST";
 const sPrisma = new PrismaClient();
@@ -1169,6 +1177,7 @@ const GROUP_INTENT = "pi_mp3_e2e_group_intent";
 const MIXED_INTENT = "pi_mp3_e2e_mixed_intent";
 const LEGACY_INTENT = "pi_mp3_e2e_legacy_intent";
 const PRELINK_INTENT = "pi_mp3_e2e_prelink_intent";
+const SIBLING_INTENT = "pi_mp3_e2e_sibling_intent";
 
 test.describe.serial("Money pipeline: Stripe rails mirror both sides", () => {
   test.beforeAll(async () => {
@@ -1422,12 +1431,61 @@ test.describe.serial("Money pipeline: Stripe rails mirror both sides", () => {
         status: "Paid", stripePaymentIntentId: PRELINK_INTENT,
       },
     });
+
+    // Seventh fixture: E(null intent) with clones A(SIBLING_INTENT) and B(null).
+    // B is reachable only by walking invoice->estimate and then back out again.
+    await sPrisma.estimate.upsert({
+      where: { id: S.estimate7 },
+      update: { status: "Paid", totalAmount: 700, balanceDue: 0, statusBeforePayment: "Invoiced" },
+      create: {
+        id: S.estimate7, title: `${S_NAME} 7`, code: "EST-MP3TEST-7", projectId: S.project,
+        status: "Paid", taxExempt: true, totalAmount: 700, balanceDue: 0, statusBeforePayment: "Invoiced",
+      },
+    });
+    for (const [id, code] of [[S.invoice7a, "7A"], [S.invoice7b, "7B"]] as const) {
+      await sPrisma.invoice.upsert({
+        where: { id },
+        update: { status: "Paid", totalAmount: 700, balanceDue: 0 },
+        create: {
+          id, code: `INV-MP3TEST-${code}`, projectId: S.project, clientId: S.client,
+          estimateId: S.estimate7, status: "Paid", totalAmount: 700, balanceDue: 0, issueDate: new Date(),
+        },
+      });
+    }
+    await sPrisma.estimatePaymentSchedule.upsert({
+      where: { id: S.estSib },
+      update: { status: "Paid", stripePaymentIntentId: null, paidAt: new Date(), paymentDate: new Date() },
+      create: {
+        id: S.estSib, estimateId: S.estimate7, name: "MP3 Sibling", amount: 700, status: "Paid", order: 1,
+      },
+    });
+    await sPrisma.paymentSchedule.upsert({
+      where: { id: S.invSibCharge },
+      update: { status: "Paid", stripePaymentIntentId: SIBLING_INTENT, paidAt: new Date(), paymentDate: new Date() },
+      create: {
+        id: S.invSibCharge, invoiceId: S.invoice7a, name: "MP3 Sibling", amount: 700,
+        status: "Paid", sourceScheduleId: S.estSib, stripePaymentIntentId: SIBLING_INTENT,
+      },
+    });
+    await sPrisma.paymentSchedule.upsert({
+      where: { id: S.invSibNull },
+      update: { status: "Paid", stripePaymentIntentId: null, paymentMethod: "check", paidAt: new Date(), paymentDate: new Date() },
+      create: {
+        id: S.invSibNull, invoiceId: S.invoice7b, name: "MP3 Sibling", amount: 700,
+        status: "Paid", sourceScheduleId: S.estSib, paymentMethod: "check",
+      },
+    });
   });
 
   test.afterAll(async () => {
     try {
-      const invoiceIds = [S.invoice, S.invoice2, S.invoice3a, S.invoice3b, S.invoice4a, S.invoice4b, S.invoice5, S.invoice6];
-      const estimateIds = [S.estimate, S.estimate2, S.estimate3, S.estimate4, S.estimate5, S.estimate6];
+      const invoiceIds = [
+        S.invoice, S.invoice2, S.invoice3a, S.invoice3b, S.invoice4a, S.invoice4b,
+        S.invoice5, S.invoice6, S.invoice7a, S.invoice7b,
+      ];
+      const estimateIds = [
+        S.estimate, S.estimate2, S.estimate3, S.estimate4, S.estimate5, S.estimate6, S.estimate7,
+      ];
       await sPrisma.paymentSchedule.deleteMany({ where: { invoiceId: { in: invoiceIds } } });
       await sPrisma.invoice.deleteMany({ where: { id: { in: invoiceIds } } });
       await sPrisma.estimatePaymentSchedule.deleteMany({ where: { estimateId: { in: estimateIds } } });
@@ -1683,5 +1741,25 @@ test.describe.serial("Money pipeline: Stripe rails mirror both sides", () => {
       where: { id: { in: [S.estPrelinkA, S.estPrelinkB] } },
     });
     expect(rows.every((r) => r.status === "Paid"), "neither candidate was touched").toBe(true);
+  });
+
+  test("S12: a null-intent sibling reachable only through a null-intent original is still reported", async () => {
+    // E(null) -> clones A(charge) and B(null). Walking out only from milestones
+    // that carry the charge never reaches B, because E does not carry it either.
+    // B is safe from being reset, but a report that claims to name every Paid
+    // mirror must actually name it (Codex round 3).
+    const group = await resolveChargeGroup(sPrisma, SIBLING_INTENT);
+    expect(group.invoiceSchedules.map((r) => r.id), "only the clone carrying the charge releases")
+      .toEqual([S.invSibCharge]);
+    expect(group.unattributable.map((r) => r.id).sort(), "BOTH null-intent mirrors are named")
+      .toEqual([S.estSib, S.invSibNull].sort());
+
+    const unwound = await unwindRefundedCharge(sPrisma, SIBLING_INTENT);
+    expect(unwound.unattributable.map((r) => r.id).sort()).toEqual([S.estSib, S.invSibNull].sort());
+
+    const untouched = await sPrisma.paymentSchedule.findUniqueOrThrow({ where: { id: S.invSibNull } });
+    expect(untouched.status, "and neither is written").toBe("Paid");
+    const est = await sPrisma.estimatePaymentSchedule.findUniqueOrThrow({ where: { id: S.estSib } });
+    expect(est.status).toBe("Paid");
   });
 });

--- a/e2e/money-pipeline.spec.ts
+++ b/e2e/money-pipeline.spec.ts
@@ -8,12 +8,8 @@ import {
   persistOwnedSignature,
   type SignatureStorageBucket,
 } from "../src/lib/signature-storage";
-import {
-  mirrorInvoiceSettleToEstimate,
-  mirrorInvoiceUnsettleToEstimate,
-  mirrorEstimateUnsettleToInvoice,
-  findInvoiceMirrorOfEstimateSchedule,
-} from "../src/lib/payment-mirror";
+import { mirrorInvoiceSettleToEstimate } from "../src/lib/payment-mirror";
+import { resolveChargeGroup, unwindRefundedCharge } from "../src/lib/refund-group";
 import {
   approveChangeOrderWithSignature,
   type ChangeOrderApprovalDependencies,
@@ -1129,11 +1125,25 @@ const S = {
   invoice2: "mp3-e2e-invoice-2",
   estOther: "mp3-e2e-eps-other",
   invOtherCharge: "mp3-e2e-ps-other-charge",
+  // S7/S8: ONE estimate milestone with TWO paid invoice clones carrying the same
+  // PaymentIntent — the shape `convertEstimateToInvoice` produces when a paid
+  // estimate is converted more than once, and the bug this suite section exists
+  // for. Its own documents again, so the group unwind can't disturb S1-S6.
+  estimate3: "mp3-e2e-estimate-3",
+  invoice3a: "mp3-e2e-invoice-3a",
+  invoice3b: "mp3-e2e-invoice-3b",
+  estGroup: "mp3-e2e-eps-group",
+  invGroupA: "mp3-e2e-ps-group-a",
+  invGroupB: "mp3-e2e-ps-group-b",
 };
 const S_NAME = "Stripe Mirror Drill - MP3TEST";
 const sPrisma = new PrismaClient();
+// One intent per scenario: a refund now unwinds EVERY row recording the charge,
+// so sharing an intent across scenarios would make them unwind each other.
 const INTENT = "pi_mp3_e2e_intent";
+const PAIR2_INTENT = "pi_mp3_e2e_pair2_intent";
 const OTHER_INTENT = "pi_mp3_e2e_other_intent";
+const GROUP_INTENT = "pi_mp3_e2e_group_intent";
 
 test.describe.serial("Money pipeline: Stripe rails mirror both sides", () => {
   test.beforeAll(async () => {
@@ -1220,28 +1230,70 @@ test.describe.serial("Money pipeline: Stripe rails mirror both sides", () => {
     });
     await sPrisma.estimatePaymentSchedule.upsert({
       where: { id: S.estOther },
-      update: { status: "Paid", stripePaymentIntentId: INTENT },
+      update: { status: "Paid", stripePaymentIntentId: PAIR2_INTENT, paidAt: new Date(), paymentDate: new Date() },
       create: {
         id: S.estOther, estimateId: S.estimate2, name: "MP3 Other", amount: 200,
-        status: "Paid", order: 1, stripePaymentIntentId: INTENT,
+        status: "Paid", order: 1, stripePaymentIntentId: PAIR2_INTENT,
       },
     });
     await sPrisma.paymentSchedule.upsert({
       where: { id: S.invOtherCharge },
-      update: { status: "Paid", stripePaymentIntentId: OTHER_INTENT },
+      update: { status: "Paid", stripePaymentIntentId: OTHER_INTENT, paidAt: new Date(), paymentDate: new Date() },
       create: {
         id: S.invOtherCharge, invoiceId: S.invoice2, name: "MP3 Other", amount: 200,
         status: "Paid", sourceScheduleId: S.estOther, stripePaymentIntentId: OTHER_INTENT,
       },
     });
+
+    // Third fixture: ONE estimate milestone, TWO invoices, both clones Paid and
+    // both carrying the same charge. $500 milestone on a $500 estimate.
+    await sPrisma.estimate.upsert({
+      where: { id: S.estimate3 },
+      update: { status: "Paid", totalAmount: 500, balanceDue: 0, statusBeforePayment: "Invoiced" },
+      create: {
+        id: S.estimate3, title: `${S_NAME} 3`, code: "EST-MP3TEST-3", projectId: S.project,
+        status: "Paid", taxExempt: true, totalAmount: 500, balanceDue: 0, statusBeforePayment: "Invoiced",
+      },
+    });
+    for (const id of [S.invoice3a, S.invoice3b]) {
+      await sPrisma.invoice.upsert({
+        where: { id },
+        update: { status: "Paid", totalAmount: 500, balanceDue: 0 },
+        create: {
+          id, code: `INV-MP3TEST-${id.endsWith("a") ? "3A" : "3B"}`, projectId: S.project,
+          clientId: S.client, estimateId: S.estimate3, status: "Paid",
+          totalAmount: 500, balanceDue: 0, issueDate: new Date(),
+        },
+      });
+    }
+    await sPrisma.estimatePaymentSchedule.upsert({
+      where: { id: S.estGroup },
+      update: { status: "Paid", stripePaymentIntentId: GROUP_INTENT, paidAt: new Date(), paymentDate: new Date() },
+      create: {
+        id: S.estGroup, estimateId: S.estimate3, name: "MP3 Group", amount: 500,
+        status: "Paid", order: 1, stripePaymentIntentId: GROUP_INTENT,
+      },
+    });
+    for (const [id, invoiceId] of [[S.invGroupA, S.invoice3a], [S.invGroupB, S.invoice3b]] as const) {
+      await sPrisma.paymentSchedule.upsert({
+        where: { id },
+        update: { status: "Paid", stripePaymentIntentId: GROUP_INTENT, paidAt: new Date(), paymentDate: new Date() },
+        create: {
+          id, invoiceId, name: "MP3 Group", amount: 500, status: "Paid",
+          sourceScheduleId: S.estGroup, stripePaymentIntentId: GROUP_INTENT,
+        },
+      });
+    }
   });
 
   test.afterAll(async () => {
     try {
-      await sPrisma.paymentSchedule.deleteMany({ where: { invoiceId: { in: [S.invoice, S.invoice2] } } });
-      await sPrisma.invoice.deleteMany({ where: { id: { in: [S.invoice, S.invoice2] } } });
-      await sPrisma.estimatePaymentSchedule.deleteMany({ where: { estimateId: { in: [S.estimate, S.estimate2] } } });
-      await sPrisma.estimate.deleteMany({ where: { id: { in: [S.estimate, S.estimate2] } } });
+      const invoiceIds = [S.invoice, S.invoice2, S.invoice3a, S.invoice3b];
+      const estimateIds = [S.estimate, S.estimate2, S.estimate3];
+      await sPrisma.paymentSchedule.deleteMany({ where: { invoiceId: { in: invoiceIds } } });
+      await sPrisma.invoice.deleteMany({ where: { id: { in: invoiceIds } } });
+      await sPrisma.estimatePaymentSchedule.deleteMany({ where: { estimateId: { in: estimateIds } } });
+      await sPrisma.estimate.deleteMany({ where: { id: { in: estimateIds } } });
       await sPrisma.project.deleteMany({ where: { id: S.project } });
       await sPrisma.client.deleteMany({ where: { id: S.client } });
     } finally {
@@ -1303,16 +1355,15 @@ test.describe.serial("Money pipeline: Stripe rails mirror both sides", () => {
     expect(Number(after.balanceDue)).toBe(Number(before.balanceDue));
   });
 
-  test("S3: a full refund unwinds the estimate mirror and keeps its Stripe ids", async () => {
-    const payment = await sPrisma.paymentSchedule.findUniqueOrThrow({ where: { id: S.invDeposit } });
+  test("S3: a full refund unwinds both sides of the charge and keeps its Stripe ids", async () => {
+    const unwound = await unwindRefundedCharge(sPrisma, INTENT);
 
-    const unwound = await sPrisma.$transaction((tx) =>
-      mirrorInvoiceUnsettleToEstimate(tx, { estimateId: S.estimate, payment }),
-    );
-
-    expect(unwound, "the estimate copy was released").toBe(true);
+    expect(unwound.estimateSchedules.map((r) => r.id), "the estimate copy was released").toEqual([S.estDeposit]);
+    expect(unwound.invoiceSchedules.map((r) => r.id), "the invoice copy was released too").toEqual([S.invDeposit]);
     const estCopy = await sPrisma.estimatePaymentSchedule.findUniqueOrThrow({ where: { id: S.estDeposit } });
     expect(estCopy.status).toBe("Pending");
+    const invCopy = await sPrisma.paymentSchedule.findUniqueOrThrow({ where: { id: S.invDeposit } });
+    expect(invCopy.status).toBe("Pending");
     // The Stripe ids MUST survive the reset: they are how a redelivered refund
     // re-finds this exact row. Clearing them would let a duplicate delivery land
     // on a different clone sharing the intent and unset a real payment.
@@ -1322,6 +1373,9 @@ test.describe.serial("Money pipeline: Stripe rails mirror both sides", () => {
     expect(Number(estimate.balanceDue), "estimate balance restored in full").toBe(1000);
     expect(estimate.status, "pre-payment status restored").toBe("Invoiced");
     expect(estimate.statusBeforePayment).toBeNull();
+    const invoice = await sPrisma.invoice.findUniqueOrThrow({ where: { id: S.invoice } });
+    expect(Number(invoice.balanceDue), "invoice balance restored in full").toBe(1000);
+    expect(invoice.status).toBe("Issued");
   });
 
   test("S4: an ambiguous unlinked pair is left alone rather than guessed at", async () => {
@@ -1343,37 +1397,87 @@ test.describe.serial("Money pipeline: Stripe rails mirror both sides", () => {
     expect(rows.every((r) => r.status === "Pending"), "no candidate was touched").toBe(true);
   });
 
-  test("S5: refunding an estimate milestone never releases a clone paid by another charge", async () => {
-    const schedule = await sPrisma.estimatePaymentSchedule.findUniqueOrThrow({ where: { id: S.estOther } });
+  test("S5: refunding a charge never releases a clone paid by another charge", async () => {
+    const group = await resolveChargeGroup(sPrisma, PAIR2_INTENT);
 
-    const mirror = await sPrisma.$transaction((tx) =>
-      findInvoiceMirrorOfEstimateSchedule(tx, schedule),
-    );
+    expect(group.estimateSchedules.map((r) => r.id), "only the row this charge settled").toEqual([S.estOther]);
+    expect(group.invoiceSchedules, "the linked clone carries a DIFFERENT PaymentIntent").toEqual([]);
 
-    expect(mirror, "the sole linked clone carries a different PaymentIntent").toBeNull();
+    await unwindRefundedCharge(sPrisma, PAIR2_INTENT);
     const clone = await sPrisma.paymentSchedule.findUniqueOrThrow({ where: { id: S.invOtherCharge } });
     expect(clone.status, "the other charge's payment stays Paid").toBe("Paid");
+    const invoice = await sPrisma.invoice.findUniqueOrThrow({ where: { id: S.invoice2 } });
+    expect(Number(invoice.balanceDue), "and its invoice balance is untouched").toBe(0);
   });
 
-  test("S6: refunding an estimate milestone unwinds its invoice clone and balance", async () => {
-    // Re-point the clone at THIS charge, which is the ordinary settled pair.
+  test("S6: refunding a charge unwinds the invoice clone that recorded it", async () => {
+    // Re-point the clone at a charge shared with its estimate original, which is
+    // the ordinary settled pair. (S5 already released the estimate side.)
+    await sPrisma.estimatePaymentSchedule.update({
+      where: { id: S.estOther },
+      data: { status: "Paid", paidAt: new Date(), paymentDate: new Date() },
+    });
     await sPrisma.paymentSchedule.update({
       where: { id: S.invOtherCharge },
-      data: { stripePaymentIntentId: INTENT, status: "Paid" },
-    });
-    const schedule = await sPrisma.estimatePaymentSchedule.findUniqueOrThrow({ where: { id: S.estOther } });
-
-    const unwound = await sPrisma.$transaction(async (tx) => {
-      const mirror = await findInvoiceMirrorOfEstimateSchedule(tx, schedule);
-      expect(mirror?.id, "the same-charge clone is the mirror").toBe(S.invOtherCharge);
-      return mirror ? await mirrorEstimateUnsettleToInvoice(tx, mirror) : false;
+      data: { stripePaymentIntentId: PAIR2_INTENT, status: "Paid" },
     });
 
-    expect(unwound, "the invoice clone was released").toBe(true);
+    const unwound = await unwindRefundedCharge(sPrisma, PAIR2_INTENT);
+
+    expect(unwound.invoiceSchedules.map((r) => r.id), "the invoice clone was released").toEqual([S.invOtherCharge]);
     const clone = await sPrisma.paymentSchedule.findUniqueOrThrow({ where: { id: S.invOtherCharge } });
     expect(clone.status).toBe("Pending");
     const invoice = await sPrisma.invoice.findUniqueOrThrow({ where: { id: S.invoice2 } });
     expect(Number(invoice.balanceDue), "invoice balance restored by the refunded amount").toBe(200);
     expect(invoice.status).toBe("Issued");
+  });
+
+  test("S7: a refund releases EVERY clone of the charge, across every invoice", async () => {
+    // The regression: `stripePaymentIntentId` is not unique, so the old handler
+    // reset exactly one of these three rows. The other two kept showing money
+    // the client got back, and their invoices kept a wrong balanceDue.
+    const group = await resolveChargeGroup(sPrisma, GROUP_INTENT);
+    expect(group.invoiceSchedules.map((r) => r.id).sort(), "both clones are in the group")
+      .toEqual([S.invGroupA, S.invGroupB].sort());
+    expect(group.invoiceIds.length, "spanning two separate invoices").toBe(2);
+
+    const unwound = await unwindRefundedCharge(sPrisma, GROUP_INTENT);
+
+    expect(unwound.estimateSchedules.map((r) => r.id)).toEqual([S.estGroup]);
+    expect(unwound.invoiceSchedules.map((r) => r.id).sort()).toEqual([S.invGroupA, S.invGroupB].sort());
+
+    const rows = await sPrisma.paymentSchedule.findMany({ where: { id: { in: [S.invGroupA, S.invGroupB] } } });
+    expect(rows.every((r) => r.status === "Pending"), "no clone is left claiming the refunded money").toBe(true);
+    expect(rows.every((r) => r.stripePaymentIntentId === GROUP_INTENT), "charge links survive the reset").toBe(true);
+
+    for (const id of [S.invoice3a, S.invoice3b]) {
+      const invoice = await sPrisma.invoice.findUniqueOrThrow({ where: { id } });
+      expect(Number(invoice.balanceDue), `invoice ${id} balance restored`).toBe(500);
+      expect(invoice.status).toBe("Issued");
+    }
+    const estimate = await sPrisma.estimate.findUniqueOrThrow({ where: { id: S.estimate3 } });
+    expect(Number(estimate.balanceDue), "estimate balance restored").toBe(500);
+    expect(estimate.status).toBe("Invoiced");
+  });
+
+  test("S8: a redelivered refund is a no-op, not a second unwind", async () => {
+    const before = await sPrisma.invoice.findMany({
+      where: { id: { in: [S.invoice3a, S.invoice3b] } },
+      orderBy: { id: "asc" },
+    });
+
+    const group = await resolveChargeGroup(sPrisma, GROUP_INTENT);
+    expect(group.estimateSchedules.length + group.invoiceSchedules.length,
+      "nothing Paid still records the charge").toBe(0);
+    const unwound = await unwindRefundedCharge(sPrisma, GROUP_INTENT);
+    expect(unwound.estimateSchedules).toEqual([]);
+    expect(unwound.invoiceSchedules).toEqual([]);
+
+    const after = await sPrisma.invoice.findMany({
+      where: { id: { in: [S.invoice3a, S.invoice3b] } },
+      orderBy: { id: "asc" },
+    });
+    expect(after.map((i) => Number(i.balanceDue))).toEqual(before.map((i) => Number(i.balanceDue)));
+    expect(after.map((i) => i.status)).toEqual(before.map((i) => i.status));
   });
 });

--- a/src/app/api/webhook/stripe/route.ts
+++ b/src/app/api/webhook/stripe/route.ts
@@ -241,10 +241,11 @@ async function processEvent(eventId: string) {
                     // total-refunded-so-far, not this delivery's delta. We frame it that way explicitly.
                     const summary = !isFullyRefunded
                         ? `This is a <strong>partial refund</strong>. The milestones below remain marked Paid; please reconcile the balances manually in the Stripe dashboard.`
-                        // An earlier delivery of this same refund already did the work — say so
-                        // rather than reporting a failure the office would chase.
-                        : unwound?.alreadyUnwound
-                        ? `Already reconciled by an earlier delivery of this refund. Nothing was left to reset.`
+                        // Nothing was still Paid once the unwind held its locks. Usually a
+                        // redelivery of this refund, but a staff "undo payment" landing first
+                        // looks the same, so this must not credit an earlier delivery.
+                        : unwound?.nothingLeftPaid
+                        ? `Nothing recording this charge was still marked Paid when reconciliation ran, so there was nothing to reset.`
                         : reset.length === found.length
                         ? `All ${reset.length} milestone(s) recording this charge were reset to Pending and their balances restored.`
                         : reset.length > 0

--- a/src/app/api/webhook/stripe/route.ts
+++ b/src/app/api/webhook/stripe/route.ts
@@ -220,7 +220,7 @@ async function processEvent(eventId: string) {
                 const group = await resolveChargeGroup(prisma, paymentIntentId);
                 if (chargeGroupIsEmpty(group)) break;
 
-                let unwound: UnwindResult = { estimateSchedules: [], invoiceSchedules: [] };
+                let unwound: UnwindResult | null = null;
                 if (isFullyRefunded) {
                     unwound = await unwindRefundedCharge(prisma, paymentIntentId);
                 }
@@ -230,11 +230,21 @@ async function processEvent(eventId: string) {
                     const label = (rows: { name: string; parentCode: string | null }[]) =>
                         rows.map((r) => `${r.parentCode ?? "(no code)"} — ${r.name}`);
                     const found = [...label(group.invoiceSchedules), ...label(group.estimateSchedules)];
-                    const reset = [...label(unwound.invoiceSchedules), ...label(unwound.estimateSchedules)];
+                    const reset = unwound
+                        ? [...label(unwound.invoiceSchedules), ...label(unwound.estimateSchedules)]
+                        : [];
+                    // Paid mirror partners with no PaymentIntent that sit in a one-to-many
+                    // group: they might be this charge or a separate manual payment, so the
+                    // unwind refuses to guess and hands them to a human instead.
+                    const ambiguous = label(unwound?.unattributable ?? group.unattributable);
                     // `charge.amount_refunded` is the CUMULATIVE refund total, so this message reflects
                     // total-refunded-so-far, not this delivery's delta. We frame it that way explicitly.
                     const summary = !isFullyRefunded
                         ? `This is a <strong>partial refund</strong>. The milestones below remain marked Paid; please reconcile the balances manually in the Stripe dashboard.`
+                        // An earlier delivery of this same refund already did the work — say so
+                        // rather than reporting a failure the office would chase.
+                        : unwound?.alreadyUnwound
+                        ? `Already reconciled by an earlier delivery of this refund. Nothing was left to reset.`
                         : reset.length === found.length
                         ? `All ${reset.length} milestone(s) recording this charge were reset to Pending and their balances restored.`
                         : reset.length > 0
@@ -242,6 +252,7 @@ async function processEvent(eventId: string) {
                         : `These milestones were <strong>not</strong> reset automatically — they no longer matched this charge when the refund was processed. Please reconcile the balances manually in the Stripe dashboard.`;
                     const primaryCode = group.invoiceSchedules[0]?.parentCode
                         ?? group.estimateSchedules[0]?.parentCode
+                        ?? group.unattributable[0]?.parentCode
                         ?? paymentIntentId;
                     await sendNotification(
                         refundSettings.notificationEmail,
@@ -249,9 +260,13 @@ async function processEvent(eventId: string) {
                         `<div style="font-family: sans-serif; padding: 20px;">
                             <h2>Refund Processed</h2>
                             <p>Total refunded to date: <strong>${formatCurrency(refundedAmount)}</strong> of ${formatCurrency(chargeAmount)}.</p>
-                            <p>Milestones recording this charge:</p>
-                            <ul>${found.map((l) => `<li>${l}</li>`).join("")}</ul>
+                            ${found.length > 0 ? `<p>Milestones recording this charge:</p>
+                            <ul>${found.map((l) => `<li>${l}</li>`).join("")}</ul>` : ""}
                             <p>${summary}</p>
+                            ${ambiguous.length > 0 ? `<p><strong>Needs a human:</strong> these milestones mirror one of the above but carry no
+                            payment reference, so we cannot tell whether they recorded this charge or a separate
+                            payment. They were left as-is — please check them in the Stripe dashboard:</p>
+                            <ul>${ambiguous.map((l) => `<li>${l}</li>`).join("")}</ul>` : ""}
                         </div>`
                     );
                 }

--- a/src/app/api/webhook/stripe/route.ts
+++ b/src/app/api/webhook/stripe/route.ts
@@ -8,12 +8,13 @@ import { sendNotification } from "@/lib/email";
 import { toNum } from "@/lib/prisma-helpers";
 import { formatCurrency } from "@/lib/utils";
 import { settleStripeEstimatePayment } from "@/lib/stripe-estimate-settlement";
+import { mirrorInvoiceSettleToEstimate } from "@/lib/payment-mirror";
 import {
-    mirrorInvoiceSettleToEstimate,
-    mirrorInvoiceUnsettleToEstimate,
-    mirrorEstimateUnsettleToInvoice,
-    findInvoiceMirrorOfEstimateSchedule,
-} from "@/lib/payment-mirror";
+    resolveChargeGroup,
+    unwindRefundedCharge,
+    chargeGroupIsEmpty,
+    type UnwindResult,
+} from "@/lib/refund-group";
 
 // Helper function to process a single event by eventId asynchronously
 async function processEvent(eventId: string) {
@@ -210,191 +211,49 @@ async function processEvent(eventId: string) {
                 const isFullyRefunded = chargeAmount > 0
                     && Math.abs(chargeAmount - refundedAmount) < 0.005;
 
-                // Try invoice payment schedule first. `stripePaymentIntentId` is NOT unique —
-                // invoice creation copies it onto every clone of an already-paid estimate
-                // milestone — so prefer a row that is actually Paid (the one a refund is
-                // about) and pick deterministically among ties instead of taking whatever
-                // the planner returns first.
-                const invoiceSchedule =
-                    (await prisma.paymentSchedule.findFirst({
-                        where: { stripePaymentIntentId: paymentIntentId, status: "Paid" },
-                        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-                        include: { invoice: true },
-                    }))
-                    ?? (await prisma.paymentSchedule.findFirst({
-                        where: { stripePaymentIntentId: paymentIntentId },
-                        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-                        include: { invoice: true },
-                    }));
+                // One charge can be recorded on several milestone rows across both
+                // tables — invoice conversion copies the PaymentIntent onto every
+                // clone of an already-paid estimate milestone. Resolve the whole
+                // group so a full refund releases all of it, instead of picking one
+                // row and leaving the rest showing money the client got back.
+                // See src/lib/refund-group.ts.
+                const group = await resolveChargeGroup(prisma, paymentIntentId);
+                if (chargeGroupIsEmpty(group)) break;
 
-                if (invoiceSchedule) {
-                    // Whether THIS delivery actually reset the schedule — the office email
-                    // must not claim a reset the claim guard refused.
-                    let didReset = false;
-                    if (isFullyRefunded) {
-                        // Full refund: reset the schedule and recompute the invoice in one transaction
-                        // so we don't race with a concurrent payment settlement on a sibling schedule.
-                        const outcome = await withTxRetry(() => prisma.$transaction(async (t) => {
-                            // Canonical Estimate → Invoice → schedules order. Lock the parents
-                            // first so a concurrent settle on a sibling milestone can't have its
-                            // balanceDue effect lost to this recompute. The estimate is locked
-                            // too because the estimate-side mirror is unwound below.
-                            await lockMoneyParents(t, {
-                                estimateId: invoiceSchedule.invoice.estimateId,
-                                invoiceId: invoiceSchedule.invoiceId,
-                            });
-                            // Re-read the parent AFTER the lock — the outer query's snapshot of
-                            // totalAmount/status may be stale if a concurrent flow changed it.
-                            const invoice = await t.invoice.findUnique({ where: { id: invoiceSchedule.invoiceId } });
-                            if (invoice) {
-                                // CLAIMED reset: the schedule row was read before the locks were
-                                // taken, so a settlement that landed while this worker waited may
-                                // have re-pointed it at a NEWER charge. Guarding on both the Paid
-                                // status and this refund's PaymentIntent means a stale refund can
-                                // never reset a payment it isn't about. The Stripe ids stay on the
-                                // row: they are how a redelivered refund re-finds it.
-                                const reset = await t.paymentSchedule.updateMany({
-                                    where: { id: invoiceSchedule.id, status: "Paid", stripePaymentIntentId: paymentIntentId },
-                                    data: { status: "Pending", paidAt: null, paymentDate: null },
-                                });
-                                if (reset.count === 0) return { claimed: false };
-                                const siblings = await t.paymentSchedule.findMany({
-                                    where: { invoiceId: invoiceSchedule.invoiceId },
-                                });
-                                const totalPaid = siblings.filter(s => s.status === "Paid").reduce((sum, s) => sum + toNum(s.amount), 0);
-                                const newBalance = Math.max(0, toNum(invoice.totalAmount) - totalPaid);
-                                const newStatus = newBalance <= 0
-                                    ? "Paid"
-                                    : totalPaid > 0 ? "Partially Paid"
-                                    : "Issued";
-                                await t.invoice.update({
-                                    where: { id: invoice.id },
-                                    data: { balanceDue: newBalance, status: newStatus },
-                                });
-                                // Unwind the estimate-side mirror too, or the estimate keeps
-                                // claiming money the invoice no longer shows as received.
-                                await mirrorInvoiceUnsettleToEstimate(t, {
-                                    estimateId: invoice.estimateId,
-                                    payment: invoiceSchedule,
-                                });
-                                return { claimed: true };
-                            }
-                            return { claimed: false };
-                        }));
-                        didReset = outcome.claimed;
-                    }
-
-                    const refundSettings = await prisma.companySettings.findUnique({ where: { id: "singleton" } });
-                    if (refundSettings?.notificationEmail) {
-                        // `charge.amount_refunded` is the CUMULATIVE refund total, so this message reflects
-                        // total-refunded-so-far, not this delivery's delta. We frame it that way explicitly.
-                        const summary = !isFullyRefunded
-                            ? `This is a <strong>partial refund</strong>. The schedule remains marked Paid; please reconcile the invoice balance manually in the Stripe dashboard.`
-                            : didReset
-                            ? `The schedule has been reset to Pending and the invoice balance restored.`
-                            : `This milestone was <strong>not</strong> reset automatically — it no longer matched this charge when the refund was processed. Please reconcile the invoice balance manually in the Stripe dashboard.`;
-                        await sendNotification(
-                            refundSettings.notificationEmail,
-                            `${isFullyRefunded ? "Refund Issued" : "Partial Refund Issued"}: Invoice ${invoiceSchedule.invoice.code}`,
-                            `<div style="font-family: sans-serif; padding: 20px;">
-                                <h2>Refund Processed</h2>
-                                <p>Total refunded to date: <strong>${formatCurrency(refundedAmount)}</strong> of ${formatCurrency(chargeAmount)} on Invoice #${invoiceSchedule.invoice.code} (milestone: ${invoiceSchedule.name}).</p>
-                                <p>${summary}</p>
-                            </div>`
-                        );
-                    }
-                    break;
+                let unwound: UnwindResult = { estimateSchedules: [], invoiceSchedules: [] };
+                if (isFullyRefunded) {
+                    unwound = await unwindRefundedCharge(prisma, paymentIntentId);
                 }
 
-                // Try estimate payment schedule
-                const estSchedule =
-                    (await prisma.estimatePaymentSchedule.findFirst({
-                        where: { stripePaymentIntentId: paymentIntentId, status: "Paid" },
-                        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-                        include: { estimate: true },
-                    }))
-                    ?? (await prisma.estimatePaymentSchedule.findFirst({
-                        where: { stripePaymentIntentId: paymentIntentId },
-                        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-                        include: { estimate: true },
-                    }));
-
-                if (estSchedule) {
-                    let didReset = false;
-                    if (isFullyRefunded) {
-                        const outcome = await withTxRetry(() => prisma.$transaction(async (t) => {
-                            // Canonical Estimate → Invoice → schedules order. Lock the estimate
-                            // first so a concurrent settle on a sibling milestone can't have its
-                            // balanceDue effect lost to this recompute; the invoice-side mirror
-                            // (unwound below) is located and then locked in that same order.
-                            await lockMoneyParents(t, { estimateId: estSchedule.estimateId });
-                            let invoiceMirror = await findInvoiceMirrorOfEstimateSchedule(t, estSchedule);
-                            if (invoiceMirror) {
-                                await lockMoneyParents(t, { invoiceId: invoiceMirror.invoiceId });
-                                // The candidate was chosen BEFORE its Invoice row was locked, so
-                                // re-resolve under the lock and only keep it if it still resolves
-                                // to the same row. Anything else means the mirror group moved and
-                                // this refund should not touch it.
-                                const confirmed = await findInvoiceMirrorOfEstimateSchedule(t, estSchedule);
-                                invoiceMirror = confirmed && confirmed.id === invoiceMirror.id ? confirmed : null;
-                            }
-                            // Re-read the parent AFTER the lock — the outer query's snapshot of
-                            // totalAmount/status may be stale if a concurrent flow changed it.
-                            const estimate = await t.estimate.findUnique({ where: { id: estSchedule.estimateId } });
-                            if (estimate) {
-                                // CLAIMED reset — same reasoning as the invoice branch above.
-                                const reset = await t.estimatePaymentSchedule.updateMany({
-                                    where: { id: estSchedule.id, status: "Paid", stripePaymentIntentId: paymentIntentId },
-                                    data: { status: "Pending", paidAt: null, paymentDate: null },
-                                });
-                                if (reset.count === 0) return { claimed: false };
-                                const siblings = await t.estimatePaymentSchedule.findMany({
-                                    where: { estimateId: estSchedule.estimateId },
-                                });
-                                const totalPaid = siblings.filter(s => s.status === "Paid").reduce((sum, s) => sum + toNum(s.amount), 0);
-                                const newBalance = Math.max(0, toNum(estimate.totalAmount) - totalPaid);
-                                const newStatus =
-                                    totalPaid === 0 ? estimate.statusBeforePayment ?? "Approved"
-                                    : newBalance <= 0 ? "Paid"
-                                    : "Partially Paid";
-
-                                await t.estimate.update({
-                                    where: { id: estimate.id },
-                                    data: {
-                                        balanceDue: newBalance,
-                                        status: newStatus,
-                                        ...(totalPaid === 0 && { statusBeforePayment: null }),
-                                    },
-                                });
-                                // Unwind the invoice-side mirror too, or the invoice keeps
-                                // showing a milestone the estimate no longer counts as paid.
-                                if (invoiceMirror) {
-                                    await mirrorEstimateUnsettleToInvoice(t, invoiceMirror);
-                                }
-                                return { claimed: true };
-                            }
-                            return { claimed: false };
-                        }));
-                        didReset = outcome.claimed;
-                    }
-
-                    const refundSettings = await prisma.companySettings.findUnique({ where: { id: "singleton" } });
-                    if (refundSettings?.notificationEmail) {
-                        const summary = !isFullyRefunded
-                            ? `This is a <strong>partial refund</strong>. The schedule remains marked Paid; please reconcile manually.`
-                            : didReset
-                            ? `The schedule has been reset to Pending and the estimate balance restored.`
-                            : `This milestone was <strong>not</strong> reset automatically — it no longer matched this charge when the refund was processed. Please reconcile manually.`;
-                        await sendNotification(
-                            refundSettings.notificationEmail,
-                            `${isFullyRefunded ? "Refund Issued" : "Partial Refund Issued"}: Estimate ${estSchedule.estimate.code}`,
-                            `<div style="font-family: sans-serif; padding: 20px;">
-                                <h2>Refund Processed</h2>
-                                <p>Total refunded to date: <strong>${formatCurrency(refundedAmount)}</strong> of ${formatCurrency(chargeAmount)} on Estimate #${estSchedule.estimate.code} (milestone: ${estSchedule.name}).</p>
-                                <p>${summary}</p>
-                            </div>`
-                        );
-                    }
+                const refundSettings = await prisma.companySettings.findUnique({ where: { id: "singleton" } });
+                if (refundSettings?.notificationEmail) {
+                    const label = (rows: { name: string; parentCode: string | null }[]) =>
+                        rows.map((r) => `${r.parentCode ?? "(no code)"} — ${r.name}`);
+                    const found = [...label(group.invoiceSchedules), ...label(group.estimateSchedules)];
+                    const reset = [...label(unwound.invoiceSchedules), ...label(unwound.estimateSchedules)];
+                    // `charge.amount_refunded` is the CUMULATIVE refund total, so this message reflects
+                    // total-refunded-so-far, not this delivery's delta. We frame it that way explicitly.
+                    const summary = !isFullyRefunded
+                        ? `This is a <strong>partial refund</strong>. The milestones below remain marked Paid; please reconcile the balances manually in the Stripe dashboard.`
+                        : reset.length === found.length
+                        ? `All ${reset.length} milestone(s) recording this charge were reset to Pending and their balances restored.`
+                        : reset.length > 0
+                        ? `${reset.length} of ${found.length} milestone(s) were reset. The rest no longer matched this charge when the refund was processed — please reconcile them manually in the Stripe dashboard.`
+                        : `These milestones were <strong>not</strong> reset automatically — they no longer matched this charge when the refund was processed. Please reconcile the balances manually in the Stripe dashboard.`;
+                    const primaryCode = group.invoiceSchedules[0]?.parentCode
+                        ?? group.estimateSchedules[0]?.parentCode
+                        ?? paymentIntentId;
+                    await sendNotification(
+                        refundSettings.notificationEmail,
+                        `${isFullyRefunded ? "Refund Issued" : "Partial Refund Issued"}: ${primaryCode}`,
+                        `<div style="font-family: sans-serif; padding: 20px;">
+                            <h2>Refund Processed</h2>
+                            <p>Total refunded to date: <strong>${formatCurrency(refundedAmount)}</strong> of ${formatCurrency(chargeAmount)}.</p>
+                            <p>Milestones recording this charge:</p>
+                            <ul>${found.map((l) => `<li>${l}</li>`).join("")}</ul>
+                            <p>${summary}</p>
+                        </div>`
+                    );
                 }
                 break;
             }

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -268,36 +268,41 @@ export async function createInvoiceFromEstimateCore(estimateId: string) {
     });
 
     const invoiceCode = `INV-${String(invoice.number).padStart(5, "0")}`;
-    await prisma.invoice.update({ where: { id: invoice.id }, data: { code: invoiceCode } });
 
     // Clone the estimate's milestones into invoice-side PaymentSchedules. The
-    // source read + clone inserts run in ONE transaction that first takes the
-    // same Project row lock setProjectStartDate uses: a start-date move can
-    // then never slip between our read of the source dueDates and the clone
-    // inserts (which would leave the new clones on pre-shift dates while their
-    // EPS rows and the project's tasks moved -- a partially shifted mirror
-    // group). Lock order is parent-before-child (Project before its Estimate/
-    // Invoice children), matching the canonical money-lock direction in
-    // tx-retry.ts; withTxRetry covers residual serialization failures.
+    // source read, the clone inserts AND the resulting balance/status write run
+    // in ONE transaction that takes the same Project row lock setProjectStartDate
+    // uses: a start-date move can then never slip between our read of the source
+    // dueDates and the clone inserts (which would leave the new clones on
+    // pre-shift dates while their EPS rows and the project's tasks moved -- a
+    // partially shifted mirror group). withTxRetry covers residual serialization
+    // failures.
     // (Lock + scheduleTaskId propagation ported from c250526 during the
     // feat/company-pipeline-dashboard merge.)
-    const paidAmount = await withTxRetry(() => prisma.$transaction(async (tx) => {
-        // Lead-owned estimates (no projectId) need no lock -- start-date
-        // moves only target projects.
-        if (estimate.projectId) {
-            await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${estimate.projectId} FOR UPDATE`;
-        }
-        // Then the Estimate, keeping the Project -> Estimate -> Invoice
-        // direction (no site locks an Estimate before a Project). This clone
-        // copies each milestone's status AND its stripePaymentIntentId, so
-        // without it a conversion could insert a fresh Paid clone of a charge
-        // that a `charge.refunded` unwind had already resolved and was about to
-        // release -- the new clone would keep the refunded money and its
+    await withTxRetry(() => prisma.$transaction(async (tx) => {
+        // Estimate FIRST, then Project. This clone copies each milestone's
+        // status AND its stripePaymentIntentId, so without the Estimate lock a
+        // conversion could insert a fresh Paid clone of a charge that a
+        // `charge.refunded` unwind had already resolved and was about to
+        // release -- the new clone would keep the refunded money and leave its
         // invoice a zero balance. Sharing the lock forces the two to order:
         // convert-then-refund (the clone is seen and released) or
         // refund-then-convert (the milestone is already Pending when cloned).
         // See lib/refund-group.ts.
-        await lockMoneyParents(tx, { estimateId });
+        //
+        // The order is Estimate -> Project, NOT the reverse:
+        // restoreEstimateItemAssociations in actions.ts holds one transaction
+        // spanning PurchaseOrder -> Estimate -> EstimateItem -> Project, so
+        // taking Project first here would let that flow hold Estimate while
+        // waiting on Project and this one hold Project while waiting on
+        // Estimate (Codex round 2). Holding both across the read+insert is what
+        // the Project lock was for, and that is unchanged by the reorder.
+        await lockMoneyParents(tx, { estimateId, invoiceId: invoice.id });
+        // Lead-owned estimates (no projectId) need no Project lock -- start-date
+        // moves only target projects.
+        if (estimate.projectId) {
+            await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${estimate.projectId} FOR UPDATE`;
+        }
 
         const schedules = await tx.estimatePaymentSchedule.findMany({
             where: { estimateId },
@@ -339,18 +344,24 @@ export async function createInvoiceFromEstimateCore(estimateId: string) {
                 },
             });
         }
+        // The derived balance/status is written INSIDE this transaction, under
+        // the same Estimate+Invoice locks the clone inserts hold. It used to
+        // run after the commit, which let a `charge.refunded` unwind slip in
+        // between: the refund would reset the just-cloned Paid milestone and
+        // recompute the invoice to Issued, and this write would then overwrite
+        // it back to Paid/zero-balance from a paidAmount that was already
+        // stale. Rows Pending, invoice claiming nothing was owed (Codex
+        // round 2).
+        const newBalanceDue = Math.max(0, total - paidAmount);
+        const invoiceStatus = paidAmount > 0
+            ? (newBalanceDue <= 0 ? "Paid" : "Partially Paid")
+            : "Draft";
+        await tx.invoice.update({
+            where: { id: invoice.id },
+            data: { code: invoiceCode, balanceDue: newBalanceDue, status: invoiceStatus },
+        });
         return paidAmount;
     }));
-
-    const newBalanceDue = Math.max(0, total - paidAmount);
-    const invoiceStatus = paidAmount > 0
-        ? (newBalanceDue <= 0 ? "Paid" : "Partially Paid")
-        : "Draft";
-
-    await prisma.invoice.update({
-        where: { id: invoice.id },
-        data: { code: invoiceCode, balanceDue: newBalanceDue, status: invoiceStatus },
-    });
 
     revalidatePath(`/projects/${estimate.projectId}/invoices`);
     return { id: invoice.id, projectId: estimate.projectId };

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -287,6 +287,17 @@ export async function createInvoiceFromEstimateCore(estimateId: string) {
         if (estimate.projectId) {
             await tx.$queryRaw`SELECT id FROM "Project" WHERE id = ${estimate.projectId} FOR UPDATE`;
         }
+        // Then the Estimate, keeping the Project -> Estimate -> Invoice
+        // direction (no site locks an Estimate before a Project). This clone
+        // copies each milestone's status AND its stripePaymentIntentId, so
+        // without it a conversion could insert a fresh Paid clone of a charge
+        // that a `charge.refunded` unwind had already resolved and was about to
+        // release -- the new clone would keep the refunded money and its
+        // invoice a zero balance. Sharing the lock forces the two to order:
+        // convert-then-refund (the clone is seen and released) or
+        // refund-then-convert (the milestone is already Pending when cloned).
+        // See lib/refund-group.ts.
+        await lockMoneyParents(tx, { estimateId });
 
         const schedules = await tx.estimatePaymentSchedule.findMany({
             where: { estimateId },

--- a/src/lib/billing-core.ts
+++ b/src/lib/billing-core.ts
@@ -267,7 +267,14 @@ export async function createInvoiceFromEstimateCore(estimateId: string) {
         },
     });
 
+    // Named immediately, outside the clone transaction. Folding this into that
+    // transaction briefly made a retryable or terminal failure leave the
+    // already-visible invoice reading "INV-TEMP", which
+    // createInvoiceFromEstimateGuarded would later mistake for a finished
+    // conversion (Codex round 3). The orphan-invoice failure mode is
+    // pre-existing; this keeps it no worse than it was.
     const invoiceCode = `INV-${String(invoice.number).padStart(5, "0")}`;
+    await prisma.invoice.update({ where: { id: invoice.id }, data: { code: invoiceCode } });
 
     // Clone the estimate's milestones into invoice-side PaymentSchedules. The
     // source read, the clone inserts AND the resulting balance/status write run
@@ -297,7 +304,17 @@ export async function createInvoiceFromEstimateCore(estimateId: string) {
         // waiting on Project and this one hold Project while waiting on
         // Estimate (Codex round 2). Holding both across the read+insert is what
         // the Project lock was for, and that is unchanged by the reorder.
-        await lockMoneyParents(tx, { estimateId, invoiceId: invoice.id });
+        //
+        // The INVOICE is deliberately not locked here. It was, briefly, and that
+        // put Invoice before Project -- which deadlocks against deleteProjects,
+        // whose `onDelete: Cascade` locks Project and then its Invoice children
+        // (and which is not retry-wrapped; Codex round 3). It buys nothing
+        // either: this invoice was created moments ago and the only way another
+        // flow can reach it is through a clone, and clones are inserted under
+        // the Estimate lock. The implicit row lock from the update below lands
+        // after Project, giving Estimate -> Project -> Invoice, which agrees
+        // with deleteProjects' Project -> Invoice.
+        await lockMoneyParents(tx, { estimateId });
         // Lead-owned estimates (no projectId) need no Project lock -- start-date
         // moves only target projects.
         if (estimate.projectId) {
@@ -358,7 +375,7 @@ export async function createInvoiceFromEstimateCore(estimateId: string) {
             : "Draft";
         await tx.invoice.update({
             where: { id: invoice.id },
-            data: { code: invoiceCode, balanceDue: newBalanceDue, status: invoiceStatus },
+            data: { balanceDue: newBalanceDue, status: invoiceStatus },
         });
         return paidAmount;
     }));

--- a/src/lib/payment-mirror.ts
+++ b/src/lib/payment-mirror.ts
@@ -17,6 +17,14 @@ import { toNum } from "@/lib/prisma-helpers";
  * already taken the canonical Estimate → Invoice row locks (`lockMoneyParents`).
  * They only touch the MIRROR side and its parent aggregate — the caller still
  * owns the primary side it settled.
+ *
+ * UNSETTLING is not here. It used to be — a matching set of one-row unwind
+ * helpers keyed off `sourceScheduleId` plus the PaymentIntent. But that link
+ * identifies a mirror GROUP rather than a row (invoice conversion clones a paid
+ * estimate milestone, intent and all), so a per-row unwind could only ever fix
+ * one member of a refunded charge and had to bail out as "ambiguous" whenever
+ * there were several. Refunds now unwind the whole charge group at once — see
+ * `refund-group.ts`.
  */
 
 type Tx = Prisma.TransactionClient;
@@ -26,7 +34,6 @@ type ScheduleRef = {
     name: string;
     amount: unknown;
     sourceScheduleId?: string | null;
-    stripePaymentIntentId?: string | null;
 };
 
 export type MirrorSettleData = {
@@ -39,28 +46,20 @@ export type MirrorSettleData = {
 };
 
 /**
- * Locate the estimate-side original of an invoice milestone. Link-first via
- * `sourceScheduleId`; a name+amount match is accepted only when EXACTLY one
- * unpaid/paid candidate exists, which is the same pre-link legacy fallback the
- * manual and QuickBooks rails use.
+ * Locate the UNPAID estimate-side original of an invoice milestone that was just
+ * paid. Link-first via `sourceScheduleId`; a name+amount match is accepted only
+ * when EXACTLY one unpaid candidate exists, which is the same pre-link legacy
+ * fallback the manual and QuickBooks rails use.
  */
-async function findEstimateMirror(
+async function findUnpaidEstimateMirror(
     tx: Tx,
     estimateId: string,
     payment: ScheduleRef,
-    wantStatus: "Paid" | "Unpaid",
 ): Promise<{ id: string } | null> {
-    const statusFilter = wantStatus === "Paid" ? { status: "Paid" } : { status: { not: "Paid" } };
-    // Unsettling additionally requires the mirror to belong to the SAME charge:
-    // a row settled through some other intent must never be released by this
-    // refund. A null intent is accepted because manual and legacy settlements
-    // carry none.
-    const intentFilter = wantStatus === "Paid" && payment.stripePaymentIntentId
-        ? { OR: [{ stripePaymentIntentId: payment.stripePaymentIntentId }, { stripePaymentIntentId: null }] }
-        : {};
+    const statusFilter = { status: { not: "Paid" } };
     if (payment.sourceScheduleId) {
         return await tx.estimatePaymentSchedule.findFirst({
-            where: { id: payment.sourceScheduleId, estimateId, ...statusFilter, ...intentFilter },
+            where: { id: payment.sourceScheduleId, estimateId, ...statusFilter },
             select: { id: true },
         });
     }
@@ -69,7 +68,7 @@ async function findEstimateMirror(
     // and make a genuinely ambiguous fallback look unique. Milestone counts are
     // small (tens per estimate), so the unbounded read is cheap.
     const candidates = await tx.estimatePaymentSchedule.findMany({
-        where: { estimateId, name: payment.name, ...statusFilter, ...intentFilter },
+        where: { estimateId, name: payment.name, ...statusFilter },
     });
     const matching = candidates.filter((c) => toNum(c.amount) === toNum(payment.amount));
     return matching.length === 1 ? { id: matching[0].id } : null;
@@ -80,8 +79,15 @@ async function findEstimateMirror(
  * decides what the estimate reverts to once nothing is paid: `"restore"` puts
  * back the captured pre-payment status (unsettle), `"keep"` leaves the current
  * status alone (settle, where a zero total means nothing changed).
+ *
+ * The `statusBeforePayment ?? …` fallback only fires for legacy rows settled
+ * before that column was captured. It is derived rather than hard-coded because
+ * the two refund rails disagreed on it: the mirror path always ran on an
+ * estimate that had an invoice and fell back to "Invoiced", while the
+ * estimate-side webhook branch could run on an un-invoiced estimate and fell
+ * back to "Approved". Asking whether an invoice exists reproduces both.
  */
-async function recomputeEstimate(tx: Tx, estimateId: string, zeroPaid: "restore" | "keep"): Promise<void> {
+export async function recomputeEstimate(tx: Tx, estimateId: string, zeroPaid: "restore" | "keep"): Promise<void> {
     const estimate = await tx.estimate.findUnique({ where: { id: estimateId } });
     if (!estimate) return;
     const siblings = await tx.estimatePaymentSchedule.findMany({ where: { estimateId } });
@@ -91,8 +97,11 @@ async function recomputeEstimate(tx: Tx, estimateId: string, zeroPaid: "restore"
     const balance = Math.max(0, toNum(estimate.totalAmount) - paid);
     // Captured so a later unsettle can restore the pre-payment status.
     const capturePriorStatus = paid > 0 && !["Paid", "Partially Paid"].includes(estimate.status);
+    const restoredStatus = paid === 0 && zeroPaid === "restore" && !estimate.statusBeforePayment
+        ? ((await tx.invoice.count({ where: { estimateId } })) > 0 ? "Invoiced" : "Approved")
+        : null;
     const status = paid === 0
-        ? (zeroPaid === "restore" ? estimate.statusBeforePayment ?? "Invoiced" : estimate.status)
+        ? (zeroPaid === "restore" ? estimate.statusBeforePayment ?? restoredStatus! : estimate.status)
         : balance <= 0 ? "Paid"
         : "Partially Paid";
     await tx.estimate.update({
@@ -107,7 +116,7 @@ async function recomputeEstimate(tx: Tx, estimateId: string, zeroPaid: "restore"
 }
 
 /** Recompute an invoice's balance/status from its own milestones. */
-async function recomputeInvoice(tx: Tx, invoiceId: string): Promise<void> {
+export async function recomputeInvoice(tx: Tx, invoiceId: string): Promise<void> {
     const invoice = await tx.invoice.findUnique({ where: { id: invoiceId } });
     if (!invoice) return;
     const siblings = await tx.paymentSchedule.findMany({ where: { invoiceId } });
@@ -133,7 +142,7 @@ export async function mirrorInvoiceSettleToEstimate(
     args: { estimateId: string | null | undefined; payment: ScheduleRef; data: MirrorSettleData },
 ): Promise<boolean> {
     if (!args.estimateId) return false;
-    const mirror = await findEstimateMirror(tx, args.estimateId, args.payment, "Unpaid");
+    const mirror = await findUnpaidEstimateMirror(tx, args.estimateId, args.payment);
     if (!mirror) return false;
     const claim = await tx.estimatePaymentSchedule.updateMany({
         where: { id: mirror.id, estimateId: args.estimateId, status: { not: "Paid" } },
@@ -152,88 +161,3 @@ export async function mirrorInvoiceSettleToEstimate(
     return true;
 }
 
-/**
- * Unsettle the estimate-side copy of an invoice milestone that was just fully
- * refunded, and recompute the estimate.
- */
-export async function mirrorInvoiceUnsettleToEstimate(
-    tx: Tx,
-    args: { estimateId: string | null | undefined; payment: ScheduleRef },
-): Promise<boolean> {
-    if (!args.estimateId) return false;
-    const mirror = await findEstimateMirror(tx, args.estimateId, args.payment, "Paid");
-    if (!mirror) return false;
-    const claim = await tx.estimatePaymentSchedule.updateMany({
-        where: { id: mirror.id, estimateId: args.estimateId, status: "Paid" },
-        // Deliberately leaves the Stripe ids in place, matching the primary
-        // refund reset. They are how a redelivered `charge.refunded` re-finds
-        // this row; clearing them would let a duplicate delivery land on a
-        // DIFFERENT clone sharing the same intent and unset a real payment.
-        // (That a Pending row still carrying an intent is refused by progress
-        // billing is a real, pre-existing gap — tracked separately, because
-        // fixing it means fixing the refund row-identity problem first.)
-        data: { status: "Pending", paidAt: null, paymentDate: null },
-    });
-    if (claim.count === 0) return false;
-    await recomputeEstimate(tx, args.estimateId, "restore");
-    return true;
-}
-
-/**
- * Find the invoice-side copy of an estimate milestone.
- *
- * `sourceScheduleId` identifies a mirror GROUP, not a single row — one estimate
- * milestone can have several invoice-side clones (progress billing clones them,
- * and `convertEstimateToInvoice` copies the whole schedule). So the link alone
- * is not enough to pick the row a specific charge settled. Order of preference:
- *
- *  1. The Paid clone carrying this charge's PaymentIntent — exact, when unique.
- *     (The intent is copied onto clones at creation, so it is NOT unique on its
- *     own; combining it with the link is what makes the match safe.)
- *  2. The Paid linked clone, but ONLY when exactly one exists.
- *
- * Anything ambiguous returns null and the mirror is left alone rather than
- * guessed at — a wrong unsettle would silently move a client-visible balance.
- */
-export async function findInvoiceMirrorOfEstimateSchedule(
-    tx: Tx,
-    schedule: ScheduleRef,
-): Promise<{ id: string; invoiceId: string } | null> {
-    const linked = await tx.paymentSchedule.findMany({
-        where: { sourceScheduleId: schedule.id, status: "Paid" },
-        select: { id: true, invoiceId: true, stripePaymentIntentId: true },
-    });
-    if (schedule.stripePaymentIntentId) {
-        // Same-charge only. A clone carrying a DIFFERENT non-null intent was
-        // settled by another payment and must never be released by this refund,
-        // so it is excluded rather than accepted as a sole fallback.
-        const sameCharge = linked.filter((row) =>
-            row.stripePaymentIntentId === schedule.stripePaymentIntentId
-            || row.stripePaymentIntentId === null
-        );
-        const exact = sameCharge.filter((row) => row.stripePaymentIntentId === schedule.stripePaymentIntentId);
-        if (exact.length === 1) return { id: exact[0].id, invoiceId: exact[0].invoiceId };
-        if (exact.length > 1) return null;
-        return sameCharge.length === 1 ? { id: sameCharge[0].id, invoiceId: sameCharge[0].invoiceId } : null;
-    }
-    return linked.length === 1 ? { id: linked[0].id, invoiceId: linked[0].invoiceId } : null;
-}
-
-/**
- * Unsettle a located invoice-side mirror and recompute its invoice. The caller
- * must already hold the Invoice row lock (canonical Estimate → Invoice order).
- */
-export async function mirrorEstimateUnsettleToInvoice(
-    tx: Tx,
-    mirror: { id: string; invoiceId: string },
-): Promise<boolean> {
-    const claim = await tx.paymentSchedule.updateMany({
-        where: { id: mirror.id, invoiceId: mirror.invoiceId, status: "Paid" },
-        // Stripe ids left in place for the same reason as the estimate-side
-        // unsettle above.
-        data: { status: "Pending", paidAt: null, paymentDate: null },
-    });
-    if (claim.count === 0) return false;
-    await recomputeInvoice(tx, mirror.invoiceId);
-    return true;
-}

--- a/src/lib/refund-group.ts
+++ b/src/lib/refund-group.ts
@@ -34,20 +34,28 @@ import { toNum } from "@/lib/prisma-helpers";
  * silently reopen all of those. Making the refund group-complete fixes the bug
  * without touching what any of them see.
  *
- * ── Why a NULL intent is not a match ────────────────────────────────────────
+ * ── Why a NULL intent is never a match ──────────────────────────────────────
  *
  * Manual, QuickBooks and pre-mirror legacy settlements leave the column null,
  * so a Paid mirror partner carrying no intent MIGHT be the same money. But it
  * might equally be a genuinely separate payment: once the estimate milestone is
- * Paid, a mirror claim on it fails, so a second invoice clone settled by cheque
- * also ends up Paid with a null intent. Releasing that on a refund of X would
- * raise a balance the client has already paid — the exact class of error this
- * module exists to prevent (Codex round 1).
+ * Paid, a mirror claim on it fails, so an invoice clone settled by cheque also
+ * ends up Paid with a null intent. Releasing that on a refund of X would raise
+ * a balance the client has already paid — the exact class of error this module
+ * exists to prevent.
  *
- * So a null-intent partner is adopted ONLY where the mirror is genuinely 1:1
- * (the estimate milestone has exactly one Paid clone). In a one-to-many group
- * it cannot be attributed to a charge, so it is left alone and reported to the
- * office instead of guessed at.
+ * A first attempt adopted such a partner where the mirror was 1:1, on the
+ * theory that a single clone leaves nothing to confuse it with. That is wrong:
+ * cardinality is not payment identity, and a lone cheque-paid mirror is
+ * indistinguishable from a lone legacy Stripe mirror (Codex round 2). Nothing
+ * on these rows records WHICH payment a null-intent settlement was, so there is
+ * no honest way to decide.
+ *
+ * So: only rows carrying the intent are released. Paid mirror partners with no
+ * intent are collected as `unattributable` — never written, always reported —
+ * so a human resolves them instead of the code guessing. The cost is that a
+ * genuinely legacy 1:1 mirror is no longer auto-unwound; the office is told
+ * about it by name in the refund email, which is the honest trade.
  */
 
 /** Anything with the schedule delegates — the client or a transaction client. */
@@ -66,9 +74,9 @@ export type ChargeGroup = {
     estimateSchedules: ChargeGroupRow[];
     invoiceSchedules: ChargeGroupRow[];
     /**
-     * Paid mirror partners carrying no intent that sit in a one-to-many group,
-     * so they cannot be attributed to this charge. Never touched; surfaced so
-     * the office can reconcile them by hand.
+     * Paid mirror partners carrying no PaymentIntent. They may or may not
+     * record this charge and nothing on the row says which, so they are never
+     * touched — only surfaced, so the office can reconcile them by hand.
      */
     unattributable: ChargeGroupRow[];
     estimateIds: string[];
@@ -113,66 +121,61 @@ export async function resolveChargeGroup(db: Db, paymentIntentId: string): Promi
         select: INV_SELECT,
     });
 
-    const adoptedEst: ChargeGroupRow[] = [];
-    const adoptedInv: ChargeGroupRow[] = [];
+    // Nothing below is ever released. These are the Paid mirror partners that
+    // carry no PaymentIntent — possibly this charge, possibly a cheque — which
+    // the office is asked to resolve by hand.
     const unattributable: ChargeGroupRow[] = [];
 
-    // ── estimate → invoice ──────────────────────────────────────────────────
-    // A Paid clone with a null intent is this charge's mirror only when it is
-    // the milestone's ONLY Paid clone.
-    for (const est of directEst) {
+    // ── estimate → invoice: null-intent clones of a released milestone ──────
+    if (directEst.length > 0) {
         const clones = await db.paymentSchedule.findMany({
-            where: { sourceScheduleId: est.id, status: "Paid" },
+            where: {
+                sourceScheduleId: { in: directEst.map((r) => r.id) },
+                status: "Paid",
+                stripePaymentIntentId: null,
+            },
             select: INV_SELECT,
         });
-        const nulls = clones.filter((c) => c.stripePaymentIntentId === null);
-        if (nulls.length === 0) continue;
-        if (clones.length === 1) adoptedInv.push(invRow(nulls[0]));
-        else unattributable.push(...nulls.map(invRow));
+        unattributable.push(...clones.map(invRow));
     }
 
-    // ── invoice → estimate ──────────────────────────────────────────────────
+    // ── invoice → estimate: null-intent originals of a released clone ───────
+    const sourceIds = directInv.map((r) => r.sourceScheduleId).filter((id): id is string => !!id);
+    if (sourceIds.length > 0) {
+        const sources = await db.estimatePaymentSchedule.findMany({
+            where: { id: { in: sourceIds }, status: "Paid", stripePaymentIntentId: null },
+            select: EST_SELECT,
+        });
+        unattributable.push(...sources.map(estRow));
+    }
+
+    // ── pre-link legacy rows: no `sourceScheduleId` to follow ───────────────
+    // Same name+amount shape the removed per-row helper matched on, but used
+    // only to NAME a candidate for the office. Every plausible candidate is
+    // reported, including an ambiguous set — dropping those silently would let
+    // the invoice reset while its estimate quietly kept the money (round 2).
     for (const inv of directInv) {
-        if (inv.sourceScheduleId) {
-            const source = await db.estimatePaymentSchedule.findFirst({
-                where: { id: inv.sourceScheduleId, status: "Paid", stripePaymentIntentId: null },
-                select: EST_SELECT,
-            });
-            if (!source) continue;
-            // Same 1:1 test from the estimate's side: if the milestone has other
-            // Paid clones, this null-intent original cannot be attributed.
-            const paidClones = await db.paymentSchedule.count({
-                where: { sourceScheduleId: source.id, status: "Paid" },
-            });
-            if (paidClones === 1) adoptedEst.push(estRow(source));
-            else unattributable.push(estRow(source));
-            continue;
-        }
-        // Pre-link legacy row: no `sourceScheduleId`, so fall back to the same
-        // name+amount uniqueness rule the removed per-row unsettle helper used.
-        // A 1:1 legacy pair has no second clone to confuse it with.
+        if (inv.sourceScheduleId) continue;
         const estimateId = inv.invoice?.estimateId;
         if (!estimateId) continue;
         const candidates = await db.estimatePaymentSchedule.findMany({
-            where: {
-                estimateId, name: inv.name, status: "Paid",
-                OR: [{ stripePaymentIntentId: paymentIntentId }, { stripePaymentIntentId: null }],
-            },
+            where: { estimateId, name: inv.name, status: "Paid", stripePaymentIntentId: null },
             select: EST_SELECT,
         });
-        const matching = candidates.filter((c) => toNum(c.amount) === toNum(inv.amount));
-        if (matching.length === 1) adoptedEst.push(estRow(matching[0]));
+        unattributable.push(
+            ...candidates.filter((c) => toNum(c.amount) === toNum(inv.amount)).map(estRow),
+        );
     }
 
-    const estimateSchedules = dedupeById([...directEst.map(estRow), ...adoptedEst]);
-    const invoiceSchedules = dedupeById([...directInv.map(invRow), ...adoptedInv]);
+    const estimateSchedules = dedupeById(directEst.map(estRow));
+    const invoiceSchedules = dedupeById(directInv.map(invRow));
+    // A row carrying the intent is released, so it can never also be reported
+    // as unresolved by one of the link paths above.
     const claimed = new Set([...estimateSchedules, ...invoiceSchedules].map((r) => r.id));
 
     return {
         estimateSchedules,
         invoiceSchedules,
-        // A row adopted via one path must never also be reported as unresolved
-        // via another.
         unattributable: dedupeById(unattributable).filter((r) => !claimed.has(r.id)),
         estimateIds: distinct(estimateSchedules.map((r) => r.parentId)),
         invoiceIds: distinct(invoiceSchedules.map((r) => r.parentId)),
@@ -184,11 +187,14 @@ export type UnwindResult = {
     invoiceSchedules: ChargeGroupRow[];
     unattributable: ChargeGroupRow[];
     /**
-     * True when the group was already empty under the locks — an earlier
-     * delivery of the same refund had done the work. Distinguishes "nothing to
-     * do" from "we tried and failed", which the office email must not conflate.
+     * True when nothing recording this charge was still Paid once the locks
+     * were held. That is all it means: usually a redelivery of the same refund,
+     * but a staff `unrecordPayment` winning the locks first looks identical, so
+     * the office wording must not credit an earlier refund delivery for it
+     * (Codex round 2). It exists to separate "there was nothing left to do"
+     * from "we tried and could not".
      */
-    alreadyUnwound: boolean;
+    nothingLeftPaid: boolean;
 };
 
 /**
@@ -202,47 +208,30 @@ export type UnwindResult = {
  * Re-running on an already-unwound group is a no-op, because the group only
  * ever contains Paid rows.
  *
- * The resets are two batched `updateMany` calls rather than one per row: the
- * whole unwind shares a single transaction with a bounded timeout, and a wide
- * mirror group would otherwise put a hundred-odd sequential statements inside
- * it.
+ * Each side resets in ONE statement rather than one per row: the whole unwind
+ * shares a single transaction with a bounded timeout, and a wide mirror group
+ * would otherwise put a hundred-odd sequential statements inside it.
+ *
+ * The statements are raw so they can use `RETURNING id`, which reports exactly
+ * the rows THIS update changed. An `updateMany` count plus a re-read cannot:
+ * a row another writer had already moved off Paid reads back as not-Paid and
+ * would be counted as reset by us (Codex round 2).
  */
-export async function unwindChargeGroup(tx: Db, group: ChargeGroup): Promise<Omit<UnwindResult, "alreadyUnwound">> {
-    const estIds = group.estimateSchedules.map((r) => r.id);
-    const invIds = group.invoiceSchedules.map((r) => r.id);
+export async function unwindChargeGroup(tx: Db, group: ChargeGroup): Promise<Omit<UnwindResult, "nothingLeftPaid">> {
+    const resetRows = async (table: "EstimatePaymentSchedule" | "PaymentSchedule", ids: string[]) => {
+        if (ids.length === 0) return new Set<string>();
+        const rows = await tx.$queryRaw<{ id: string }[]>`
+            UPDATE ${Prisma.raw(`"${table}"`)}
+               SET "status" = 'Pending', "paidAt" = NULL, "paymentDate" = NULL
+             WHERE "id" = ANY(${ids}) AND "status" = 'Paid'
+         RETURNING "id"`;
+        return new Set(rows.map((r) => r.id));
+    };
 
-    let estimateSchedules = group.estimateSchedules;
-    if (estIds.length > 0) {
-        const reset = await tx.estimatePaymentSchedule.updateMany({
-            where: { id: { in: estIds }, status: "Paid" },
-            data: { status: "Pending", paidAt: null, paymentDate: null },
-        });
-        // The group was resolved under the parent locks, so every member should
-        // still be Paid. Re-read only if something slipped past a writer that
-        // does not take those locks, so the report never over-claims.
-        if (reset.count !== estIds.length) {
-            const still = await tx.estimatePaymentSchedule.findMany({
-                where: { id: { in: estIds }, status: "Paid" }, select: { id: true },
-            });
-            const stuck = new Set(still.map((r) => r.id));
-            estimateSchedules = estimateSchedules.filter((r) => !stuck.has(r.id));
-        }
-    }
-
-    let invoiceSchedules = group.invoiceSchedules;
-    if (invIds.length > 0) {
-        const reset = await tx.paymentSchedule.updateMany({
-            where: { id: { in: invIds }, status: "Paid" },
-            data: { status: "Pending", paidAt: null, paymentDate: null },
-        });
-        if (reset.count !== invIds.length) {
-            const still = await tx.paymentSchedule.findMany({
-                where: { id: { in: invIds }, status: "Paid" }, select: { id: true },
-            });
-            const stuck = new Set(still.map((r) => r.id));
-            invoiceSchedules = invoiceSchedules.filter((r) => !stuck.has(r.id));
-        }
-    }
+    const estDone = await resetRows("EstimatePaymentSchedule", group.estimateSchedules.map((r) => r.id));
+    const invDone = await resetRows("PaymentSchedule", group.invoiceSchedules.map((r) => r.id));
+    const estimateSchedules = group.estimateSchedules.filter((r) => estDone.has(r.id));
+    const invoiceSchedules = group.invoiceSchedules.filter((r) => invDone.has(r.id));
 
     // Recompute only the parents that actually lost a payment.
     for (const estimateId of distinct(estimateSchedules.map((r) => r.parentId))) {
@@ -300,7 +289,11 @@ export async function unwindRefundedCharge(
             const unwound = await unwindChargeGroup(tx, group);
             return {
                 missingParents: null,
-                result: { ...unwound, alreadyUnwound: chargeGroupIsEmpty(group) },
+                result: {
+                    ...unwound,
+                    nothingLeftPaid: group.estimateSchedules.length === 0
+                        && group.invoiceSchedules.length === 0,
+                },
             };
         // Locks, two batched resets and a recompute per parent. The 5s default
         // is tight once a wide group also has to wait on a busy Invoice lock,

--- a/src/lib/refund-group.ts
+++ b/src/lib/refund-group.ts
@@ -126,27 +126,33 @@ export async function resolveChargeGroup(db: Db, paymentIntentId: string): Promi
     // the office is asked to resolve by hand.
     const unattributable: ChargeGroupRow[] = [];
 
-    // ── estimate → invoice: null-intent clones of a released milestone ──────
-    if (directEst.length > 0) {
+    // ── invoice → estimate: null-intent originals of a released clone ───────
+    const sourceIds = directInv.map((r) => r.sourceScheduleId).filter((id): id is string => !!id);
+    const nullSources = sourceIds.length > 0
+        ? await db.estimatePaymentSchedule.findMany({
+            where: { id: { in: sourceIds }, status: "Paid", stripePaymentIntentId: null },
+            select: EST_SELECT,
+        })
+        : [];
+    unattributable.push(...nullSources.map(estRow));
+
+    // ── estimate → invoice: null-intent clones of a milestone in the group ──
+    // The source set is the released milestones PLUS the null-intent originals
+    // just found. Walking only the released ones missed the shape where the
+    // estimate row carries no intent: E(null) with clones A(intent X) and
+    // B(null) reports E but never reached B, so a Paid mirror went unmentioned
+    // in a report that claims to name them all (Codex round 3).
+    const mirrorSourceIds = distinct([...directEst.map((r) => r.id), ...nullSources.map((r) => r.id)]);
+    if (mirrorSourceIds.length > 0) {
         const clones = await db.paymentSchedule.findMany({
             where: {
-                sourceScheduleId: { in: directEst.map((r) => r.id) },
+                sourceScheduleId: { in: mirrorSourceIds },
                 status: "Paid",
                 stripePaymentIntentId: null,
             },
             select: INV_SELECT,
         });
         unattributable.push(...clones.map(invRow));
-    }
-
-    // ── invoice → estimate: null-intent originals of a released clone ───────
-    const sourceIds = directInv.map((r) => r.sourceScheduleId).filter((id): id is string => !!id);
-    if (sourceIds.length > 0) {
-        const sources = await db.estimatePaymentSchedule.findMany({
-            where: { id: { in: sourceIds }, status: "Paid", stripePaymentIntentId: null },
-            select: EST_SELECT,
-        });
-        unattributable.push(...sources.map(estRow));
     }
 
     // ── pre-link legacy rows: no `sourceScheduleId` to follow ───────────────

--- a/src/lib/refund-group.ts
+++ b/src/lib/refund-group.ts
@@ -1,0 +1,217 @@
+import { Prisma, PrismaClient } from "@prisma/client";
+import { withTxRetry, lockMoneyParentsMany } from "@/lib/tx-retry";
+import { recomputeEstimate, recomputeInvoice } from "@/lib/payment-mirror";
+
+/**
+ * Row identity for refunds.
+ *
+ * `stripePaymentIntentId` is NOT unique on either schedule table. One Stripe
+ * charge can be recorded on many rows:
+ *
+ *  - `convertEstimateToInvoice` (billing-core.ts) copies the intent onto every
+ *    invoice-side clone it makes of an already-paid estimate milestone, and an
+ *    estimate can be converted more than once;
+ *  - the estimate-side original keeps the intent as well;
+ *  - `mirrorInvoiceSettleToEstimate` writes the intent onto the mirror it
+ *    settles.
+ *
+ * The old `charge.refunded` handler picked ONE of those rows and unwound it.
+ * PR #371 made that pick deterministic, but deterministic is not correct: the
+ * other Paid rows kept showing money the client no longer has, and their
+ * parents kept a wrong balanceDue.
+ *
+ * The fix here is to treat the charge, not the row, as the unit of a refund. A
+ * row carrying intent X exists only because charge X settled it (nothing else
+ * ever writes that column), so a FULL refund of X must release every such row
+ * and recompute every document that holds one.
+ *
+ * We deliberately do NOT stop copying the intent onto clones. Several callers
+ * read it as "this row records a Stripe payment" rather than as an identity —
+ * the in-flight/settled guards in `billing-core.ts` and `progress-billing.ts`,
+ * the schedule-delete guard in `actions.ts`, and the `hasStripeIntent` undo
+ * affordance in the estimate/invoice editors. Dropping it from clones would
+ * silently reopen all of those. Making the refund group-complete fixes the bug
+ * without touching what any of them see.
+ */
+
+/** Anything with the two schedule delegates — the client or a transaction client. */
+type Db = Prisma.TransactionClient;
+
+export type ChargeGroupRow = {
+    id: string;
+    name: string;
+    /** Estimate id for estimate schedules, Invoice id for invoice schedules. */
+    parentId: string;
+    parentCode: string | null;
+};
+
+export type ChargeGroup = {
+    estimateSchedules: ChargeGroupRow[];
+    invoiceSchedules: ChargeGroupRow[];
+    estimateIds: string[];
+    invoiceIds: string[];
+};
+
+const distinct = (ids: string[]): string[] => [...new Set(ids)].sort();
+
+export const chargeGroupIsEmpty = (group: ChargeGroup): boolean =>
+    group.estimateSchedules.length === 0 && group.invoiceSchedules.length === 0;
+
+/**
+ * Every Paid milestone row that records `paymentIntentId`, on both sides.
+ *
+ * Direct match is the intent column itself. On top of that we follow the
+ * `sourceScheduleId` mirror link to Paid partners that carry NO intent: manual
+ * and pre-mirror legacy settlements leave the column null, and
+ * `findEstimateMirror` in payment-mirror.ts already treats a null-intent linked
+ * partner as the same payment when it unsettles. A partner carrying a
+ * DIFFERENT non-null intent was settled by another charge and is never
+ * included.
+ */
+export async function resolveChargeGroup(db: Db, paymentIntentId: string): Promise<ChargeGroup> {
+    const estRows = await db.estimatePaymentSchedule.findMany({
+        where: { stripePaymentIntentId: paymentIntentId, status: "Paid" },
+        select: { id: true, name: true, estimateId: true, estimate: { select: { code: true } } },
+    });
+    const invRows = await db.paymentSchedule.findMany({
+        where: { stripePaymentIntentId: paymentIntentId, status: "Paid" },
+        select: {
+            id: true, name: true, invoiceId: true, sourceScheduleId: true,
+            invoice: { select: { code: true } },
+        },
+    });
+
+    // Link expansion, one hop in each direction. One hop is enough: a partner
+    // reached this way is Paid with a null intent, so it can only lead back to
+    // rows already in the direct sets.
+    const linkedInv = estRows.length
+        ? await db.paymentSchedule.findMany({
+            where: {
+                sourceScheduleId: { in: estRows.map((r) => r.id) },
+                status: "Paid",
+                stripePaymentIntentId: null,
+            },
+            select: { id: true, name: true, invoiceId: true, invoice: { select: { code: true } } },
+        })
+        : [];
+    const sourceIds = invRows.map((r) => r.sourceScheduleId).filter((id): id is string => !!id);
+    const linkedEst = sourceIds.length
+        ? await db.estimatePaymentSchedule.findMany({
+            where: { id: { in: sourceIds }, status: "Paid", stripePaymentIntentId: null },
+            select: { id: true, name: true, estimateId: true, estimate: { select: { code: true } } },
+        })
+        : [];
+
+    const estimateSchedules = dedupeById([...estRows, ...linkedEst].map((r) => ({
+        id: r.id, name: r.name, parentId: r.estimateId, parentCode: r.estimate?.code ?? null,
+    })));
+    const invoiceSchedules = dedupeById([...invRows, ...linkedInv].map((r) => ({
+        id: r.id, name: r.name, parentId: r.invoiceId, parentCode: r.invoice?.code ?? null,
+    })));
+
+    return {
+        estimateSchedules,
+        invoiceSchedules,
+        estimateIds: distinct(estimateSchedules.map((r) => r.parentId)),
+        invoiceIds: distinct(invoiceSchedules.map((r) => r.parentId)),
+    };
+}
+
+function dedupeById(rows: ChargeGroupRow[]): ChargeGroupRow[] {
+    const byId = new Map<string, ChargeGroupRow>();
+    for (const row of rows) if (!byId.has(row.id)) byId.set(row.id, row);
+    return [...byId.values()].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+}
+
+export type UnwindResult = {
+    estimateSchedules: ChargeGroupRow[];
+    invoiceSchedules: ChargeGroupRow[];
+};
+
+/**
+ * Release every member of a resolved group and recompute each affected parent.
+ * Must run inside a transaction that already holds all of the group's parent
+ * locks (`lockMoneyParentsMany`) — `unwindRefundedCharge` below is the wrapper
+ * that guarantees that.
+ *
+ * The Stripe ids stay on the released rows, matching the single-row reset this
+ * replaces: they are how a redelivered `charge.refunded` re-finds the group.
+ * Re-running on an already-unwound group is a no-op, because the group only
+ * ever contains Paid rows.
+ */
+export async function unwindChargeGroup(tx: Db, group: ChargeGroup): Promise<UnwindResult> {
+    const estimateSchedules: ChargeGroupRow[] = [];
+    for (const row of group.estimateSchedules) {
+        const reset = await tx.estimatePaymentSchedule.updateMany({
+            where: { id: row.id, status: "Paid" },
+            data: { status: "Pending", paidAt: null, paymentDate: null },
+        });
+        if (reset.count > 0) estimateSchedules.push(row);
+    }
+    const invoiceSchedules: ChargeGroupRow[] = [];
+    for (const row of group.invoiceSchedules) {
+        const reset = await tx.paymentSchedule.updateMany({
+            where: { id: row.id, status: "Paid" },
+            data: { status: "Pending", paidAt: null, paymentDate: null },
+        });
+        if (reset.count > 0) invoiceSchedules.push(row);
+    }
+
+    // Recompute only the parents that actually lost a payment.
+    for (const estimateId of distinct(estimateSchedules.map((r) => r.parentId))) {
+        await recomputeEstimate(tx, estimateId, "restore");
+    }
+    for (const invoiceId of distinct(invoiceSchedules.map((r) => r.parentId))) {
+        await recomputeInvoice(tx, invoiceId);
+    }
+    return { estimateSchedules, invoiceSchedules };
+}
+
+/**
+ * Unwind a fully-refunded charge across every document that recorded it.
+ *
+ * The group has to be resolved before its parents can be locked, so it is
+ * re-resolved UNDER the locks and compared: if a concurrent conversion or
+ * backfill added a member on a document we don't hold, nothing is written and
+ * the whole transaction re-runs with that document added to the lock set. The
+ * lock set only ever grows, so this converges; the attempt cap is a backstop
+ * against a pathological writer, and exhausting it raises rather than doing a
+ * partial unwind.
+ */
+export async function unwindRefundedCharge(
+    db: PrismaClient,
+    paymentIntentId: string,
+    attempts = 4,
+): Promise<UnwindResult> {
+    const seed = await resolveChargeGroup(db, paymentIntentId);
+    const estimateIds = new Set(seed.estimateIds);
+    const invoiceIds = new Set(seed.invoiceIds);
+
+    for (let attempt = 0; attempt < attempts; attempt++) {
+        const outcome: {
+            missingParents: { estimateIds: string[]; invoiceIds: string[] } | null;
+            result: UnwindResult | null;
+        } = await withTxRetry(() => db.$transaction(async (tx) => {
+            await lockMoneyParentsMany(tx, {
+                estimateIds: [...estimateIds],
+                invoiceIds: [...invoiceIds],
+            });
+            const group = await resolveChargeGroup(tx, paymentIntentId);
+            const missingParents = {
+                estimateIds: group.estimateIds.filter((id) => !estimateIds.has(id)),
+                invoiceIds: group.invoiceIds.filter((id) => !invoiceIds.has(id)),
+            };
+            if (missingParents.estimateIds.length > 0 || missingParents.invoiceIds.length > 0) {
+                return { missingParents, result: null };
+            }
+            return { missingParents: null, result: await unwindChargeGroup(tx, group) };
+        }));
+        if (outcome.result) return outcome.result;
+        outcome.missingParents?.estimateIds.forEach((id) => estimateIds.add(id));
+        outcome.missingParents?.invoiceIds.forEach((id) => invoiceIds.add(id));
+    }
+
+    throw new Error(
+        `Refund group for ${paymentIntentId} kept growing under lock after ${attempts} attempts — nothing was unwound.`,
+    );
+}

--- a/src/lib/refund-group.ts
+++ b/src/lib/refund-group.ts
@@ -1,6 +1,7 @@
 import { Prisma, PrismaClient } from "@prisma/client";
 import { withTxRetry, lockMoneyParentsMany } from "@/lib/tx-retry";
 import { recomputeEstimate, recomputeInvoice } from "@/lib/payment-mirror";
+import { toNum } from "@/lib/prisma-helpers";
 
 /**
  * Row identity for refunds.
@@ -32,9 +33,24 @@ import { recomputeEstimate, recomputeInvoice } from "@/lib/payment-mirror";
  * affordance in the estimate/invoice editors. Dropping it from clones would
  * silently reopen all of those. Making the refund group-complete fixes the bug
  * without touching what any of them see.
+ *
+ * ── Why a NULL intent is not a match ────────────────────────────────────────
+ *
+ * Manual, QuickBooks and pre-mirror legacy settlements leave the column null,
+ * so a Paid mirror partner carrying no intent MIGHT be the same money. But it
+ * might equally be a genuinely separate payment: once the estimate milestone is
+ * Paid, a mirror claim on it fails, so a second invoice clone settled by cheque
+ * also ends up Paid with a null intent. Releasing that on a refund of X would
+ * raise a balance the client has already paid — the exact class of error this
+ * module exists to prevent (Codex round 1).
+ *
+ * So a null-intent partner is adopted ONLY where the mirror is genuinely 1:1
+ * (the estimate milestone has exactly one Paid clone). In a one-to-many group
+ * it cannot be attributed to a charge, so it is left alone and reported to the
+ * office instead of guessed at.
  */
 
-/** Anything with the two schedule delegates — the client or a transaction client. */
+/** Anything with the schedule delegates — the client or a transaction client. */
 type Db = Prisma.TransactionClient;
 
 export type ChargeGroupRow = {
@@ -46,8 +62,15 @@ export type ChargeGroupRow = {
 };
 
 export type ChargeGroup = {
+    /** Rows a full refund of this charge releases. */
     estimateSchedules: ChargeGroupRow[];
     invoiceSchedules: ChargeGroupRow[];
+    /**
+     * Paid mirror partners carrying no intent that sit in a one-to-many group,
+     * so they cannot be attributed to this charge. Never touched; surfaced so
+     * the office can reconcile them by hand.
+     */
+    unattributable: ChargeGroupRow[];
     estimateIds: string[];
     invoiceIds: string[];
 };
@@ -55,67 +78,9 @@ export type ChargeGroup = {
 const distinct = (ids: string[]): string[] => [...new Set(ids)].sort();
 
 export const chargeGroupIsEmpty = (group: ChargeGroup): boolean =>
-    group.estimateSchedules.length === 0 && group.invoiceSchedules.length === 0;
-
-/**
- * Every Paid milestone row that records `paymentIntentId`, on both sides.
- *
- * Direct match is the intent column itself. On top of that we follow the
- * `sourceScheduleId` mirror link to Paid partners that carry NO intent: manual
- * and pre-mirror legacy settlements leave the column null, and
- * `findEstimateMirror` in payment-mirror.ts already treats a null-intent linked
- * partner as the same payment when it unsettles. A partner carrying a
- * DIFFERENT non-null intent was settled by another charge and is never
- * included.
- */
-export async function resolveChargeGroup(db: Db, paymentIntentId: string): Promise<ChargeGroup> {
-    const estRows = await db.estimatePaymentSchedule.findMany({
-        where: { stripePaymentIntentId: paymentIntentId, status: "Paid" },
-        select: { id: true, name: true, estimateId: true, estimate: { select: { code: true } } },
-    });
-    const invRows = await db.paymentSchedule.findMany({
-        where: { stripePaymentIntentId: paymentIntentId, status: "Paid" },
-        select: {
-            id: true, name: true, invoiceId: true, sourceScheduleId: true,
-            invoice: { select: { code: true } },
-        },
-    });
-
-    // Link expansion, one hop in each direction. One hop is enough: a partner
-    // reached this way is Paid with a null intent, so it can only lead back to
-    // rows already in the direct sets.
-    const linkedInv = estRows.length
-        ? await db.paymentSchedule.findMany({
-            where: {
-                sourceScheduleId: { in: estRows.map((r) => r.id) },
-                status: "Paid",
-                stripePaymentIntentId: null,
-            },
-            select: { id: true, name: true, invoiceId: true, invoice: { select: { code: true } } },
-        })
-        : [];
-    const sourceIds = invRows.map((r) => r.sourceScheduleId).filter((id): id is string => !!id);
-    const linkedEst = sourceIds.length
-        ? await db.estimatePaymentSchedule.findMany({
-            where: { id: { in: sourceIds }, status: "Paid", stripePaymentIntentId: null },
-            select: { id: true, name: true, estimateId: true, estimate: { select: { code: true } } },
-        })
-        : [];
-
-    const estimateSchedules = dedupeById([...estRows, ...linkedEst].map((r) => ({
-        id: r.id, name: r.name, parentId: r.estimateId, parentCode: r.estimate?.code ?? null,
-    })));
-    const invoiceSchedules = dedupeById([...invRows, ...linkedInv].map((r) => ({
-        id: r.id, name: r.name, parentId: r.invoiceId, parentCode: r.invoice?.code ?? null,
-    })));
-
-    return {
-        estimateSchedules,
-        invoiceSchedules,
-        estimateIds: distinct(estimateSchedules.map((r) => r.parentId)),
-        invoiceIds: distinct(invoiceSchedules.map((r) => r.parentId)),
-    };
-}
+    group.estimateSchedules.length === 0
+    && group.invoiceSchedules.length === 0
+    && group.unattributable.length === 0;
 
 function dedupeById(rows: ChargeGroupRow[]): ChargeGroupRow[] {
     const byId = new Map<string, ChargeGroupRow>();
@@ -123,38 +88,160 @@ function dedupeById(rows: ChargeGroupRow[]): ChargeGroupRow[] {
     return [...byId.values()].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
 }
 
+const estRow = (r: { id: string; name: string; estimateId: string; estimate?: { code: string | null } | null }): ChargeGroupRow =>
+    ({ id: r.id, name: r.name, parentId: r.estimateId, parentCode: r.estimate?.code ?? null });
+const invRow = (r: { id: string; name: string; invoiceId: string; invoice?: { code: string | null } | null }): ChargeGroupRow =>
+    ({ id: r.id, name: r.name, parentId: r.invoiceId, parentCode: r.invoice?.code ?? null });
+
+const EST_SELECT = {
+    id: true, name: true, amount: true, estimateId: true,
+    stripePaymentIntentId: true, estimate: { select: { code: true } },
+} as const;
+const INV_SELECT = {
+    id: true, name: true, amount: true, invoiceId: true, sourceScheduleId: true,
+    stripePaymentIntentId: true, invoice: { select: { code: true, estimateId: true } },
+} as const;
+
+/** Every Paid milestone row that records `paymentIntentId`, on both sides. */
+export async function resolveChargeGroup(db: Db, paymentIntentId: string): Promise<ChargeGroup> {
+    const directEst = await db.estimatePaymentSchedule.findMany({
+        where: { stripePaymentIntentId: paymentIntentId, status: "Paid" },
+        select: EST_SELECT,
+    });
+    const directInv = await db.paymentSchedule.findMany({
+        where: { stripePaymentIntentId: paymentIntentId, status: "Paid" },
+        select: INV_SELECT,
+    });
+
+    const adoptedEst: ChargeGroupRow[] = [];
+    const adoptedInv: ChargeGroupRow[] = [];
+    const unattributable: ChargeGroupRow[] = [];
+
+    // ── estimate → invoice ──────────────────────────────────────────────────
+    // A Paid clone with a null intent is this charge's mirror only when it is
+    // the milestone's ONLY Paid clone.
+    for (const est of directEst) {
+        const clones = await db.paymentSchedule.findMany({
+            where: { sourceScheduleId: est.id, status: "Paid" },
+            select: INV_SELECT,
+        });
+        const nulls = clones.filter((c) => c.stripePaymentIntentId === null);
+        if (nulls.length === 0) continue;
+        if (clones.length === 1) adoptedInv.push(invRow(nulls[0]));
+        else unattributable.push(...nulls.map(invRow));
+    }
+
+    // ── invoice → estimate ──────────────────────────────────────────────────
+    for (const inv of directInv) {
+        if (inv.sourceScheduleId) {
+            const source = await db.estimatePaymentSchedule.findFirst({
+                where: { id: inv.sourceScheduleId, status: "Paid", stripePaymentIntentId: null },
+                select: EST_SELECT,
+            });
+            if (!source) continue;
+            // Same 1:1 test from the estimate's side: if the milestone has other
+            // Paid clones, this null-intent original cannot be attributed.
+            const paidClones = await db.paymentSchedule.count({
+                where: { sourceScheduleId: source.id, status: "Paid" },
+            });
+            if (paidClones === 1) adoptedEst.push(estRow(source));
+            else unattributable.push(estRow(source));
+            continue;
+        }
+        // Pre-link legacy row: no `sourceScheduleId`, so fall back to the same
+        // name+amount uniqueness rule the removed per-row unsettle helper used.
+        // A 1:1 legacy pair has no second clone to confuse it with.
+        const estimateId = inv.invoice?.estimateId;
+        if (!estimateId) continue;
+        const candidates = await db.estimatePaymentSchedule.findMany({
+            where: {
+                estimateId, name: inv.name, status: "Paid",
+                OR: [{ stripePaymentIntentId: paymentIntentId }, { stripePaymentIntentId: null }],
+            },
+            select: EST_SELECT,
+        });
+        const matching = candidates.filter((c) => toNum(c.amount) === toNum(inv.amount));
+        if (matching.length === 1) adoptedEst.push(estRow(matching[0]));
+    }
+
+    const estimateSchedules = dedupeById([...directEst.map(estRow), ...adoptedEst]);
+    const invoiceSchedules = dedupeById([...directInv.map(invRow), ...adoptedInv]);
+    const claimed = new Set([...estimateSchedules, ...invoiceSchedules].map((r) => r.id));
+
+    return {
+        estimateSchedules,
+        invoiceSchedules,
+        // A row adopted via one path must never also be reported as unresolved
+        // via another.
+        unattributable: dedupeById(unattributable).filter((r) => !claimed.has(r.id)),
+        estimateIds: distinct(estimateSchedules.map((r) => r.parentId)),
+        invoiceIds: distinct(invoiceSchedules.map((r) => r.parentId)),
+    };
+}
+
 export type UnwindResult = {
     estimateSchedules: ChargeGroupRow[];
     invoiceSchedules: ChargeGroupRow[];
+    unattributable: ChargeGroupRow[];
+    /**
+     * True when the group was already empty under the locks — an earlier
+     * delivery of the same refund had done the work. Distinguishes "nothing to
+     * do" from "we tried and failed", which the office email must not conflate.
+     */
+    alreadyUnwound: boolean;
 };
 
 /**
  * Release every member of a resolved group and recompute each affected parent.
  * Must run inside a transaction that already holds all of the group's parent
- * locks (`lockMoneyParentsMany`) — `unwindRefundedCharge` below is the wrapper
- * that guarantees that.
+ * locks (`lockMoneyParentsMany`) — `unwindRefundedCharge` is the wrapper that
+ * guarantees that.
  *
  * The Stripe ids stay on the released rows, matching the single-row reset this
  * replaces: they are how a redelivered `charge.refunded` re-finds the group.
  * Re-running on an already-unwound group is a no-op, because the group only
  * ever contains Paid rows.
+ *
+ * The resets are two batched `updateMany` calls rather than one per row: the
+ * whole unwind shares a single transaction with a bounded timeout, and a wide
+ * mirror group would otherwise put a hundred-odd sequential statements inside
+ * it.
  */
-export async function unwindChargeGroup(tx: Db, group: ChargeGroup): Promise<UnwindResult> {
-    const estimateSchedules: ChargeGroupRow[] = [];
-    for (const row of group.estimateSchedules) {
+export async function unwindChargeGroup(tx: Db, group: ChargeGroup): Promise<Omit<UnwindResult, "alreadyUnwound">> {
+    const estIds = group.estimateSchedules.map((r) => r.id);
+    const invIds = group.invoiceSchedules.map((r) => r.id);
+
+    let estimateSchedules = group.estimateSchedules;
+    if (estIds.length > 0) {
         const reset = await tx.estimatePaymentSchedule.updateMany({
-            where: { id: row.id, status: "Paid" },
+            where: { id: { in: estIds }, status: "Paid" },
             data: { status: "Pending", paidAt: null, paymentDate: null },
         });
-        if (reset.count > 0) estimateSchedules.push(row);
+        // The group was resolved under the parent locks, so every member should
+        // still be Paid. Re-read only if something slipped past a writer that
+        // does not take those locks, so the report never over-claims.
+        if (reset.count !== estIds.length) {
+            const still = await tx.estimatePaymentSchedule.findMany({
+                where: { id: { in: estIds }, status: "Paid" }, select: { id: true },
+            });
+            const stuck = new Set(still.map((r) => r.id));
+            estimateSchedules = estimateSchedules.filter((r) => !stuck.has(r.id));
+        }
     }
-    const invoiceSchedules: ChargeGroupRow[] = [];
-    for (const row of group.invoiceSchedules) {
+
+    let invoiceSchedules = group.invoiceSchedules;
+    if (invIds.length > 0) {
         const reset = await tx.paymentSchedule.updateMany({
-            where: { id: row.id, status: "Paid" },
+            where: { id: { in: invIds }, status: "Paid" },
             data: { status: "Pending", paidAt: null, paymentDate: null },
         });
-        if (reset.count > 0) invoiceSchedules.push(row);
+        if (reset.count !== invIds.length) {
+            const still = await tx.paymentSchedule.findMany({
+                where: { id: { in: invIds }, status: "Paid" }, select: { id: true },
+            });
+            const stuck = new Set(still.map((r) => r.id));
+            invoiceSchedules = invoiceSchedules.filter((r) => !stuck.has(r.id));
+        }
     }
 
     // Recompute only the parents that actually lost a payment.
@@ -164,7 +251,7 @@ export async function unwindChargeGroup(tx: Db, group: ChargeGroup): Promise<Unw
     for (const invoiceId of distinct(invoiceSchedules.map((r) => r.parentId))) {
         await recomputeInvoice(tx, invoiceId);
     }
-    return { estimateSchedules, invoiceSchedules };
+    return { estimateSchedules, invoiceSchedules, unattributable: group.unattributable };
 }
 
 /**
@@ -177,6 +264,12 @@ export async function unwindChargeGroup(tx: Db, group: ChargeGroup): Promise<Unw
  * lock set only ever grows, so this converges; the attempt cap is a backstop
  * against a pathological writer, and exhausting it raises rather than doing a
  * partial unwind.
+ *
+ * That check only sees rows a concurrent writer has COMMITTED. The writer that
+ * can insert a brand-new Paid clone carrying this intent —
+ * `convertEstimateToInvoice` — therefore takes the Estimate row lock too, so it
+ * either commits before this transaction resolves (and is seen) or waits until
+ * after it commits (and clones a milestone that is already Pending).
  */
 export async function unwindRefundedCharge(
     db: PrismaClient,
@@ -204,8 +297,16 @@ export async function unwindRefundedCharge(
             if (missingParents.estimateIds.length > 0 || missingParents.invoiceIds.length > 0) {
                 return { missingParents, result: null };
             }
-            return { missingParents: null, result: await unwindChargeGroup(tx, group) };
-        }));
+            const unwound = await unwindChargeGroup(tx, group);
+            return {
+                missingParents: null,
+                result: { ...unwound, alreadyUnwound: chargeGroupIsEmpty(group) },
+            };
+        // Locks, two batched resets and a recompute per parent. The 5s default
+        // is tight once a wide group also has to wait on a busy Invoice lock,
+        // and a timeout here strands the refund: the webhook has already
+        // answered Stripe 200 and nothing re-drains a FAILED StripeEvent.
+        }, { timeout: 15_000 }));
         if (outcome.result) return outcome.result;
         outcome.missingParents?.estimateIds.forEach((id) => estimateIds.add(id));
         outcome.missingParents?.invoiceIds.forEach((id) => invoiceIds.add(id));

--- a/src/lib/tx-retry.ts
+++ b/src/lib/tx-retry.ts
@@ -83,3 +83,27 @@ export async function lockMoneyParents(
         await tx.$queryRaw`SELECT id FROM "Invoice" WHERE id = ${ids.invoiceId} FOR UPDATE`;
     }
 }
+
+/**
+ * Multi-parent variant of `lockMoneyParents`, for flows that legitimately span
+ * several Estimates/Invoices at once — a refunded Stripe charge can be recorded
+ * on milestone rows belonging to more than one document (see `refund-group.ts`).
+ *
+ * Keeps the same global Estimate → Invoice direction, and adds a second rule so
+ * two such transactions can't deadlock against each other: within a table the
+ * ids are locked in ascending order. Single-id callers of `lockMoneyParents`
+ * are trivially consistent with that ordering, so the two helpers interleave
+ * safely. Locked one row per statement rather than one `= ANY(...) ORDER BY`
+ * query so the acquisition order is explicit rather than plan-dependent.
+ */
+export async function lockMoneyParentsMany(
+    tx: Prisma.TransactionClient,
+    ids: { estimateIds?: readonly string[]; invoiceIds?: readonly string[] },
+): Promise<void> {
+    for (const estimateId of [...new Set(ids.estimateIds ?? [])].sort()) {
+        await tx.$queryRaw`SELECT id FROM "Estimate" WHERE id = ${estimateId} FOR UPDATE`;
+    }
+    for (const invoiceId of [...new Set(ids.invoiceIds ?? [])].sort()) {
+        await tx.$queryRaw`SELECT id FROM "Invoice" WHERE id = ${invoiceId} FOR UPDATE`;
+    }
+}


### PR DESCRIPTION
## The bug

`stripePaymentIntentId` is **not unique** on either schedule table. `convertEstimateToInvoice` copies it onto every invoice-side clone of an already-paid estimate milestone, and an estimate can be converted more than once — so one Stripe charge can be recorded on several rows across `EstimatePaymentSchedule` and `PaymentSchedule`.

The `charge.refunded` handler dispatched on that column and reset exactly **one** row. #371 made the pick deterministic, but deterministic is not correct: the other Paid clones kept showing money the client had gotten back, and their invoices kept a wrong `balanceDue`.

Codex raised this as a blocker in both review rounds of #371, where it was deliberately left out of scope as pre-existing rather than a regression.

## The fix

Refunds now take the **charge** as their unit of identity, not the row.

- **`src/lib/refund-group.ts`** (new) resolves every Paid row carrying the intent across both tables, locks every affected Estimate and Invoice, releases them, and recomputes every parent.
- `unwindRefundedCharge` re-resolves the group **under** the locks. If a concurrent writer added a member on a document we don't hold, nothing is written and the transaction re-runs with a wider lock set — no partial unwind.
- **`lockMoneyParentsMany`** keeps the canonical Estimate → Invoice direction and adds ascending-id ordering within each table, so two multi-parent transactions can't deadlock.

### A null PaymentIntent is never treated as a match

Manual, QuickBooks and pre-mirror legacy settlements leave the column null, so a Paid mirror partner with no intent *might* be the same money — or might be a cheque. Once the estimate milestone is Paid a mirror claim on it fails, so a second clone settled by cheque also lands Paid with a null intent, shape-identical to a legacy Stripe mirror.

An earlier revision adopted such a partner when the mirror was 1:1. That was wrong — cardinality is not payment identity, and nothing on these rows records *which* payment settled them. Only intent-carrying rows are released now. Null-intent partners are collected as `unattributable`, never written, and named in the office email so a human resolves them.

**Trade-off:** a genuinely legacy 1:1 mirror no longer auto-unwinds. It gets reported instead. That is the honest answer when the data cannot decide.

### Deliberately not changed

Conversion still copies the intent onto clones. Five callers read that column as *"this row records a Stripe payment"* rather than as an identity — the in-flight guards in `billing-core.ts` and `progress-billing.ts`, the schedule-delete guard in `actions.ts`, and the `hasStripeIntent` undo affordance in both editors. Dropping it would silently reopen all of them.

### Two conversion races fixed along the way

- `createInvoiceFromEstimateCore` wrote the derived invoice balance/status **after** its transaction committed. A refund landing in between reset the freshly cloned Paid milestone and recomputed the invoice to Issued — then that post-commit write restored Paid/zero-balance from a stale `paidAmount`. Rows Pending, invoice claiming nothing was owed. The write now runs inside the lock-bearing transaction.
- That transaction now also takes the Estimate lock (**Estimate → Project**, extending the `restoreEstimateItemAssociations` chain of PurchaseOrder → Estimate → EstimateItem → Project) so a conversion can't commit a fresh Paid clone of a charge a refund has already resolved.

## Removed

The three per-row unsettle helpers in `payment-mirror.ts` had no production caller left, along with the now-unreachable `wantStatus: "Paid"` branch of the mirror finder. `recomputeEstimate`'s `statusBeforePayment` fallback is derived (has-an-invoice → `"Invoiced"`, else `"Approved"`) because the two removed rails disagreed on it; it only fires for legacy rows that never captured the column.

## Tests

`e2e/money-pipeline.spec.ts` S3/S5/S6 rewritten against the path that actually runs, plus:

| | |
|---|---|
| **S7** | one estimate milestone, two invoices — all three clones release |
| **S8** | a redelivered refund is a no-op |
| **S9** | a cheque-paid clone survives a refund of the Stripe charge |
| **S10** | a lone null-intent mirror is reported, not released |
| **S11** | an ambiguous pre-link candidate set is reported, never silently dropped |

S9 and S10 are the tension: either naive rule fails one of them.

## Verification status

- `npm run build` passes (exit 0).
- **The e2e suite has not been executed anywhere yet** — there's no local Postgres on the dev box, so CI on this PR is its first real run. Please don't merge on a red or skipped money-pipeline job.
- Codex (gpt-5.6-sol, xhigh) reviewed two rounds. Round 2 returned *not ready to merge* on the state at `14522811`; every finding is addressed in `b03be975`, **but those fixes have not themselves been peer-reviewed** — the review protocol stops at round 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
