### PR TITLE
fix(migrations): backfill the missing migration files behind #386/#392 (unbreaks the reproduce-production gate)

### DIFF
--- a/prisma/migrations/20260814230000_payment_tz_and_automation_indexes/migration.sql
+++ b/prisma/migrations/20260814230000_payment_tz_and_automation_indexes/migration.sql
@@ -1,0 +1,21 @@
+-- Backfills the migration history for two schema.prisma changes that merged without
+-- migration files (the "Migrations reproduce production" gate flagged them on every
+-- subsequent PR):
+--   * #386 fix(money): PaymentSchedule.paymentDate/.paidAt widened to TIMESTAMPTZ(6)
+--     to match their mirrored twins on EstimatePaymentSchedule.
+--   * #392 automation dashboard: two AutomationEvent lookup indexes.
+-- Prod already has all four objects (applied 2026-08-14 via #386's own
+-- apply-payment-timestamp-alignment.mjs SQL + CREATE INDEX IF NOT EXISTS, verified
+-- against information_schema/pg_indexes). This file exists so a DB built from the
+-- committed migrations reproduces that same shape.
+
+-- AlterTable (#386 — on the CI throwaway DB the columns are empty; prod conversion
+-- used USING "col" AT TIME ZONE 'UTC' and is already done)
+ALTER TABLE "PaymentSchedule" ALTER COLUMN "paymentDate" SET DATA TYPE TIMESTAMPTZ(6),
+ALTER COLUMN "paidAt" SET DATA TYPE TIMESTAMPTZ(6);
+
+-- CreateIndex (#392)
+CREATE INDEX "AutomationEvent_qbPurchaseId_idx" ON "AutomationEvent"("qbPurchaseId");
+
+-- CreateIndex (#392)
+CREATE INDEX "AutomationEvent_driveFileId_idx" ON "AutomationEvent"("driveFileId");


### PR DESCRIPTION
The #382 "Migrations reproduce production" gate fails on every current-main PR (first seen on #383) because two PRs changed schema.prisma without migration files — their branches predated the gate, so it never ran on them:

- **#386** — `PaymentSchedule.paymentDate`/`.paidAt` widened to `TIMESTAMPTZ(6)`
- **#392** — `AutomationEvent_qbPurchaseId_idx` and `AutomationEvent_driveFileId_idx`

This adds the one migration covering both, so a DB built from committed migrations matches schema.prisma again.

**Prod was aligned FIRST, per the schema workflow:** #386's own apply-script SQL (`USING "col" AT TIME ZONE 'UTC'`, `SET LOCAL lock_timeout='5s'`, value-preserving per that script's documented semantics) plus `CREATE INDEX IF NOT EXISTS` for both indexes ran against prod 2026-08-14 ~16:10 PT. Verified after: all four mirrored payment columns (both schedule tables) are `timestamptz(6)`, both indexes exist.

Migration-file-only change — no code, no schema.prisma edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
