### PR TITLE
fix(takeoffs): credit rows derive their real margin instead of a fabricated 25%

### DIFF
--- a/src/app/api/takeoffs/convert-to-estimate/route.ts
+++ b/src/app/api/takeoffs/convert-to-estimate/route.ts
@@ -60,14 +60,22 @@ function recomputeMilestoneAmounts(
  *     positive, so the ratio (and the margin it implies) is unchanged by flipping both signs
  *     positive before calling derivedMarginPct, which only guards `price <= 0` as "no margin".
  *     Mirrors the identical sign-check `splitTakeoffTax` already applies to the tax row's own
- *     credit case (`src/lib/takeoff-costing.ts`).
+ *     credit case (`src/lib/takeoff-costing.ts`). A credit sold BELOW cost (raw margin negative)
+ *     clamps to 0 exactly like the equivalent positive loss row does — and, like it, is flagged
+ *     by `marginIsUnrepresentable` (its rate<0 gate) rather than trusted.
  *  3. Convert the stated markup: margin = markup / (100 + markup) x 100.
  *  4. A cost/price pair present with MIXED signs (one negative, one not) is not a rate-based
  *     relationship — the ratio implies a number the row's own figures contradict (e.g. it can
  *     clamp to 99% while the numbers show the opposite). Rather than fabricate
  *     DEFAULT_MARGIN_PCT next to a pair it doesn't describe, such a row is stored at 0% margin —
  *     the same sentinel already written for pass-through tax rows, so downstream readers already
- *     treat 0 as a legitimate, non-default value.
+ *     treat 0 as a legitimate, non-default value. The sentinel is safe ONLY because the guard
+ *     layer refuses to trust it: both mixed orientations are flagged by `marginIsUnrepresentable`
+ *     (negative cost trips its rate<0 gate; negative sell its price<=0 gate), `marginIsSettable`
+ *     disables margin editing wherever sell <= 0, and baseCost/unitCost stay the authoritative
+ *     pair — nothing regenerates them from this margin without an explicit user edit (the
+ *     2026-08-09 warn-don't-rewrite product decision, see lib/budget-math.ts). Guard parity is
+ *     pinned by tests in tests/takeoff-convert-tax.test.ts.
  *  5. Fall back to the default margin — rows with no costing data at all (legacy rows saved
  *     before costing was carried).
  */

--- a/src/app/api/takeoffs/convert-to-estimate/route.ts
+++ b/src/app/api/takeoffs/convert-to-estimate/route.ts
@@ -56,16 +56,34 @@ function recomputeMilestoneAmounts(
  * Preference order:
  *  1. Derive from the row's own cost and price — the pair is what the client was quoted, so the
  *     margin derived from it keeps the row internally consistent no matter what the model claimed.
- *  2. Convert the stated markup: margin = markup / (100 + markup) x 100.
- *  3. Fall back to the default margin (also covers legacy rows saved before costing was carried).
+ *  2. Credit rows: cost and price both negative derive the SAME way — dividing two negatives is
+ *     positive, so the ratio (and the margin it implies) is unchanged by flipping both signs
+ *     positive before calling derivedMarginPct, which only guards `price <= 0` as "no margin".
+ *     Mirrors the identical sign-check `splitTakeoffTax` already applies to the tax row's own
+ *     credit case (`src/lib/takeoff-costing.ts`).
+ *  3. Convert the stated markup: margin = markup / (100 + markup) x 100.
+ *  4. A cost/price pair present with MIXED signs (one negative, one not) is not a rate-based
+ *     relationship — the ratio implies a number the row's own figures contradict (e.g. it can
+ *     clamp to 99% while the numbers show the opposite). Rather than fabricate
+ *     DEFAULT_MARGIN_PCT next to a pair it doesn't describe, such a row is stored at 0% margin —
+ *     the same sentinel already written for pass-through tax rows, so downstream readers already
+ *     treat 0 as a legitimate, non-default value.
+ *  5. Fall back to the default margin — rows with no costing data at all (legacy rows saved
+ *     before costing was carried).
  */
 function marginPercentFor(item: any, baseCost: number | null, unitCost: number): number {
     if (baseCost != null && baseCost > 0 && unitCost > 0) {
         return derivedMarginPct(baseCost, unitCost);
     }
+    if (baseCost != null && baseCost < 0 && unitCost < 0) {
+        return derivedMarginPct(-baseCost, -unitCost);
+    }
     const markup = numOrNull(item.markupPercent);
     if (markup != null && markup > -100) {
         return (markup / (100 + markup)) * 100;
+    }
+    if ((baseCost != null && baseCost < 0) || unitCost < 0) {
+        return 0;
     }
     return DEFAULT_MARGIN_PCT;
 }

--- a/tests/takeoff-convert-tax.test.ts
+++ b/tests/takeoff-convert-tax.test.ts
@@ -53,7 +53,7 @@
 import { test, before, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import Module from "node:module";
-import { derivedMarginPct } from "../src/lib/budget-math";
+import { derivedMarginPct, marginIsSettable, marginIsUnrepresentable } from "../src/lib/budget-math";
 
 type CreateCall<T> = { data: T };
 
@@ -425,6 +425,27 @@ test("mixed-sign cost/price (no stated markup) is genuinely underivable and stor
 
     assert.equal(calls.estimateItemCreates.length, 1);
     assert.equal(calls.estimateItemCreates[0].data.markupPercent, 0);
+});
+
+// The stored sentinel/clamped margin on a sign-broken pair is only safe because the guard layer
+// refuses to trust it: marginIsUnrepresentable flags every such shape (so the UI warns and repair
+// sweeps exclude it), and marginIsSettable disables margin EDITING wherever sell <= 0. These
+// assertions pin that contract — if the guards ever loosen, the conversion's sentinel writes above
+// become silent lies and must change with them. (Codex review 2026-08-14, round 2.)
+test("guard parity: every sign-broken pair the conversion can store is flagged unrepresentable", () => {
+    // Mixed sign, negative cost against positive sell — the rate<0 gate.
+    assert.equal(marginIsUnrepresentable(-500, 1000), true);
+    // Mixed sign, positive cost against negative sell — the price<=0 gate.
+    assert.equal(marginIsUnrepresentable(500, -1000), true);
+    // Same-sign credit sold BELOW cost (raw margin -75%): clamps to 0 exactly like the equivalent
+    // positive loss row, and like it is flagged rather than trusted.
+    assert.equal(marginIsUnrepresentable(-35000, -20000), true);
+    // Margin editing is disabled outright wherever the sell price is not positive, so the flagged
+    // value cannot be used to regenerate cost/sell from the negative-sell orientation at all.
+    assert.equal(marginIsSettable(-1000), false);
+    assert.equal(marginIsSettable(0), false);
+    // Control: an ordinary representable pair is NOT flagged — the guard is a gate, not a blanket.
+    assert.equal(marginIsUnrepresentable(20000, 35000), false);
 });
 
 test("mixed-sign cost/price WITH a stated markupPercent still converts the stated markup, rather than jumping straight to 0", async () => {

--- a/tests/takeoff-convert-tax.test.ts
+++ b/tests/takeoff-convert-tax.test.ts
@@ -371,6 +371,110 @@ test("canonical conversion: tax row stripped from line items, rate/name/total pe
     assert.equal(calls.takeoffUpdates[0].data.status, "Completed");
 });
 
+// --- marginPercentFor: negative-costing rows -------------------------------------------------
+
+test("credit row: cost and price both negative derive the SAME margin the positive pair would", async () => {
+    // No 99-TAX row, so splitTakeoffTax never runs and finalTotal falls back to the raw
+    // totalEstimate — the only thing under test here is marginPercentFor's own branch, not the
+    // tax split.
+    const items = [{ costCode: "02-FRAME", name: "Credit Frame", total: -35000, baseCost: -20000, unitCost: -35000, quantity: 1 }];
+    state.takeoff = {
+        id: "takeoff-credit",
+        name: "Credit Job",
+        projectId: "project-1",
+        leadId: null,
+        aiEstimateData: JSON.stringify({
+            items,
+            totalEstimate: -35000,
+            paymentMilestones: [{ name: "Refund", percentage: "100", amount: "-35000" }],
+        }),
+    };
+
+    const res = await POST(postRequest("takeoff-credit"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+
+    assert.equal(calls.estimateItemCreates.length, 1);
+    const row = calls.estimateItemCreates[0].data;
+    assert.equal(row.baseCost, -20000); // sign preserved on the stored cost/price themselves
+    assert.equal(row.unitCost, -35000);
+    // Same margin as the canonical positive Frame row (baseCost 20000, unitCost 35000) above —
+    // flipping both signs before deriving must not change the implied margin.
+    const expectedMargin = derivedMarginPct(20000, 35000);
+    assert.equal(row.markupPercent, expectedMargin);
+    assert.notEqual(row.markupPercent, 25); // proves this derived, rather than hit the default
+});
+
+test("mixed-sign cost/price (no stated markup) is genuinely underivable and stores 0%, not the fabricated default", async () => {
+    const items = [{ costCode: "02-FRAME", name: "Mixed Sign Item", total: -1000, baseCost: 500, unitCost: -1000, quantity: 1 }];
+    state.takeoff = {
+        id: "takeoff-mixed",
+        name: "Mixed Sign Job",
+        projectId: "project-1",
+        leadId: null,
+        aiEstimateData: JSON.stringify({
+            items,
+            totalEstimate: -1000,
+            paymentMilestones: [{ name: "Full", percentage: "100", amount: "-1000" }],
+        }),
+    };
+
+    const res = await POST(postRequest("takeoff-mixed"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+
+    assert.equal(calls.estimateItemCreates.length, 1);
+    assert.equal(calls.estimateItemCreates[0].data.markupPercent, 0);
+});
+
+test("mixed-sign cost/price WITH a stated markupPercent still converts the stated markup, rather than jumping straight to 0", async () => {
+    // markupPercent 25 (true markup) here converts to a 20% margin — proves the markup-conversion
+    // branch is still consulted before the mixed-sign fallback, not bypassed by it.
+    const items = [
+        { costCode: "02-FRAME", name: "Mixed Sign With Markup", total: -1000, baseCost: 500, unitCost: -1000, quantity: 1, markupPercent: 25 },
+    ];
+    state.takeoff = {
+        id: "takeoff-mixed-markup",
+        name: "Mixed Sign Job With Markup",
+        projectId: "project-1",
+        leadId: null,
+        aiEstimateData: JSON.stringify({
+            items,
+            totalEstimate: -1000,
+            paymentMilestones: [{ name: "Full", percentage: "100", amount: "-1000" }],
+        }),
+    };
+
+    const res = await POST(postRequest("takeoff-mixed-markup"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+
+    assert.equal(calls.estimateItemCreates.length, 1);
+    assert.equal(calls.estimateItemCreates[0].data.markupPercent, 20);
+});
+
+test("no costing data at all (no baseCost/unitCost pair, no stated markup) still defaults to 25% — unaffected by the negative-costing fix", async () => {
+    const items = [{ costCode: "02-FRAME", name: "No Costing Data", total: 1000, quantity: 1 }];
+    state.takeoff = {
+        id: "takeoff-legacy",
+        name: "Legacy Job",
+        projectId: "project-1",
+        leadId: null,
+        aiEstimateData: JSON.stringify({
+            items,
+            totalEstimate: 1000,
+            paymentMilestones: [{ name: "Full", percentage: "100", amount: "1000" }],
+        }),
+    };
+
+    const res = await POST(postRequest("takeoff-legacy"));
+    const body = await res.json();
+    assert.equal(res.status, 200, JSON.stringify(body));
+
+    assert.equal(calls.estimateItemCreates.length, 1);
+    assert.equal(calls.estimateItemCreates[0].data.markupPercent, 25);
+});
+
 // --- bail-out case: no usable rate ------------------------------------------------------------
 
 function bailOutTakeoff() {


### PR DESCRIPTION
## What

The takeoff→estimate conversion fabricated a 25% margin on credit rows. `marginPercentFor` required `baseCost > 0 && unitCost > 0` to derive the margin from the row's own cost/price, so a credit line (both negative) skipped derivation and landed on `DEFAULT_MARGIN_PCT` — a stored margin contradicting the row's own numbers.

This was chip 2 of the "takeoff conversion hardening" batch. Chips 1 and 3 were verified **already fixed on main** before any code was written: the hardcoded 8.4% prompt tax died in #381 (tax is now computed server-side), and atomicity/idempotency landed in #385.

## How

Mirrors the sign convention `splitTakeoffTax` already uses:

- **Same-sign negative** (credit) pairs derive via `derivedMarginPct(-baseCost, -unitCost)` — double negation leaves the ratio, and therefore the margin, unchanged.
- **Mixed-sign** pairs with no stated markup store `0%` — not the fabricated 25 — because no storable margin describes them. The stated-markup branch still runs first.
- True no-data rows keep the 25% default (unchanged, out of scope).

4 new tests cover each branch; unit suite 202/202; build green.

## Review

Codex peer review, two rounds. Round 1: no blockers; two real issues, both about whether the stored sentinel/clamped margin on a sign-broken pair could later **regenerate** wrong cost/sell numbers. Round 2 resolution — the existing guard layer already forbids exactly that: `marginIsUnrepresentable` flags every such shape (negative cost trips its `rate<0` gate, negative sell its `price<=0` gate, loss-credits its range check), `marginIsSettable` disables margin editing at `sell<=0`, and `baseCost`/`unitCost` remain the authoritative pair per the 2026-08-09 warn-don't-rewrite product decision. Rather than add a new sentinel state (the schema column is non-nullable, and lowering `MIN_MARGIN_PCT` was explicitly rejected in #331), the round-2 commit makes that contract **executable**: the fallback's doc comment states it, and a guard-parity test asserts each gate fires — so a future guard loosening breaks CI instead of silently turning the sentinel into a lie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
